### PR TITLE
feat(observability): enrich apply failure-path logs with triage identifiers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ Before handing a PR to the user, review it the way an operator will experience i
 - **Check Run vs stored check state.** Use precise terms. A GitHub Check Run is the visible object on the PR commit. Stored check state is SchemaBot's database record used to decide what Check Run to create or update. Comments, logs, tests, and docs should make clear which one is being changed.
 - **TOCTOU review.** For async flows, webhooks, reconciliation, and background watchers, ask what happens if the latest commit on the PR branch changes, another pod writes first, an apply starts or finishes concurrently, or a rollback changes the target schema. Use conditional storage updates, ownership identifiers, and final state reloads where stale workers could otherwise overwrite newer state.
 - **Started applies remain authoritative.** Once an apply has started, a later PR commit that removes the schema change must not make the aggregate check pass by cleanup alone. Example: commit A adds a column and starts an apply; commit B removes that column before the apply finishes. The stored state must continue to block merge until an operator reconciles the target environment.
-- **Logs must answer the triage question.** Error and warning logs on critical paths should include the identifiers an operator needs: repo, PR, head SHA when relevant, environment, database type, database, apply ID or identifier, check ID or Check Run ID, and the operation being attempted.
+- **Logs must answer the triage question.** Error and warning logs on critical paths should include the identifiers an operator needs: repo, PR, head SHA when relevant, environment, database type, database, apply ID or identifier, check ID or Check Run ID, and the operation being attempted. For apply/operation/task logs, build these with the `LogAttrs()` helpers (see *Go Style → Logging*) rather than hand-listing identifiers.
 - **Metrics should be actionable.** Add counters for rare or dangerous branches that operators can investigate, such as ownership misses, stale cleanup blocking, or status-check update failures. If a metric spikes, the expected operator action should be obvious from the metric name, attributes, and nearby code comments or docs.
 - **Readability is a review gate.** Extract named helpers for compound state predicates, separate error handling from state decisions, and keep comments focused on invariants and operator-facing behavior. Avoid clever SQL, dense boolean expressions, and control flow that requires reconstructing the state machine in your head.
 - **Tests must prove documented behavior.** If a PR summary or docs mention an edge case, add focused tests for it or explicitly call out why it cannot be tested in this layer. Prefer integration-style webhook/storage tests for check-run lifecycle behavior.
@@ -198,6 +198,16 @@ All SQL statements processed by SchemaBot **must be parseable by the TiDB parser
   - Use `state.Apply.Stopped`, `state.Apply.Running`, etc. for apply states.
   - Use `state.IsState(s, state.Apply.Stopped)` for case-insensitive, normalized comparison (handles proto prefixes like `STATE_STOPPED`).
   - Use `state.IsTerminalApplyState(s)` to check if a state is terminal.
+
+### Logging
+
+- **Use the `LogAttrs()` helpers for apply/operation/task logs.** When a `*storage.Apply`, `*storage.ApplyOperation`, or `*storage.Task` is in scope, build the triage attributes with its `LogAttrs()` method instead of hand-listing identifiers:
+  ```go
+  logger.Error("failed to drive apply", append(apply.LogAttrs(), "error", err)...)
+  ```
+  The helpers (`pkg/storage/logattrs.go`) return the canonical triage set — apply/operation/task identifier, database, database type, environment, deployment, state, and (when set) repo, pr, external id(s), caller. This keeps key names consistent and lets a failed or stalled apply be triaged from logs alone. Append call-specific attrs (`"error", err`, etc.) after the spread, and don't repeat identifiers the helper already provides (avoid duplicate keys).
+- **Never log the internal numeric row ID** (`apply.ID`, `op.ApplyID`, `task.ApplyID`) — it is confusable with the user-facing string identifier and is not a useful triage handle. Log the string identifier (`apply_id` = `ApplyIdentifier`), which the helpers already do. When only an `apply_operation` is in scope (parent apply not loaded), `ApplyOperation.LogAttrs()` is sufficient on its own.
+- **The operation's own deployment is the routing key.** When a log is scoped to an `apply_operation` but uses the parent `Apply.LogAttrs()` (whose `deployment` is the apply's), also add `"operation_deployment", op.Deployment` — the two can differ.
 
 ### Imports
 

--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -253,7 +253,7 @@ func (s *Service) logControlOperation(r *http.Request, applyID, caller, eventTyp
 func (s *Service) logControlOperationForApply(ctx context.Context, apply *storage.Apply, caller, eventType, message string) {
 	logStore := s.storage.ApplyLogs()
 	if logStore == nil {
-		s.logger.Error("apply log store not available for control operation log", "apply_id", apply.ApplyIdentifier, "event", eventType)
+		s.logger.Error("apply log store not available for control operation log", append(apply.LogAttrs(), "event", eventType)...)
 		return
 	}
 	logMessage := fmt.Sprintf("%s (caller: %s)", message, controlOperationCaller(caller))
@@ -1644,7 +1644,7 @@ func (s *Service) handleSkipRevert(w http.ResponseWriter, r *http.Request) {
 	// Record skip-revert on the apply for progress visibility.
 	if resp.Accepted && apply.Engine == storage.EnginePlanetScale {
 		if err := s.storage.Applies().SetRevertSkipped(r.Context(), apply.ID, time.Now()); err != nil {
-			s.logger.Error("failed to record skip-revert on apply", "apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier, "error", err)
+			s.logger.Error("failed to record skip-revert on apply", append(apply.LogAttrs(), "error", err)...)
 		}
 	}
 	if resp.Accepted {

--- a/pkg/api/ensure_schema.go
+++ b/pkg/api/ensure_schema.go
@@ -198,6 +198,7 @@ func EnsureSchema(dsn string, logger *slog.Logger) error {
 			// log search. Include the DDL count and the underlying message so a
 			// failed bootstrap is triageable from the message line alone.
 			logger.Error("storage schema change failed; SchemaBot storage will not initialize",
+				"database", "schemabot",
 				"ddl_count", len(tableChanges),
 				"error", progress.ErrorMessage,
 			)
@@ -229,6 +230,7 @@ func EnsureSchema(dsn string, logger *slog.Logger) error {
 // online DDL) instead of surfacing a bare "context canceled" from the driver.
 func ensureSchemaTimeoutError(ctx context.Context, ddlCount int, logger *slog.Logger) error {
 	logger.Error("storage schema change did not complete before EnsureSchemaTimeout; SchemaBot storage will not initialize",
+		"database", "schemabot",
 		"timeout", EnsureSchemaTimeout,
 		"ddl_count", ddlCount,
 	)

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -464,7 +464,7 @@ func (s *Service) recoverSingleApplyOperation(ctx context.Context, driverID int,
 	if err != nil {
 		s.logger.Error("operator: failed to update apply_operation from its tasks; derived apply state not updated",
 			append(apply.LogAttrs(),
-				"driver", driverID, "apply_operation_id", op.ID, "error", err)...)
+				"driver", driverID, "apply_operation_id", op.ID, "operation_deployment", op.Deployment, "error", err)...)
 		return
 	}
 	if !marked {
@@ -480,7 +480,7 @@ func (s *Service) recoverSingleApplyOperation(ctx context.Context, driverID int,
 	if err := s.stopPendingOperationsForPendingStop(applyLeaseCtx, driverID, apply); err != nil {
 		s.logger.Error("operator: failed to stop pending sibling operations for pending stop request; derived apply state not updated",
 			append(apply.LogAttrs(),
-				"driver", driverID, "apply_operation_id", op.ID, "error", err)...)
+				"driver", driverID, "apply_operation_id", op.ID, "operation_deployment", op.Deployment, "error", err)...)
 		return
 	}
 
@@ -495,6 +495,7 @@ func (s *Service) recoverSingleApplyOperation(ctx context.Context, driverID int,
 			append(apply.LogAttrs(),
 				"driver", driverID,
 				"apply_operation_id", op.ID,
+				"operation_deployment", op.Deployment,
 				"error", err)...)
 		return
 	}
@@ -502,14 +503,15 @@ func (s *Service) recoverSingleApplyOperation(ctx context.Context, driverID int,
 		s.logger.Error("operator: parent apply not found after resume; derived apply state not updated",
 			append(apply.LogAttrs(),
 				"driver", driverID,
-				"apply_operation_id", op.ID)...)
+				"apply_operation_id", op.ID,
+				"operation_deployment", op.Deployment)...)
 		return
 	}
 
 	if _, err := s.updateApplyStateFromOperations(applyLeaseCtx, driverID, finalApply, allowLeaseScopedFailedReopen); err != nil {
 		s.logger.Error("operator: failed to update derived apply state from apply_operations",
 			append(finalApply.LogAttrs(),
-				"driver", driverID, "apply_operation_id", op.ID, "error", err)...)
+				"driver", driverID, "apply_operation_id", op.ID, "operation_deployment", op.Deployment, "error", err)...)
 		return
 	}
 
@@ -519,7 +521,7 @@ func (s *Service) recoverSingleApplyOperation(ctx context.Context, driverID int,
 	if err := s.completePendingStopIfApplyResolved(applyLeaseCtx, driverID, finalApply.ID); err != nil {
 		s.logger.Error("operator: failed to complete pending stop request for resolved apply",
 			append(finalApply.LogAttrs(),
-				"driver", driverID, "apply_operation_id", op.ID, "error", err)...)
+				"driver", driverID, "apply_operation_id", op.ID, "operation_deployment", op.Deployment, "error", err)...)
 		return
 	}
 }

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -236,11 +236,9 @@ func (s *Service) recoverApplies(ctx context.Context, driverID int) {
 	lease := apply.Lease()
 	if !lease.Valid() {
 		s.logger.Error("operator: claimed apply without a valid lease token; operator will not resume it",
-			"driver", driverID,
-			"lease_owner", owner,
-			"apply_id", apply.ApplyIdentifier,
-			"database", apply.Database,
-			"environment", apply.Environment)
+			append(apply.LogAttrs(),
+				"driver", driverID,
+				"lease_owner", owner)...)
 		metrics.RecordOperatorClaimFailure(ctx, "missing_lease_token")
 		return
 	}
@@ -279,11 +277,9 @@ func (s *Service) recoverApplyOperation(ctx context.Context, driverID int, owner
 	opLease := op.Lease()
 	if !opLease.Valid() {
 		s.logger.Error("operator: claimed apply_operation without a valid operation lease token; operation will not be driven",
-			"driver", driverID,
-			"lease_owner", owner,
-			"apply_operation_id", op.ID,
-			"apply_db_id", op.ApplyID,
-			"deployment", op.Deployment)
+			append(op.LogAttrs(),
+				"driver", driverID,
+				"lease_owner", owner)...)
 		metrics.RecordOperatorClaimFailure(ctx, "missing_operation_lease_token")
 		return
 	}
@@ -295,15 +291,15 @@ func (s *Service) recoverApplyOperation(ctx context.Context, driverID int, owner
 	ops, err := s.storage.ApplyOperations().ListByApply(ctx, op.ApplyID)
 	if err != nil {
 		s.logger.Error("operator: failed to list operations for claimed apply; operation will not be driven",
-			"driver", driverID, "lease_owner", owner, "apply_operation_id", op.ID,
-			"apply_db_id", op.ApplyID, "deployment", op.Deployment, "error", err)
+			append(op.LogAttrs(),
+				"driver", driverID, "lease_owner", owner, "error", err)...)
 		metrics.RecordOperatorClaimFailure(ctx, "operation_set_list_error")
 		return
 	}
 	if !operationSetContainsID(ops, op.ID) {
 		s.logger.Error("operator: claimed operation is not part of its apply's operation set; operation will not be driven",
-			"driver", driverID, "lease_owner", owner, "apply_operation_id", op.ID,
-			"apply_db_id", op.ApplyID, "deployment", op.Deployment, "operation_count", len(ops))
+			append(op.LogAttrs(),
+				"driver", driverID, "lease_owner", owner, "operation_count", len(ops))...)
 		metrics.RecordOperatorClaimFailure(ctx, "operation_set_missing")
 		return
 	}
