### PR TITLE
fix(github): surface the deploy-request URL and VSchema status in remote-apply comments

### DIFF
--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -1179,7 +1179,7 @@ func (c *GRPCClient) mirrorRemoteDisplayMetadata(ctx context.Context, apply *sto
 	if c.storage == nil || apply == nil || apply.Engine != storage.EnginePlanetScale {
 		return lastBlob
 	}
-	blob, err := EngineDisplayMetadataStorageBlob(md)
+	blob, err := PSDisplayMetadataStorageBlob(md)
 	if err != nil {
 		slog.Warn("comment may omit engine display metadata: failed to encode remote display metadata",
 			"apply_id", apply.ApplyIdentifier, "error", err)
@@ -1188,46 +1188,46 @@ func (c *GRPCClient) mirrorRemoteDisplayMetadata(ctx context.Context, apply *sto
 	if blob == "" || blob == lastBlob {
 		return lastBlob
 	}
-	opID, err := c.operationIDForDisplayMirror(ctx, apply, scope)
-	if err != nil {
-		slog.Warn("comment may omit engine display metadata: could not resolve apply_operation",
+	// Load the operation so the write can preserve its engine_resume_context (the
+	// remote apply id for a multi-operation drive). SaveEngineResumeState writes
+	// both columns, so if we cannot read the current context we must not write:
+	// clobbering the remote apply id to empty would break resuming the remote
+	// apply after a restart. The mirror is best-effort — skip and retry next poll.
+	op, err := c.operationForDisplayMirror(ctx, apply, scope)
+	if err != nil || op == nil {
+		slog.Warn("comment may omit engine display metadata: could not load apply_operation to preserve resume context",
 			"apply_id", apply.ApplyIdentifier, "error", err)
 		return lastBlob
 	}
-	// Preserve the operation's engine_resume_context (the remote apply id for a
-	// multi-operation drive); SaveEngineResumeState writes both columns.
-	resumeContext := ""
-	if cur, getErr := c.storage.ApplyOperations().Get(ctx, opID); getErr == nil && cur != nil {
-		resumeContext = cur.EngineResumeContext
-	}
-	if err := c.storage.ApplyOperations().SaveEngineResumeState(ctx, opID, &storage.EngineResumeState{
-		ApplyOperationID: opID,
-		MigrationContext: resumeContext,
+	if err := c.storage.ApplyOperations().SaveEngineResumeState(ctx, op.ID, &storage.EngineResumeState{
+		ApplyOperationID: op.ID,
+		MigrationContext: op.EngineResumeContext,
 		Metadata:         blob,
 	}); err != nil {
 		slog.Warn("comment may omit engine display metadata: failed to persist to control-plane operation",
-			"apply_id", apply.ApplyIdentifier, "apply_operation_id", opID, "error", err)
+			"apply_id", apply.ApplyIdentifier, "apply_operation_id", op.ID, "error", err)
 		return lastBlob
 	}
 	return blob
 }
 
-// operationIDForDisplayMirror resolves the apply_operation whose
+// operationForDisplayMirror loads the apply_operation whose
 // engine_resume_metadata should carry the display projection. An
-// operation-scoped drive already knows its operation; a whole-apply
-// (single-operation) drive resolves the apply's sole operation.
-func (c *GRPCClient) operationIDForDisplayMirror(ctx context.Context, apply *storage.Apply, scope applyTaskScope) (int64, error) {
+// operation-scoped drive already knows its operation id; a whole-apply
+// (single-operation) drive resolves the apply's sole operation. The loaded row
+// carries the current engine_resume_context the mirror must preserve.
+func (c *GRPCClient) operationForDisplayMirror(ctx context.Context, apply *storage.Apply, scope applyTaskScope) (*storage.ApplyOperation, error) {
 	if scope.applyOperationID > 0 {
-		return scope.applyOperationID, nil
+		return c.storage.ApplyOperations().Get(ctx, scope.applyOperationID)
 	}
 	ops, err := c.storage.ApplyOperations().ListByApply(ctx, apply.ID)
 	if err != nil {
-		return 0, fmt.Errorf("list apply operations for apply %s: %w", apply.ApplyIdentifier, err)
+		return nil, fmt.Errorf("list apply operations for apply %s: %w", apply.ApplyIdentifier, err)
 	}
 	if len(ops) != 1 {
-		return 0, fmt.Errorf("apply %s has %d operations; need an operation scope to mirror display metadata", apply.ApplyIdentifier, len(ops))
+		return nil, fmt.Errorf("apply %s has %d operations; need an operation scope to mirror display metadata", apply.ApplyIdentifier, len(ops))
 	}
-	return ops[0].ID, nil
+	return ops[0], nil
 }
 
 // loadApplyTasks loads the task rows the remote drive operates on, scoped either

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -1167,6 +1167,69 @@ func (c *GRPCClient) persistRemoteApplyID(ctx context.Context, apply *storage.Ap
 	return nil
 }
 
+// mirrorRemoteDisplayMetadata persists the data-plane progress response's display
+// fields (deploy-request URL, VSchema status) onto the control-plane operation's
+// engine_resume_metadata, so the PR comment's stored-state display projection
+// (resolveDisplayByOperation) can render them. For a remote (gRPC) apply the
+// engine runs in the data plane, so the control plane never sees this metadata
+// otherwise. It returns the blob it persisted (or lastBlob unchanged) so the
+// caller skips redundant writes across polls. Best-effort: a failure is logged,
+// not fatal — the next poll re-mirrors it.
+func (c *GRPCClient) mirrorRemoteDisplayMetadata(ctx context.Context, apply *storage.Apply, scope applyTaskScope, md map[string]string, lastBlob string) string {
+	if c.storage == nil || apply == nil || apply.Engine != storage.EnginePlanetScale {
+		return lastBlob
+	}
+	blob, err := EngineDisplayMetadataStorageBlob(md)
+	if err != nil {
+		slog.Warn("comment may omit engine display metadata: failed to encode remote display metadata",
+			"apply_id", apply.ApplyIdentifier, "error", err)
+		return lastBlob
+	}
+	if blob == "" || blob == lastBlob {
+		return lastBlob
+	}
+	opID, err := c.operationIDForDisplayMirror(ctx, apply, scope)
+	if err != nil {
+		slog.Warn("comment may omit engine display metadata: could not resolve apply_operation",
+			"apply_id", apply.ApplyIdentifier, "error", err)
+		return lastBlob
+	}
+	// Preserve the operation's engine_resume_context (the remote apply id for a
+	// multi-operation drive); SaveEngineResumeState writes both columns.
+	resumeContext := ""
+	if cur, getErr := c.storage.ApplyOperations().Get(ctx, opID); getErr == nil && cur != nil {
+		resumeContext = cur.EngineResumeContext
+	}
+	if err := c.storage.ApplyOperations().SaveEngineResumeState(ctx, opID, &storage.EngineResumeState{
+		ApplyOperationID: opID,
+		MigrationContext: resumeContext,
+		Metadata:         blob,
+	}); err != nil {
+		slog.Warn("comment may omit engine display metadata: failed to persist to control-plane operation",
+			"apply_id", apply.ApplyIdentifier, "apply_operation_id", opID, "error", err)
+		return lastBlob
+	}
+	return blob
+}
+
+// operationIDForDisplayMirror resolves the apply_operation whose
+// engine_resume_metadata should carry the display projection. An
+// operation-scoped drive already knows its operation; a whole-apply
+// (single-operation) drive resolves the apply's sole operation.
+func (c *GRPCClient) operationIDForDisplayMirror(ctx context.Context, apply *storage.Apply, scope applyTaskScope) (int64, error) {
+	if scope.applyOperationID > 0 {
+		return scope.applyOperationID, nil
+	}
+	ops, err := c.storage.ApplyOperations().ListByApply(ctx, apply.ID)
+	if err != nil {
+		return 0, fmt.Errorf("list apply operations for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if len(ops) != 1 {
+		return 0, fmt.Errorf("apply %s has %d operations; need an operation scope to mirror display metadata", apply.ApplyIdentifier, len(ops))
+	}
+	return ops[0].ID, nil
+}
+
 // loadApplyTasks loads the task rows the remote drive operates on, scoped either
 // to the whole apply or to a single apply_operation. It never widens an
 // operation-scoped query back to the whole apply.
@@ -2796,6 +2859,7 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 	consecutiveProgressErrors := 0
 	loggedStoppedAfterStart := false
 	var stoppedAfterStartDeadline time.Time
+	var lastDisplayBlob string
 	for {
 		select {
 		case <-ctx.Done():
@@ -2871,6 +2935,13 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 				message := fmt.Sprintf("remote apply %s returned no active schema change for exact apply_id", apply.ExternalID)
 				return c.failMissingRemoteApply(ctx, apply, message, nil, scope)
 			}
+
+			// Mirror the data-plane display metadata (deploy-request URL, VSchema
+			// status) onto the control-plane operation so the PR comment's
+			// stored-state projection can render it. The engine that produces this
+			// metadata runs in the data plane, so the control plane never sees it
+			// otherwise.
+			lastDisplayBlob = c.mirrorRemoteDisplayMetadata(ctx, apply, scope, resp.Metadata, lastDisplayBlob)
 
 			// Update apply state from the remote response. An exact apply-id poll
 			// must return a concrete state; unknown states are unsafe to reconcile.

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -868,6 +868,20 @@ func TestGRPCClientMirrorsRemoteDisplayMetadata(t *testing.T) {
 		assert.Empty(t, client.mirrorRemoteDisplayMetadata(t.Context(), apply, wholeApplyTaskScope(), display, ""))
 		assert.Empty(t, ops.savedResumes)
 	})
+
+	// If the operation can't be loaded, the mirror must skip the write rather than
+	// persist with an empty context — clobbering the remote apply id would break
+	// resuming the remote apply.
+	t.Run("skips the write when the operation cannot be loaded", func(t *testing.T) {
+		ops := &mockApplyOperationStore{ops: map[int64]*storage.ApplyOperation{}} // op 7 absent
+		client := &GRPCClient{storage: &mockStorage{operations: ops}}
+		apply := &storage.Apply{ID: 100, ApplyIdentifier: "apply-x", Engine: storage.EnginePlanetScale}
+		scope := applyTaskScope{applyOperationID: 7, multiOperation: true}
+
+		blob := client.mirrorRemoteDisplayMetadata(t.Context(), apply, scope, display, "")
+		assert.Empty(t, blob, "a failed operation load returns the unchanged lastBlob")
+		assert.Empty(t, ops.savedResumes, "no write when the context can't be preserved")
+	})
 }
 
 func (m *mockStorage) Applies() storage.ApplyStore {

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -812,6 +812,64 @@ func (m *mockApplyOperationStore) SaveEngineResumeState(_ context.Context, opera
 	return nil
 }
 
+// For a remote PlanetScale apply the engine runs in the data plane, so the
+// control plane mirrors the progress display fields (deploy-request URL, VSchema)
+// onto the operation's engine_resume_metadata — the source the PR comment reads.
+// The mirror must preserve a multi-operation drive's remote-apply-id context,
+// resolve the operation for a whole-apply (single-operation) drive, skip
+// redundant writes, and stay a no-op for non-PlanetScale applies.
+func TestGRPCClientMirrorsRemoteDisplayMetadata(t *testing.T) {
+	display := map[string]string{
+		"deploy_request_url": "https://app.planetscale.com/org/db/deploy-requests/106",
+		"branch_name":        "schemabot-db",
+	}
+
+	t.Run("multi-operation preserves the remote-apply-id context", func(t *testing.T) {
+		ops := &mockApplyOperationStore{ops: map[int64]*storage.ApplyOperation{
+			7: {ID: 7, ApplyID: 100, EngineResumeContext: "remote-apply-xyz"},
+		}}
+		client := &GRPCClient{storage: &mockStorage{operations: ops}}
+		apply := &storage.Apply{ID: 100, ApplyIdentifier: "apply-x", Engine: storage.EnginePlanetScale}
+		scope := applyTaskScope{applyOperationID: 7, operation: ops.ops[7], multiOperation: true}
+
+		blob := client.mirrorRemoteDisplayMetadata(t.Context(), apply, scope, display, "")
+		require.NotEmpty(t, blob)
+
+		got, err := PSDisplayMetadata(ops.ops[7].EngineResumeMetadata)
+		require.NoError(t, err)
+		assert.Equal(t, "https://app.planetscale.com/org/db/deploy-requests/106", got["deploy_request_url"])
+		assert.Equal(t, "remote-apply-xyz", ops.ops[7].EngineResumeContext, "the remote apply id must survive the display-metadata write")
+
+		// A second poll with the same metadata skips the redundant write.
+		before := len(ops.savedResumes)
+		blob2 := client.mirrorRemoteDisplayMetadata(t.Context(), apply, scope, display, blob)
+		assert.Equal(t, blob, blob2)
+		assert.Len(t, ops.savedResumes, before, "unchanged metadata must not re-write")
+	})
+
+	t.Run("whole-apply drive resolves the sole operation", func(t *testing.T) {
+		ops := &mockApplyOperationStore{ops: map[int64]*storage.ApplyOperation{
+			9: {ID: 9, ApplyID: 200},
+		}}
+		client := &GRPCClient{storage: &mockStorage{operations: ops}}
+		apply := &storage.Apply{ID: 200, ApplyIdentifier: "apply-y", Engine: storage.EnginePlanetScale}
+
+		blob := client.mirrorRemoteDisplayMetadata(t.Context(), apply, wholeApplyTaskScope(), display, "")
+		require.NotEmpty(t, blob)
+		got, err := PSDisplayMetadata(ops.ops[9].EngineResumeMetadata)
+		require.NoError(t, err)
+		assert.Equal(t, "https://app.planetscale.com/org/db/deploy-requests/106", got["deploy_request_url"])
+	})
+
+	t.Run("non-PlanetScale apply is a no-op", func(t *testing.T) {
+		ops := &mockApplyOperationStore{ops: map[int64]*storage.ApplyOperation{9: {ID: 9, ApplyID: 200}}}
+		client := &GRPCClient{storage: &mockStorage{operations: ops}}
+		apply := &storage.Apply{ID: 200, Engine: storage.EngineSpirit}
+		assert.Empty(t, client.mirrorRemoteDisplayMetadata(t.Context(), apply, wholeApplyTaskScope(), display, ""))
+		assert.Empty(t, ops.savedResumes)
+	})
+}
+
 func (m *mockStorage) Applies() storage.ApplyStore {
 	if m.applies != nil {
 		return m.applies

--- a/pkg/tern/state_converters.go
+++ b/pkg/tern/state_converters.go
@@ -364,7 +364,7 @@ func PSDisplayMetadata(resumeStateMetadata string) (map[string]string, error) {
 	return m, nil
 }
 
-// EngineDisplayMetadataStorageBlob converts a progress response's display
+// PSDisplayMetadataStorageBlob converts a progress response's display
 // metadata — the map a data-plane progress poll returns (deploy_request_url, the
 // encoded VSchema status, instant/deferred flags) — back into the stored
 // psMetadataForStorage JSON that the PR comment's display projection
@@ -373,7 +373,7 @@ func PSDisplayMetadata(resumeStateMetadata string) (map[string]string, error) {
 // the control-plane operation; mirroring these display fields is how the comment
 // surfaces the deploy-request link and VSchema status. Returns "" when there is
 // nothing worth storing, so callers leave the operation's metadata untouched.
-func EngineDisplayMetadataStorageBlob(md map[string]string) (string, error) {
+func PSDisplayMetadataStorageBlob(md map[string]string) (string, error) {
 	if len(md) == 0 {
 		return "", nil
 	}

--- a/pkg/tern/state_converters.go
+++ b/pkg/tern/state_converters.go
@@ -363,3 +363,42 @@ func PSDisplayMetadata(resumeStateMetadata string) (map[string]string, error) {
 	}
 	return m, nil
 }
+
+// EngineDisplayMetadataStorageBlob converts a progress response's display
+// metadata — the map a data-plane progress poll returns (deploy_request_url, the
+// encoded VSchema status, instant/deferred flags) — back into the stored
+// psMetadataForStorage JSON that the PR comment's display projection
+// (resolveDisplayByOperation → PSDisplayMetadata) reads. For a remote (gRPC)
+// apply the engine runs in the data plane, so its resume metadata never lands on
+// the control-plane operation; mirroring these display fields is how the comment
+// surfaces the deploy-request link and VSchema status. Returns "" when there is
+// nothing worth storing, so callers leave the operation's metadata untouched.
+func EngineDisplayMetadataStorageBlob(md map[string]string) (string, error) {
+	if len(md) == 0 {
+		return "", nil
+	}
+	m := psMetadataForStorage{
+		BranchName:       md["branch_name"],
+		DeployRequestURL: md["deploy_request_url"],
+		IsInstant:        md["is_instant"] == "true",
+		DeferredDeploy:   md["deferred_deploy"] == "true",
+	}
+	changes, err := apitypes.ParseVSchemaChanges(md)
+	if err != nil {
+		return "", fmt.Errorf("parse vschema changes from display metadata: %w", err)
+	}
+	for _, ch := range changes {
+		if m.VSchemaStatus == "" {
+			m.VSchemaStatus = ch.Status
+		}
+		m.VSchemaDiffs = append(m.VSchemaDiffs, vschemaKeyspaceDiff{Namespace: ch.Namespace, Diff: ch.Diff})
+	}
+	if m.DeployRequestURL == "" && m.BranchName == "" && !m.IsInstant && !m.DeferredDeploy && len(m.VSchemaDiffs) == 0 {
+		return "", nil
+	}
+	encoded, err := json.Marshal(m)
+	if err != nil {
+		return "", fmt.Errorf("encode display metadata for storage: %w", err)
+	}
+	return string(encoded), nil
+}

--- a/pkg/tern/state_converters_test.go
+++ b/pkg/tern/state_converters_test.go
@@ -64,3 +64,49 @@ func TestPSDisplayMetadata(t *testing.T) {
 	_, err = PSDisplayMetadata(`{not json`)
 	require.Error(t, err)
 }
+
+// The display map a data-plane progress poll returns round-trips through
+// EngineDisplayMetadataStorageBlob back into the same display fields when read
+// via PSDisplayMetadata — the path the control plane uses to mirror a remote
+// apply's deploy-request URL and VSchema status onto its operation so the PR
+// comment can render them.
+func TestEngineDisplayMetadataStorageBlobRoundTrip(t *testing.T) {
+	encodedVSchema, err := apitypes.EncodeVSchemaChanges([]apitypes.VSchemaChange{
+		{Namespace: "commerce_sharded", Status: "applied", Diff: `+ "xxhash": {}`},
+	})
+	require.NoError(t, err)
+	display := map[string]string{
+		"branch_name":                      "schemabot-db-7",
+		"deploy_request_url":               "https://app.planetscale.com/org/db/deploy-requests/106",
+		"is_instant":                       "true",
+		apitypes.VSchemaChangesMetadataKey: encodedVSchema,
+	}
+
+	blob, err := EngineDisplayMetadataStorageBlob(display)
+	require.NoError(t, err)
+	require.NotEmpty(t, blob)
+
+	got, err := PSDisplayMetadata(blob)
+	require.NoError(t, err)
+	assert.Equal(t, "https://app.planetscale.com/org/db/deploy-requests/106", got["deploy_request_url"])
+	assert.Equal(t, "schemabot-db-7", got["branch_name"])
+	assert.Equal(t, "true", got["is_instant"])
+
+	changes, err := apitypes.ParseVSchemaChanges(got)
+	require.NoError(t, err)
+	require.Len(t, changes, 1)
+	assert.Equal(t, "commerce_sharded", changes[0].Namespace)
+	assert.Equal(t, "applied", changes[0].Status)
+}
+
+// A display map with nothing worth storing yields an empty blob, so the caller
+// leaves the operation's metadata untouched rather than clobbering it with "{}".
+func TestEngineDisplayMetadataStorageBlobEmpty(t *testing.T) {
+	blob, err := EngineDisplayMetadataStorageBlob(nil)
+	require.NoError(t, err)
+	assert.Empty(t, blob)
+
+	blob, err = EngineDisplayMetadataStorageBlob(map[string]string{"volume": "2"})
+	require.NoError(t, err)
+	assert.Empty(t, blob)
+}

--- a/pkg/tern/state_converters_test.go
+++ b/pkg/tern/state_converters_test.go
@@ -66,11 +66,11 @@ func TestPSDisplayMetadata(t *testing.T) {
 }
 
 // The display map a data-plane progress poll returns round-trips through
-// EngineDisplayMetadataStorageBlob back into the same display fields when read
+// PSDisplayMetadataStorageBlob back into the same display fields when read
 // via PSDisplayMetadata — the path the control plane uses to mirror a remote
 // apply's deploy-request URL and VSchema status onto its operation so the PR
 // comment can render them.
-func TestEngineDisplayMetadataStorageBlobRoundTrip(t *testing.T) {
+func TestPSDisplayMetadataStorageBlobRoundTrip(t *testing.T) {
 	encodedVSchema, err := apitypes.EncodeVSchemaChanges([]apitypes.VSchemaChange{
 		{Namespace: "commerce_sharded", Status: "applied", Diff: `+ "xxhash": {}`},
 	})
@@ -82,7 +82,7 @@ func TestEngineDisplayMetadataStorageBlobRoundTrip(t *testing.T) {
 		apitypes.VSchemaChangesMetadataKey: encodedVSchema,
 	}
 
-	blob, err := EngineDisplayMetadataStorageBlob(display)
+	blob, err := PSDisplayMetadataStorageBlob(display)
 	require.NoError(t, err)
 	require.NotEmpty(t, blob)
 
@@ -101,12 +101,12 @@ func TestEngineDisplayMetadataStorageBlobRoundTrip(t *testing.T) {
 
 // A display map with nothing worth storing yields an empty blob, so the caller
 // leaves the operation's metadata untouched rather than clobbering it with "{}".
-func TestEngineDisplayMetadataStorageBlobEmpty(t *testing.T) {
-	blob, err := EngineDisplayMetadataStorageBlob(nil)
+func TestPSDisplayMetadataStorageBlobEmpty(t *testing.T) {
+	blob, err := PSDisplayMetadataStorageBlob(nil)
 	require.NoError(t, err)
 	assert.Empty(t, blob)
 
-	blob, err = EngineDisplayMetadataStorageBlob(map[string]string{"volume": "2"})
+	blob, err = PSDisplayMetadataStorageBlob(map[string]string{"volume": "2"})
 	require.NoError(t, err)
 	assert.Empty(t, blob)
 }


### PR DESCRIPTION
## Why this matters

For a remote (gRPC) apply the engine runs in the data plane, so the engine resume metadata — which carries the deploy-request URL and per-keyspace VSchema status — is persisted only in the data-plane's storage. The PR comment's display projection (`resolveDisplayByOperation`) reads the **control-plane** operation's `engine_resume_metadata`, which the control-plane driver leaves empty (`{}`). So the comment never rendered the deploy-request link or VSchema status for remote applies — even though the CLI showed them, because the CLI reads the live progress proxied from the data plane (and once the apply completes, the CLI loses them too, since there's no live engine left).

## What it does

On each progress poll, mirror the data-plane response's display fields onto the control-plane operation's `engine_resume_metadata`:

```
data plane (engine)            control plane                         comment
───────────────────            ─────────────                         ───────
meta.DeployRequestURL          driver poll receives                  resolveDisplayByOperation
 persisted to DATA-PLANE   →   resp.Metadata[deploy_request_url]  →  reads CONTROL-PLANE
 engine_resume_metadata        mirror → CONTROL-PLANE                engine_resume_metadata
                               engine_resume_metadata                → renders the link ✓
```

- `EngineDisplayMetadataStorageBlob` converts the progress display map back into the stored metadata shape the comment projection reads.
- The mirror preserves the operation's `engine_resume_context` (the remote apply id for a multi-operation drive), resolves the operation for a whole-apply (single-operation) drive, and dedupes across polls so a long copy doesn't re-write unchanged metadata.
- Best-effort: a failure is logged, not fatal — the next poll re-mirrors. The fix also restores the deploy-request URL on the completed-apply CLI view (it reads the same stored metadata once the engine is gone).

## How it moves toward northstar

The PR comment is the operator's primary surface during a schema change. The deploy-request link (jump to the console) and VSchema status are core signals; they shouldn't silently disappear just because the engine runs out-of-process for a remotely-dispatched apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)