### PR TITLE
feat(github): make skip-revert a durable, comment-driven control command

### DIFF
--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -1856,6 +1856,13 @@ func (s *Service) ExecuteSkipRevert(ctx context.Context, req apitypes.ControlReq
 // immediate skip. The returned HTTP status is meaningful only when err == nil;
 // error paths return a zero status and callers derive it from the error.
 func (s *Service) executeSkipRevertForApply(ctx context.Context, client tern.Client, apply *storage.Apply, ternApplyID, caller string) (*apitypes.ControlResponse, int, error) {
+	// Skip-revert closes a PlanetScale revert window; other engines hard-error
+	// it. Gate on the engine so a non-PlanetScale apply can never accumulate a
+	// permanently-pending skip-revert request.
+	if apply.Engine != storage.EnginePlanetScale {
+		metrics.RecordControlOperation(ctx, "skip_revert", apply.Database, apply.Deployment, apply.Environment, "rejected")
+		return nil, 0, controlConflictf("skip-revert is only supported for PlanetScale schema changes")
+	}
 	// Skip-revert is only meaningful while the apply is in its revert window.
 	if !state.IsState(apply.State, state.Apply.RevertWindow) {
 		metrics.RecordControlOperation(ctx, "skip_revert", apply.Database, apply.Deployment, apply.Environment, "rejected")
@@ -1870,15 +1877,24 @@ func (s *Service) executeSkipRevertForApply(ctx context.Context, client tern.Cli
 	// Record durable skip-revert intent before the engine call, so a
 	// comment-driven skip-revert survives the API process dying before the call
 	// lands, and so the apply owner (the data-plane operator for a remote apply,
-	// not the webhook pod) can drive it to completion. Idempotent if already pending.
-	if _, _, err := controlStore.RequestPending(ctx, &storage.ApplyControlRequest{
+	// not the webhook pod) can drive it to completion.
+	_, alreadyPending, err := controlStore.RequestPending(ctx, &storage.ApplyControlRequest{
 		ApplyID:     apply.ID,
 		Operation:   storage.ControlOperationSkipRevert,
 		Status:      storage.ControlRequestPending,
 		RequestedBy: caller,
-	}); err != nil {
+	})
+	if err != nil {
 		metrics.RecordControlOperation(ctx, "skip_revert", apply.Database, apply.Deployment, apply.Environment, "error")
 		return nil, 0, fmt.Errorf("record skip-revert control request for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if alreadyPending {
+		// A prior skip-revert request is already queued; do not re-drive the
+		// engine. The apply owner is completing the existing one.
+		metrics.RecordControlOperation(ctx, "skip_revert", apply.Database, apply.Deployment, apply.Environment, "success")
+		s.logControlOperationForApply(ctx, apply, caller, storage.LogEventSkipRevertTriggered, "Skip-revert requested by user while skip-revert request already pending")
+		s.wakeOperator(apply.ApplyIdentifier, apply.Database, apply.Environment)
+		return &apitypes.ControlResponse{Accepted: true, Status: apitypes.ControlStatusAlreadyRequested}, http.StatusAccepted, nil
 	}
 	s.logControlOperationForApply(ctx, apply, caller, storage.LogEventSkipRevertTriggered, "Skip-revert triggered by user")
 

--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -1828,36 +1828,93 @@ type SkipRevertRequest struct {
 // handleSkipRevert handles POST /api/skip-revert requests.
 func (s *Service) handleSkipRevert(w http.ResponseWriter, r *http.Request) {
 	var req SkipRevertRequest
-	client, apply, applyID, ok := s.decodeControlRequest(w, r, &req, &req.ApplyID, &req.Environment)
+	client, apply, ternApplyID, ok := s.decodeControlRequest(w, r, &req, &req.ApplyID, &req.Environment)
 	if !ok {
 		return
 	}
-
-	resp, err := client.SkipRevert(r.Context(), &ternv1.SkipRevertRequest{
-		ApplyId:     applyID,
-		Environment: apply.Environment,
-	})
+	resp, httpStatus, err := s.executeSkipRevertForApply(r.Context(), client, apply, ternApplyID, req.Caller)
 	if err != nil {
-		metrics.RecordControlOperation(r.Context(), "skip_revert", apply.Database, apply.Deployment, apply.Environment, "error")
 		s.writeControlError(w, "skip-revert", apply, err)
 		return
 	}
-	metrics.RecordControlOperation(r.Context(), "skip_revert", apply.Database, apply.Deployment, apply.Environment, controlStatus(resp.Accepted))
+	s.writeJSON(w, httpStatus, resp)
+}
 
-	// Record skip-revert on the apply for progress visibility.
-	if resp.Accepted && apply.Engine == storage.EnginePlanetScale {
-		if err := s.storage.Applies().SetRevertSkipped(r.Context(), apply.ID, time.Now()); err != nil {
-			s.logger.Error("failed to record skip-revert on apply", append(apply.LogAttrs(), "error", err)...)
-		}
+// ExecuteSkipRevert records durable skip-revert intent for an apply and attempts
+// an immediate skip. The apply owner completes it if the immediate attempt
+// cannot. It is the in-process entry the PR-comment command path reuses.
+func (s *Service) ExecuteSkipRevert(ctx context.Context, req apitypes.ControlRequest) (*apitypes.ControlResponse, error) {
+	client, apply, ternApplyID, err := s.controlTarget(ctx, "skip-revert", req.ApplyID, req.Environment)
+	if err != nil {
+		return nil, err
 	}
-	if resp.Accepted {
-		s.logControlOperation(r, apply.ApplyIdentifier, req.Caller, storage.LogEventSkipRevertTriggered, "Skip-revert triggered by user")
+	resp, _, err := s.executeSkipRevertForApply(ctx, client, apply, ternApplyID, req.Caller)
+	return resp, err
+}
+
+// executeSkipRevertForApply records durable skip-revert intent and attempts an
+// immediate skip. The returned HTTP status is meaningful only when err == nil;
+// error paths return a zero status and callers derive it from the error.
+func (s *Service) executeSkipRevertForApply(ctx context.Context, client tern.Client, apply *storage.Apply, ternApplyID, caller string) (*apitypes.ControlResponse, int, error) {
+	// Skip-revert is only meaningful while the apply is in its revert window.
+	if !state.IsState(apply.State, state.Apply.RevertWindow) {
+		metrics.RecordControlOperation(ctx, "skip_revert", apply.Database, apply.Deployment, apply.Environment, "rejected")
+		return nil, 0, controlConflictf("schema change is not in its revert window (current state: %s)", apply.State)
+	}
+	controlStore := s.storage.ControlRequests()
+	if controlStore == nil {
+		metrics.RecordControlOperation(ctx, "skip_revert", apply.Database, apply.Deployment, apply.Environment, "error")
+		return nil, 0, fmt.Errorf("control request store is not available")
 	}
 
-	s.writeJSON(w, http.StatusOK, &apitypes.ControlResponse{
-		Accepted:     resp.Accepted,
-		ErrorMessage: resp.ErrorMessage,
+	// Record durable skip-revert intent before the engine call, so a
+	// comment-driven skip-revert survives the API process dying before the call
+	// lands, and so the apply owner (the data-plane operator for a remote apply,
+	// not the webhook pod) can drive it to completion. Idempotent if already pending.
+	if _, _, err := controlStore.RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationSkipRevert,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: caller,
+	}); err != nil {
+		metrics.RecordControlOperation(ctx, "skip_revert", apply.Database, apply.Deployment, apply.Environment, "error")
+		return nil, 0, fmt.Errorf("record skip-revert control request for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	s.logControlOperationForApply(ctx, apply, caller, storage.LogEventSkipRevertTriggered, "Skip-revert triggered by user")
+
+	// Attempt the skip immediately. If it fails or this process dies, the durable
+	// request remains pending for the apply owner to retry.
+	resp, err := client.SkipRevert(ctx, &ternv1.SkipRevertRequest{
+		ApplyId:     ternApplyID,
+		Environment: apply.Environment,
 	})
+	if err != nil {
+		metrics.RecordControlOperation(ctx, "skip_revert", apply.Database, apply.Deployment, apply.Environment, "error")
+		s.logger.Warn("immediate skip-revert failed; durable request remains pending for apply owner retry",
+			append(apply.LogAttrs(), "error", err)...)
+		s.wakeOperator(apply.ApplyIdentifier, apply.Database, apply.Environment)
+		return &apitypes.ControlResponse{Accepted: true}, http.StatusAccepted, nil
+	}
+	metrics.RecordControlOperation(ctx, "skip_revert", apply.Database, apply.Deployment, apply.Environment, controlStatus(resp.Accepted))
+
+	if resp.Accepted {
+		if apply.Engine == storage.EnginePlanetScale {
+			if err := s.storage.Applies().SetRevertSkipped(ctx, apply.ID, time.Now()); err != nil {
+				s.logger.Error("failed to record skip-revert on apply", append(apply.LogAttrs(), "error", err)...)
+			}
+		}
+		// The engine accepted the skip; the durable request's work is done.
+		if err := controlStore.CompletePending(ctx, apply.ID, storage.ControlOperationSkipRevert); err != nil {
+			s.logger.Warn("failed to complete skip-revert control request after immediate success; operator will reconcile",
+				append(apply.LogAttrs(), "error", err)...)
+		}
+	} else if err := controlStore.FailPending(ctx, apply.ID, storage.ControlOperationSkipRevert, resp.ErrorMessage); err != nil {
+		s.logger.Warn("failed to fail rejected skip-revert control request",
+			append(apply.LogAttrs(), "error", err)...)
+	}
+	s.wakeOperator(apply.ApplyIdentifier, apply.Database, apply.Environment)
+
+	return &apitypes.ControlResponse{Accepted: resp.Accepted, ErrorMessage: resp.ErrorMessage}, http.StatusOK, nil
 }
 
 // RollbackPlanRequest is the HTTP request body for POST /api/rollback/plan.

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -5119,6 +5119,60 @@ func TestSkipRevertHandler(t *testing.T) {
 		assert.Contains(t, w.Body.String(), "apply_id is required")
 		assert.Nil(t, mock.skipRevertReq)
 	})
+
+	// Skip-revert is PlanetScale-only; a non-PlanetScale apply is rejected before
+	// any durable request is recorded, so it can't accumulate a stuck request.
+	t.Run("rejects a non-PlanetScale apply", func(t *testing.T) {
+		mock := &mockTernClient{skipRevertResp: &ternv1.SkipRevertResponse{Accepted: true}}
+		apply := activeTestApply("apply-skip-mysql")
+		apply.State = state.Apply.RevertWindow
+		apply.Engine = storage.EngineSpirit
+		svc := newControlTestService(mock, apply)
+		mux := http.NewServeMux()
+		svc.ConfigureRoutes(mux)
+
+		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/skip-revert", strings.NewReader(`{"environment":"staging","apply_id":"apply-skip-mysql"}`))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusConflict, w.Code, w.Body.String())
+		assert.Contains(t, w.Body.String(), "only supported for PlanetScale")
+		assert.Nil(t, mock.skipRevertReq, "no engine call for a rejected non-PlanetScale apply")
+	})
+
+	// When a skip-revert request is already pending (e.g. the first immediate
+	// attempt failed and left it queued for the apply owner), a second request is
+	// accepted as already_requested and does not re-drive the engine.
+	t.Run("already pending does not re-drive the engine", func(t *testing.T) {
+		// The immediate attempt fails, so the durable request stays pending.
+		mock := &mockTernClient{skipRevertErr: fmt.Errorf("transient data-plane error")}
+		apply := activeTestApply("apply-skip-dup")
+		apply.State = state.Apply.RevertWindow
+		apply.Engine = storage.EnginePlanetScale
+		apply.DatabaseType = storage.DatabaseTypeVitess
+		svc := newControlTestService(mock, apply)
+		mux := http.NewServeMux()
+		svc.ConfigureRoutes(mux)
+		body := `{"environment":"staging","apply_id":"apply-skip-dup"}`
+
+		first := httptest.NewRecorder()
+		req1 := httptest.NewRequestWithContext(t.Context(), "POST", "/api/skip-revert", strings.NewReader(body))
+		req1.Header.Set("Content-Type", "application/json")
+		mux.ServeHTTP(first, req1)
+		require.Equal(t, http.StatusAccepted, first.Code, first.Body.String())
+		require.NotNil(t, mock.skipRevertReq, "first request attempts the engine and leaves the request pending")
+
+		mock.skipRevertReq = nil
+		second := httptest.NewRecorder()
+		req2 := httptest.NewRequestWithContext(t.Context(), "POST", "/api/skip-revert", strings.NewReader(body))
+		req2.Header.Set("Content-Type", "application/json")
+		mux.ServeHTTP(second, req2)
+
+		assert.Equal(t, http.StatusAccepted, second.Code, second.Body.String())
+		assert.Contains(t, second.Body.String(), apitypes.ControlStatusAlreadyRequested)
+		assert.Nil(t, mock.skipRevertReq, "a duplicate request must not re-drive the engine")
+	})
 }
 
 func TestDeriveErrorCode(t *testing.T) {

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -204,6 +204,9 @@ func (s *staticApplyStore) GetByApplyIdentifier(_ context.Context, applyIdentifi
 func (s *staticApplyStore) Get(context.Context, int64) (*storage.Apply, error) {
 	return s.apply, s.err
 }
+func (s *staticApplyStore) SetRevertSkipped(context.Context, int64, time.Time) error {
+	return nil
+}
 func (s *staticApplyStore) GetByDatabase(_ context.Context, database, dbType, environment string) ([]*storage.Apply, error) {
 	if s.err != nil {
 		return nil, s.err
@@ -5079,7 +5082,12 @@ func TestSkipRevertHandler(t *testing.T) {
 		mock := &mockTernClient{
 			skipRevertResp: &ternv1.SkipRevertResponse{Accepted: true},
 		}
-		svc := newControlTestService(mock, activeTestApply("apply-skip456"))
+		// Skip-revert is only accepted while the apply is in its revert window.
+		apply := activeTestApply("apply-skip456")
+		apply.State = state.Apply.RevertWindow
+		apply.Engine = storage.EnginePlanetScale
+		apply.DatabaseType = storage.DatabaseTypeVitess
+		svc := newControlTestService(mock, apply)
 		mux := http.NewServeMux()
 		svc.ConfigureRoutes(mux)
 

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -744,6 +744,12 @@ const (
 	ControlOperationCancel ControlOperation = "cancel"
 	// ControlOperationCutover triggers deferred cutover.
 	ControlOperationCutover ControlOperation = "cutover"
+	// ControlOperationSkipRevert closes the revert window, making a PlanetScale
+	// schema change permanent. Durable so a comment-driven skip-revert survives
+	// the API process dying before the engine call lands, and so the apply owner
+	// (which for a remote apply is the data-plane operator, not the webhook pod)
+	// drives it to completion.
+	ControlOperationSkipRevert ControlOperation = "skip_revert"
 	// ControlOperationRelease releases a rollout paused after a failure under
 	// on_failure 'pause', letting the held later deployments proceed (like
 	// 'continue'). It is a one-way latch and is deliberately distinct from

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -601,7 +601,10 @@ func (c *GRPCClient) processPendingSkipRevertControlRequest(ctx context.Context,
 		return fmt.Errorf("process pending skip-revert for apply %s: %w", apply.ApplyIdentifier, err)
 	}
 	if !resp.Accepted {
-		message := fmt.Sprintf("skip-revert was not accepted: %s", resp.ErrorMessage)
+		message := "skip-revert was not accepted by the data plane"
+		if resp.ErrorMessage != "" {
+			message = fmt.Sprintf("skip-revert was not accepted: %s", resp.ErrorMessage)
+		}
 		return failPendingControlRequests(ctx, c.storage, apply, storage.ControlOperationSkipRevert, message)
 	}
 	if apply.Engine == storage.EnginePlanetScale {

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -573,6 +573,47 @@ func (c *GRPCClient) Cancel(ctx context.Context, req *ternv1.CancelRequest) (*te
 	return c.client.Cancel(ctx, req)
 }
 
+// processPendingSkipRevertControlRequest drives a durable skip-revert control
+// request for a remote apply: it proxies SkipRevert to the data plane and
+// completes the request. This is the apply owner's retry path when the API's
+// immediate skip attempt failed or its process died, leaving the request pending.
+// A transient failure returns an error so the drive exits and the operator
+// retries (the request stays pending); a rejected skip fails the request.
+func (c *GRPCClient) processPendingSkipRevertControlRequest(ctx context.Context, apply *storage.Apply, remoteID string) error {
+	controlReq, err := pendingControlRequest(ctx, c.storage, apply, storage.ControlOperationSkipRevert)
+	if err != nil {
+		return err
+	}
+	if controlReq == nil {
+		return nil
+	}
+	// Skip-revert is only meaningful in the revert window. Once the apply has
+	// left it (finalized, reverted, …) the request is moot — complete it so it
+	// does not linger.
+	if !state.IsState(apply.State, state.Apply.RevertWindow) {
+		return completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationSkipRevert)
+	}
+	resp, err := c.client.SkipRevert(ctx, &ternv1.SkipRevertRequest{
+		ApplyId:     remoteID,
+		Environment: apply.Environment,
+	})
+	if err != nil {
+		return fmt.Errorf("process pending skip-revert for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if !resp.Accepted {
+		message := fmt.Sprintf("skip-revert was not accepted: %s", resp.ErrorMessage)
+		return failPendingControlRequests(ctx, c.storage, apply, storage.ControlOperationSkipRevert, message)
+	}
+	if apply.Engine == storage.EnginePlanetScale {
+		if err := c.storage.Applies().SetRevertSkipped(ctx, apply.ID, time.Now()); err != nil {
+			slog.Warn("failed to record skip-revert on apply", "apply_id", apply.ApplyIdentifier, "error", err)
+		}
+	}
+	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventSkipRevertTriggered,
+		fmt.Sprintf("Skip-revert triggered by user%s", callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
+	return completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationSkipRevert)
+}
+
 // logOperationDriveLeavesParentStop records that a multi-operation
 // operation-only drive observed an apply-level pending stop request and is
 // leaving it pending. Such a drive owns only its operation; the parent stop
@@ -2962,6 +3003,15 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 			}
 			if err := c.processPendingCutoverControlRequest(ctx, apply, scope); err != nil {
 				slog.Warn("pending gRPC cutover request processing failed; current apply owner will exit for operator retry",
+					"apply_id", apply.ApplyIdentifier,
+					"external_id", apply.ExternalID,
+					"database", apply.Database,
+					"environment", apply.Environment,
+					"error", err)
+				return err
+			}
+			if err := c.processPendingSkipRevertControlRequest(ctx, apply, scope.remoteApplyID(apply)); err != nil {
+				slog.Warn("pending gRPC skip-revert request processing failed; current apply owner will exit for operator retry",
 					"apply_id", apply.ApplyIdentifier,
 					"external_id", apply.ExternalID,
 					"database", apply.Database,

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -466,6 +466,7 @@ type capturingTernServer struct {
 	stopApplyID       string
 	startApplyID      string
 	cutoverApplyID    string
+	skipRevertApplyID string
 	progressApplyID   string
 	progressReq       *ternv1.ProgressRequest
 	progressState     ternv1.State // state returned by Progress; 0 = STATE_COMPLETED
@@ -539,6 +540,13 @@ func (s *capturingTernServer) Cutover(_ context.Context, req *ternv1.CutoverRequ
 	return &ternv1.CutoverResponse{Accepted: accepted, ErrorMessage: message}, nil
 }
 
+func (s *capturingTernServer) SkipRevert(_ context.Context, req *ternv1.SkipRevertRequest) (*ternv1.SkipRevertResponse, error) {
+	s.mu.Lock()
+	s.skipRevertApplyID = req.ApplyId
+	s.mu.Unlock()
+	return &ternv1.SkipRevertResponse{Accepted: true}, nil
+}
+
 func (s *capturingTernServer) Progress(_ context.Context, req *ternv1.ProgressRequest) (*ternv1.ProgressResponse, error) {
 	s.mu.Lock()
 	s.progressReq = &ternv1.ProgressRequest{
@@ -584,6 +592,12 @@ func (s *capturingTernServer) getCancelApplyID() string {
 	return s.cancelApplyID
 }
 
+func (s *capturingTernServer) getSkipRevertApplyID() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.skipRevertApplyID
+}
+
 func (s *capturingTernServer) getCutoverApplyID() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -617,9 +631,15 @@ func (s *capturingTernServer) getApplyRequest() *ternv1.ApplyRequest {
 // mockApplyStore is a minimal ApplyStore for testing ResumeApply.
 type mockApplyStore struct {
 	storage.ApplyStore
-	apply     *storage.Apply
-	updateErr error
-	updates   []*storage.Apply
+	apply           *storage.Apply
+	updateErr       error
+	updates         []*storage.Apply
+	revertSkippedAt *time.Time
+}
+
+func (m *mockApplyStore) SetRevertSkipped(_ context.Context, _ int64, at time.Time) error {
+	m.revertSkippedAt = &at
+	return nil
 }
 
 func (m *mockApplyStore) GetByApplyIdentifier(context.Context, string) (*storage.Apply, error) {
@@ -4460,6 +4480,63 @@ func TestGRPCClient_ProcessPendingCutoverWaitsWhenNotReady(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, pendingCutover)
 	assert.Equal(t, storage.ControlRequestPending, pendingCutover.Status)
+}
+
+// A pending skip-revert request on a revert-window apply is the operator's retry
+// path: the drive proxies SkipRevert to the data plane, records revert_skipped,
+// and completes the request. Once the apply has left the revert window, the
+// request is moot and is completed without another engine call.
+func TestGRPCClient_ProcessPendingSkipRevert(t *testing.T) {
+	newApply := func(s string) *storage.Apply {
+		return &storage.Apply{
+			ID: 1, ApplyIdentifier: "apply-skiprevert-grpc",
+			Database: "testdb", DatabaseType: storage.DatabaseTypeVitess,
+			Environment: "staging", Engine: storage.EnginePlanetScale,
+			ExternalID: "remote-skiprevert-grpc", State: s,
+		}
+	}
+	newStore := func(apply *storage.Apply) (*mockStorage, *testControlRequestStore, *mockApplyStore) {
+		controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{{
+			ApplyID: apply.ID, Operation: storage.ControlOperationSkipRevert,
+			Status: storage.ControlRequestPending, RequestedBy: "cli:alice",
+		}}}
+		stored := *apply
+		applies := &mockApplyStore{apply: &stored}
+		return &mockStorage{applies: applies, tasks: &mockTaskStore{}, logs: &mockApplyLogStore{}, controlRequests: controlRequests}, controlRequests, applies
+	}
+
+	t.Run("revert window: proxies skip and completes the request", func(t *testing.T) {
+		server := &capturingTernServer{}
+		client, cleanup := testCapturingGRPCClient(t, server)
+		defer cleanup()
+		apply := newApply(state.Apply.RevertWindow)
+		store, controlRequests, applies := newStore(apply)
+		client.storage = store
+
+		err := client.processPendingSkipRevertControlRequest(t.Context(), apply, apply.ExternalID)
+		require.NoError(t, err)
+		assert.Equal(t, "remote-skiprevert-grpc", server.getSkipRevertApplyID(), "skip-revert proxied to the data plane")
+		assert.NotNil(t, applies.revertSkippedAt, "revert_skipped recorded")
+		pending, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationSkipRevert)
+		require.NoError(t, err)
+		assert.Nil(t, pending, "request completed after a successful skip")
+	})
+
+	t.Run("apply already left the revert window: completes without an engine call", func(t *testing.T) {
+		server := &capturingTernServer{}
+		client, cleanup := testCapturingGRPCClient(t, server)
+		defer cleanup()
+		apply := newApply(state.Apply.Completed)
+		store, controlRequests, _ := newStore(apply)
+		client.storage = store
+
+		err := client.processPendingSkipRevertControlRequest(t.Context(), apply, apply.ExternalID)
+		require.NoError(t, err)
+		assert.Empty(t, server.getSkipRevertApplyID(), "no engine call once the revert window is gone")
+		pending, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationSkipRevert)
+		require.NoError(t, err)
+		assert.Nil(t, pending, "moot request completed")
+	})
 }
 
 func TestGRPCClient_ProcessPendingCutoverWaitsWhileRecovering(t *testing.T) {

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -794,7 +794,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		if pending, err := pendingControlRequest(ctx, c.storage, apply, storage.ControlOperationSkipRevert); err != nil {
 			c.logger.Warn("could not load pending skip-revert control request", "apply_id", apply.ApplyIdentifier, "error", err)
 		} else if pending != nil {
-			c.logger.Info("skip-revert requested by user; closing revert window", "apply_id", apply.ApplyIdentifier)
+			c.logger.Info("skip-revert requested by user; closing revert window", "apply_id", apply.ApplyIdentifier, "requested_by", controlRequestCaller(pending))
 			if _, err := eng.SkipRevert(ctx, controlReq); err != nil {
 				// Leave the request pending so the next drive tick retries.
 				c.logger.Error("skip-revert (control request) failed; will retry", "error", err, "apply_id", apply.ApplyIdentifier)
@@ -805,7 +805,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 					c.logger.Warn("failed to complete skip-revert control request", "apply_id", apply.ApplyIdentifier, "error", err)
 				}
 				c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventSkipRevertTriggered, storage.LogSourceSchemaBot,
-					"Skip-revert triggered by user", state.Apply.RevertWindow, "")
+					fmt.Sprintf("Skip-revert triggered by user%s", callerApplyLogSuffix(controlRequestCaller(pending))), state.Apply.RevertWindow, "")
 			}
 		}
 	}

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -786,6 +786,30 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		ps.revertSkipped = true
 	}
 
+	// A durable skip-revert control request (the interactive "skip now" command,
+	// vs the upfront --skip-revert flag above) was queued; honor it. This is the
+	// apply owner's retry path: the API's immediate skip attempt may have failed
+	// or its process may have died, leaving the request pending for the drive.
+	if result.State == engine.StateRevertWindow && !ps.revertSkipped {
+		if pending, err := pendingControlRequest(ctx, c.storage, apply, storage.ControlOperationSkipRevert); err != nil {
+			c.logger.Warn("could not load pending skip-revert control request", "apply_id", apply.ApplyIdentifier, "error", err)
+		} else if pending != nil {
+			c.logger.Info("skip-revert requested by user; closing revert window", "apply_id", apply.ApplyIdentifier)
+			if _, err := eng.SkipRevert(ctx, controlReq); err != nil {
+				// Leave the request pending so the next drive tick retries.
+				c.logger.Error("skip-revert (control request) failed; will retry", "error", err, "apply_id", apply.ApplyIdentifier)
+			} else {
+				c.markRevertSkipped(ctx, apply)
+				ps.revertSkipped = true
+				if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationSkipRevert); err != nil {
+					c.logger.Warn("failed to complete skip-revert control request", "apply_id", apply.ApplyIdentifier, "error", err)
+				}
+				c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventSkipRevertTriggered, storage.LogSourceSchemaBot,
+					"Skip-revert triggered by user", state.Apply.RevertWindow, "")
+			}
+		}
+	}
+
 	// Revert window enabled (default): auto-skip based on deployed_at + configured duration.
 	// Falls back to stateEnteredAt if deployed_at is unavailable.
 	if result.State == engine.StateRevertWindow && !opts.SkipRevert && !ps.revertSkipped {

--- a/pkg/webhook/control.go
+++ b/pkg/webhook/control.go
@@ -287,3 +287,28 @@ func (h *Handler) handleCutoverCommand(repo string, pr int, installationID int64
 		Status:      resp.Status,
 	}))
 }
+
+func (h *Handler) handleSkipRevertCommand(repo string, pr int, installationID int64, requestedBy string, result CommandResult) {
+	ctx, cancel := h.commandContext(commandTimeout)
+	defer cancel()
+
+	resp := runControlCommand(h, ctx, repo, pr, installationID, requestedBy, result, action.SkipRevert,
+		h.service.ExecuteSkipRevert,
+		func(r *apitypes.ControlResponse) bool { return r.Accepted },
+		func(r *apitypes.ControlResponse) string { return r.ErrorMessage })
+	if resp == nil {
+		return
+	}
+
+	h.logger.Info("skip-revert PR command accepted",
+		"repo", repo,
+		"pr", pr,
+		"apply_id", result.ApplyID,
+		"environment", result.Environment,
+		"requested_by", requestedBy)
+	h.postComment(repo, pr, installationID, templates.RenderSkipRevertCommandAccepted(templates.SkipRevertCommandAcceptedData{
+		ApplyID:     result.ApplyID,
+		Environment: result.Environment,
+		RequestedBy: requestedBy,
+	}))
+}

--- a/pkg/webhook/handler_test.go
+++ b/pkg/webhook/handler_test.go
@@ -606,13 +606,14 @@ func TestWebhookEyesReaction(t *testing.T) {
 func TestWebhookPhase2CommandNotYetAvailable(t *testing.T) {
 	h, comments, _ := newTestHandler(t)
 
-	// Test remaining Phase 2 commands (apply, apply-confirm, unlock, stop, start, and cutover are now implemented)
+	// revert is the only remaining Phase 2 command not yet available via PR
+	// comments (apply, apply-confirm, unlock, stop, start, cutover, and skip-revert
+	// are now implemented).
 	cmds := []struct {
 		comment string
 		action  string
 	}{
 		{"schemabot revert -e staging", "revert"},
-		{"schemabot skip-revert -e staging", "skip-revert"},
 	}
 
 	for _, cmd := range cmds {

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -304,8 +304,13 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 			h.handleCutoverCommand(repo, pr, installationID, requestedBy, result)
 		})
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "cutover started"})
+	case action.SkipRevert:
+		h.goSafe(repo, pr, installationID, func() {
+			h.handleSkipRevertCommand(repo, pr, installationID, requestedBy, result)
+		})
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "skip-revert started"})
 	// Phase 2 commands — acknowledge but not yet implemented
-	case action.Revert, action.SkipRevert:
+	case action.Revert:
 		h.postComment(repo, pr, installationID,
 			templates.RenderCommandNotYetAvailable(result.Action, result.Environment))
 		h.writeJSON(w, http.StatusOK, map[string]string{

--- a/pkg/webhook/templates/issue_comment.go
+++ b/pkg/webhook/templates/issue_comment.go
@@ -129,7 +129,7 @@ func RenderSkipRevertCommandAccepted(data SkipRevertCommandAcceptedData) string 
 	if data.RequestedBy != "" {
 		body += fmt.Sprintf("**Requested by**: @%s\n", data.RequestedBy)
 	}
-	body += "\nSkip-revert request accepted. SchemaBot is closing the revert window — this schema change will become permanent. Status remains available from the PR progress comment or CLI.\n"
+	body += "\nSkip-revert requested. SchemaBot will close the revert window, making this schema change permanent; status remains available from the PR progress comment or CLI.\n"
 	return body
 }
 

--- a/pkg/webhook/templates/issue_comment.go
+++ b/pkg/webhook/templates/issue_comment.go
@@ -113,6 +113,26 @@ func RenderStartCommandAccepted(data StartCommandAcceptedData) string {
 	return body
 }
 
+// SkipRevertCommandAcceptedData contains data for a PR comment skip-revert acknowledgement.
+type SkipRevertCommandAcceptedData struct {
+	ApplyID     string
+	Environment string
+	RequestedBy string
+}
+
+// RenderSkipRevertCommandAccepted renders the acknowledgement posted when a PR
+// comment skip-revert command records durable skip-revert intent.
+func RenderSkipRevertCommandAccepted(data SkipRevertCommandAcceptedData) string {
+	body := "## Skip-Revert Request Accepted\n\n" +
+		fmt.Sprintf("**Apply**: `%s`\n", data.ApplyID) +
+		fmt.Sprintf("**Environment**: `%s`\n", data.Environment)
+	if data.RequestedBy != "" {
+		body += fmt.Sprintf("**Requested by**: @%s\n", data.RequestedBy)
+	}
+	body += "\nSkip-revert request accepted. SchemaBot is closing the revert window — this schema change will become permanent. Status remains available from the PR progress comment or CLI.\n"
+	return body
+}
+
 // PreviewCommentStartCommandAccepted renders a sample start command
 // acknowledgement comment.
 func PreviewCommentStartCommandAccepted() string {


### PR DESCRIPTION
## Why this matters

Skip-revert closes a PlanetScale schema change's revert window, making it permanent — a deliberate, hard-to-reverse operator action, often taken during an incident. Yet it was the weakest of the control commands: the PR-comment command was stubbed ("not yet available"), so an operator had to drop to the CLI, and the CLI/API path was a synchronous engine call with no durability — if the call failed or the process died mid-flight, the intent was simply lost. `stop` and `cutover` already record durable intent and let the apply owner finish the job; skip-revert should too.

## What it does

Brings skip-revert in line with `stop`/`cutover`:

- **Durable intent.** The handler records an `ApplyControlRequest` (operation `skip_revert`) *before* the engine call. It still attempts the skip immediately; on failure the request stays pending for retry, on rejection it's failed, on success it's completed. So a crashed process or a transient engine error no longer drops the request.
- **Apply-owner retry.** Both the in-process drive and the remote-dispatch drive process a pending skip-revert request from the revert-window poll (mirroring the cutover path), so the skip still executes even if the immediate attempt didn't. For a remotely-dispatched apply this matters especially: the engine runs out-of-process, so the apply owner — not the request-receiving process — is the right actor to drive it.
- **Working PR-comment command.** `schemabot skip-revert` from a PR comment now records durable intent and posts an acknowledgement, instead of "not yet available". (`revert` stays stubbed.)
- **State-gated.** Skip-revert is only accepted while the apply is in its `revert_window`.

No schema migration — the control-request `operation` column is already a free-form string.

## How it moves toward northstar

The revert window is a safety mechanism, and skip-revert is its most consequential action. Making it reachable from the PR comment (where operators already work) and crash-safe (durable + recoverable) removes a sharp edge. It's also the foundation for the visible `skipping_revert` state (a follow-up): the apply-owner processing added here is the natural place to project that state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)