@@ -314,8 +310,8 @@ func (s *Service) recoverApplyOperation(ctx context.Context, driverID int, owner
 	hasTasks, err := s.claimedOperationHasTasks(ctx, op)
 	if err != nil {
 		s.logger.Error("operator: failed to inspect claimed operation tasks; operation will not be driven",
-			"driver", driverID, "lease_owner", owner, "apply_operation_id", op.ID,
-			"apply_db_id", op.ApplyID, "deployment", op.Deployment, "error", err)
+			append(op.LogAttrs(),
+				"driver", driverID, "lease_owner", owner, "error", err)...)
 		metrics.RecordOperatorClaimFailure(ctx, "operation_task_inspect_error")
 		return
 	}
@@ -366,12 +362,10 @@ func (s *Service) recoverSingleApplyOperation(ctx context.Context, driverID int,
 	apply, err := s.storage.Applies().ClaimApplyByID(ctx, op.ApplyID, owner)
 	if err != nil {
 		s.logger.Error("operator: failed to claim parent apply for operation",
-			"driver", driverID,
-			"lease_owner", owner,
-			"apply_operation_id", op.ID,
-			"apply_db_id", op.ApplyID,
-			"deployment", op.Deployment,
-			"error", err)
+			append(op.LogAttrs(),
+				"driver", driverID,
+				"lease_owner", owner,
+				"error", err)...)
 		metrics.RecordOperatorClaimFailure(ctx, "operation_parent_claim_error")
 		return
 	}
@@ -469,8 +463,8 @@ func (s *Service) recoverSingleApplyOperation(ctx context.Context, driverID int,
 	marked, err := s.markOperationFromOwnResult(operationLeaseCtx, driverID, op)
 	if err != nil {
 		s.logger.Error("operator: failed to update apply_operation from its tasks; derived apply state not updated",
-			"driver", driverID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
-			"deployment", op.Deployment, "environment", apply.Environment, "error", err)
+			append(apply.LogAttrs(),
+				"driver", driverID, "apply_operation_id", op.ID, "error", err)...)
 		return
 	}
 	if !marked {
@@ -485,8 +479,8 @@ func (s *Service) recoverSingleApplyOperation(ctx context.Context, driverID int,
 	// a terminal verdict so the rollout (and the stop request) can resolve.
 	if err := s.stopPendingOperationsForPendingStop(applyLeaseCtx, driverID, apply); err != nil {
 		s.logger.Error("operator: failed to stop pending sibling operations for pending stop request; derived apply state not updated",
-			"driver", driverID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
-			"deployment", op.Deployment, "environment", apply.Environment, "error", err)
+			append(apply.LogAttrs(),
+				"driver", driverID, "apply_operation_id", op.ID, "error", err)...)
 		return
 	}
 
@@ -498,26 +492,24 @@ func (s *Service) recoverSingleApplyOperation(ctx context.Context, driverID int,
 	finalApply, err := s.storage.Applies().Get(applyLeaseCtx, apply.ID)
 	if err != nil {
 		s.logger.Error("operator: failed to reload parent apply after resume; derived apply state not updated",
-			"driver", driverID,
-			"apply_operation_id", op.ID,
-			"apply_id", apply.ApplyIdentifier,
-			"deployment", op.Deployment,
-			"error", err)
+			append(apply.LogAttrs(),
+				"driver", driverID,
+				"apply_operation_id", op.ID,
+				"error", err)...)
 		return
 	}
 	if finalApply == nil {
 		s.logger.Error("operator: parent apply not found after resume; derived apply state not updated",
-			"driver", driverID,
-			"apply_operation_id", op.ID,
-			"apply_id", apply.ApplyIdentifier,
-			"deployment", op.Deployment)
+			append(apply.LogAttrs(),
+				"driver", driverID,
+				"apply_operation_id", op.ID)...)
 		return
 	}
 
 	if _, err := s.updateApplyStateFromOperations(applyLeaseCtx, driverID, finalApply, allowLeaseScopedFailedReopen); err != nil {
 		s.logger.Error("operator: failed to update derived apply state from apply_operations",
-			"driver", driverID, "apply_operation_id", op.ID, "apply_id", finalApply.ApplyIdentifier,
-			"deployment", op.Deployment, "environment", finalApply.Environment, "error", err)
+			append(finalApply.LogAttrs(),
+				"driver", driverID, "apply_operation_id", op.ID, "error", err)...)
 		return
 	}
 
@@ -526,8 +518,8 @@ func (s *Service) recoverSingleApplyOperation(ctx context.Context, driverID int,
 	// has stopped.
 	if err := s.completePendingStopIfApplyResolved(applyLeaseCtx, driverID, finalApply.ID); err != nil {
 		s.logger.Error("operator: failed to complete pending stop request for resolved apply",
-			"driver", driverID, "apply_operation_id", op.ID, "apply_id", finalApply.ApplyIdentifier,
-			"deployment", op.Deployment, "environment", finalApply.Environment, "error", err)
+			append(finalApply.LogAttrs(),
+				"driver", driverID, "apply_operation_id", op.ID, "error", err)...)
 		return
 	}
 }
@@ -558,15 +550,15 @@ func (s *Service) driveClaimedMultiOperation(ctx context.Context, driverID int, 
 	apply, err := s.storage.Applies().Get(operationLeaseCtx, op.ApplyID)
 	if err != nil {
 		s.logger.Error("operator: failed to load parent apply for operation drive; operation will not be driven",
-			"driver", driverID, "apply_operation_id", op.ID, "apply_db_id", op.ApplyID,
-			"deployment", op.Deployment, "error", err)
+			append(op.LogAttrs(),
+				"driver", driverID, "error", err)...)
 		metrics.RecordOperatorClaimFailure(ctx, "operation_parent_load_error")
 		return
 	}
 	if apply == nil {
 		s.logger.Error("operator: parent apply not found for claimed operation; operation will not be driven",
-			"driver", driverID, "apply_operation_id", op.ID, "apply_db_id", op.ApplyID,
-			"deployment", op.Deployment)
+			append(op.LogAttrs(),
+				"driver", driverID)...)
 		metrics.RecordOperatorClaimFailure(ctx, "operation_parent_missing")
 		return
 	}
@@ -579,8 +571,8 @@ func (s *Service) driveClaimedMultiOperation(ctx context.Context, driverID int, 
 	// empty deployment is a corrupt row with no routing key, so fail closed.
 	if op.Deployment == "" {
 		s.logger.Error("operator: claimed operation is missing deployment metadata; operation will not be driven",
-			"driver", driverID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
-			"database", apply.Database, "environment", apply.Environment)
+			append(apply.LogAttrs(),
+				"driver", driverID, "apply_operation_id", op.ID)...)
 		metrics.RecordOperatorClaimFailure(ctx, "missing_operation_deployment")
 		return
 	}
@@ -592,8 +584,9 @@ func (s *Service) driveClaimedMultiOperation(ctx context.Context, driverID int, 
 	// drive. The op lease authorizes the derived-state CAS.
 	if _, err := s.updateApplyStateFromOperations(operationLeaseCtx, driverID, apply, allowLeaseScopedFailedReopen); err != nil {
 		s.logger.Error("operator: failed to project parent running before operation drive; operation will not be driven",
-			"driver", driverID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
-			"database", apply.Database, "environment", apply.Environment, "error", err)
+			append(apply.LogAttrs(),
+				"driver", driverID, "apply_operation_id", op.ID,
+				"operation_deployment", op.Deployment, "error", err)...)
 		return
 	}
 
@@ -623,8 +616,9 @@ func (s *Service) driveClaimedMultiOperation(ctx context.Context, driverID int, 
 		failApply := apply
 		if reloaded, reloadErr := s.storage.Applies().Get(operationLeaseCtx, apply.ID); reloadErr != nil {
 			s.logger.Error("operator: failed to reload parent apply before failing task-less operation; using pre-drive apply state",
-				"driver", driverID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
-				"database", apply.Database, "environment", apply.Environment, "error", reloadErr)
+				append(apply.LogAttrs(),
+					"driver", driverID, "apply_operation_id", op.ID,
+					"operation_deployment", op.Deployment, "error", reloadErr)...)
 		} else if reloaded != nil {
 			failApply = reloaded
 		}
@@ -643,8 +637,9 @@ func (s *Service) driveClaimedMultiOperation(ctx context.Context, driverID int, 
 	marked, err := s.markOperationFromOwnResult(operationLeaseCtx, driverID, op)
 	if err != nil {
 		s.logger.Error("operator: failed to update apply_operation from its tasks; derived apply state not updated",
-			"driver", driverID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
-			"deployment", op.Deployment, "environment", apply.Environment, "error", err)
+			append(apply.LogAttrs(),
+				"driver", driverID, "apply_operation_id", op.ID,
+				"operation_deployment", op.Deployment, "error", err)...)
 		return
 	}
 	if !marked {
@@ -656,8 +651,9 @@ func (s *Service) driveClaimedMultiOperation(ctx context.Context, driverID int, 
 	// by this operation's own lease (the 6a op-lease branch).
 	if err := s.stopPendingOperationsForPendingStop(operationLeaseCtx, driverID, apply); err != nil {
 		s.logger.Error("operator: failed to stop pending sibling operations for pending stop request; derived apply state not updated",
-			"driver", driverID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
-			"deployment", op.Deployment, "environment", apply.Environment, "error", err)
+			append(apply.LogAttrs(),
+				"driver", driverID, "apply_operation_id", op.ID,
+				"operation_deployment", op.Deployment, "error", err)...)
 		return
 	}
 
@@ -666,22 +662,25 @@ func (s *Service) driveClaimedMultiOperation(ctx context.Context, driverID int, 
 	finalApply, err := s.storage.Applies().Get(operationLeaseCtx, apply.ID)
 	if err != nil {
 		s.logger.Error("operator: failed to reload parent apply after operation drive; derived apply state not updated",
-			"driver", driverID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
-			"deployment", op.Deployment, "error", err)
+			append(apply.LogAttrs(),
+				"driver", driverID, "apply_operation_id", op.ID,
+				"operation_deployment", op.Deployment, "error", err)...)
 		return
 	}
 	if finalApply == nil {
 		s.logger.Error("operator: parent apply not found after operation drive; derived apply state not updated",
-			"driver", driverID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
-			"deployment", op.Deployment)
+			append(apply.LogAttrs(),
+				"driver", driverID, "apply_operation_id", op.ID,
+				"operation_deployment", op.Deployment)...)
 		return
 	}
 
 	result, err := s.updateApplyStateFromOperations(operationLeaseCtx, driverID, finalApply, allowLeaseScopedFailedReopen)
 	if err != nil {
 		s.logger.Error("operator: failed to update derived apply state from apply_operations",
-			"driver", driverID, "apply_operation_id", op.ID, "apply_id", finalApply.ApplyIdentifier,
-			"deployment", op.Deployment, "environment", finalApply.Environment, "error", err)
+			append(finalApply.LogAttrs(),
+				"driver", driverID, "apply_operation_id", op.ID,
+				"operation_deployment", op.Deployment, "error", err)...)
 		return
 	}
 
