### PR TITLE
feat(github): add schema change cancel command

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -722,6 +722,7 @@ schemabot apply -e staging --allow-unsafe
 | `schemabot apply-confirm -e <env>` | Confirm a downgraded locked plan |
 | `schemabot unlock` | Release lock and discard plan |
 | `schemabot stop <apply-id> -e <env>` | Stop an in-progress deployment |
+| `schemabot cancel <apply-id> -e <env>` | Permanently cancel an in-progress deployment |
 | `schemabot start <apply-id> -e <env>` | Resume a stopped deployment |
 | `schemabot cutover <apply-id> -e <env>` | Complete a deferred cutover |
 | `schemabot rollback <apply-id> -e <env>` | Generate a rollback plan |
@@ -750,6 +751,7 @@ That command wasn't recognized. Available commands:
 | `schemabot apply-confirm -e <env>` | Confirm a downgraded locked plan |
 | `schemabot unlock` | Release lock and discard plan |
 | `schemabot stop <apply-id> -e <env>` | Stop an in-progress deployment |
+| `schemabot cancel <apply-id> -e <env>` | Permanently cancel an in-progress deployment |
 | `schemabot start <apply-id> -e <env>` | Resume a stopped deployment |
 | `schemabot cutover <apply-id> -e <env>` | Complete a deferred cutover |
 | `schemabot rollback <apply-id> -e <env>` | Generate a rollback plan |
@@ -942,6 +944,7 @@ That command wasn't recognized. Available commands:
 | `schemabot apply-confirm -e <env>` | Confirm a downgraded locked plan |
 | `schemabot unlock` | Release lock and discard plan |
 | `schemabot stop <apply-id> -e <env>` | Stop an in-progress deployment |
+| `schemabot cancel <apply-id> -e <env>` | Permanently cancel an in-progress deployment |
 | `schemabot start <apply-id> -e <env>` | Resume a stopped deployment |
 | `schemabot cutover <apply-id> -e <env>` | Complete a deferred cutover |
 | `schemabot rollback <apply-id> -e <env>` | Generate a rollback plan |
@@ -2286,9 +2289,9 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 
 ---
 
-To stop this schema change:
+To cancel this schema change:
 ```
-schemabot stop apply-a1b2c3d4e5f6 -e staging
+schemabot cancel apply-a1b2c3d4e5f6 -e staging
 ```
 
 _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
@@ -2327,9 +2330,9 @@ ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
 
 ---
 
-To stop this schema change:
+To cancel this schema change:
 ```
-schemabot stop apply-a1b2c3d4e5f6 -e staging
+schemabot cancel apply-a1b2c3d4e5f6 -e staging
 ```
 
 _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
@@ -2363,9 +2366,9 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 ---
 
-To stop this schema change:
+To cancel this schema change:
 ```
-schemabot stop apply-a1b2c3d4e5f6 -e staging
+schemabot cancel apply-a1b2c3d4e5f6 -e staging
 ```
 
 _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_