@@ -693,8 +692,9 @@ func (s *Service) driveClaimedMultiOperation(ctx context.Context, driverID int, 
 
 	if err := s.completePendingStopIfApplyResolved(operationLeaseCtx, driverID, finalApply.ID); err != nil {
 		s.logger.Error("operator: failed to complete pending stop request for resolved apply",
-			"driver", driverID, "apply_operation_id", op.ID, "apply_id", finalApply.ApplyIdentifier,
-			"deployment", op.Deployment, "environment", finalApply.Environment, "error", err)
+			append(finalApply.LogAttrs(),
+				"driver", driverID, "apply_operation_id", op.ID,
+				"operation_deployment", op.Deployment, "error", err)...)
 		return
 	}
 }
@@ -729,8 +729,8 @@ func (s *Service) recoverApplyOperationCutover(ctx context.Context, driverID int
 	opLease := op.Lease()
 	if !opLease.Valid() {
 		s.logger.Error("operator: claimed apply_operation cutover without a valid operation lease token; operation will not be driven",
-			"driver", driverID, "lease_owner", owner, "apply_operation_id", op.ID,
-			"apply_db_id", op.ApplyID, "deployment", op.Deployment)
+			append(op.LogAttrs(),
+				"driver", driverID, "lease_owner", owner)...)
 		metrics.RecordOperatorClaimFailure(ctx, "missing_operation_cutover_lease_token")
 		return true
 	}
@@ -742,15 +742,15 @@ func (s *Service) recoverApplyOperationCutover(ctx context.Context, driverID int
 	ops, err := s.storage.ApplyOperations().ListByApply(ctx, op.ApplyID)
 	if err != nil {
 		s.logger.Error("operator: failed to list operations for claimed cutover; operation will not be driven",
-			"driver", driverID, "lease_owner", owner, "apply_operation_id", op.ID,
-			"apply_db_id", op.ApplyID, "deployment", op.Deployment, "error", err)
+			append(op.LogAttrs(),
+				"driver", driverID, "lease_owner", owner, "error", err)...)
 		metrics.RecordOperatorClaimFailure(ctx, "operation_cutover_set_list_error")
 		return true
 	}
 	if len(ops) <= 1 || !operationSetContainsID(ops, op.ID) {
 		s.logger.Error("operator: claimed cutover operation is not part of a multi-operation apply set; operation will not be driven",
-			"driver", driverID, "lease_owner", owner, "apply_operation_id", op.ID,
-			"apply_db_id", op.ApplyID, "deployment", op.Deployment, "operation_count", len(ops))
+			append(op.LogAttrs(),
+				"driver", driverID, "lease_owner", owner, "operation_count", len(ops))...)
 		metrics.RecordOperatorClaimFailure(ctx, "operation_cutover_set_invalid")
 		return true
 	}
@@ -829,8 +829,8 @@ func (s *Service) recoverApplyPendingStop(ctx context.Context, driverID int, own
 	// stop).
 	if err := s.markPendingOperationsStopped(applyLeaseCtx, driverID, apply); err != nil {
 		s.logger.Error("operator: failed to stop pending sibling operations during stop reconciliation",
-			"driver", driverID, "apply_id", apply.ApplyIdentifier,
-			"database", apply.Database, "environment", apply.Environment, "error", err)
+			append(apply.LogAttrs(),
+				"driver", driverID, "error", err)...)
 		return true
 	}
 
@@ -863,8 +863,8 @@ func (s *Service) recoverApplyPendingStop(ctx context.Context, driverID int, own
 
 	if err := s.completePendingStopIfApplyResolved(applyLeaseCtx, driverID, finalApply.ID); err != nil {
 		s.logger.Error("operator: failed to complete pending stop request after stop reconciliation",
-			"driver", driverID, "apply_id", finalApply.ApplyIdentifier,
-			"database", finalApply.Database, "environment", finalApply.Environment, "error", err)
+			append(finalApply.LogAttrs(),
+				"driver", driverID, "error", err)...)
 		return true
 	}
 	return true
@@ -950,20 +950,16 @@ func (s *Service) reconcileUnclaimableParent(ctx context.Context, driverID int, 
 	parent, err := s.storage.Applies().Get(ctx, op.ApplyID)
 	if err != nil {
 		s.logger.Error("operator: failed to load unclaimable parent apply; operation will be retried",
-			"driver", driverID,
-			"apply_operation_id", op.ID,
-			"apply_db_id", op.ApplyID,
-			"deployment", op.Deployment,
-			"error", err)
+			append(op.LogAttrs(),
+				"driver", driverID,
+				"error", err)...)
 		metrics.RecordOperatorClaimFailure(ctx, "operation_parent_not_claimable")
 		return
 	}
 	if parent == nil {
 		s.logger.Error("operator: parent apply not found for claimed operation; operation will be retried",
-			"driver", driverID,
-			"apply_operation_id", op.ID,
-			"apply_db_id", op.ApplyID,
-			"deployment", op.Deployment)
+			append(op.LogAttrs(),
+				"driver", driverID)...)
 		metrics.RecordOperatorClaimFailure(ctx, "operation_parent_not_claimable")
 		return
 	}
@@ -972,12 +968,10 @@ func (s *Service) reconcileUnclaimableParent(ctx context.Context, driverID int, 
 		return
 	}
 	s.logger.Warn("operator: parent apply not claimable for operation; operation will be retried",
-		"driver", driverID,
-		"apply_operation_id", op.ID,
-		"apply_id", parent.ApplyIdentifier,
-		"deployment", op.Deployment,
-		"environment", parent.Environment,
-		"state", parent.State)
+		append(parent.LogAttrs(),
+			"driver", driverID,
+			"apply_operation_id", op.ID,
+			"operation_deployment", op.Deployment)...)
 	metrics.RecordOperatorClaimFailure(ctx, "operation_parent_not_claimable")
 }
 
@@ -992,8 +986,9 @@ func (s *Service) reconcileClaimedOperationFromTerminalParent(ctx context.Contex
 	marked, err := s.markOperationFromApplyState(ctx, driverID, op, parent)
 	if err != nil {
 		s.logger.Error("operator: failed to reconcile apply_operation from terminal parent; derived apply state not updated",
-			"driver", driverID, "apply_operation_id", op.ID, "apply_id", parent.ApplyIdentifier,
-			"deployment", op.Deployment, "environment", parent.Environment, "state", parent.State, "error", err)
+			append(parent.LogAttrs(),
+				"driver", driverID, "apply_operation_id", op.ID,
+				"operation_deployment", op.Deployment, "error", err)...)
 		return
 	}
 	if !marked {
@@ -1001,8 +996,9 @@ func (s *Service) reconcileClaimedOperationFromTerminalParent(ctx context.Contex
 	}
 	if _, err := s.updateApplyStateFromOperations(ctx, driverID, parent, rejectFailedApplyReopen); err != nil {
 		s.logger.Error("operator: failed to update derived apply state for terminal parent",
-			"driver", driverID, "apply_operation_id", op.ID, "apply_id", parent.ApplyIdentifier,
-			"deployment", op.Deployment, "environment", parent.Environment, "error", err)
+			append(parent.LogAttrs(),
+				"driver", driverID, "apply_operation_id", op.ID,
+				"operation_deployment", op.Deployment, "error", err)...)
 		return
 	}
 }
@@ -1019,15 +1015,17 @@ func (s *Service) failOperationWithoutTasks(opCtx, applyCtx context.Context, dri
 	const reason = "operation has no tasks; invalid or stale claim"
 	if err := s.storage.ApplyOperations().MarkFailed(opCtx, op.ID, reason); err != nil {
 		s.logger.Error("operator: failed to mark task-less apply_operation failed; operation will be retried",
-			"driver", driverID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
-			"deployment", op.Deployment, "environment", apply.Environment, "error", err)
+			append(apply.LogAttrs(),
+				"driver", driverID, "apply_operation_id", op.ID,
+				"operation_deployment", op.Deployment, "error", err)...)
 		return
 	}
 	result, err := s.updateApplyStateFromOperations(applyCtx, driverID, apply, allowLeaseScopedFailedReopen)
 	if err != nil {
 		s.logger.Error("operator: failed to update derived apply state after failing task-less operation",
-			"driver", driverID, "apply_operation_id", op.ID, "apply_id", apply.ApplyIdentifier,
-			"deployment", op.Deployment, "environment", apply.Environment, "error", err)
+			append(apply.LogAttrs(),
+				"driver", driverID, "apply_operation_id", op.ID,
+				"operation_deployment", op.Deployment, "error", err)...)
 		return
 	}
 
@@ -1732,26 +1730,26 @@ func (s *Service) publishTerminalSummaryIfWon(ctx context.Context, driverID int,
 	terminalApply, err := s.storage.Applies().Get(ctx, apply.ID)
 	if err != nil {
 		s.logger.Error("operator: failed to reload terminal apply for aggregate summary; summary not published",
-			"driver", driverID, "apply_id", apply.ApplyIdentifier,
-			"database", apply.Database, "environment", apply.Environment,
-			"derived_state", result.DerivedState, "operation_count", result.OperationCount, "error", err)
+			append(apply.LogAttrs(),
+				"driver", driverID,
+				"derived_state", result.DerivedState, "operation_count", result.OperationCount, "error", err)...)
 		metrics.RecordOperatorTerminalSummaryFailure(ctx, "reload_apply_error")
 		return
 	}
 	if terminalApply == nil {
 		s.logger.Error("operator: terminal apply not found while publishing aggregate summary; summary not published",
-			"driver", driverID, "apply_id", apply.ApplyIdentifier,
-			"database", apply.Database, "environment", apply.Environment,
-			"derived_state", result.DerivedState, "operation_count", result.OperationCount)
+			append(apply.LogAttrs(),
+				"driver", driverID,
+				"derived_state", result.DerivedState, "operation_count", result.OperationCount)...)
 		metrics.RecordOperatorTerminalSummaryFailure(ctx, "apply_missing")
 		return
 	}
 	if !state.IsTerminalApplyState(terminalApply.State) {
 		s.logger.Error("operator: reloaded apply is no longer terminal while publishing aggregate summary; summary not published",
-			"driver", driverID, "apply_id", terminalApply.ApplyIdentifier,
-			"database", terminalApply.Database, "environment", terminalApply.Environment,
-			"reloaded_state", terminalApply.State, "derived_state", result.DerivedState,
-			"operation_count", result.OperationCount)
+			append(terminalApply.LogAttrs(),
+				"driver", driverID,
+				"reloaded_state", terminalApply.State, "derived_state", result.DerivedState,
+				"operation_count", result.OperationCount)...)
 		metrics.RecordOperatorTerminalSummaryFailure(ctx, "apply_not_terminal_after_cas")
 		return
 	}
@@ -1761,18 +1759,18 @@ func (s *Service) publishTerminalSummaryIfWon(ctx context.Context, driverID int,
 	tasks, err := s.storage.Tasks().GetByApplyID(ctx, terminalApply.ID)
 	if err != nil {
 		s.logger.Error("operator: failed to reload tasks for aggregate terminal summary; summary not published",
-			"driver", driverID, "apply_id", terminalApply.ApplyIdentifier,
-			"database", terminalApply.Database, "environment", terminalApply.Environment,
-			"derived_state", result.DerivedState, "operation_count", result.OperationCount, "error", err)
+			append(terminalApply.LogAttrs(),
+				"driver", driverID,
+				"derived_state", result.DerivedState, "operation_count", result.OperationCount, "error", err)...)
 		metrics.RecordOperatorTerminalSummaryFailure(ctx, "reload_tasks_error")
 		return
 	}
 
 	if err := s.OnApplyTerminalSummary(ctx, terminalApply, tasks); err != nil {
 		s.logger.Error("operator: aggregate terminal summary publish failed; parent state stays terminal, summary left for reconciliation",
-			"driver", driverID, "apply_id", terminalApply.ApplyIdentifier,
-			"database", terminalApply.Database, "environment", terminalApply.Environment,
-			"derived_state", result.DerivedState, "operation_count", result.OperationCount, "error", err)
+			append(terminalApply.LogAttrs(),
+				"driver", driverID,
+				"derived_state", result.DerivedState, "operation_count", result.OperationCount, "error", err)...)
 		metrics.RecordOperatorTerminalSummaryFailure(ctx, "callback_error")
 		return
 	}

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -275,7 +275,6 @@ func (s *Service) bestEffortProgressOperations(ctx context.Context, apply *stora
 		// Serve progress without the enrichment and log the storage uncertainty.
 		s.logger.Warn("progress response will omit per-deployment operations",
 			"apply_id", apply.ApplyIdentifier,
-			"apply_db_id", apply.ID,
 			"database", apply.Database,
 			"environment", apply.Environment,
 			"error", err)

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -309,7 +309,7 @@ func (s *Service) handleProgressByApplyID(w http.ResponseWriter, r *http.Request
 	if shouldServeProgressFromStorage(apply.State) {
 		httpResp, err := s.progressFromLocalStorage(r.Context(), apply)
 		if err != nil {
-			s.logger.Error("failed to read apply progress from storage", "apply_id", applyID, "state", apply.State, "error", err)
+			s.logger.Error("failed to read apply progress from storage", append(apply.LogAttrs(), "error", err)...)
 			s.writeErrorCode(w, http.StatusInternalServerError, apitypes.ErrCodeStorageError, "failed to read tasks: "+err.Error())
 			return
 		}
@@ -368,7 +368,7 @@ func (s *Service) handleProgressByApplyID(w http.ResponseWriter, r *http.Request
 	if shouldServeRemoteProgressFromStorage(apply, client) {
 		httpResp, err := s.progressFromLocalStorage(r.Context(), queuedRemoteProgressApply(apply))
 		if err != nil {
-			s.logger.Error("failed to read queued remote apply progress from storage", "apply_id", applyID, "state", apply.State, "error", err)
+			s.logger.Error("failed to read queued remote apply progress from storage", append(apply.LogAttrs(), "error", err)...)
 			s.writeErrorCode(w, http.StatusInternalServerError, apitypes.ErrCodeStorageError, "failed to read tasks: "+err.Error())
 			return
 		}
@@ -381,7 +381,7 @@ func (s *Service) handleProgressByApplyID(w http.ResponseWriter, r *http.Request
 		Environment: apply.Environment,
 	})
 	if err != nil {
-		s.logger.Error("progress failed", "apply_id", applyID, "database", apply.Database, "error", err)
+		s.logger.Error("progress failed", append(apply.LogAttrs(), "error", err)...)
 		s.writeErrorCode(w, http.StatusInternalServerError, apitypes.ErrCodeEngineUnavailable, "progress failed: "+err.Error())
 		return
 	}
@@ -1067,7 +1067,7 @@ func (s *Service) syncTasksFromTern(ctx context.Context, apply *storage.Apply, t
 		task.ChecksumRowsTotal = tp.ChecksumRowsTotal
 		task.UpdatedAt = now
 		if err := s.storage.Tasks().Update(ctx, task); err != nil {
-			s.logger.Error("sync task failed", "task_id", task.TaskIdentifier, "error", err)
+			s.logger.Error("sync task failed", append(task.LogAttrs(), "error", err)...)
 			continue
 		}
 		synced++

--- a/pkg/engine/planetscale/apply.go
+++ b/pkg/engine/planetscale/apply.go
@@ -550,7 +550,7 @@ func (e *Engine) applyKeyspaceChanges(ctx context.Context, sc engine.SchemaChang
 
 		if err := e.applyKeyspaceChangesOnce(ctx, sc, schemaFiles, password, client, org, database, branchName); err != nil {
 			lastErr = err
-			e.logger.Error(fmt.Sprintf("keyspace %s apply attempt %d failed", sc.Namespace, attempt+1), "keyspace", sc.Namespace, "attempt", attempt+1, "error", err)
+			e.logger.Error(fmt.Sprintf("keyspace %s apply attempt %d failed", sc.Namespace, attempt+1), "keyspace", sc.Namespace, "database", database, "branch", branchName, "attempt", attempt+1, "error", err)
 			if !isRetryableEngineError(err) {
 				return engine.NewPermanentError("apply keyspace %s: %w", sc.Namespace, err)
 			}

--- a/pkg/serve/serve.go
+++ b/pkg/serve/serve.go
@@ -142,7 +142,7 @@ func Run(ctx context.Context, cfg *api.ServerConfig, opts ...Option) error {
 			// Serve returns ErrServerStopped on GracefulStop during normal
 			// shutdown; that is expected, not an error worth alerting on.
 			if err := grpcServer.Serve(listener); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
-				srv.logger.Error("gRPC server error", "error", err)
+				srv.logger.Error("gRPC server error", "port", grpcPort, "error", err)
 			}
 		}()
 		defer grpcServer.GracefulStop()
@@ -587,7 +587,7 @@ func buildSingleAppWebhookRuntime(serverConfig *api.ServerConfig, svc *api.Servi
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusServiceUnavailable)
 			if _, err := w.Write([]byte(`{"error":"GitHub App credentials not available — webhook endpoint is disabled"}`)); err != nil {
-				logger.Error("failed to write disabled webhook response", "error", err)
+				logger.Error("failed to write disabled webhook response", "method", r.Method, "path", r.URL.Path, "error", err)
 			}
 		})}, nil
 	}

--- a/pkg/storage/logattrs.go
+++ b/pkg/storage/logattrs.go
@@ -37,8 +37,9 @@ func (a *Apply) LogAttrs() []any {
 // Apply.LogAttrs for the database/environment context. A nil receiver returns nil.
 //
 // deployment here is the operation's own (authoritative routing) deployment.
-// external_id (the remote data plane's identifier for this operation) is included
-// only when set.
+// external_id (the remote data plane's apply identifier for this operation) and
+// external_operation_id (the remote data plane's operation handle) are included
+// only when set, so operators can correlate a stuck operation to the data plane.
 func (op *ApplyOperation) LogAttrs() []any {
 	if op == nil {
 		return nil
@@ -51,6 +52,9 @@ func (op *ApplyOperation) LogAttrs() []any {
 	}
 	if op.ExternalID != "" {
 		attrs = append(attrs, "external_id", op.ExternalID)
+	}
+	if op.ExternalOperationID != "" {
+		attrs = append(attrs, "external_operation_id", op.ExternalOperationID)
 	}
 	return attrs
 }

--- a/pkg/storage/logattrs.go
+++ b/pkg/storage/logattrs.go
@@ -7,11 +7,16 @@ package storage
 //	logger.Error("failed to drive apply", append(apply.LogAttrs(), "error", err)...)
 //
 // A nil receiver returns nil so callers on not-found paths can log safely.
+//
+// apply_id is the searchable string identifier; the internal numeric row ID is
+// deliberately not logged so it can't be confused with the user-facing id.
+// external_id (the remote data plane's identifier for this apply) is included
+// only when set, so operators can correlate to the data plane during triage.
 func (a *Apply) LogAttrs() []any {
 	if a == nil {
 		return nil
 	}
-	return []any{
+	attrs := []any{
 		"apply_id", a.ApplyIdentifier,
 		"database", a.Database,
 		"database_type", a.DatabaseType,
@@ -19,6 +24,10 @@ func (a *Apply) LogAttrs() []any {
 		"deployment", a.Deployment,
 		"state", a.State,
 	}
+	if a.ExternalID != "" {
+		attrs = append(attrs, "external_id", a.ExternalID)
+	}
+	return attrs
 }
 
 // LogAttrs returns the canonical triage attributes for an apply_operation. The
@@ -26,17 +35,24 @@ func (a *Apply) LogAttrs() []any {
 // the operation is in scope these identifiers (plus deployment and kind) are what
 // pin down the stuck operation; once the parent apply is loaded, prefer
 // Apply.LogAttrs for the database/environment context. A nil receiver returns nil.
+//
+// deployment here is the operation's own (authoritative routing) deployment.
+// external_id (the remote data plane's identifier for this operation) is included
+// only when set.
 func (op *ApplyOperation) LogAttrs() []any {
 	if op == nil {
 		return nil
 	}
-	return []any{
+	attrs := []any{
 		"apply_operation_id", op.ID,
-		"apply_db_id", op.ApplyID,
 		"deployment", op.Deployment,
 		"operation_kind", op.OperationKind,
 		"state", op.State,
 	}
+	if op.ExternalID != "" {
+		attrs = append(attrs, "external_id", op.ExternalID)
+	}
+	return attrs
 }
 
 // LogAttrs returns the canonical triage attributes for a task: which task, on
@@ -48,7 +64,6 @@ func (t *Task) LogAttrs() []any {
 	}
 	return []any{
 		"task_id", t.TaskIdentifier,
-		"apply_db_id", t.ApplyID,
 		"database", t.Database,
 		"database_type", t.DatabaseType,
 		"environment", t.Environment,

--- a/pkg/storage/logattrs.go
+++ b/pkg/storage/logattrs.go
@@ -10,9 +10,9 @@ package storage
 //
 // apply_id is the searchable string identifier; the internal numeric row ID is
 // deliberately not logged so it can't be confused with the user-facing id.
-// external_id (the remote data plane's identifier for this apply) and caller (who
-// initiated the apply) are included only when set, so operators can correlate to
-// the data plane and to who triggered the change during triage.
+// repo, pr, external_id (the remote data plane's identifier for this apply), and
+// caller (who initiated the apply) are included only when set, so operators can
+// tie the apply to its PR, correlate to the data plane, and see who triggered it.
 func (a *Apply) LogAttrs() []any {
 	if a == nil {
 		return nil
@@ -24,6 +24,12 @@ func (a *Apply) LogAttrs() []any {
 		"environment", a.Environment,
 		"deployment", a.Deployment,
 		"state", a.State,
+	}
+	if a.Repository != "" {
+		attrs = append(attrs, "repo", a.Repository)
+	}
+	if a.PullRequest > 0 {
+		attrs = append(attrs, "pr", a.PullRequest)
 	}
 	if a.ExternalID != "" {
 		attrs = append(attrs, "external_id", a.ExternalID)

--- a/pkg/storage/logattrs.go
+++ b/pkg/storage/logattrs.go
@@ -1,0 +1,58 @@
+package storage
+
+// LogAttrs returns the canonical slog key/value attributes for triaging this
+// apply from logs alone: which apply, on which database and environment, and in
+// what state. Append call-specific attributes after it, e.g.:
+//
+//	logger.Error("failed to drive apply", append(apply.LogAttrs(), "error", err)...)
+//
+// A nil receiver returns nil so callers on not-found paths can log safely.
+func (a *Apply) LogAttrs() []any {
+	if a == nil {
+		return nil
+	}
+	return []any{
+		"apply_id", a.ApplyIdentifier,
+		"database", a.Database,
+		"database_type", a.DatabaseType,
+		"environment", a.Environment,
+		"deployment", a.Deployment,
+		"state", a.State,
+	}
+}
+
+// LogAttrs returns the canonical triage attributes for an apply_operation. The
+// parent apply's database and environment require a separate load, so when only
+// the operation is in scope these identifiers (plus deployment and kind) are what
+// pin down the stuck operation; once the parent apply is loaded, prefer
+// Apply.LogAttrs for the database/environment context. A nil receiver returns nil.
+func (op *ApplyOperation) LogAttrs() []any {
+	if op == nil {
+		return nil
+	}
+	return []any{
+		"apply_operation_id", op.ID,
+		"apply_db_id", op.ApplyID,
+		"deployment", op.Deployment,
+		"operation_kind", op.OperationKind,
+		"state", op.State,
+	}
+}
+
+// LogAttrs returns the canonical triage attributes for a task: which task, on
+// which database and environment, which table, and in what state. A nil receiver
+// returns nil.
+func (t *Task) LogAttrs() []any {
+	if t == nil {
+		return nil
+	}
+	return []any{
+		"task_id", t.TaskIdentifier,
+		"apply_db_id", t.ApplyID,
+		"database", t.Database,
+		"database_type", t.DatabaseType,
+		"environment", t.Environment,
+		"table", t.TableName,
+		"state", t.State,
+	}
+}

--- a/pkg/storage/logattrs.go
+++ b/pkg/storage/logattrs.go
@@ -10,8 +10,9 @@ package storage
 //
 // apply_id is the searchable string identifier; the internal numeric row ID is
 // deliberately not logged so it can't be confused with the user-facing id.
-// external_id (the remote data plane's identifier for this apply) is included
-// only when set, so operators can correlate to the data plane during triage.
+// external_id (the remote data plane's identifier for this apply) and caller (who
+// initiated the apply) are included only when set, so operators can correlate to
+// the data plane and to who triggered the change during triage.
 func (a *Apply) LogAttrs() []any {
 	if a == nil {
 		return nil
@@ -26,6 +27,9 @@ func (a *Apply) LogAttrs() []any {
 	}
 	if a.ExternalID != "" {
 		attrs = append(attrs, "external_id", a.ExternalID)
+	}
+	if a.Caller != "" {
+		attrs = append(attrs, "caller", a.Caller)
 	}
 	return attrs
 }

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -1574,7 +1574,6 @@ func refuseStoppedClaimForActiveTarget(ctx context.Context, tx *sql.Tx, apply *s
 	}
 	slog.WarnContext(ctx, "claim refused: another active apply exists for target; failing pending start control request",
 		"apply_id", apply.ApplyIdentifier,
-		"apply_db_id", apply.ID,
 		"database", database,
 		"database_type", dbType,
 		"environment", environment,

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -2317,7 +2317,6 @@ func (c *GRPCClient) completeApplyStartRequestForScope(ctx context.Context, appl
 	if scope.usesOperationRemoteResume() {
 		slog.Debug("skipping apply-level start request completion during multi-operation drive; shared start request is owned by the rollout projection",
 			"apply_id", apply.ApplyIdentifier,
-			"apply_db_id", apply.ID,
 			"apply_operation_id", scope.applyOperationID,
 			"deployment", scope.operation.Deployment,
 			"environment", apply.Environment)
@@ -2335,7 +2334,6 @@ func (c *GRPCClient) persistParentApply(ctx context.Context, apply *storage.Appl
 	if scope.suppressesDirectParentApplyWrites() {
 		slog.Debug("skipping direct parent apply write during multi-operation drive; parent state is owned by the rollout projection",
 			"apply_id", apply.ApplyIdentifier,
-			"apply_db_id", apply.ID,
 			"apply_operation_id", scope.applyOperationID,
 			"deployment", scope.operation.Deployment,
 			"environment", apply.Environment,
@@ -2431,7 +2429,6 @@ func (c *GRPCClient) markRemoteApplyFailedWithOptions(ctx context.Context, remot
 		}
 		slog.Debug("recorded operation task failures during multi-operation drive; parent failure is owned by the rollout projection",
 			"apply_id", storedApply.ApplyIdentifier,
-			"apply_db_id", storedApply.ID,
 			"apply_operation_id", scope.applyOperationID,
 			"deployment", scope.operation.Deployment,
 			"environment", storedApply.Environment,
@@ -2553,7 +2550,6 @@ func (c *GRPCClient) persistTerminalStateFromRemote(ctx context.Context, storedA
 		}
 		slog.Debug("skipping parent terminal write during multi-operation drive; operation tasks are resolved and parent state is owned by the rollout projection",
 			"apply_id", storedApply.ApplyIdentifier,
-			"apply_db_id", storedApply.ID,
 			"apply_operation_id", scope.applyOperationID,
 			"deployment", scope.operation.Deployment,
 			"environment", storedApply.Environment,

--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -428,7 +428,7 @@ func applyEventStateTransition(apply *storage.Apply, event engine.ApplyEvent, up
 	apply.State = newState
 	apply.UpdatedAt = time.Now()
 	if err := updateFn(apply); err != nil {
-		logger.Error("failed to update apply phase", "apply_id", apply.ApplyIdentifier, "state", newState, "error", err)
+		logger.Error("failed to update apply phase", append(apply.LogAttrs(), "error", err)...)
 		apply.State = oldState
 		return ""
 	}

--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -43,7 +43,7 @@ func (c *LocalClient) checkActiveTaskConflict(ctx context.Context, plan *storage
 			continue
 		}
 
-		return fmt.Errorf("schema change already in progress for this database")
+		return fmt.Errorf("schema change already in progress for database %q (plan %s): blocking task %s", plan.Database, plan.PlanIdentifier, blockingTaskID)
 	}
 	return nil
 }
@@ -89,7 +89,7 @@ func (c *LocalClient) findBlockingTask(ctx context.Context, tasks []*storage.Tas
 func (c *LocalClient) tryResolveStaleTask(ctx context.Context, t *storage.Task, database string) bool {
 	eng := c.getEngine()
 	if eng == nil {
-		c.logger.Error("tryResolveStaleTask: engine is nil", "database", database)
+		c.logger.Error("tryResolveStaleTask: engine is nil", t.LogAttrs()...)
 		return false
 	}
 
@@ -99,7 +99,7 @@ func (c *LocalClient) tryResolveStaleTask(ctx context.Context, t *storage.Task, 
 	})
 	if err != nil {
 		// result may be nil when err is non-nil, so it must not be dereferenced here.
-		c.logger.Warn("conflict check: engine progress failed", "task_id", t.TaskIdentifier, "err", err)
+		c.logger.Warn("conflict check: engine progress failed", append(t.LogAttrs(), "err", err)...)
 		return false
 	}
 	c.logger.Debug("conflict check: engine progress", "task_id", t.TaskIdentifier, "engine_state", result.State, "message", result.Message)
@@ -157,7 +157,7 @@ func (c *LocalClient) logApplyEvent(ctx context.Context, applyID int64, taskID *
 		CreatedAt: time.Now(),
 	}
 	if err := c.storage.ApplyLogs().Append(ctx, log); err != nil {
-		c.logger.Warn("failed to log apply event", "error", err, "event", eventType, "message", message)
+		c.logger.Warn("failed to log apply event", "apply_id", applyID, "error", err, "event", eventType, "message", message)
 	}
 }
 
@@ -208,7 +208,7 @@ func (c *LocalClient) transitionTaskState(ctx context.Context, task *storage.Tas
 	task.State = newState
 	task.UpdatedAt = time.Now()
 	if err := c.storage.Tasks().Update(ctx, task); err != nil {
-		c.logger.Error("failed to update task state", "task_id", task.TaskIdentifier, "state", newState, "error", err)
+		c.logger.Error("failed to update task state", append(task.LogAttrs(), "error", err)...)
 	}
 	if logMsg != "" && applyID > 0 {
 		taskID := task.ID
@@ -225,7 +225,7 @@ func (c *LocalClient) markTasksRunning(ctx context.Context, tasks []*storage.Tas
 		task.StartedAt = &now
 		task.UpdatedAt = now
 		if err := c.storage.Tasks().Update(ctx, task); err != nil {
-			c.logger.Error("failed to update task state", "task_id", task.TaskIdentifier, "state", state.Task.Running, "error", err)
+			c.logger.Error("failed to update task state", append(task.LogAttrs(), "error", err)...)
 		}
 	}
 }
@@ -236,7 +236,7 @@ func (c *LocalClient) runWithRecovery(ctx context.Context, apply *storage.Apply,
 	defer func() {
 		if r := recover(); r != nil {
 			errMsg := fmt.Sprintf("panic in apply goroutine: %v", r)
-			c.logger.Error(errMsg, "apply_id", apply.ApplyIdentifier)
+			c.logger.Error(errMsg, apply.LogAttrs()...)
 			c.failApplyWithTasks(ctx, apply, tasks, errMsg)
 		}
 	}()

--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -157,7 +157,7 @@ func (c *LocalClient) logApplyEvent(ctx context.Context, applyID int64, taskID *
 		CreatedAt: time.Now(),
 	}
 	if err := c.storage.ApplyLogs().Append(ctx, log); err != nil {
-		c.logger.Warn("failed to log apply event", "apply_id", applyID, "error", err, "event", eventType, "message", message)
+		c.logger.Warn("failed to log apply event", "error", err, "event", eventType, "message", message)
 	}
 }
 

--- a/pkg/tern/local_apply_failure.go
+++ b/pkg/tern/local_apply_failure.go
@@ -39,7 +39,7 @@ func (c *LocalClient) failApplyWithTasks(ctx context.Context, apply *storage.App
 	apply.CompletedAt = &now
 	apply.UpdatedAt = now
 	if err := c.storage.Applies().Update(ctx, apply); err != nil {
-		c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Failed, "error", err)
+		c.logger.Error("failed to update apply state", append(apply.LogAttrs(), "error", err)...)
 	}
 	metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Deployment, apply.Environment)
 }
@@ -73,7 +73,7 @@ func (c *LocalClient) markApplyRetryableWithTasks(ctx context.Context, apply *st
 	apply.CompletedAt = nil
 	apply.UpdatedAt = time.Now()
 	if err := c.storage.Applies().Update(ctx, apply); err != nil {
-		c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.FailedRetryable, "error", err)
+		c.logger.Error("failed to update apply state", append(apply.LogAttrs(), "error", err)...)
 	}
 	metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Deployment, apply.Environment)
 	if obs := c.getObserver(apply.ID); obs != nil {

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -853,7 +853,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 	}
 	if freshApply == nil {
 		c.logger.Warn("apply row missing before progress state update; yielding",
-			append(apply.LogAttrs(), "apply_db_id", apply.ID)...)
+			apply.LogAttrs()...)
 		return true
 	}
 	if state.IsTerminalApplyState(freshApply.State) {

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -74,11 +74,11 @@ func (c *LocalClient) executeGroupedApply(ctx context.Context, apply *storage.Ap
 	apply.StartedAt = &now
 	apply.UpdatedAt = now
 	if err := c.storage.Applies().Update(ctx, apply); err != nil {
-		c.logger.Error("failed to set started_at", "apply_id", apply.ApplyIdentifier, "error", err)
+		c.logger.Error("failed to set started_at", append(apply.LogAttrs(), "error", err)...)
 	}
 	if handled, err := c.processPendingStopControlRequest(ctx, apply); err != nil {
 		c.logger.Warn("pending stop request processing failed before grouped engine apply; current apply owner will exit for operator retry",
-			"apply_id", apply.ApplyIdentifier, "error", err)
+			append(apply.LogAttrs(), "error", err)...)
 		return
 	} else if handled {
 		return
@@ -110,7 +110,7 @@ func (c *LocalClient) executeGroupedApply(ctx context.Context, apply *storage.Ap
 				return
 			}
 			if saveErr := c.saveEngineResumeState(ctx, apply, tasks, rs); saveErr != nil {
-				c.logger.Warn("OnStateChange: failed to persist opaque resume state", "apply_id", apply.ApplyIdentifier, "error", saveErr)
+				c.logger.Warn("OnStateChange: failed to persist opaque resume state", append(apply.LogAttrs(), "error", saveErr)...)
 			}
 		},
 	})
@@ -124,9 +124,9 @@ func (c *LocalClient) executeGroupedApply(ctx context.Context, apply *storage.Ap
 			c.failApplyWithTasks(ctx, apply, tasks, err.Error())
 		}
 		if newState == state.Apply.FailedRetryable {
-			c.logger.Warn("apply paused for operator retry", "mode", mode, "error", err, "apply_id", apply.ApplyIdentifier)
+			c.logger.Warn("apply paused for operator retry", append(apply.LogAttrs(), "mode", mode, "error", err)...)
 		} else {
-			c.logger.Error("apply failed", "mode", mode, "error", err, "apply_id", apply.ApplyIdentifier)
+			c.logger.Error("apply failed", append(apply.LogAttrs(), "mode", mode, "error", err)...)
 		}
 		logLevel := storage.LogLevelError
 		if newState == state.Apply.FailedRetryable {
@@ -160,7 +160,7 @@ func (c *LocalClient) executeGroupedApply(ctx context.Context, apply *storage.Ap
 		resumeState = result.ResumeState
 		if c.config.Type == storage.DatabaseTypeVitess {
 			if saveErr := c.saveEngineResumeState(ctx, apply, tasks, resumeState); saveErr != nil {
-				c.logger.Error("failed to save opaque engine resume state", "apply_id", apply.ApplyIdentifier, "error", saveErr)
+				c.logger.Error("failed to save opaque engine resume state", append(apply.LogAttrs(), "error", saveErr)...)
 				c.failApplyWithTasks(ctx, apply, tasks, fmt.Sprintf("failed to save engine resume state: %v", saveErr))
 				return
 			}
@@ -186,7 +186,7 @@ func (c *LocalClient) executeGroupedApply(ctx context.Context, apply *storage.Ap
 	}
 	apply.UpdatedAt = time.Now()
 	if err := c.storage.Applies().Update(ctx, apply); err != nil {
-		c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Running, "error", err)
+		c.logger.Error("failed to update apply state", append(apply.LogAttrs(), "error", err)...)
 	}
 	c.logger.Info("apply started", "mode", mode, "apply_id", apply.ApplyIdentifier, "task_count", len(tasks))
 	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
@@ -643,13 +643,13 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		var permanent *engine.PermanentError
 		if errors.As(err, &permanent) {
 			c.logger.Error("progress check failed with permanent error",
-				"error", err, "apply_id", apply.ApplyIdentifier)
+				append(apply.LogAttrs(), "error", err)...)
 			c.failApplyWithTasks(ctx, apply, tasks, fmt.Sprintf("progress polling failed: %v", err))
 			return true
 		}
 		ps.consecutiveErrors++
 		c.logger.Warn("progress check failed",
-			"error", err, "apply_id", apply.ApplyIdentifier, "consecutive_errors", ps.consecutiveErrors)
+			append(apply.LogAttrs(), "error", err, "consecutive_errors", ps.consecutiveErrors)...)
 		if ps.consecutiveErrors >= 10 {
 			if c.shouldRetryEngineError(err) {
 				c.logger.Warn("progress polling failed repeatedly, pausing apply for operator retry",
@@ -673,7 +673,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		if c.config.Type == storage.DatabaseTypeVitess {
 			if saveErr := c.saveEngineResumeState(ctx, apply, tasks, resumeState); saveErr != nil {
 				c.logger.Error("failed to save Vitess engine resume state from progress polling",
-					"apply_id", apply.ApplyIdentifier, "error", saveErr)
+					append(apply.LogAttrs(), "error", saveErr)...)
 				c.markApplyRetryableWithTasks(ctx, apply, tasks, fmt.Sprintf("failed to save engine resume state from progress polling: %v", saveErr))
 				return true
 			}
@@ -726,7 +726,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventDeployTriggered, storage.LogSourceSchemaBot,
 			"Auto-triggering deploy (defer_deploy not set)", "", "")
 		if _, err := eng.Start(ctx, controlReq); err != nil {
-			c.logger.Error("auto-deploy failed", "error", err, "apply_id", apply.ApplyIdentifier)
+			c.logger.Error("auto-deploy failed", append(apply.LogAttrs(), "error", err)...)
 		}
 	}
 
@@ -736,7 +736,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventCutoverTriggered, storage.LogSourceSchemaBot,
 			"Auto-triggering cutover (defer_cutover not set)", "", "")
 		if _, err := eng.Cutover(ctx, controlReq); err != nil {
-			c.logger.Error("auto-cutover failed", "error", err, "apply_id", apply.ApplyIdentifier)
+			c.logger.Error("auto-cutover failed", append(apply.LogAttrs(), "error", err)...)
 		}
 	}
 
@@ -848,12 +848,12 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 	apply.UpdatedAt = now
 	freshApply, err := c.storage.Applies().Get(ctx, apply.ID)
 	if err != nil {
-		c.logger.Error("failed to reload apply before progress state update", "apply_id", apply.ApplyIdentifier, "error", err)
+		c.logger.Error("failed to reload apply before progress state update", append(apply.LogAttrs(), "error", err)...)
 		return true
 	}
 	if freshApply == nil {
 		c.logger.Warn("apply row missing before progress state update; yielding",
-			"apply_id", apply.ApplyIdentifier, "apply_db_id", apply.ID)
+			append(apply.LogAttrs(), "apply_db_id", apply.ID)...)
 		return true
 	}
 	if state.IsTerminalApplyState(freshApply.State) {
@@ -1189,7 +1189,7 @@ func (c *LocalClient) writeShardProgress(ctx context.Context, table *storage.Tas
 		}
 		c.logger.Error("operator: failed to persist shard progress",
 			"apply_id", table.ApplyID, "apply_operation_id", operationID,
-			"database", table.Database, "environment", table.Environment,
+			"database", table.Database, "database_type", table.DatabaseType, "environment", table.Environment,
 			"namespace", table.Namespace, "table", table.TableName, "shard", sh.Shard,
 			"error", err)
 	}

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -146,7 +146,7 @@ func (c *LocalClient) executeGroupedApply(ctx context.Context, apply *storage.Ap
 
 	if isTasklessVSchemaOnlyPlan(tasks, plan) {
 		if completeErr := c.completeTasklessGroupedApply(ctx, apply, result.Message); completeErr != nil {
-			c.logger.Error("failed to complete task-less grouped apply", "apply_id", apply.ApplyIdentifier, "error", completeErr)
+			c.logger.Error("failed to complete task-less grouped apply", append(apply.LogAttrs(), "error", completeErr)...)
 		}
 		return
 	}
@@ -748,7 +748,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelWarn, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
 			fmt.Sprintf("Waiting for deploy timed out after %s, cancelling", waitingForManualActionTimeout), "", "")
 		if _, err := eng.Stop(ctx, controlReq); err != nil {
-			c.logger.Error("timeout stop failed", "error", err, "apply_id", apply.ApplyIdentifier)
+			c.logger.Error("timeout stop failed", append(apply.LogAttrs(), "error", err)...)
 		}
 	}
 
@@ -763,7 +763,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelWarn, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
 			fmt.Sprintf("Waiting for cutover timed out after %s, cancelling", waitingForManualActionTimeout), "", "")
 		if _, err := eng.Stop(ctx, controlReq); err != nil {
-			c.logger.Error("timeout stop failed", "error", err, "apply_id", apply.ApplyIdentifier)
+			c.logger.Error("timeout stop failed", append(apply.LogAttrs(), "error", err)...)
 		}
 	}
 
@@ -776,7 +776,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 			"Auto-skipping revert window (--skip-revert)", "", "")
 		_, err := eng.SkipRevert(ctx, controlReq)
 		if err != nil {
-			c.logger.Error("auto-skip revert failed", "error", err, "apply_id", apply.ApplyIdentifier)
+			c.logger.Error("auto-skip revert failed", append(apply.LogAttrs(), "error", err)...)
 		} else {
 			c.logger.Info("skip-revert triggered", "apply_id", apply.ApplyIdentifier, "reason", "--skip-revert")
 			c.markRevertSkipped(ctx, apply)
@@ -795,7 +795,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 			c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
 				"Revert window expired, finalizing", "", "")
 			if _, err := eng.SkipRevert(ctx, controlReq); err != nil {
-				c.logger.Error("revert window timeout skip failed", "error", err, "apply_id", apply.ApplyIdentifier)
+				c.logger.Error("revert window timeout skip failed", append(apply.LogAttrs(), "error", err)...)
 			} else {
 				c.markRevertSkipped(ctx, apply)
 				c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventSkipRevertTriggered, storage.LogSourceSchemaBot,
@@ -901,7 +901,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		ensureApplyFailureMessage(apply, tasks)
 		swapped, err := c.storage.Applies().UpdateDerivedState(ctx, apply.ID, expectedState, apply.State, apply.ErrorMessage, apply.StartedAt, apply.CompletedAt)
 		if err != nil {
-			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", apply.State, "error", err)
+			c.logger.Error("failed to update apply state", append(apply.LogAttrs(), "error", err)...)
 		} else if !swapped {
 			// Another drive advanced the apply between our reload and write; it
 			// owns the terminal transition and its side-effects. Skip ours.
@@ -950,7 +950,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 
 	swapped, err := c.storage.Applies().UpdateDerivedState(ctx, apply.ID, expectedState, apply.State, apply.ErrorMessage, apply.StartedAt, apply.CompletedAt)
 	if err != nil {
-		c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", apply.State, "error", err)
+		c.logger.Error("failed to update apply state", append(apply.LogAttrs(), "error", err)...)
 	} else if !swapped {
 		// Another drive advanced the apply between our reload and write; our
 		// progress projection is stale. Skip the observer update and let the next
@@ -1001,7 +1001,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 // finalization is in progress.
 func (c *LocalClient) markRevertSkipped(ctx context.Context, apply *storage.Apply) {
 	if err := c.storage.Applies().SetRevertSkipped(ctx, apply.ID, time.Now()); err != nil {
-		c.logger.Warn("failed to record skip-revert on apply", "apply_id", apply.ApplyIdentifier, "error", err)
+		c.logger.Warn("failed to record skip-revert on apply", append(apply.LogAttrs(), "error", err)...)
 	}
 }
 

--- a/pkg/tern/local_apply_sequential.go
+++ b/pkg/tern/local_apply_sequential.go
@@ -34,7 +34,7 @@ func (c *LocalClient) executeApplySequential(ctx context.Context, apply *storage
 	apply.StartedAt = &now
 	apply.UpdatedAt = now
 	if err := c.storage.Applies().Update(ctx, apply); err != nil {
-		c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Running, "error", err)
+		c.logger.Error("failed to update apply state", append(apply.LogAttrs(), "error", err)...)
 	}
 
 	var failedTask *storage.Task
@@ -117,11 +117,11 @@ func (c *LocalClient) checkTaskReady(ctx context.Context, task *storage.Task) ta
 	}
 	freshTask, err := c.storage.Tasks().Get(ctx, task.TaskIdentifier)
 	if err != nil {
-		c.logger.Error("failed to fetch task state", "task_id", task.TaskIdentifier, "error", err)
+		c.logger.Error("failed to fetch task state", append(task.LogAttrs(), "error", err)...)
 		return taskSkip
 	}
 	if freshTask == nil {
-		c.logger.Error("task not found", "task_id", task.TaskIdentifier)
+		c.logger.Error("task not found", task.LogAttrs()...)
 		return taskSkip
 	}
 	if freshTask.State == state.Task.Stopped {
@@ -181,7 +181,7 @@ func (c *LocalClient) runEngineTask(ctx context.Context, apply *storage.Apply, t
 		taskCreds, err = c.credentialsForMySQLNamespace(task.Namespace)
 		if err != nil {
 			c.markTaskFailed(ctx, task, err.Error())
-			c.logger.Error("task failed to resolve namespace credentials", "error", err, "task_id", task.TaskIdentifier, "namespace", task.Namespace, "table", task.TableName)
+			c.logger.Error("task failed to resolve namespace credentials", append(task.LogAttrs(), "namespace", task.Namespace, "error", err)...)
 			return taskFailed
 		}
 	}
@@ -197,12 +197,12 @@ func (c *LocalClient) runEngineTask(ctx context.Context, apply *storage.Apply, t
 		} else {
 			c.markTaskFailed(ctx, task, err.Error())
 		}
-		c.logger.Error("task failed", "error", err, "task_id", task.TaskIdentifier, "table", task.TableName)
+		c.logger.Error("task failed", append(task.LogAttrs(), "error", err)...)
 		return taskFailed
 	}
 	if !result.Accepted {
 		c.markTaskFailed(ctx, task, result.Message)
-		c.logger.Error("task rejected", "message", result.Message, "task_id", task.TaskIdentifier, "table", task.TableName)
+		c.logger.Error("task rejected", append(task.LogAttrs(), "message", result.Message)...)
 		return taskFailed
 	}
 
@@ -348,7 +348,7 @@ func (c *LocalClient) pollTaskToCompletion(ctx context.Context, apply *storage.A
 				// grouped poll.
 				var permanent *engine.PermanentError
 				if errors.As(err, &permanent) {
-					c.logger.Error("progress check failed with permanent error", "error", err, "task_id", task.TaskIdentifier)
+					c.logger.Error("progress check failed with permanent error", append(task.LogAttrs(), "error", err)...)
 					c.markTaskFailed(ctx, task, fmt.Sprintf("progress polling failed: %v", err))
 					return taskFailed
 				}
@@ -357,7 +357,7 @@ func (c *LocalClient) pollTaskToCompletion(ctx context.Context, apply *storage.A
 				// database's active-apply slot and blocks every later apply. Fail
 				// after a bounded run of errors, matching the grouped poll.
 				consecutiveErrors++
-				c.logger.Warn("progress check failed", "error", err, "task_id", task.TaskIdentifier, "consecutive_errors", consecutiveErrors)
+				c.logger.Warn("progress check failed", append(task.LogAttrs(), "error", err, "consecutive_errors", consecutiveErrors)...)
 				if consecutiveErrors >= 10 {
 					if c.shouldRetryEngineError(err) {
 						c.markTaskRetryable(ctx, task, fmt.Sprintf("progress polling failed after %d consecutive errors: %v", consecutiveErrors, err))
@@ -464,7 +464,7 @@ func (c *LocalClient) shouldRetryEngineError(err error) bool {
 func (c *LocalClient) finalizeSequentialApply(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, failedTask *storage.Task, stoppedByUser bool) {
 	now := time.Now()
 	if freshApply, err := c.storage.Applies().Get(ctx, apply.ID); err != nil {
-		c.logger.Error("failed to reload apply before sequential finalization", "apply_id", apply.ApplyIdentifier, "error", err)
+		c.logger.Error("failed to reload apply before sequential finalization", append(apply.LogAttrs(), "error", err)...)
 		return
 	} else if freshApply != nil && state.IsTerminalApplyState(freshApply.State) {
 		c.logger.Info("apply already terminal in storage, not overwriting during sequential finalization",

--- a/pkg/tern/local_apply_sequential.go
+++ b/pkg/tern/local_apply_sequential.go
@@ -277,10 +277,7 @@ func (c *LocalClient) startApplyHeartbeat(ctx context.Context, apply *storage.Ap
 				if err := c.storage.Applies().Heartbeat(hbCtx, apply.ID); err != nil {
 					if errors.Is(err, storage.ErrApplyLeaseLost) {
 						c.logger.Warn("heartbeat failed because apply lease was lost; local driver will stop executing and writing apply state",
-							"apply_id", apply.ApplyIdentifier,
-							"database", apply.Database,
-							"environment", apply.Environment,
-							"error", err)
+							append(apply.LogAttrs(), "error", err)...)
 						metrics.RecordOperatorResumeFailure(hbCtx, apply.Database, apply.Deployment, apply.Environment, "lease_lost")
 						for _, cancel := range cancelApply {
 							if cancel != nil {
@@ -290,7 +287,7 @@ func (c *LocalClient) startApplyHeartbeat(ctx context.Context, apply *storage.Ap
 						cancel()
 						return
 					}
-					c.logger.Warn("heartbeat failed", "apply_id", apply.ApplyIdentifier, "error", err)
+					c.logger.Warn("heartbeat failed", append(apply.LogAttrs(), "error", err)...)
 				}
 			}
 		}
@@ -499,12 +496,12 @@ func (c *LocalClient) finalizeSequentialApply(ctx context.Context, apply *storag
 	}
 	apply.UpdatedAt = now
 	if err := c.storage.Applies().Update(ctx, apply); err != nil {
-		c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", apply.State, "error", err)
+		c.logger.Error("failed to update apply state", append(apply.LogAttrs(), "error", err)...)
 	}
 	if state.IsTerminalApplyState(apply.State) {
 		if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStop); err != nil {
 			c.logger.Warn("failed to complete pending stop request after sequential finalization",
-				"apply_id", apply.ApplyIdentifier, "error", err)
+				append(apply.LogAttrs(), "error", err)...)
 			return
 		}
 	}

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -673,12 +673,12 @@ func (c *LocalClient) resolveRevertWindowApplyIdentifier(ctx context.Context, re
 	apply, err := c.storage.Applies().Get(ctx, revertTask.ApplyID)
 	if err != nil {
 		c.logger.Warn("could not load apply to resolve revert-window stop identifier; using task identifier",
-			"apply_db_id", revertTask.ApplyID, "task_id", revertTask.TaskIdentifier, "error", err)
+			"task_id", revertTask.TaskIdentifier, "error", err)
 		return revertTask.TaskIdentifier
 	}
 	if apply == nil {
 		c.logger.Warn("apply not found while resolving revert-window stop identifier; using task identifier",
-			"apply_db_id", revertTask.ApplyID, "task_id", revertTask.TaskIdentifier)
+			"task_id", revertTask.TaskIdentifier)
 		return revertTask.TaskIdentifier
 	}
 	return apply.ApplyIdentifier

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -663,7 +663,7 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 				return
 			}
 			if saveErr := c.saveEngineResumeState(ctx, apply, tasks, rs); saveErr != nil {
-				c.logger.Warn("OnStateChange: failed to persist opaque resume state", "apply_id", apply.ApplyIdentifier, "error", saveErr)
+				c.logger.Warn("OnStateChange: failed to persist opaque resume state", append(apply.LogAttrs(), "error", saveErr)...)
 			}
 		},
 	})
@@ -716,7 +716,7 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 	// drive. Tasks are already running/recovering above.
 	if !suppressParent {
 		if err := c.storage.Applies().Update(ctx, apply); err != nil {
-			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", apply.State, "error", err)
+			c.logger.Error("failed to update apply state", append(apply.LogAttrs(), "error", err)...)
 			return fmt.Errorf("mark grouped resume apply %s %s: %w", apply.ApplyIdentifier, apply.State, err)
 		}
 		if startRequested {
@@ -1370,7 +1370,7 @@ func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.A
 		apply.CompletedAt = &now
 		apply.UpdatedAt = now
 		if err := c.storage.Applies().Update(ctx, apply); err != nil {
-			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Completed, "error", err)
+			c.logger.Error("failed to update apply state", append(apply.LogAttrs(), "error", err)...)
 		}
 		if startRequested {
 			if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStart); err != nil {
@@ -1406,7 +1406,7 @@ func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.A
 		apply.State = state.Apply.Running
 		apply.UpdatedAt = now
 		if err := c.storage.Applies().Update(ctx, apply); err != nil {
-			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Running, "error", err)
+			c.logger.Error("failed to update apply state", append(apply.LogAttrs(), "error", err)...)
 			return fmt.Errorf("mark sequential resume apply %s running: %w", apply.ApplyIdentifier, err)
 		}
 		if startRequested {

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -619,7 +619,7 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 			return nil
 		}
 		if err := c.storage.Applies().Update(ctx, apply); err != nil {
-			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Completed, "error", err)
+			c.logger.Error("failed to update apply state", append(apply.LogAttrs(), "error", err)...)
 			return fmt.Errorf("mark grouped resume apply %s completed after final schema check: %w", apply.ApplyIdentifier, err)
 		}
 		if startRequested {
@@ -638,6 +638,8 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 
 	resumeState, err := c.groupedResumeState(ctx, apply, tasks)
 	if err != nil {
+		c.logger.Error("failed to resolve engine resume state for grouped resume; current apply owner will exit for operator retry",
+			append(apply.LogAttrs(), "error", err)...)
 		return err
 	}
 
@@ -1233,7 +1235,7 @@ func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.A
 		apply.State = state.Apply.Failed
 		apply.ErrorMessage = "plan not found during recovery"
 		if err := c.storage.Applies().Update(ctx, apply); err != nil {
-			c.logger.Error("failed to update apply state", "apply_id", apply.ApplyIdentifier, "state", state.Apply.Failed, "error", err)
+			c.logger.Error("failed to update apply state", append(apply.LogAttrs(), "error", err)...)
 		}
 		c.notifyTerminalObserver(apply, tasks)
 		return nil
@@ -1336,8 +1338,8 @@ func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.A
 
 	rp, err := c.replanAndFilterTasks(ctx, apply, tasks, plan)
 	if err != nil {
-		c.logger.Error("re-plan failed during recovery", "apply_id", apply.ApplyIdentifier, "error", err)
-		return fmt.Errorf("re-plan failed during recovery: %w", err)
+		c.logger.Error("re-plan failed during recovery", append(apply.LogAttrs(), "error", err)...)
+		return fmt.Errorf("re-plan failed during recovery for apply %s (database %s): %w", apply.ApplyIdentifier, apply.Database, err)
 	}
 
 	activeTasks := rp.ActiveTasks

--- a/pkg/tern/target_router.go
+++ b/pkg/tern/target_router.go
@@ -363,7 +363,7 @@ func (r *TargetRouter) SetObserver(applyID int64, observer ProgressObserver) {
 	}
 	client, err := r.clientForStoredApply(context.Background(), apply)
 	if err != nil {
-		r.logger.Warn("target router: failed to resolve apply target for observer attachment", "apply_id", applyID, "apply_identifier", apply.ApplyIdentifier, "error", err)
+		r.logger.Warn("target router: failed to resolve apply target for observer attachment", append(apply.LogAttrs(), "error", err)...)
 		return
 	}
 	client.SetObserver(applyID, observer)

--- a/pkg/webhook/apply_check_records.go
+++ b/pkg/webhook/apply_check_records.go
@@ -101,13 +101,15 @@ func (h *Handler) updateCheckRecordForApplyStart(ctx context.Context, client *gh
 func (h *Handler) updateCheckRunAfterUnlock(ctx context.Context, repo string, pr int, lock *storage.Lock, installationID int64) {
 	client, err := h.clientForRepo(repo, installationID)
 	if err != nil {
-		h.logger.Error("failed to create GitHub client for check run update", "error", err)
+		h.logger.Error("failed to create GitHub client for check run update",
+			"repo", repo, "pr", pr, "database", lock.DatabaseName, "database_type", lock.DatabaseType, "error", err)
 		return
 	}
 
 	prInfo, err := client.FetchPullRequest(ctx, repo, pr)
 	if err != nil {
-		h.logger.Error("failed to fetch PR for check run update", "error", err)
+		h.logger.Error("failed to fetch PR for check run update",
+			"repo", repo, "pr", pr, "database", lock.DatabaseName, "database_type", lock.DatabaseType, "error", err)
 		return
 	}
 
@@ -124,6 +126,7 @@ func (h *Handler) updateCheckRunAfterUnlock(ctx context.Context, repo string, pr
 	}
 
 	if _, err := client.CreateCheckRun(ctx, repo, prInfo.HeadSHA, opts); err != nil {
-		h.logger.Error("failed to update check run after unlock", "error", err)
+		h.logger.Error("failed to update check run after unlock",
+			"repo", repo, "pr", pr, "database", lock.DatabaseName, "database_type", lock.DatabaseType, "head_sha", prInfo.HeadSHA, "error", err)
 	}
 }

--- a/pkg/webhook/apply_execute.go
+++ b/pkg/webhook/apply_execute.go
@@ -134,7 +134,7 @@ func (h *Handler) executeApply(
 			updated, err := h.updateCheckRecordForApplyResult(context.Background(), repo, pr, apply)
 			if err != nil {
 				h.logger.Error("observer: failed to update check record",
-					append(apply.LogAttrs(), "repo", repo, "pr", pr, "error", err)...)
+					append(apply.LogAttrs(), "error", err)...)
 				return
 			}
 			if !updated {
@@ -145,7 +145,7 @@ func (h *Handler) executeApply(
 			ghInstClient, err := factory.ForInstallation(installationID)
 			if err != nil {
 				h.logger.Error("observer: failed to create GitHub client",
-					append(apply.LogAttrs(), "repo", repo, "pr", pr,
+					append(apply.LogAttrs(),
 						"installation_id", installationID, "error", err)...)
 				return
 			}

--- a/pkg/webhook/apply_execute.go
+++ b/pkg/webhook/apply_execute.go
@@ -134,7 +134,7 @@ func (h *Handler) executeApply(
 			updated, err := h.updateCheckRecordForApplyResult(context.Background(), repo, pr, apply)
 			if err != nil {
 				h.logger.Error("observer: failed to update check record",
-					append(apply.LogAttrs(), "repo", repo, "pr", pr, "apply_db_id", apply.ID, "error", err)...)
+					append(apply.LogAttrs(), "repo", repo, "pr", pr, "error", err)...)
 				return
 			}
 			if !updated {
@@ -145,7 +145,7 @@ func (h *Handler) executeApply(
 			ghInstClient, err := factory.ForInstallation(installationID)
 			if err != nil {
 				h.logger.Error("observer: failed to create GitHub client",
-					append(apply.LogAttrs(), "repo", repo, "pr", pr, "apply_db_id", apply.ID,
+					append(apply.LogAttrs(), "repo", repo, "pr", pr,
 						"installation_id", installationID, "error", err)...)
 				return
 			}
@@ -200,7 +200,7 @@ func (h *Handler) executeApply(
 		h.logger.Error("accepted apply did not return an apply id",
 			"repo", repo, "pr", pr, "database", database,
 			"database_type", schemaResult.Type, "environment", environment,
-			"apply_db_id", applyID, "apply_id", applyResp.ApplyID)
+			"apply_id", applyResp.ApplyID)
 		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Apply was accepted, but SchemaBot did not receive a stored apply ID. SchemaBot cannot safely track progress or update required status checks. An operator must reconcile the apply state before retrying.")
 		return
 	}

--- a/pkg/webhook/apply_execute.go
+++ b/pkg/webhook/apply_execute.go
@@ -45,7 +45,7 @@ func (h *Handler) executeApply(
 
 	planResp, err := h.executePlanWithTransientRetry(ctx, planReq, repo, pr)
 	if err != nil {
-		h.logger.Error("plan execution failed on confirm", "repo", repo, "pr", pr, "error", err)
+		h.logger.Error("plan execution failed on confirm", "repo", repo, "pr", pr, "database", database, "database_type", dbType, "environment", environment, "error", err)
 		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, err.Error())
 		return
 	}
@@ -115,7 +115,7 @@ func (h *Handler) executeApply(
 	factory, factoryErr := h.factoryForRepo(repo)
 	if factoryErr != nil {
 		h.logger.Error("apply blocked: cannot resolve GitHub App client for repo",
-			"repo", repo, "pr", pr, "database", database, "environment", environment, "error", factoryErr)
+			"repo", repo, "pr", pr, "database", database, "database_type", dbType, "environment", environment, "error", factoryErr)
 		return
 	}
 
@@ -134,8 +134,7 @@ func (h *Handler) executeApply(
 			updated, err := h.updateCheckRecordForApplyResult(context.Background(), repo, pr, apply)
 			if err != nil {
 				h.logger.Error("observer: failed to update check record",
-					"repo", repo, "pr", pr, "database", apply.Database,
-					"environment", apply.Environment, "apply_id", apply.ID, "error", err)
+					append(apply.LogAttrs(), "repo", repo, "pr", pr, "apply_db_id", apply.ID, "error", err)...)
 				return
 			}
 			if !updated {
@@ -146,8 +145,8 @@ func (h *Handler) executeApply(
 			ghInstClient, err := factory.ForInstallation(installationID)
 			if err != nil {
 				h.logger.Error("observer: failed to create GitHub client",
-					"repo", repo, "pr", pr, "apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,
-					"installation_id", installationID, "error", err)
+					append(apply.LogAttrs(), "repo", repo, "pr", pr, "apply_db_id", apply.ID,
+						"installation_id", installationID, "error", err)...)
 				return
 			}
 			checkRecord, err := h.service.Storage().Checks().Get(context.Background(), repo, pr, apply.Environment, apply.DatabaseType, apply.Database)
@@ -182,7 +181,7 @@ func (h *Handler) executeApply(
 	applyResp, applyID, err := h.service.ExecuteApply(ctx, applyReq)
 	if err != nil {
 		h.service.SetPendingObserver(database, "", environment, nil)
-		h.logger.Error("apply execution failed", "repo", repo, "pr", pr, "error", err)
+		h.logger.Error("apply execution failed", "repo", repo, "pr", pr, "database", database, "database_type", dbType, "environment", environment, "error", err)
 		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Failed to execute apply: "+err.Error())
 		return
 	}
@@ -200,7 +199,8 @@ func (h *Handler) executeApply(
 		h.service.SetPendingObserver(database, "", environment, nil)
 		h.logger.Error("accepted apply did not return an apply id",
 			"repo", repo, "pr", pr, "database", database,
-			"database_type", schemaResult.Type, "environment", environment)
+			"database_type", schemaResult.Type, "environment", environment,
+			"apply_db_id", applyID, "apply_id", applyResp.ApplyID)
 		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Apply was accepted, but SchemaBot did not receive a stored apply ID. SchemaBot cannot safely track progress or update required status checks. An operator must reconcile the apply state before retrying.")
 		return
 	}

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -21,7 +21,7 @@ import (
 func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseName string, installationID int64, requestedBy string, result CommandResult) {
 	ctx, cancel, client, err := h.commandBootstrap(repo, installationID)
 	if err != nil {
-		h.logger.Error("apply: failed to bootstrap command", "error", err)
+		h.logger.Error("apply: failed to bootstrap command", "repo", repo, "pr", pr, "database", databaseName, "environment", environment, "error", err)
 		return
 	}
 	defer cancel()
@@ -66,7 +66,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	// Tier 2: PR checks gate — block if non-SchemaBot checks are not passing
 	prInfo, err := client.FetchPullRequest(ctx, repo, pr)
 	if err != nil {
-		h.logger.Error("failed to fetch PR for checks gate", "error", err)
+		h.logger.Error("failed to fetch PR for checks gate", "repo", repo, "pr", pr, "database", schemaResult.Database, "database_type", schemaResult.Type, "environment", environment, "error", err)
 		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Failed to fetch PR info: "+err.Error())
 		return
 	}
@@ -87,7 +87,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	// Check for existing lock
 	existingLock, err := h.service.Storage().Locks().Get(ctx, database, dbType)
 	if err != nil {
-		h.logger.Error("failed to check lock", "error", err)
+		h.logger.Error("failed to check lock", "repo", repo, "pr", pr, "database", database, "database_type", dbType, "environment", environment, "error", err)
 		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Failed to check lock status: "+err.Error())
 		return
 	}
@@ -136,7 +136,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		relErr := h.service.Storage().Locks().Release(ctx, database, dbType, lockOwner)
 		if relErr != nil && !errors.Is(relErr, storage.ErrLockNotFound) && !errors.Is(relErr, storage.ErrLockNotOwned) {
 			h.logger.Error("failed to release stale lock",
-				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
+				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "environment", environment, "error", relErr)
 		}
 	}
 
@@ -214,7 +214,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	prInfo, prErr := client.FetchPullRequestNoCache(ctx, repo, pr)
 	if prErr != nil {
 		h.logger.Error("failed to fetch PR for stale-schema check, releasing lock",
-			"repo", repo, "pr", pr, "database", database, "error", prErr)
+			"repo", repo, "pr", pr, "database", database, "database_type", dbType, "environment", environment, "error", prErr)
 		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Failed to verify PR HEAD before apply: "+prErr.Error())
 		relErr := h.service.Storage().Locks().Release(ctx, database, dbType, lockOwner)
 		if relErr != nil && !errors.Is(relErr, storage.ErrLockNotFound) && !errors.Is(relErr, storage.ErrLockNotOwned) {
@@ -337,7 +337,7 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 	// against a stale HeadSHA if a new commit landed during this delivery.
 	confirmPRInfo, err := client.FetchPullRequestNoCache(ctx, repo, pr)
 	if err != nil {
-		h.logger.Error("failed to fetch PR for checks gate", "error", err)
+		h.logger.Error("failed to fetch PR for checks gate", "repo", repo, "pr", pr, "database", schemaResult.Database, "database_type", schemaResult.Type, "environment", environment, "error", err)
 		h.postCommandError(repo, pr, installationID, action.ApplyConfirm, environment, requestedBy, "Failed to fetch PR info: "+err.Error())
 		return
 	}
@@ -373,7 +373,7 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 	// Check lock ownership
 	existingLock, err := h.service.Storage().Locks().Get(ctx, database, dbType)
 	if err != nil {
-		h.logger.Error("failed to check lock", "error", err)
+		h.logger.Error("failed to check lock", "repo", repo, "pr", pr, "database", database, "database_type", dbType, "environment", environment, "error", err)
 		h.postCommandError(repo, pr, installationID, action.ApplyConfirm, environment, requestedBy, "Failed to check lock status: "+err.Error())
 		return
 	}

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -347,7 +347,7 @@ func (h *Handler) ReconcileMissingSummaryComments(ctx context.Context) {
 	for _, apply := range applies {
 		tasks, err := h.service.Storage().Tasks().GetByApplyID(ctx, apply.ID)
 		if err != nil {
-			h.logger.Error("failed to load tasks for missing summary reconciliation", "apply_id", apply.ApplyIdentifier, "error", err)
+			h.logger.Error("failed to load tasks for missing summary reconciliation", append(apply.LogAttrs(), "error", err)...)
 			continue
 		}
 


### PR DESCRIPTION
Hardens incident-triage logging so a failed or stalled schema change can be triaged **from logs alone** — which apply/operation/task, on which database and environment, in what state, tied to its PR, who triggered it, and how to correlate to the data plane — without reaching the live system.

**What it does**
- Adds `LogAttrs()` helpers on `storage.Apply` / `ApplyOperation` / `Task` returning the canonical triage attributes, and routes the failure/stall-path `Error`/`Warn` logs across the operator driver, the data-plane apply/cutover/resume paths, the webhook apply path, and the progress/control handlers through them.
- **Apply** logs carry apply id, database, database type, environment, deployment, state, and — when set — repo, pr, external id, and caller. **Operation** logs carry operation id, deployment, kind, state, and the remote `external_id` / `external_operation_id`. **Task** logs carry task id, database, database type, environment, table, and state.
- Stops logging the internal numeric row id (confusable with the user-facing identifier and not a useful triage handle), and adds `operation_deployment` where an operation-scoped log would otherwise surface only the parent apply's deployment.
- Documents the convention in `AGENTS.md` so new apply/operation/task logs use the helpers.

No control flow or behavior changes — logging and error-context enrichment only.

---
*PR summary updated by Claude Code (Opus 4.8).*