--- a/pkg/webhook/action/action.go
+++ b/pkg/webhook/action/action.go
@@ -8,6 +8,7 @@ const (
 	ApplyConfirm    = "apply-confirm"
 	Unlock          = "unlock"
 	Stop            = "stop"
+	Cancel          = "cancel"
 	Start           = "start"
 	Cutover         = "cutover"
 	Revert          = "revert"

--- a/pkg/webhook/actor_authorization_test.go
+++ b/pkg/webhook/actor_authorization_test.go
@@ -373,7 +373,7 @@ func TestWebhookApplyScopedControlCommandBlocksUnauthorizedActor(t *testing.T) {
 		logger:    testLogger(),
 	}
 
-	for _, command := range []string{action.Stop, action.Start} {
+	for _, command := range []string{action.Stop, action.Cancel, action.Start} {
 		t.Run(command, func(t *testing.T) {
 			req := buildWebhookRequest(t, webhookPayloadOpts{
 				comment:   "schemabot " + command + " " + apply.ApplyIdentifier + " -e staging",

--- a/pkg/webhook/commands.go
+++ b/pkg/webhook/commands.go
@@ -65,6 +65,7 @@ var commandSpecs = []CommandSpec{
 	{Name: action.Unlock, SupportsDB: true, SupportsForce: true},
 	{Name: action.FixLint, SupportsDB: true},
 	{Name: action.Stop, RequiresEnv: true, HasApplyID: true},
+	{Name: action.Cancel, RequiresEnv: true, HasApplyID: true},
 	{Name: action.Start, RequiresEnv: true, HasApplyID: true},
 	{Name: action.Revert, RequiresEnv: true},
 	{Name: action.SkipRevert, RequiresEnv: true},

--- a/pkg/webhook/commands_test.go
+++ b/pkg/webhook/commands_test.go
@@ -19,6 +19,7 @@ func TestCommandSpecs_CoverEveryDispatcherAction(t *testing.T) {
 		action.Unlock,
 		action.FixLint,
 		action.Stop,
+		action.Cancel,
 		action.Start,
 		action.Revert,
 		action.SkipRevert,
@@ -58,6 +59,7 @@ func TestCommandSpecs_FlagsRespected(t *testing.T) {
 		{name: action.Unlock, supportsDB: true, supportsForce: true},
 		{name: action.FixLint, supportsDB: true},
 		{name: action.Stop, requiresEnv: true, hasApplyID: true},
+		{name: action.Cancel, requiresEnv: true, hasApplyID: true},
 		{name: action.Start, requiresEnv: true, hasApplyID: true},
 		{name: action.Revert, requiresEnv: true},
 		{name: action.SkipRevert, requiresEnv: true},
@@ -467,6 +469,17 @@ func TestParseCommand(t *testing.T) {
 			body: "schemabot start apply_abc123 -e production",
 			expected: CommandResult{
 				Action:      "start",
+				ApplyID:     "apply_abc123",
+				Environment: "production",
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
+			name: "cancel",
+			body: "schemabot cancel apply_abc123 -e production",
+			expected: CommandResult{
+				Action:      "cancel",
 				ApplyID:     "apply_abc123",
 				Environment: "production",
 				Found:       true,

--- a/pkg/webhook/control.go
+++ b/pkg/webhook/control.go
@@ -226,6 +226,39 @@ func (h *Handler) handleStopCommand(repo string, pr int, installationID int64, r
 	}))
 }
 
+// handleCancelCommand handles the "schemabot cancel <apply-id> -e <env>" PR
+// comment command by recording durable cancel intent for the operator owner.
+func (h *Handler) handleCancelCommand(repo string, pr int, installationID int64, requestedBy string, result CommandResult) {
+	ctx, cancel := h.commandContext(commandTimeout)
+	defer cancel()
+
+	resp := runControlCommand(h, ctx, repo, pr, installationID, requestedBy, result, action.Cancel,
+		h.service.ExecuteCancel,
+		func(r *apitypes.CancelResponse) bool { return r.Accepted },
+		func(r *apitypes.CancelResponse) string { return r.ErrorMessage })
+	if resp == nil {
+		return
+	}
+
+	h.logger.Info("cancel PR command accepted",
+		"repo", repo,
+		"pr", pr,
+		"apply_id", result.ApplyID,
+		"environment", result.Environment,
+		"requested_by", requestedBy,
+		"status", resp.Status,
+		"cancelled_count", resp.CancelledCount,
+		"skipped_count", resp.SkippedCount)
+	h.postComment(repo, pr, installationID, templates.RenderCancelCommandAccepted(templates.CancelCommandAcceptedData{
+		ApplyID:        result.ApplyID,
+		Environment:    result.Environment,
+		RequestedBy:    requestedBy,
+		Status:         resp.Status,
+		CancelledCount: resp.CancelledCount,
+		SkippedCount:   resp.SkippedCount,
+	}))
+}
+
 // handleStartCommand handles the "schemabot start <apply-id> -e <env>" PR
 // comment command by recording durable start intent for the operator owner.
 func (h *Handler) handleStartCommand(repo string, pr int, installationID int64, requestedBy string, result CommandResult) {

--- a/pkg/webhook/control_integration_test.go
+++ b/pkg/webhook/control_integration_test.go
@@ -140,6 +140,71 @@ func TestE2EStopCommandRecordsDurableRequest(t *testing.T) {
 	assertReactionEventually(t, reactions)
 }
 
+// TestE2ECancelCommandRecordsDurableRequest verifies that a PR comment cancel
+// command records permanent cancel intent and preserves the caller in apply logs.
+func TestE2ECancelCommandRecordsDurableRequest(t *testing.T) {
+	ctx := t.Context()
+	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
+	require.NoError(t, err)
+	require.NoError(t, schemabotDB.PingContext(ctx))
+
+	store := mysqlstore.New(schemabotDB)
+	applyIdentifier := "apply_cace1234"
+	database := "cancel_pr_comments_db"
+	cleanupStopCommandTestRows(t, schemabotDB, applyIdentifier, database)
+	t.Cleanup(func() {
+		cleanupStopCommandTestRows(t, schemabotDB, applyIdentifier, database)
+		utils.CloseAndLog(schemabotDB)
+	})
+	applyID := createStopCommandApply(t, store, applyIdentifier, database)
+
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 10)
+	reactions := make(chan string, 10)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Body string `json:"body"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		comments <- body.Body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+	})
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/comments/42/reactions", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Content string `json:"content"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		reactions <- body.Content
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+
+	service := apiServiceForStopCommandTest(t, store, database)
+	service.RegisterTernClient(database, "staging", &stopCommandTernClient{remote: true})
+	h := &Handler{
+		service:   service,
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())}),
+		logger:    testLogger(),
+	}
+
+	postCancelCommand(t, h, applyIdentifier, "alice")
+	comment := readComment(t, comments)
+	assert.Contains(t, comment, "Cancel Request Accepted")
+	assert.Contains(t, comment, "`"+applyIdentifier+"`")
+	assert.Contains(t, comment, "@alice")
+
+	controlReq, err := store.ControlRequests().GetPending(ctx, applyID, storage.ControlOperationCancel)
+	require.NoError(t, err)
+	require.NotNil(t, controlReq)
+	assert.Equal(t, "github:alice@octocat/hello-world#1", controlReq.RequestedBy)
+	assert.Equal(t, storage.ControlRequestPending, controlReq.Status)
+	logs, err := store.ApplyLogs().List(ctx, storage.ApplyLogFilter{ApplyID: applyID, Limit: 20})
+	require.NoError(t, err)
+	assert.True(t, applyLogContains(logs, "Cancel requested by user (caller: github:alice@octocat/hello-world#1)"))
+	assertReactionEventually(t, reactions)
+}
+
 // TestE2EStopCommandQueuesDeferredCutoverLocalApplyWithoutRunner verifies that
 // a PR comment stop command records durable stop intent when storage has an
 // active local schema change but this process does not own the Spirit runner.
@@ -636,6 +701,19 @@ func postStopCommand(t *testing.T, h *Handler, applyIdentifier, user string) {
 	assert.Contains(t, rr.Body.String(), "stop started")
 }
 
+func postCancelCommand(t *testing.T, h *Handler, applyIdentifier, user string) {
+	t.Helper()
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment:   "schemabot cancel " + applyIdentifier + " -e staging",
+		userLogin: user,
+		isPR:      true,
+	}, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "cancel started")
+}
+
 func postStartCommand(t *testing.T, h *Handler, applyIdentifier, user string) {
 	t.Helper()
 	req := buildWebhookRequest(t, webhookPayloadOpts{
@@ -694,10 +772,11 @@ func applyLogContains(logs []*storage.ApplyLog, want string) bool {
 
 type stopCommandTernClient struct {
 	tern.Client
-	mu        sync.Mutex
-	remote    bool
-	stopCalls int
-	onStop    func(context.Context, *ternv1.StopRequest) (*ternv1.StopResponse, error)
+	mu          sync.Mutex
+	remote      bool
+	stopCalls   int
+	cancelCalls int
+	onStop      func(context.Context, *ternv1.StopRequest) (*ternv1.StopResponse, error)
 }
 
 func (c *stopCommandTernClient) Plan(context.Context, *ternv1.PlanRequest) (*ternv1.PlanResponse, error) {
@@ -724,6 +803,13 @@ func (c *stopCommandTernClient) Stop(ctx context.Context, req *ternv1.StopReques
 		return c.onStop(ctx, req)
 	}
 	return &ternv1.StopResponse{Accepted: true, StoppedCount: 1}, nil
+}
+
+func (c *stopCommandTernClient) Cancel(context.Context, *ternv1.CancelRequest) (*ternv1.CancelResponse, error) {
+	c.mu.Lock()
+	c.cancelCalls++
+	c.mu.Unlock()
+	return &ternv1.CancelResponse{Accepted: true, CancelledCount: 1}, nil
 }
 
 func (c *stopCommandTernClient) Start(context.Context, *ternv1.StartRequest) (*ternv1.StartResponse, error) {

--- a/pkg/webhook/handler_test.go
+++ b/pkg/webhook/handler_test.go
@@ -457,6 +457,7 @@ func TestWebhookControlCommandMissingApplyID(t *testing.T) {
 		action  string
 	}{
 		{name: "stop", comment: "schemabot stop -e staging", action: "stop"},
+		{name: "cancel", comment: "schemabot cancel -e staging", action: "cancel"},
 		{name: "start", comment: "schemabot start -e staging", action: "start"},
 		{name: "cutover", comment: "schemabot cutover -e staging", action: "cutover"},
 	}

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -294,6 +294,11 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 			h.handleStopCommand(repo, pr, installationID, requestedBy, result)
 		})
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "stop started"})
+	case action.Cancel:
+		h.goSafe(repo, pr, installationID, func() {
+			h.handleCancelCommand(repo, pr, installationID, requestedBy, result)
+		})
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "cancel started"})
 	case action.Start:
 		h.goSafe(repo, pr, installationID, func() {
 			h.handleStartCommand(repo, pr, installationID, requestedBy, result)

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -10,6 +10,7 @@ import (
 	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/ddl"
 	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/ui"
 )
 
@@ -261,6 +262,22 @@ func writeDeployRequestLink(sb *strings.Builder, data ApplyStatusCommentData) {
 		return
 	}
 	fmt.Fprintf(sb, "\n🔗 **Deploy request**: %s\n", data.DeployRequestURL)
+}
+
+func stopOrCancelCommand(data ApplyStatusCommentData) string {
+	if strings.EqualFold(data.Engine, storage.EnginePlanetScale) {
+		return "cancel"
+	}
+	return "stop"
+}
+
+func writeStopOrCancelFooterAction(sb *strings.Builder, data ApplyStatusCommentData, stopPrefix, cancelPrefix string) {
+	command := stopOrCancelCommand(data)
+	prefix := stopPrefix
+	if command == "cancel" {
+		prefix = cancelPrefix
+	}
+	writeFooterAction(sb, prefix, fmt.Sprintf("schemabot %s %s -e %s", command, data.ApplyID, data.Environment))
 }
 
 // writeCutoverSummary writes a readiness summary for cutover states,
@@ -795,18 +812,17 @@ func writeApplyFooter(sb *strings.Builder, data ApplyStatusCommentData) {
 		sb.WriteString("\n---\n\n")
 		sb.WriteString("Cutover in progress — typically completes within seconds.\n")
 	case state.Apply.Running, state.Apply.RunningDegraded:
-		writeFooterAction(sb, "To stop this schema change:", fmt.Sprintf("schemabot stop %s -e %s", data.ApplyID, data.Environment))
+		writeStopOrCancelFooterAction(sb, data, "To stop this schema change:", "To cancel this schema change:")
 	case state.Apply.PreparingBranch,
 		state.Apply.ApplyingBranchChanges,
 		state.Apply.ValidatingBranch,
 		state.Apply.CreatingDeployRequest,
 		state.Apply.ValidatingDeployRequest:
-		// PlanetScale's branch and deploy-request phases are active, stoppable
-		// work — the operator can halt the change before cutover just as during
-		// row copy.
-		writeFooterAction(sb, "To stop this schema change:", fmt.Sprintf("schemabot stop %s -e %s", data.ApplyID, data.Environment))
+		writeStopOrCancelFooterAction(sb, data, "To stop this schema change:", "To cancel this schema change:")
 	case state.Apply.FailedRetryable:
-		writeFooterAction(sb, "An error interrupted this schema change. SchemaBot retries automatically and marks it failed if retries are exhausted. To stop retrying:", fmt.Sprintf("schemabot stop %s -e %s", data.ApplyID, data.Environment))
+		writeStopOrCancelFooterAction(sb, data,
+			"An error interrupted this schema change. SchemaBot retries automatically and marks it failed if retries are exhausted. To stop retrying:",
+			"An error interrupted this schema change. SchemaBot retries automatically and marks it failed if retries are exhausted. To cancel it:")
 	case state.Apply.Stopped:
 		writeFooterAction(sb, "Paused — to resume from where it stopped:", fmt.Sprintf("schemabot start %s -e %s", data.ApplyID, data.Environment))
 	case state.Apply.Cancelled:

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -492,8 +492,8 @@ func TestRenderApplyStatusComment_ValidatingDeployRequest(t *testing.T) {
 
 	assert.Contains(t, result, "## Schema Change In Progress")
 	assert.Contains(t, result, "**Status**: Validating Deploy Request")
-	assert.Contains(t, result, "To stop this schema change:")
-	assert.Contains(t, result, "schemabot stop apply-7aa13cf03496454b -e staging")
+	assert.Contains(t, result, "To cancel this schema change:")
+	assert.Contains(t, result, "schemabot cancel apply-7aa13cf03496454b -e staging")
 }
 
 // A PlanetScale apply links its deploy request so the operator can follow the

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -476,8 +476,9 @@ func TestRenderApplyStatusComment_ShardSummary(t *testing.T) {
 }
 
 // A PlanetScale apply in a deploy-request phase renders its first-class phase
-// header (not a generic "In Progress") and still offers the operator a stop
-// action — the change is active, stoppable work before cutover.
+// header (not a generic "In Progress") and offers the operator a cancel action —
+// PlanetScale changes are externally authoritative, so before cutover they can
+// only be permanently cancelled, not paused and resumed.
 func TestRenderApplyStatusComment_ValidatingDeployRequest(t *testing.T) {
 	data := ApplyStatusCommentData{
 		Database:    "boardgames",
@@ -494,6 +495,44 @@ func TestRenderApplyStatusComment_ValidatingDeployRequest(t *testing.T) {
 	assert.Contains(t, result, "**Status**: Validating Deploy Request")
 	assert.Contains(t, result, "To cancel this schema change:")
 	assert.Contains(t, result, "schemabot cancel apply-7aa13cf03496454b -e staging")
+}
+
+// The in-progress footer offers the right terminal action per engine across the
+// active states that share the stop/cancel footer: resumable engines (Spirit)
+// can be stopped and later resumed, while PlanetScale changes are externally
+// authoritative and can only be permanently cancelled.
+func TestRenderApplyStatusComment_StopOrCancelFooterByEngine(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		engine      string
+		state       string
+		wantAction  string
+		otherAction string
+	}{
+		{"planetscale running cancels", "PlanetScale", state.Apply.Running, "schemabot cancel apply-abc123 -e staging", "schemabot stop apply-abc123 -e staging"},
+		{"planetscale failed-retryable cancels", "PlanetScale", state.Apply.FailedRetryable, "schemabot cancel apply-abc123 -e staging", "schemabot stop apply-abc123 -e staging"},
+		{"spirit running stops", "Spirit", state.Apply.Running, "schemabot stop apply-abc123 -e staging", "schemabot cancel apply-abc123 -e staging"},
+		{"spirit failed-retryable stops", "Spirit", state.Apply.FailedRetryable, "schemabot stop apply-abc123 -e staging", "schemabot cancel apply-abc123 -e staging"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			data := ApplyStatusCommentData{
+				Database:    "testapp",
+				Environment: "staging",
+				RequestedBy: "aparajon",
+				ApplyID:     "apply-abc123",
+				State:       tc.state,
+				Engine:      tc.engine,
+				Tables: []TableProgressData{
+					{TableName: "users", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", Status: state.Task.Running, PercentComplete: 40},
+				},
+			}
+
+			result := RenderApplyStatusComment(data)
+
+			assert.Contains(t, result, tc.wantAction)
+			assert.NotContains(t, result, tc.otherAction)
+		})
+	}
 }
 
 // A PlanetScale apply links its deploy request so the operator can follow the

--- a/pkg/webhook/templates/help.go
+++ b/pkg/webhook/templates/help.go
@@ -10,6 +10,7 @@ func commandReference() string {
 | ` + "`schemabot apply-confirm -e <env>`" + ` | Confirm a downgraded locked plan |
 | ` + "`schemabot unlock`" + ` | Release lock and discard plan |
 | ` + "`schemabot stop <apply-id> -e <env>`" + ` | Stop an in-progress deployment |
+| ` + "`schemabot cancel <apply-id> -e <env>`" + ` | Permanently cancel an in-progress deployment |
 | ` + "`schemabot start <apply-id> -e <env>`" + ` | Resume a stopped deployment |
 | ` + "`schemabot cutover <apply-id> -e <env>`" + ` | Complete a deferred cutover |
 | ` + "`schemabot rollback <apply-id> -e <env>`" + ` | Generate a rollback plan |

--- a/pkg/webhook/templates/issue_comment.go
+++ b/pkg/webhook/templates/issue_comment.go
@@ -45,6 +45,16 @@ type StopCommandAcceptedData struct {
 	SkippedCount int64
 }
 
+// CancelCommandAcceptedData contains data for a PR comment cancel acknowledgement.
+type CancelCommandAcceptedData struct {
+	ApplyID        string
+	Environment    string
+	RequestedBy    string
+	Status         string
+	CancelledCount int64
+	SkippedCount   int64
+}
+
 // StartCommandAcceptedData contains data for a PR comment start acknowledgement.
 type StartCommandAcceptedData struct {
 	ApplyID      string
@@ -88,6 +98,27 @@ func RenderStopCommandAccepted(data StopCommandAcceptedData) string {
 	body += "\n" + statusLine + "\n"
 	if data.StoppedCount > 0 || data.SkippedCount > 0 {
 		body += fmt.Sprintf("\n**Tasks selected for stop**: %d stopped, %d skipped.\n", data.StoppedCount, data.SkippedCount)
+	}
+	return body
+}
+
+// RenderCancelCommandAccepted renders the acknowledgement posted when a PR
+// comment cancel command records durable cancel intent.
+func RenderCancelCommandAccepted(data CancelCommandAcceptedData) string {
+	statusLine := "Cancel request accepted. SchemaBot will permanently cancel this schema change; status remains available from the PR progress comment or CLI."
+	if data.Status == apitypes.ControlStatusAlreadyRequested {
+		statusLine = "Cancel was already requested. SchemaBot will keep the existing cancel request pending until the operator owner finishes it."
+	}
+
+	body := "## Cancel Request Accepted\n\n" +
+		fmt.Sprintf("**Apply**: `%s`\n", data.ApplyID) +
+		fmt.Sprintf("**Environment**: `%s`\n", data.Environment)
+	if data.RequestedBy != "" {
+		body += fmt.Sprintf("**Requested by**: @%s\n", data.RequestedBy)
+	}
+	body += "\n" + statusLine + "\n"
+	if data.CancelledCount > 0 || data.SkippedCount > 0 {
+		body += fmt.Sprintf("\n**Tasks selected for cancel**: %d cancelled, %d skipped.\n", data.CancelledCount, data.SkippedCount)
 	}
 	return body
 }

--- a/pkg/webhook/templates/issue_comment_test.go
+++ b/pkg/webhook/templates/issue_comment_test.go
@@ -69,6 +69,30 @@ func TestRenderStopCommandAcceptedAlreadyRequested(t *testing.T) {
 	assert.Contains(t, rendered, "Stop was already requested")
 }
 
+func TestRenderCancelCommandAccepted(t *testing.T) {
+	rendered := RenderCancelCommandAccepted(CancelCommandAcceptedData{
+		ApplyID:        "apply_abc123",
+		Environment:    "staging",
+		RequestedBy:    "alice",
+		CancelledCount: 1,
+		SkippedCount:   2,
+	})
+	assert.Contains(t, rendered, "Cancel Request Accepted")
+	assert.Contains(t, rendered, "`apply_abc123`")
+	assert.Contains(t, rendered, "`staging`")
+	assert.Contains(t, rendered, "@alice")
+	assert.Contains(t, rendered, "1 cancelled, 2 skipped")
+}
+
+func TestRenderCancelCommandAcceptedAlreadyRequested(t *testing.T) {
+	rendered := RenderCancelCommandAccepted(CancelCommandAcceptedData{
+		ApplyID:     "apply_abc123",
+		Environment: "staging",
+		Status:      apitypes.ControlStatusAlreadyRequested,
+	})
+	assert.Contains(t, rendered, "Cancel was already requested")
+}
+
 func TestRenderStartCommandAccepted(t *testing.T) {
 	rendered := RenderStartCommandAccepted(StartCommandAcceptedData{
 		ApplyID:      "apply_abc123",


### PR DESCRIPTION
## Why
PR-based users need the same permanent-cancel control the CLI already offers, and progress comments should show the right action for the engine model — externally-authoritative applies (e.g. PlanetScale/Vitess) can only be permanently cancelled, not paused, so suggesting a resumable `stop` there is misleading.

## What
- Add `schemabot cancel <apply-id> -e <env>` as a PR comment command, routed alongside the other control commands
- Add the cancel acknowledgement comment, help text, comment templates, and preview output
- Update progress comments to show **cancel** guidance for externally-authoritative applies while keeping **stop** guidance for resumable applies
- Update Vitess E2E cleanup/tests to use cancel for permanent aborts

```diagram
╭────────────────────╮     ╭────────────────────╮
│ schemabot stop     │────▶│ resumable pause    │
╰────────────────────╯     ╰────────────────────╯

╭────────────────────╮     ╭────────────────────╮
│ schemabot cancel   │────▶│ terminal abort     │
╰────────────────────╯     ╰────────────────────╯
```

## Risk Assessment
Medium — this changes operator-facing GitHub guidance and command routing. It builds on the merged backend cancel work (#573) and CLI cancel command (#571), and is covered by webhook/template tests plus Vitess E2E coverage.

---
*PR summary updated by Claude Code (Opus 4.8).*
