### PR TITLE
feat(cli): redrive failed schema changes

### DIFF
--- a/pkg/api/redrive_handlers.go
+++ b/pkg/api/redrive_handlers.go
@@ -35,7 +35,7 @@ func (s *Service) handleRedrive(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case errors.Is(err, storage.ErrApplyNotFound):
 			status = http.StatusNotFound
-		case errors.Is(err, storage.ErrApplyNotRedrivable), errors.Is(err, storage.ErrActiveApplyExists):
+		case errors.Is(err, storage.ErrApplyNotRedrivable), errors.Is(err, storage.ErrActiveApplyExists), errors.Is(err, storage.ErrLockHeld):
 			status = http.StatusConflict
 		}
 		if status >= http.StatusInternalServerError {
@@ -86,6 +86,17 @@ func (s *Service) ExecuteRedrive(ctx context.Context, req apitypes.ControlReques
 		return nil, fmt.Errorf("plan %d not found for redrive apply %s: %w", apply.PlanID, apply.ApplyIdentifier, storage.ErrPlanNotFound)
 	}
 
+	lock, releaseLockOnReject, err := s.acquireRedriveLock(ctx, req, sourcePlan, apply)
+	if err != nil {
+		return nil, err
+	}
+	redriveAccepted := false
+	defer func() {
+		if !redriveAccepted && releaseLockOnReject {
+			s.releaseRedriveLockAfterReject(ctx, req, sourcePlan, apply)
+		}
+	}()
+
 	freshPlanResp, err := s.ExecutePlan(ctx, redrivePlanRequest(sourcePlan))
 	if err != nil {
 		return nil, fmt.Errorf("re-plan apply %s for redrive: %w", apply.ApplyIdentifier, err)
@@ -103,33 +114,26 @@ func (s *Service) ExecuteRedrive(ctx context.Context, req apitypes.ControlReques
 		return nil, err
 	}
 	if !plansEquivalentForRedrive(expectedPlan, freshPlan) {
-		s.logger.Warn("redrive rejected because re-plan changed",
-			"apply_id", apply.ApplyIdentifier,
-			"database", apply.Database,
-			"database_type", apply.DatabaseType,
-			"deployment", apply.Deployment,
-			"environment", apply.Environment,
+		s.logger.Warn("redrive rejected because re-plan changed", append(apply.LogAttrs(),
 			"source_plan_id", sourcePlan.PlanIdentifier,
 			"fresh_plan_id", freshPlan.PlanIdentifier,
-			"requested_by", req.Caller)
+			"requested_by", req.Caller,
+		)...)
 		return nil, fmt.Errorf("re-plan for apply %s changed from stored plan %s to fresh plan %s; create a new apply instead: %w",
 			apply.ApplyIdentifier, sourcePlan.PlanIdentifier, freshPlan.PlanIdentifier, storage.ErrApplyNotRedrivable)
 	}
 
-	redriven, err := s.storage.Applies().RedriveFailed(ctx, apply.ID)
+	redriven, err := s.storage.Applies().RedriveFailed(ctx, apply.ID, lock.ID)
 	if err != nil {
 		return nil, fmt.Errorf("redrive failed apply %s: %w", apply.ApplyIdentifier, err)
 	}
+	redriveAccepted = true
 	s.logControlOperationForApply(ctx, redriven, req.Caller, storage.LogEventInfo, "Redrive requested by user")
-	s.logger.Info("redrive accepted for failed apply",
-		"apply_id", redriven.ApplyIdentifier,
-		"database", redriven.Database,
-		"database_type", redriven.DatabaseType,
-		"deployment", redriven.Deployment,
-		"environment", redriven.Environment,
+	s.logger.Info("redrive accepted for failed apply", append(redriven.LogAttrs(),
 		"source_plan_id", sourcePlan.PlanIdentifier,
 		"fresh_plan_id", freshPlan.PlanIdentifier,
-		"requested_by", req.Caller)
+		"requested_by", req.Caller,
+	)...)
 	s.wakeOperator(redriven.ApplyIdentifier, redriven.Database, redriven.Environment)
 	return &apitypes.RedriveResponse{
 		Accepted: true,
@@ -138,6 +142,59 @@ func (s *Service) ExecuteRedrive(ctx context.Context, req apitypes.ControlReques
 		PlanID:   sourcePlan.PlanIdentifier,
 		Message:  "Stored plan still matches; the failed apply was queued for redrive.",
 	}, nil
+}
+
+func (s *Service) acquireRedriveLock(ctx context.Context, req apitypes.ControlRequest, plan *storage.Plan, apply *storage.Apply) (*storage.Lock, bool, error) {
+	if req.Caller == "" {
+		return nil, false, controlHTTPErrorf(http.StatusBadRequest, "caller is required")
+	}
+	existing, err := s.storage.Locks().Get(ctx, plan.Database, plan.DatabaseType)
+	if err != nil {
+		return nil, false, fmt.Errorf("load redrive lock for %s/%s before acquire: %w", plan.Database, plan.DatabaseType, err)
+	}
+	releaseOnReject := existing == nil || existing.Owner != req.Caller
+	lock := &storage.Lock{
+		DatabaseName: plan.Database,
+		DatabaseType: plan.DatabaseType,
+		Repository:   plan.Repository,
+		PullRequest:  plan.PullRequest,
+		Owner:        req.Caller,
+	}
+	if err := s.storage.Locks().Acquire(ctx, lock); err != nil {
+		if errors.Is(err, storage.ErrLockHeld) {
+			if !req.Force {
+				return nil, false, fmt.Errorf("redrive lock for %s/%s is held by another owner; retry with force to take over the lock: %w", plan.Database, plan.DatabaseType, err)
+			}
+			s.logger.Warn("redrive force releasing database lock", append(apply.LogAttrs(), "requested_by", req.Caller)...)
+			if releaseErr := s.storage.Locks().ForceRelease(ctx, plan.Database, plan.DatabaseType); releaseErr != nil {
+				return nil, false, fmt.Errorf("force release redrive lock for %s/%s owner %s: %w", plan.Database, plan.DatabaseType, req.Caller, releaseErr)
+			}
+			if acquireErr := s.storage.Locks().Acquire(ctx, lock); acquireErr != nil {
+				return nil, false, fmt.Errorf("acquire redrive lock for %s/%s owner %s after force release: %w", plan.Database, plan.DatabaseType, req.Caller, acquireErr)
+			}
+		} else {
+			return nil, false, fmt.Errorf("acquire redrive lock for %s/%s owner %s: %w", plan.Database, plan.DatabaseType, req.Caller, err)
+		}
+	}
+	acquired, err := s.storage.Locks().Get(ctx, plan.Database, plan.DatabaseType)
+	if err != nil {
+		return nil, false, fmt.Errorf("load acquired redrive lock for %s/%s: %w", plan.Database, plan.DatabaseType, err)
+	}
+	if acquired == nil || acquired.Owner != req.Caller {
+		return nil, false, fmt.Errorf("redrive lock for %s/%s was not acquired by %s: %w", plan.Database, plan.DatabaseType, req.Caller, storage.ErrLockHeld)
+	}
+	return acquired, releaseOnReject, nil
+}
+
+func (s *Service) releaseRedriveLockAfterReject(ctx context.Context, req apitypes.ControlRequest, plan *storage.Plan, apply *storage.Apply) {
+	if err := s.storage.Locks().Release(ctx, plan.Database, plan.DatabaseType, req.Caller); err != nil {
+		s.logger.Warn("redrive rejected after acquiring database lock; lock release failed", append(apply.LogAttrs(),
+			"requested_by", req.Caller,
+			"error", err,
+		)...)
+		return
+	}
+	s.logger.Info("redrive rejected after acquiring database lock; lock released", append(apply.LogAttrs(), "requested_by", req.Caller)...)
 }
 
 func validateRedriveCandidate(apply *storage.Apply) error {
@@ -280,11 +337,20 @@ func filterRedrivableNamespaceWork(namespace string, nsData *storage.NamespacePl
 		filtered.Artifacts = copyStringMap(nsData.Artifacts)
 	}
 	for _, change := range nsData.Tables {
-		if selection.taskKeys[redriveTaskKey{Namespace: namespace, Table: change.Table}] {
+		if selection.includesTable(namespace, change.Table) {
 			filtered.Tables = append(filtered.Tables, change)
 		}
 	}
 	return filtered
+}
+
+func (s redriveWorkSelection) includesTable(namespace, table string) bool {
+	for key := range s.taskKeys {
+		if key.Namespace == namespace && key.Table == table {
+			return true
+		}
+	}
+	return false
 }
 
 func redriveFinalizerNamespace(operationKey string) (string, bool) {
@@ -367,6 +433,10 @@ func redrivePlanFingerprintFor(plan *storage.Plan) redrivePlanFingerprint {
 			continue
 		}
 		tables := append([]storage.TableChange(nil), nsData.Tables...)
+		artifacts := copyStringMap(nsData.Artifacts)
+		if len(tables) == 0 && len(artifacts) == 0 {
+			continue
+		}
 		sort.Slice(tables, func(i, j int) bool {
 			if tables[i].Table != tables[j].Table {
 				return tables[i].Table < tables[j].Table
@@ -376,7 +446,7 @@ func redrivePlanFingerprintFor(plan *storage.Plan) redrivePlanFingerprint {
 			}
 			return tables[i].DDL < tables[j].DDL
 		})
-		namespaces[namespace] = redriveNamespaceFingerprint{Tables: tables, Artifacts: nsData.Artifacts}
+		namespaces[namespace] = redriveNamespaceFingerprint{Tables: tables, Artifacts: artifacts}
 	}
 
 	shards := make([]storage.ShardPlan, 0, len(plan.Shards))

--- a/pkg/api/redrive_handlers.go
+++ b/pkg/api/redrive_handlers.go
@@ -1,0 +1,414 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/block/schemabot/pkg/apitypes"
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/schema"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// handleRedrive handles POST /api/redrive requests.
+func (s *Service) handleRedrive(w http.ResponseWriter, r *http.Request) {
+	var req apitypes.ControlRequest
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&req); err != nil {
+		s.writeBodyDecodeError(w, err)
+		return
+	}
+
+	resp, err := s.ExecuteRedrive(r.Context(), req)
+	if err != nil {
+		status := controlOperationHTTPStatus(err)
+		switch {
+		case errors.Is(err, storage.ErrApplyNotFound):
+			status = http.StatusNotFound
+		case errors.Is(err, storage.ErrApplyNotRedrivable), errors.Is(err, storage.ErrActiveApplyExists):
+			status = http.StatusConflict
+		}
+		if status >= http.StatusInternalServerError {
+			s.logger.Error("redrive failed", "apply_id", req.ApplyID, "environment", req.Environment, "error", err)
+		} else {
+			s.logger.Warn("redrive rejected", "apply_id", req.ApplyID, "environment", req.Environment, "error", err)
+		}
+		s.writeError(w, status, "redrive failed: "+err.Error())
+		return
+	}
+
+	s.writeJSON(w, http.StatusOK, resp)
+}
+
+// ExecuteRedrive re-plans a failed apply's stored desired schema before
+// redriving the original apply. If the fresh plan differs, the failed apply is
+// left untouched so the caller can make an explicit new apply decision.
+func (s *Service) ExecuteRedrive(ctx context.Context, req apitypes.ControlRequest) (*apitypes.RedriveResponse, error) {
+	if req.ApplyID == "" {
+		return nil, controlHTTPErrorf(http.StatusBadRequest, "apply_id is required")
+	}
+	if req.Environment == "" {
+		return nil, controlHTTPErrorf(http.StatusBadRequest, "environment is required")
+	}
+	if s.storage == nil {
+		return nil, fmt.Errorf("storage is not available")
+	}
+
+	apply, err := s.storage.Applies().GetByApplyIdentifier(ctx, req.ApplyID)
+	if err != nil {
+		return nil, fmt.Errorf("load apply %s for redrive: %w", req.ApplyID, err)
+	}
+	if apply == nil {
+		return nil, storage.ErrApplyNotFound
+	}
+	if apply.Environment != req.Environment {
+		return nil, controlHTTPErrorf(http.StatusBadRequest, "apply %q belongs to environment %q, not %q", req.ApplyID, apply.Environment, req.Environment)
+	}
+	if err := validateRedriveCandidate(apply); err != nil {
+		return nil, err
+	}
+
+	sourcePlan, err := s.storage.Plans().GetByID(ctx, apply.PlanID)
+	if err != nil {
+		return nil, fmt.Errorf("load plan %d for redrive apply %s: %w", apply.PlanID, apply.ApplyIdentifier, err)
+	}
+	if sourcePlan == nil {
+		return nil, fmt.Errorf("plan %d not found for redrive apply %s: %w", apply.PlanID, apply.ApplyIdentifier, storage.ErrPlanNotFound)
+	}
+
+	freshPlanResp, err := s.ExecutePlan(ctx, redrivePlanRequest(sourcePlan))
+	if err != nil {
+		return nil, fmt.Errorf("re-plan apply %s for redrive: %w", apply.ApplyIdentifier, err)
+	}
+	freshPlan, err := s.storage.Plans().Get(ctx, freshPlanResp.PlanID)
+	if err != nil {
+		return nil, fmt.Errorf("load redrive plan %s for apply %s: %w", freshPlanResp.PlanID, apply.ApplyIdentifier, err)
+	}
+	if freshPlan == nil {
+		return nil, fmt.Errorf("redrive plan %s was not stored for apply %s: %w", freshPlanResp.PlanID, apply.ApplyIdentifier, storage.ErrPlanNotFound)
+	}
+
+	expectedPlan, err := s.redriveRemainingPlan(ctx, apply, sourcePlan)
+	if err != nil {
+		return nil, err
+	}
+	if !plansEquivalentForRedrive(expectedPlan, freshPlan) {
+		s.logger.Warn("redrive rejected because re-plan changed",
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"database_type", apply.DatabaseType,
+			"deployment", apply.Deployment,
+			"environment", apply.Environment,
+			"source_plan_id", sourcePlan.PlanIdentifier,
+			"fresh_plan_id", freshPlan.PlanIdentifier,
+			"requested_by", req.Caller)
+		return nil, fmt.Errorf("re-plan for apply %s changed from stored plan %s to fresh plan %s; create a new apply instead: %w",
+			apply.ApplyIdentifier, sourcePlan.PlanIdentifier, freshPlan.PlanIdentifier, storage.ErrApplyNotRedrivable)
+	}
+
+	redriven, err := s.storage.Applies().RedriveFailed(ctx, apply.ID)
+	if err != nil {
+		return nil, fmt.Errorf("redrive failed apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	s.logControlOperationForApply(ctx, redriven, req.Caller, storage.LogEventInfo, "Redrive requested by user")
+	s.logger.Info("redrive accepted for failed apply",
+		"apply_id", redriven.ApplyIdentifier,
+		"database", redriven.Database,
+		"database_type", redriven.DatabaseType,
+		"deployment", redriven.Deployment,
+		"environment", redriven.Environment,
+		"source_plan_id", sourcePlan.PlanIdentifier,
+		"fresh_plan_id", freshPlan.PlanIdentifier,
+		"requested_by", req.Caller)
+	s.wakeOperator(redriven.ApplyIdentifier, redriven.Database, redriven.Environment)
+	return &apitypes.RedriveResponse{
+		Accepted: true,
+		Status:   apitypes.RedriveStatusRedriven,
+		ApplyID:  redriven.ApplyIdentifier,
+		PlanID:   sourcePlan.PlanIdentifier,
+		Message:  "Stored plan still matches; the failed apply was queued for redrive.",
+	}, nil
+}
+
+func validateRedriveCandidate(apply *storage.Apply) error {
+	if !state.IsState(apply.State, state.Apply.Failed) {
+		return fmt.Errorf("apply %s is %s; only failed applies can be redriven: %w", apply.ApplyIdentifier, apply.State, storage.ErrApplyNotRedrivable)
+	}
+	if apply.CompletedAt == nil {
+		return fmt.Errorf("apply %s has no failure completion time; create a new apply instead: %w", apply.ApplyIdentifier, storage.ErrApplyNotRedrivable)
+	}
+	if apply.CompletedAt.Before(time.Now().AddDate(0, 0, -storage.RedriveFailureFreshnessDays)) {
+		return fmt.Errorf("apply %s failed more than %d day(s) ago; create a new apply instead: %w", apply.ApplyIdentifier, storage.RedriveFailureFreshnessDays, storage.ErrApplyNotRedrivable)
+	}
+	return nil
+}
+
+func (s *Service) redriveRemainingPlan(ctx context.Context, apply *storage.Apply, sourcePlan *storage.Plan) (*storage.Plan, error) {
+	selection, err := s.redrivableWorkSelection(ctx, apply, sourcePlan)
+	if err != nil {
+		return nil, err
+	}
+	return filterPlanToRedrivableWork(sourcePlan, selection), nil
+}
+
+func (s *Service) redrivableWorkSelection(ctx context.Context, apply *storage.Apply, sourcePlan *storage.Plan) (redriveWorkSelection, error) {
+	selection := redriveWorkSelection{
+		taskKeys:            make(map[redriveTaskKey]bool),
+		finalizerNamespaces: make(map[string]bool),
+		deployments:         make(map[string]bool),
+	}
+
+	operations, err := s.storage.ApplyOperations().ListByApply(ctx, apply.ID)
+	if err != nil {
+		return selection, fmt.Errorf("load operations for redrive apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	operationsByID := make(map[int64]*storage.ApplyOperation, len(operations))
+	for _, operation := range operations {
+		operationsByID[operation.ID] = operation
+	}
+
+	legacyTasks, err := s.storage.Tasks().GetByApplyID(ctx, apply.ID)
+	if err != nil {
+		return selection, fmt.Errorf("load tasks for redrive apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	for _, task := range legacyTasks {
+		if !state.IsState(task.State, state.Task.Failed, state.Task.Cancelled) {
+			continue
+		}
+		if task.ApplyOperationID != nil {
+			operation := operationsByID[*task.ApplyOperationID]
+			if operation == nil || !state.IsState(operation.State, state.ApplyOperation.Failed) {
+				continue
+			}
+			selection.deployments[operation.Deployment] = true
+		} else {
+			selection.deployments[sourcePlan.Deployment] = true
+		}
+		selection.taskKeys[redriveTaskKeyFor(task)] = true
+	}
+
+	for _, operation := range operations {
+		if !state.IsState(operation.State, state.ApplyOperation.Failed) {
+			continue
+		}
+		selection.deployments[operation.Deployment] = true
+		tasks, err := s.storage.Tasks().GetByApplyOperationID(ctx, operation.ID)
+		if err != nil {
+			return selection, fmt.Errorf("load operation %d tasks for redrive apply %s: %w", operation.ID, apply.ApplyIdentifier, err)
+		}
+		if len(tasks) == 0 && operation.OperationKind == storage.ApplyOperationKindGroupFinalizer {
+			namespace, ok := redriveFinalizerNamespace(operation.OperationKey)
+			if !ok {
+				return selection, fmt.Errorf("operation %d has malformed finalizer key %q for redrive apply %s: %w", operation.ID, operation.OperationKey, apply.ApplyIdentifier, storage.ErrApplyNotRedrivable)
+			}
+			selection.finalizerNamespaces[namespace] = true
+		}
+		for _, task := range tasks {
+			if state.IsState(task.State, state.Task.Failed, state.Task.Cancelled) {
+				selection.taskKeys[redriveTaskKeyFor(task)] = true
+			}
+		}
+	}
+
+	if len(selection.deployments) == 0 {
+		return selection, fmt.Errorf("apply %s has no failed work to redrive: %w", apply.ApplyIdentifier, storage.ErrApplyNotRedrivable)
+	}
+	if len(selection.deployments) > 1 || !selection.deployments[sourcePlan.Deployment] {
+		return selection, fmt.Errorf("apply %s has failed work outside primary deployment %q; create a new apply instead: %w", apply.ApplyIdentifier, sourcePlan.Deployment, storage.ErrApplyNotRedrivable)
+	}
+	return selection, nil
+}
+
+type redriveWorkSelection struct {
+	taskKeys            map[redriveTaskKey]bool
+	finalizerNamespaces map[string]bool
+	deployments         map[string]bool
+}
+
+type redriveTaskKey struct {
+	Namespace string
+	Shard     string
+	Table     string
+}
+
+func redriveTaskKeyFor(task *storage.Task) redriveTaskKey {
+	return redriveTaskKey{Namespace: task.Namespace, Shard: task.Shard, Table: task.TableName}
+}
+
+func filterPlanToRedrivableWork(plan *storage.Plan, selection redriveWorkSelection) *storage.Plan {
+	filtered := *plan
+	filtered.Namespaces = make(map[string]*storage.NamespacePlanData, len(plan.Namespaces))
+	for namespace, nsData := range plan.Namespaces {
+		if nsData == nil {
+			continue
+		}
+		filteredNS := filterRedrivableNamespaceWork(namespace, nsData, selection)
+		if len(filteredNS.Tables) > 0 || len(filteredNS.Artifacts) > 0 {
+			filtered.Namespaces[namespace] = filteredNS
+		}
+	}
+
+	filtered.Shards = make([]storage.ShardPlan, 0, len(plan.Shards))
+	for _, shard := range plan.Shards {
+		changes := make([]storage.TableChange, 0, len(shard.Changes))
+		for _, change := range shard.Changes {
+			if selection.taskKeys[redriveTaskKey{Namespace: shard.Namespace, Shard: shard.Shard, Table: change.Table}] {
+				changes = append(changes, change)
+			}
+		}
+		if len(changes) == 0 {
+			continue
+		}
+		filtered.Shards = append(filtered.Shards, storage.ShardPlan{Namespace: shard.Namespace, Shard: shard.Shard, Changes: changes})
+	}
+	return &filtered
+}
+
+func filterRedrivableNamespaceWork(namespace string, nsData *storage.NamespacePlanData, selection redriveWorkSelection) *storage.NamespacePlanData {
+	filtered := &storage.NamespacePlanData{}
+	if selection.finalizerNamespaces[namespace] {
+		filtered.Artifacts = copyStringMap(nsData.Artifacts)
+	}
+	for _, change := range nsData.Tables {
+		if selection.taskKeys[redriveTaskKey{Namespace: namespace, Table: change.Table}] {
+			filtered.Tables = append(filtered.Tables, change)
+		}
+	}
+	return filtered
+}
+
+func redriveFinalizerNamespace(operationKey string) (string, bool) {
+	const suffix = "/group_finalizer"
+	if !strings.HasSuffix(operationKey, suffix) {
+		return "", false
+	}
+	namespace := strings.TrimSuffix(operationKey, suffix)
+	return namespace, namespace != ""
+}
+
+func copyStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	maps.Copy(out, in)
+	return out
+}
+
+func redrivePlanRequest(plan *storage.Plan) PlanRequest {
+	req := PlanRequest{
+		Database:      plan.Database,
+		Environment:   plan.Environment,
+		Type:          plan.DatabaseType,
+		SchemaFiles:   storageSchemaFilesToProto(plan.SchemaFiles),
+		Repository:    plan.Repository,
+		SchemaPath:    plan.SchemaPath,
+		SourceTrusted: plan.SchemaPath != "",
+	}
+	if plan.PullRequest > 0 {
+		pr := int32(plan.PullRequest)
+		req.PullRequest = &pr
+	}
+	if plan.HeadSHA != "" {
+		headSHA := plan.HeadSHA
+		req.HeadSHA = &headSHA
+	}
+	return req
+}
+
+func storageSchemaFilesToProto(files schema.SchemaFiles) map[string]*ternv1.SchemaFiles {
+	result := make(map[string]*ternv1.SchemaFiles, len(files))
+	for namespace, ns := range files {
+		protoFiles := make(map[string]string)
+		if ns != nil {
+			protoFiles = make(map[string]string, len(ns.Files))
+			maps.Copy(protoFiles, ns.Files)
+		}
+		result[namespace] = &ternv1.SchemaFiles{Files: protoFiles}
+	}
+	return result
+}
+
+func plansEquivalentForRedrive(a, b *storage.Plan) bool {
+	aJSON, aErr := json.Marshal(redrivePlanFingerprintFor(a))
+	bJSON, bErr := json.Marshal(redrivePlanFingerprintFor(b))
+	return aErr == nil && bErr == nil && bytes.Equal(aJSON, bJSON)
+}
+
+type redrivePlanFingerprint struct {
+	Database     string
+	DatabaseType string
+	Deployment   string
+	Target       string
+	Environment  string
+	Namespaces   map[string]redriveNamespaceFingerprint
+	Shards       []storage.ShardPlan
+}
+
+type redriveNamespaceFingerprint struct {
+	Tables    []storage.TableChange
+	Artifacts map[string]string
+}
+
+func redrivePlanFingerprintFor(plan *storage.Plan) redrivePlanFingerprint {
+	namespaces := make(map[string]redriveNamespaceFingerprint, len(plan.Namespaces))
+	for namespace, nsData := range plan.Namespaces {
+		if nsData == nil {
+			continue
+		}
+		tables := append([]storage.TableChange(nil), nsData.Tables...)
+		sort.Slice(tables, func(i, j int) bool {
+			if tables[i].Table != tables[j].Table {
+				return tables[i].Table < tables[j].Table
+			}
+			if tables[i].Operation != tables[j].Operation {
+				return tables[i].Operation < tables[j].Operation
+			}
+			return tables[i].DDL < tables[j].DDL
+		})
+		namespaces[namespace] = redriveNamespaceFingerprint{Tables: tables, Artifacts: nsData.Artifacts}
+	}
+
+	shards := make([]storage.ShardPlan, 0, len(plan.Shards))
+	for _, shard := range plan.Shards {
+		if len(shard.Changes) == 0 {
+			continue
+		}
+		changes := append([]storage.TableChange(nil), shard.Changes...)
+		sort.Slice(changes, func(i, j int) bool {
+			if changes[i].Table != changes[j].Table {
+				return changes[i].Table < changes[j].Table
+			}
+			if changes[i].Operation != changes[j].Operation {
+				return changes[i].Operation < changes[j].Operation
+			}
+			return changes[i].DDL < changes[j].DDL
+		})
+		shards = append(shards, storage.ShardPlan{Namespace: shard.Namespace, Shard: shard.Shard, Changes: changes})
+	}
+	sort.Slice(shards, func(i, j int) bool {
+		if shards[i].Namespace != shards[j].Namespace {
+			return shards[i].Namespace < shards[j].Namespace
+		}
+		return shards[i].Shard < shards[j].Shard
+	})
+	return redrivePlanFingerprint{
+		Database:     plan.Database,
+		DatabaseType: plan.DatabaseType,
+		Deployment:   plan.Deployment,
+		Target:       plan.Target,
+		Environment:  plan.Environment,
+		Namespaces:   namespaces,
+		Shards:       shards,
+	}
+}

--- a/pkg/api/redrive_handlers_test.go
+++ b/pkg/api/redrive_handlers_test.go
@@ -1,0 +1,360 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/apitypes"
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/schema"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/tern"
+)
+
+func TestExecuteRedriveRedrivesFailedApplyWhenPlanStillMatches(t *testing.T) {
+	sourcePlan := redriveTestPlan("plan-source", "ALTER TABLE `users` ADD COLUMN `email` varchar(255)")
+	apply := redriveTestApply("apply-redrive", sourcePlan)
+	plans := newRedrivePlanStore(sourcePlan)
+	applies := &redriveApplyStore{apply: apply}
+	client := &mockTernClient{planResp: redrivePlanResponse("plan-fresh", "ALTER TABLE `users` ADD COLUMN `email` varchar(255)")}
+	svc := newRedriveTestService(t, client, plans, applies, redriveTestTask(apply, "users", state.Task.Failed))
+
+	resp, err := svc.ExecuteRedrive(t.Context(), apitypes.ControlRequest{
+		Environment: "staging",
+		ApplyID:     apply.ApplyIdentifier,
+		Caller:      "operator@example.com",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.True(t, resp.Accepted)
+	assert.Equal(t, apitypes.RedriveStatusRedriven, resp.Status)
+	assert.Equal(t, apply.ApplyIdentifier, resp.ApplyID)
+	assert.Equal(t, sourcePlan.PlanIdentifier, resp.PlanID)
+	assert.Equal(t, apply.ID, applies.redrivenApplyID)
+	assert.Equal(t, sourcePlan.Database, client.planReq.Database)
+	assert.Equal(t, sourcePlan.Environment, client.planReq.Environment)
+}
+
+func TestExecuteRedriveRejectsChangedPlanWithoutRedriving(t *testing.T) {
+	sourcePlan := redriveTestPlan("plan-source", "ALTER TABLE `users` ADD COLUMN `email` varchar(255)")
+	apply := redriveTestApply("apply-redrive", sourcePlan)
+	plans := newRedrivePlanStore(sourcePlan)
+	applies := &redriveApplyStore{apply: apply}
+	client := &mockTernClient{planResp: redrivePlanResponse("plan-fresh", "ALTER TABLE `users` ADD COLUMN `phone` varchar(255)")}
+	svc := newRedriveTestService(t, client, plans, applies, redriveTestTask(apply, "users", state.Task.Failed))
+
+	resp, err := svc.ExecuteRedrive(t.Context(), apitypes.ControlRequest{
+		Environment: "staging",
+		ApplyID:     apply.ApplyIdentifier,
+		Caller:      "operator@example.com",
+	})
+	require.ErrorIs(t, err, storage.ErrApplyNotRedrivable)
+	assert.Nil(t, resp)
+	assert.Zero(t, applies.redrivenApplyID)
+}
+
+func TestExecuteRedriveAcceptsRemainingWorkAfterCompletedTask(t *testing.T) {
+	sourcePlan := redriveTestPlanWithChanges("plan-source", []storage.TableChange{
+		{Table: "users", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", Operation: "alter"},
+		{Table: "orders", DDL: "ALTER TABLE `orders` ADD COLUMN `status` varchar(32)", Operation: "alter"},
+	})
+	apply := redriveTestApply("apply-redrive", sourcePlan)
+	plans := newRedrivePlanStore(sourcePlan)
+	applies := &redriveApplyStore{apply: apply}
+	client := &mockTernClient{planResp: redrivePlanResponseForChanges("plan-fresh", []*ternv1.TableChange{{
+		TableName:  "orders",
+		Ddl:        "ALTER TABLE `orders` ADD COLUMN `status` varchar(32)",
+		ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER,
+	}})}
+	svc := newRedriveTestService(t, client, plans, applies,
+		redriveTestTask(apply, "users", state.Task.Completed),
+		redriveTestTask(apply, "orders", state.Task.Failed),
+	)
+
+	resp, err := svc.ExecuteRedrive(t.Context(), apitypes.ControlRequest{
+		Environment: "staging",
+		ApplyID:     apply.ApplyIdentifier,
+		Caller:      "operator@example.com",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.True(t, resp.Accepted)
+	assert.Equal(t, apply.ID, applies.redrivenApplyID)
+}
+
+func TestExecuteRedriveRejectsFailedWorkOutsidePrimaryDeployment(t *testing.T) {
+	sourcePlan := redriveTestPlan("plan-source", "ALTER TABLE `users` ADD COLUMN `email` varchar(255)")
+	apply := redriveTestApply("apply-redrive", sourcePlan)
+	plans := newRedrivePlanStore(sourcePlan)
+	applies := &redriveApplyStore{apply: apply}
+	client := &mockTernClient{planResp: redrivePlanResponse("plan-fresh", "ALTER TABLE `users` ADD COLUMN `email` varchar(255)")}
+	completedOpID := int64(101)
+	failedOpID := int64(102)
+	svc := newRedriveTestService(t, client, plans, applies,
+		redriveTestOperation(completedOpID, apply.ID, sourcePlan.Deployment, state.ApplyOperation.Completed),
+		redriveTestOperation(failedOpID, apply.ID, "secondary", state.ApplyOperation.Failed),
+		redriveTestOperationTask(apply, completedOpID, "users", state.Task.Completed),
+		redriveTestOperationTask(apply, failedOpID, "users", state.Task.Failed),
+	)
+
+	resp, err := svc.ExecuteRedrive(t.Context(), apitypes.ControlRequest{
+		Environment: "staging",
+		ApplyID:     apply.ApplyIdentifier,
+		Caller:      "operator@example.com",
+	})
+	require.ErrorIs(t, err, storage.ErrApplyNotRedrivable)
+	assert.Nil(t, resp)
+	assert.Zero(t, applies.redrivenApplyID)
+}
+
+func TestExecuteRedriveRejectsCancelledApply(t *testing.T) {
+	sourcePlan := redriveTestPlan("plan-source", "ALTER TABLE `users` ADD COLUMN `email` varchar(255)")
+	apply := redriveTestApply("apply-redrive", sourcePlan)
+	apply.State = state.Apply.Cancelled
+	plans := newRedrivePlanStore(sourcePlan)
+	applies := &redriveApplyStore{apply: apply}
+	client := &mockTernClient{planResp: redrivePlanResponse("plan-fresh", "ALTER TABLE `users` ADD COLUMN `email` varchar(255)")}
+	svc := newRedriveTestService(t, client, plans, applies)
+
+	resp, err := svc.ExecuteRedrive(t.Context(), apitypes.ControlRequest{
+		Environment: "staging",
+		ApplyID:     apply.ApplyIdentifier,
+		Caller:      "operator@example.com",
+	})
+	require.ErrorIs(t, err, storage.ErrApplyNotRedrivable)
+	assert.Nil(t, resp)
+	assert.Zero(t, applies.redrivenApplyID)
+	assert.Nil(t, client.planReq)
+}
+
+func TestFilterPlanToRedrivableWorkDropsEmptyNamespaces(t *testing.T) {
+	sourcePlan := &storage.Plan{
+		Database:     "testdb",
+		DatabaseType: storage.DatabaseTypeMySQL,
+		Deployment:   DefaultDeployment,
+		Target:       "testdb",
+		Environment:  "staging",
+		Namespaces: map[string]*storage.NamespacePlanData{
+			"completed_ns": {Tables: []storage.TableChange{{Table: "users", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", Operation: "alter"}}},
+			"failed_ns":    {Tables: []storage.TableChange{{Table: "orders", DDL: "ALTER TABLE `orders` ADD COLUMN `status` varchar(32)", Operation: "alter"}}},
+		},
+	}
+	freshPlan := &storage.Plan{
+		Database:     sourcePlan.Database,
+		DatabaseType: sourcePlan.DatabaseType,
+		Deployment:   sourcePlan.Deployment,
+		Target:       sourcePlan.Target,
+		Environment:  sourcePlan.Environment,
+		Namespaces: map[string]*storage.NamespacePlanData{
+			"failed_ns": {Tables: []storage.TableChange{{Table: "orders", DDL: "ALTER TABLE `orders` ADD COLUMN `status` varchar(32)", Operation: "alter"}}},
+		},
+	}
+
+	failedTaskKey := redriveTaskKey{Namespace: "failed_ns", Table: "orders"}
+	filtered := filterPlanToRedrivableWork(sourcePlan, redriveWorkSelection{taskKeys: map[redriveTaskKey]bool{failedTaskKey: true}})
+
+	assert.NotContains(t, filtered.Namespaces, "completed_ns")
+	assert.True(t, plansEquivalentForRedrive(filtered, freshPlan))
+}
+
+func newRedriveTestService(t *testing.T, client tern.Client, plans storage.PlanStore, applies storage.ApplyStore, rows ...any) *Service {
+	t.Helper()
+	var tasks []*storage.Task
+	var operations []*storage.ApplyOperation
+	for _, row := range rows {
+		switch v := row.(type) {
+		case *storage.Task:
+			tasks = append(tasks, v)
+		case *storage.ApplyOperation:
+			operations = append(operations, v)
+		default:
+			require.Failf(t, "unknown redrive test row", "%T", row)
+		}
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	return New(&mockStorageWithApplyStores{
+		plans:      plans,
+		applies:    applies,
+		tasks:      &capturingTaskStore{tasks: tasks},
+		applyLogs:  &noopApplyLogStore{},
+		operations: &staticApplyOperationStore{operations: operations},
+	}, testServerConfig(), map[string]tern.Client{
+		"default/staging": client,
+	}, logger)
+}
+
+func redriveTestPlan(planID, ddl string) *storage.Plan {
+	return redriveTestPlanWithChanges(planID, []storage.TableChange{{Table: "users", DDL: ddl, Operation: "alter"}})
+}
+
+func redriveTestPlanWithChanges(planID string, changes []storage.TableChange) *storage.Plan {
+	return &storage.Plan{
+		ID:             42,
+		PlanIdentifier: planID,
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Deployment:     DefaultDeployment,
+		Target:         "testdb",
+		Repository:     "owner/repo",
+		PullRequest:    123,
+		SchemaPath:     "schema",
+		Environment:    "staging",
+		SchemaFiles: schema.SchemaFiles{
+			"testdb": {Files: map[string]string{"users.sql": "CREATE TABLE users (id bigint primary key)"}},
+		},
+		Namespaces: map[string]*storage.NamespacePlanData{
+			"testdb": {Tables: changes},
+		},
+		HeadSHA:   "abc123",
+		CreatedAt: time.Now(),
+	}
+}
+
+func redriveTestApply(applyID string, plan *storage.Plan) *storage.Apply {
+	completedAt := time.Now()
+	return &storage.Apply{
+		ID:              7,
+		ApplyIdentifier: applyID,
+		PlanID:          plan.ID,
+		Database:        plan.Database,
+		DatabaseType:    plan.DatabaseType,
+		Deployment:      plan.Deployment,
+		Environment:     plan.Environment,
+		State:           state.Apply.Failed,
+		CompletedAt:     &completedAt,
+	}
+}
+
+func redrivePlanResponse(planID, ddl string) *ternv1.PlanResponse {
+	return redrivePlanResponseForChanges(planID, []*ternv1.TableChange{{
+		TableName:  "users",
+		Ddl:        ddl,
+		ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER,
+	}})
+}
+
+func redrivePlanResponseForChanges(planID string, changes []*ternv1.TableChange) *ternv1.PlanResponse {
+	return &ternv1.PlanResponse{
+		PlanId: planID,
+		Changes: []*ternv1.SchemaChange{{
+			Namespace:    "testdb",
+			TableChanges: changes,
+		}},
+	}
+}
+
+func redriveTestTask(apply *storage.Apply, tableName, taskState string) *storage.Task {
+	completedAt := time.Now()
+	task := &storage.Task{
+		TaskIdentifier: "task_" + tableName,
+		ApplyID:        apply.ID,
+		PlanID:         apply.PlanID,
+		Database:       apply.Database,
+		DatabaseType:   apply.DatabaseType,
+		Environment:    apply.Environment,
+		State:          taskState,
+		Namespace:      "testdb",
+		TableName:      tableName,
+	}
+	if state.IsState(taskState, state.Task.Completed) {
+		task.CompletedAt = &completedAt
+	}
+	return task
+}
+
+func redriveTestOperation(id, applyID int64, deployment, operationState string) *storage.ApplyOperation {
+	return &storage.ApplyOperation{
+		ID:         id,
+		ApplyID:    applyID,
+		Deployment: deployment,
+		State:      operationState,
+	}
+}
+
+func redriveTestOperationTask(apply *storage.Apply, operationID int64, tableName, taskState string) *storage.Task {
+	task := redriveTestTask(apply, tableName, taskState)
+	task.ApplyOperationID = &operationID
+	return task
+}
+
+func (s *capturingTaskStore) GetByApplyOperationID(_ context.Context, applyOperationID int64) ([]*storage.Task, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var tasks []*storage.Task
+	for _, task := range s.tasks {
+		if task.ApplyOperationID != nil && *task.ApplyOperationID == applyOperationID {
+			tasks = append(tasks, task)
+		}
+	}
+	return tasks, s.err
+}
+
+type redrivePlanStore struct {
+	storage.PlanStore
+	plansByID         map[int64]*storage.Plan
+	plansByIdentifier map[string]*storage.Plan
+	nextID            int64
+}
+
+func newRedrivePlanStore(source *storage.Plan) *redrivePlanStore {
+	return &redrivePlanStore{
+		plansByID:         map[int64]*storage.Plan{source.ID: source},
+		plansByIdentifier: map[string]*storage.Plan{source.PlanIdentifier: source},
+		nextID:            source.ID + 1,
+	}
+}
+
+func (s *redrivePlanStore) Create(_ context.Context, plan *storage.Plan) (int64, error) {
+	if _, exists := s.plansByIdentifier[plan.PlanIdentifier]; exists {
+		return 0, storage.ErrPlanIDExists
+	}
+	stored := *plan
+	stored.ID = s.nextID
+	s.nextID++
+	s.plansByID[stored.ID] = &stored
+	s.plansByIdentifier[stored.PlanIdentifier] = &stored
+	return stored.ID, nil
+}
+
+func (s *redrivePlanStore) Get(_ context.Context, planIdentifier string) (*storage.Plan, error) {
+	return s.plansByIdentifier[planIdentifier], nil
+}
+
+func (s *redrivePlanStore) GetByID(_ context.Context, id int64) (*storage.Plan, error) {
+	return s.plansByID[id], nil
+}
+
+type redriveApplyStore struct {
+	storage.ApplyStore
+	apply           *storage.Apply
+	redrivenApplyID int64
+}
+
+func (s *redriveApplyStore) GetByApplyIdentifier(_ context.Context, applyIdentifier string) (*storage.Apply, error) {
+	if s.apply != nil && s.apply.ApplyIdentifier == applyIdentifier {
+		return s.apply, nil
+	}
+	return nil, nil
+}
+
+func (s *redriveApplyStore) RedriveFailed(_ context.Context, applyID int64) (*storage.Apply, error) {
+	if s.apply == nil || s.apply.ID != applyID {
+		return nil, storage.ErrApplyNotFound
+	}
+	if !state.IsState(s.apply.State, state.Apply.Failed) {
+		return nil, fmt.Errorf("apply %s is %s: %w", s.apply.ApplyIdentifier, s.apply.State, storage.ErrApplyNotRedrivable)
+	}
+	s.redrivenApplyID = applyID
+	redriven := *s.apply
+	redriven.State = state.Apply.FailedRetryable
+	redriven.CompletedAt = nil
+	return &redriven, nil
+}

--- a/pkg/api/redrive_handlers_test.go
+++ b/pkg/api/redrive_handlers_test.go
@@ -25,7 +25,8 @@ func TestExecuteRedriveRedrivesFailedApplyWhenPlanStillMatches(t *testing.T) {
 	plans := newRedrivePlanStore(sourcePlan)
 	applies := &redriveApplyStore{apply: apply}
 	client := &mockTernClient{planResp: redrivePlanResponse("plan-fresh", "ALTER TABLE `users` ADD COLUMN `email` varchar(255)")}
-	svc := newRedriveTestService(t, client, plans, applies, redriveTestTask(apply, "users", state.Task.Failed))
+	locks := newRedriveLockStore()
+	svc := newRedriveTestService(t, client, plans, applies, locks, redriveTestTask(apply, "users", state.Task.Failed))
 
 	resp, err := svc.ExecuteRedrive(t.Context(), apitypes.ControlRequest{
 		Environment: "staging",
@@ -39,6 +40,8 @@ func TestExecuteRedriveRedrivesFailedApplyWhenPlanStillMatches(t *testing.T) {
 	assert.Equal(t, apply.ApplyIdentifier, resp.ApplyID)
 	assert.Equal(t, sourcePlan.PlanIdentifier, resp.PlanID)
 	assert.Equal(t, apply.ID, applies.redrivenApplyID)
+	assert.Equal(t, locks.lock.ID, applies.redriveLockID)
+	assert.Equal(t, "operator@example.com", locks.lock.Owner)
 	assert.Equal(t, sourcePlan.Database, client.planReq.Database)
 	assert.Equal(t, sourcePlan.Environment, client.planReq.Environment)
 }
@@ -49,7 +52,8 @@ func TestExecuteRedriveRejectsChangedPlanWithoutRedriving(t *testing.T) {
 	plans := newRedrivePlanStore(sourcePlan)
 	applies := &redriveApplyStore{apply: apply}
 	client := &mockTernClient{planResp: redrivePlanResponse("plan-fresh", "ALTER TABLE `users` ADD COLUMN `phone` varchar(255)")}
-	svc := newRedriveTestService(t, client, plans, applies, redriveTestTask(apply, "users", state.Task.Failed))
+	locks := newRedriveLockStore()
+	svc := newRedriveTestService(t, client, plans, applies, locks, redriveTestTask(apply, "users", state.Task.Failed))
 
 	resp, err := svc.ExecuteRedrive(t.Context(), apitypes.ControlRequest{
 		Environment: "staging",
@@ -59,6 +63,7 @@ func TestExecuteRedriveRejectsChangedPlanWithoutRedriving(t *testing.T) {
 	require.ErrorIs(t, err, storage.ErrApplyNotRedrivable)
 	assert.Nil(t, resp)
 	assert.Zero(t, applies.redrivenApplyID)
+	assert.Nil(t, locks.lock)
 }
 
 func TestExecuteRedriveAcceptsRemainingWorkAfterCompletedTask(t *testing.T) {
@@ -74,7 +79,7 @@ func TestExecuteRedriveAcceptsRemainingWorkAfterCompletedTask(t *testing.T) {
 		Ddl:        "ALTER TABLE `orders` ADD COLUMN `status` varchar(32)",
 		ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER,
 	}})}
-	svc := newRedriveTestService(t, client, plans, applies,
+	svc := newRedriveTestService(t, client, plans, applies, newRedriveLockStore(),
 		redriveTestTask(apply, "users", state.Task.Completed),
 		redriveTestTask(apply, "orders", state.Task.Failed),
 	)
@@ -98,7 +103,7 @@ func TestExecuteRedriveRejectsFailedWorkOutsidePrimaryDeployment(t *testing.T) {
 	client := &mockTernClient{planResp: redrivePlanResponse("plan-fresh", "ALTER TABLE `users` ADD COLUMN `email` varchar(255)")}
 	completedOpID := int64(101)
 	failedOpID := int64(102)
-	svc := newRedriveTestService(t, client, plans, applies,
+	svc := newRedriveTestService(t, client, plans, applies, newRedriveLockStore(),
 		redriveTestOperation(completedOpID, apply.ID, sourcePlan.Deployment, state.ApplyOperation.Completed),
 		redriveTestOperation(failedOpID, apply.ID, "secondary", state.ApplyOperation.Failed),
 		redriveTestOperationTask(apply, completedOpID, "users", state.Task.Completed),
@@ -122,7 +127,7 @@ func TestExecuteRedriveRejectsCancelledApply(t *testing.T) {
 	plans := newRedrivePlanStore(sourcePlan)
 	applies := &redriveApplyStore{apply: apply}
 	client := &mockTernClient{planResp: redrivePlanResponse("plan-fresh", "ALTER TABLE `users` ADD COLUMN `email` varchar(255)")}
-	svc := newRedriveTestService(t, client, plans, applies)
+	svc := newRedriveTestService(t, client, plans, applies, newRedriveLockStore())
 
 	resp, err := svc.ExecuteRedrive(t.Context(), apitypes.ControlRequest{
 		Environment: "staging",
@@ -133,6 +138,50 @@ func TestExecuteRedriveRejectsCancelledApply(t *testing.T) {
 	assert.Nil(t, resp)
 	assert.Zero(t, applies.redrivenApplyID)
 	assert.Nil(t, client.planReq)
+}
+
+func TestExecuteRedriveRejectsLockHeldByAnotherOwner(t *testing.T) {
+	sourcePlan := redriveTestPlan("plan-source", "ALTER TABLE `users` ADD COLUMN `email` varchar(255)")
+	apply := redriveTestApply("apply-redrive", sourcePlan)
+	plans := newRedrivePlanStore(sourcePlan)
+	applies := &redriveApplyStore{apply: apply}
+	client := &mockTernClient{planResp: redrivePlanResponse("plan-fresh", "ALTER TABLE `users` ADD COLUMN `email` varchar(255)")}
+	locks := newRedriveLockStore()
+	locks.lock = &storage.Lock{ID: 99, DatabaseName: sourcePlan.Database, DatabaseType: sourcePlan.DatabaseType, Owner: "other-owner"}
+	svc := newRedriveTestService(t, client, plans, applies, locks, redriveTestTask(apply, "users", state.Task.Failed))
+
+	resp, err := svc.ExecuteRedrive(t.Context(), apitypes.ControlRequest{
+		Environment: "staging",
+		ApplyID:     apply.ApplyIdentifier,
+		Caller:      "operator@example.com",
+	})
+	require.ErrorIs(t, err, storage.ErrLockHeld)
+	assert.Nil(t, resp)
+	assert.Zero(t, applies.redrivenApplyID)
+}
+
+func TestExecuteRedriveForceTakesOverLockHeldByAnotherOwner(t *testing.T) {
+	sourcePlan := redriveTestPlan("plan-source", "ALTER TABLE `users` ADD COLUMN `email` varchar(255)")
+	apply := redriveTestApply("apply-redrive", sourcePlan)
+	plans := newRedrivePlanStore(sourcePlan)
+	applies := &redriveApplyStore{apply: apply}
+	client := &mockTernClient{planResp: redrivePlanResponse("plan-fresh", "ALTER TABLE `users` ADD COLUMN `email` varchar(255)")}
+	locks := newRedriveLockStore()
+	locks.lock = &storage.Lock{ID: 99, DatabaseName: sourcePlan.Database, DatabaseType: sourcePlan.DatabaseType, Owner: "other-owner"}
+	svc := newRedriveTestService(t, client, plans, applies, locks, redriveTestTask(apply, "users", state.Task.Failed))
+
+	resp, err := svc.ExecuteRedrive(t.Context(), apitypes.ControlRequest{
+		Environment: "staging",
+		ApplyID:     apply.ApplyIdentifier,
+		Caller:      "operator@example.com",
+		Force:       true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.True(t, resp.Accepted)
+	assert.Equal(t, apply.ID, applies.redrivenApplyID)
+	assert.Equal(t, "operator@example.com", locks.lock.Owner)
+	assert.NotEqual(t, int64(99), applies.redriveLockID)
 }
 
 func TestFilterPlanToRedrivableWorkDropsEmptyNamespaces(t *testing.T) {
@@ -165,7 +214,72 @@ func TestFilterPlanToRedrivableWorkDropsEmptyNamespaces(t *testing.T) {
 	assert.True(t, plansEquivalentForRedrive(filtered, freshPlan))
 }
 
-func newRedriveTestService(t *testing.T, client tern.Client, plans storage.PlanStore, applies storage.ApplyStore, rows ...any) *Service {
+func TestFilterPlanToRedrivableWorkKeepsNamespaceTableForShardTask(t *testing.T) {
+	tableChange := storage.TableChange{Table: "orders", DDL: "ALTER TABLE `orders` ADD COLUMN `status` varchar(32)", Operation: "alter"}
+	sourcePlan := &storage.Plan{
+		Database:     "testdb",
+		DatabaseType: storage.DatabaseTypeStrata,
+		Deployment:   DefaultDeployment,
+		Target:       "testdb",
+		Environment:  "staging",
+		Namespaces: map[string]*storage.NamespacePlanData{
+			"commerce": {Tables: []storage.TableChange{tableChange}},
+		},
+		Shards: []storage.ShardPlan{{
+			Namespace: "commerce",
+			Shard:     "-80",
+			Changes:   []storage.TableChange{tableChange},
+		}},
+	}
+	freshPlan := &storage.Plan{
+		Database:     sourcePlan.Database,
+		DatabaseType: sourcePlan.DatabaseType,
+		Deployment:   sourcePlan.Deployment,
+		Target:       sourcePlan.Target,
+		Environment:  sourcePlan.Environment,
+		Namespaces: map[string]*storage.NamespacePlanData{
+			"commerce": {Tables: []storage.TableChange{tableChange}},
+		},
+		Shards: []storage.ShardPlan{{
+			Namespace: "commerce",
+			Shard:     "-80",
+			Changes:   []storage.TableChange{tableChange},
+		}},
+	}
+
+	failedShardTaskKey := redriveTaskKey{Namespace: "commerce", Shard: "-80", Table: "orders"}
+	filtered := filterPlanToRedrivableWork(sourcePlan, redriveWorkSelection{taskKeys: map[redriveTaskKey]bool{failedShardTaskKey: true}})
+
+	require.Contains(t, filtered.Namespaces, "commerce")
+	assert.Equal(t, []storage.TableChange{tableChange}, filtered.Namespaces["commerce"].Tables)
+	assert.True(t, plansEquivalentForRedrive(filtered, freshPlan))
+}
+
+func TestPlansEquivalentForRedriveNormalizesEmptyNamespacesAndArtifacts(t *testing.T) {
+	left := &storage.Plan{
+		Database:     "testdb",
+		DatabaseType: storage.DatabaseTypeMySQL,
+		Deployment:   DefaultDeployment,
+		Target:       "testdb",
+		Environment:  "staging",
+		Namespaces: map[string]*storage.NamespacePlanData{
+			"empty":   {},
+			"routing": {Artifacts: map[string]string{}},
+		},
+	}
+	right := &storage.Plan{
+		Database:     left.Database,
+		DatabaseType: left.DatabaseType,
+		Deployment:   left.Deployment,
+		Target:       left.Target,
+		Environment:  left.Environment,
+		Namespaces:   map[string]*storage.NamespacePlanData{},
+	}
+
+	assert.True(t, plansEquivalentForRedrive(left, right))
+}
+
+func newRedriveTestService(t *testing.T, client tern.Client, plans storage.PlanStore, applies storage.ApplyStore, locks storage.LockStore, rows ...any) *Service {
 	t.Helper()
 	var tasks []*storage.Task
 	var operations []*storage.ApplyOperation
@@ -183,6 +297,7 @@ func newRedriveTestService(t *testing.T, client tern.Client, plans storage.PlanS
 	return New(&mockStorageWithApplyStores{
 		plans:      plans,
 		applies:    applies,
+		locks:      locks,
 		tasks:      &capturingTaskStore{tasks: tasks},
 		applyLogs:  &noopApplyLogStore{},
 		operations: &staticApplyOperationStore{operations: operations},
@@ -336,6 +451,7 @@ type redriveApplyStore struct {
 	storage.ApplyStore
 	apply           *storage.Apply
 	redrivenApplyID int64
+	redriveLockID   int64
 }
 
 func (s *redriveApplyStore) GetByApplyIdentifier(_ context.Context, applyIdentifier string) (*storage.Apply, error) {
@@ -345,7 +461,7 @@ func (s *redriveApplyStore) GetByApplyIdentifier(_ context.Context, applyIdentif
 	return nil, nil
 }
 
-func (s *redriveApplyStore) RedriveFailed(_ context.Context, applyID int64) (*storage.Apply, error) {
+func (s *redriveApplyStore) RedriveFailed(_ context.Context, applyID int64, lockID int64) (*storage.Apply, error) {
 	if s.apply == nil || s.apply.ID != applyID {
 		return nil, storage.ErrApplyNotFound
 	}
@@ -353,8 +469,60 @@ func (s *redriveApplyStore) RedriveFailed(_ context.Context, applyID int64) (*st
 		return nil, fmt.Errorf("apply %s is %s: %w", s.apply.ApplyIdentifier, s.apply.State, storage.ErrApplyNotRedrivable)
 	}
 	s.redrivenApplyID = applyID
+	s.redriveLockID = lockID
 	redriven := *s.apply
+	redriven.LockID = lockID
 	redriven.State = state.Apply.FailedRetryable
 	redriven.CompletedAt = nil
 	return &redriven, nil
+}
+
+type redriveLockStore struct {
+	storage.LockStore
+	lock   *storage.Lock
+	nextID int64
+}
+
+func newRedriveLockStore() *redriveLockStore {
+	return &redriveLockStore{nextID: 1}
+}
+
+func (s *redriveLockStore) Acquire(_ context.Context, lock *storage.Lock) error {
+	if s.lock != nil {
+		if s.lock.Owner != lock.Owner {
+			return storage.ErrLockHeld
+		}
+		return nil
+	}
+	stored := *lock
+	stored.ID = s.nextID
+	s.nextID++
+	s.lock = &stored
+	return nil
+}
+
+func (s *redriveLockStore) Get(_ context.Context, database, dbType string) (*storage.Lock, error) {
+	if s.lock != nil && s.lock.DatabaseName == database && s.lock.DatabaseType == dbType {
+		return s.lock, nil
+	}
+	return nil, nil
+}
+
+func (s *redriveLockStore) ForceRelease(_ context.Context, database, dbType string) error {
+	if s.lock == nil || s.lock.DatabaseName != database || s.lock.DatabaseType != dbType {
+		return storage.ErrLockNotFound
+	}
+	s.lock = nil
+	return nil
+}
+
+func (s *redriveLockStore) Release(_ context.Context, database, dbType, owner string) error {
+	if s.lock == nil || s.lock.DatabaseName != database || s.lock.DatabaseType != dbType {
+		return storage.ErrLockNotFound
+	}
+	if s.lock.Owner != owner {
+		return storage.ErrLockNotOwned
+	}
+	s.lock = nil
+	return nil
 }

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -618,6 +618,11 @@ func (s *Service) HandleStart(w http.ResponseWriter, r *http.Request) {
 	s.handleStart(w, r)
 }
 
+// HandleRedrive is the HTTP handler for POST /api/redrive.
+func (s *Service) HandleRedrive(w http.ResponseWriter, r *http.Request) {
+	s.handleRedrive(w, r)
+}
+
 // HandleVolume is the HTTP handler for POST /api/volume.
 func (s *Service) HandleVolume(w http.ResponseWriter, r *http.Request) {
 	s.handleVolume(w, r)
@@ -686,6 +691,7 @@ func (s *Service) ConfigureRoutes(mux *http.ServeMux) {
 	handle("POST /api/cutover", s.handleCutover)
 	handle("POST /api/stop", s.handleStop)
 	handle("POST /api/start", s.handleStart)
+	handle("POST /api/redrive", s.handleRedrive)
 	handle("POST /api/volume", s.handleVolume)
 	handle("POST /api/revert", s.handleRevert)
 	handle("POST /api/skip-revert", s.handleSkipRevert)

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -179,7 +179,7 @@ type ApplyRequest struct {
 }
 
 // ControlRequest is the HTTP request body for control operations
-// (stop, start, cutover, revert, skip-revert).
+// (stop, start, cutover, revert, skip-revert, redrive).
 type ControlRequest struct {
 	Environment string `json:"environment"`
 	ApplyID     string `json:"apply_id"`
@@ -366,6 +366,20 @@ type ApplyResponse struct {
 	Accepted     bool   `json:"accepted"`
 	ApplyID      string `json:"apply_id,omitempty"`
 	ErrorCode    string `json:"error_code,omitempty"`
+	ErrorMessage string `json:"error_message,omitempty"`
+}
+
+const (
+	RedriveStatusRedriven = "redriven"
+)
+
+// RedriveResponse is the HTTP response for POST /api/redrive.
+type RedriveResponse struct {
+	Accepted     bool   `json:"accepted"`
+	Status       string `json:"status"`
+	ApplyID      string `json:"apply_id,omitempty"`
+	PlanID       string `json:"plan_id,omitempty"`
+	Message      string `json:"message,omitempty"`
 	ErrorMessage string `json:"error_message,omitempty"`
 }
 

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -184,6 +184,7 @@ type ControlRequest struct {
 	Environment string `json:"environment"`
 	ApplyID     string `json:"apply_id"`
 	Caller      string `json:"caller,omitempty"`
+	Force       bool   `json:"force,omitempty"`
 }
 
 // VolumeRequest is the HTTP request body for POST /api/volume.

--- a/pkg/cmd/client/client.go
+++ b/pkg/cmd/client/client.go
@@ -323,6 +323,11 @@ func CallStartAPI(endpoint, environment, applyID string) (*apitypes.StartRespons
 	return callControlAPI[apitypes.StartResponse](endpoint, "/api/start", environment, applyID)
 }
 
+// CallRedriveAPI calls the redrive API and returns the typed result.
+func CallRedriveAPI(endpoint, environment, applyID string) (*apitypes.RedriveResponse, error) {
+	return callControlAPI[apitypes.RedriveResponse](endpoint, "/api/redrive", environment, applyID)
+}
+
 // CallVolumeAPI calls the volume API and returns the typed result.
 func CallVolumeAPI(endpoint, environment, applyID string, volume int) (*apitypes.VolumeResponse, error) {
 	req := apitypes.VolumeRequest{Environment: environment, Volume: int32(volume), ApplyID: applyID}

--- a/pkg/cmd/client/client.go
+++ b/pkg/cmd/client/client.go
@@ -166,7 +166,13 @@ func CallApplyAPI(endpoint, planID, environment, caller string, options map[stri
 // typed response. Control operations share the same ControlRequest body and
 // differ only by endpoint path and response type.
 func callControlAPI[Resp any](endpoint, path, environment, applyID string) (*Resp, error) {
-	req := apitypes.ControlRequest{Environment: environment, ApplyID: applyID, Caller: GenerateCLIOwner()}
+	return callControlAPIWithRequest[Resp](endpoint, path, apitypes.ControlRequest{Environment: environment, ApplyID: applyID, Caller: GenerateCLIOwner()})
+}
+
+func callControlAPIWithRequest[Resp any](endpoint, path string, req apitypes.ControlRequest) (*Resp, error) {
+	if req.Caller == "" {
+		req.Caller = GenerateCLIOwner()
+	}
 	var result Resp
 	if err := doPostInto(endpoint, path, req, &result); err != nil {
 		return nil, err
@@ -324,8 +330,13 @@ func CallStartAPI(endpoint, environment, applyID string) (*apitypes.StartRespons
 }
 
 // CallRedriveAPI calls the redrive API and returns the typed result.
-func CallRedriveAPI(endpoint, environment, applyID string) (*apitypes.RedriveResponse, error) {
-	return callControlAPI[apitypes.RedriveResponse](endpoint, "/api/redrive", environment, applyID)
+func CallRedriveAPI(endpoint, environment, applyID string, force bool) (*apitypes.RedriveResponse, error) {
+	return callControlAPIWithRequest[apitypes.RedriveResponse](endpoint, "/api/redrive", apitypes.ControlRequest{
+		Environment: environment,
+		ApplyID:     applyID,
+		Caller:      GenerateCLIOwner(),
+		Force:       force,
+	})
 }
 
 // CallVolumeAPI calls the volume API and returns the typed result.

--- a/pkg/cmd/commands/common.go
+++ b/pkg/cmd/commands/common.go
@@ -259,6 +259,11 @@ type startResponseWrapper struct{ r *apitypes.StartResponse }
 func (w startResponseWrapper) IsAccepted() bool        { return w.r.Accepted }
 func (w startResponseWrapper) GetErrorMessage() string { return w.r.ErrorMessage }
 
+type redriveResponseWrapper struct{ r *apitypes.RedriveResponse }
+
+func (w redriveResponseWrapper) IsAccepted() bool        { return w.r.Accepted }
+func (w redriveResponseWrapper) GetErrorMessage() string { return w.r.ErrorMessage }
+
 type volumeResponseWrapper struct{ r *apitypes.VolumeResponse }
 
 func (w volumeResponseWrapper) IsAccepted() bool        { return w.r.Accepted }

--- a/pkg/cmd/commands/redrive.go
+++ b/pkg/cmd/commands/redrive.go
@@ -10,6 +10,7 @@ import (
 // RedriveCmd re-plans and redrives a recent failed schema change.
 type RedriveCmd struct {
 	ControlFlags
+	Force bool `help:"Force redrive by taking over an existing database lock"`
 	Watch bool `short:"w" help:"Watch progress until completion" default:"true" negatable:""`
 }
 
@@ -26,7 +27,7 @@ func (cmd *RedriveCmd) Run(g *Globals) error {
 	var redriveResult *apitypes.RedriveResponse
 	err = withLoading("Re-planning failed schema change...", true, func() error {
 		var redriveErr error
-		redriveResult, redriveErr = client.CallRedriveAPI(ep, cmd.Environment, cmd.ApplyID)
+		redriveResult, redriveErr = client.CallRedriveAPI(ep, cmd.Environment, cmd.ApplyID, cmd.Force)
 		return redriveErr
 	})
 	if err != nil {

--- a/pkg/cmd/commands/redrive.go
+++ b/pkg/cmd/commands/redrive.go
@@ -1,0 +1,62 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/block/schemabot/pkg/apitypes"
+	"github.com/block/schemabot/pkg/cmd/client"
+)
+
+// RedriveCmd re-plans and redrives a recent failed schema change.
+type RedriveCmd struct {
+	ControlFlags
+	Watch bool `short:"w" help:"Watch progress until completion" default:"true" negatable:""`
+}
+
+// Run executes the redrive command.
+func (cmd *RedriveCmd) Run(g *Globals) error {
+	if err := cmd.RequireApplyID(); err != nil {
+		return err
+	}
+	ep, err := cmd.Resolve(g)
+	if err != nil {
+		return err
+	}
+
+	var redriveResult *apitypes.RedriveResponse
+	err = withLoading("Re-planning failed schema change...", true, func() error {
+		var redriveErr error
+		redriveResult, redriveErr = client.CallRedriveAPI(ep, cmd.Environment, cmd.ApplyID)
+		return redriveErr
+	})
+	if err != nil {
+		return err
+	}
+	if err := checkAccepted(redriveResponseWrapper{redriveResult}, "redrive"); err != nil {
+		return err
+	}
+
+	printRedriveResult(redriveResult)
+	if !cmd.Watch || redriveResult.ApplyID == "" {
+		return nil
+	}
+	return WatchApplyProgressByApplyID(ep, redriveResult.ApplyID, true)
+}
+
+func printRedriveResult(result *apitypes.RedriveResponse) {
+	if result == nil {
+		return
+	}
+	switch result.Status {
+	case apitypes.RedriveStatusRedriven:
+		fmt.Printf("Redrive queued for %s\n", result.ApplyID)
+	default:
+		fmt.Printf("Redrive accepted for %s\n", result.ApplyID)
+	}
+	if result.PlanID != "" {
+		fmt.Printf("Plan: %s\n", result.PlanID)
+	}
+	if result.Message != "" {
+		fmt.Println(result.Message)
+	}
+}

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -33,6 +33,7 @@ type CLI struct {
 	Cutover    commands.CutoverCmd    `cmd:"" help:"Trigger cutover for a deferred schema change"`
 	Stop       commands.StopCmd       `cmd:"" help:"Stop an in-progress schema change"`
 	Start      commands.StartCmd      `cmd:"" help:"Resume a stopped schema change"`
+	Redrive    commands.RedriveCmd    `cmd:"" help:"Re-plan and redrive a recent failed schema change"`
 	Volume     commands.VolumeCmd     `cmd:"" help:"Adjust schema change speed (1-11)"`
 	Revert     commands.RevertCmd     `cmd:"" help:"Revert a completed schema change during the revert window"`
 	SkipRevert commands.SkipRevertCmd `cmd:"" name:"skip-revert" help:"Skip the revert window, finalizing the schema change"`

--- a/pkg/storage/errors.go
+++ b/pkg/storage/errors.go
@@ -29,6 +29,9 @@ var (
 	// for the same database, type, and environment.
 	ErrActiveApplyExists = errors.New("active apply already exists")
 
+	// ErrApplyNotRedrivable is returned when a failed apply cannot be redriven.
+	ErrApplyNotRedrivable = errors.New("apply is not redrivable")
+
 	// ErrApplyLeaseLost is returned when an operator-owned write no longer
 	// matches the apply lease token stored by the latest operator claimant.
 	ErrApplyLeaseLost = errors.New("apply lease lost")

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -1762,6 +1762,135 @@ func (s *applyStore) ExpireRetryable(ctx context.Context) ([]*storage.RetryableA
 	return expirations, nil
 }
 
+// RedriveFailed transitions a recent permanently failed apply back onto the
+// retryable recovery path so operator drivers can claim and drive the
+// remaining failed work.
+func (s *applyStore) RedriveFailed(ctx context.Context, applyID int64) (*storage.Apply, error) {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
+	if err != nil {
+		return nil, fmt.Errorf("begin redrive failed apply %d transaction: %w", applyID, err)
+	}
+	defer rollbackTx(ctx, tx, "redrive failed apply")
+
+	row := tx.QueryRowContext(ctx, `
+		SELECT `+applyColumns+`
+		FROM applies
+		WHERE id = ?
+		FOR UPDATE
+	`, applyID)
+	apply, err := scanApply(row)
+	if err != nil {
+		return nil, fmt.Errorf("load apply %d for redrive: %w", applyID, err)
+	}
+	if apply == nil {
+		return nil, storage.ErrApplyNotFound
+	}
+	if !state.IsState(apply.State, state.Apply.Failed) {
+		return nil, fmt.Errorf("apply %s is %s; only failed applies can be redriven: %w", apply.ApplyIdentifier, apply.State, storage.ErrApplyNotRedrivable)
+	}
+	if apply.CompletedAt == nil {
+		return nil, fmt.Errorf("apply %s has no failure completion time; create a new apply instead: %w", apply.ApplyIdentifier, storage.ErrApplyNotRedrivable)
+	}
+	if apply.CompletedAt.Before(time.Now().AddDate(0, 0, -storage.RedriveFailureFreshnessDays)) {
+		return nil, fmt.Errorf("apply %s failed more than %d day(s) ago; create a new apply instead: %w", apply.ApplyIdentifier, storage.RedriveFailureFreshnessDays, storage.ErrApplyNotRedrivable)
+	}
+
+	database, dbType, environment, deployment := apply.Database, apply.DatabaseType, apply.Environment, apply.Deployment
+	if !hasApplyTarget(database, dbType, environment) || deployment == "" {
+		database, dbType, environment, deployment, err = applyTargetForUpdate(ctx, tx, apply)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if !hasApplyTarget(database, dbType, environment) || deployment == "" {
+		return nil, fmt.Errorf("apply %s is missing target metadata for redrive: %w", apply.ApplyIdentifier, storage.ErrApplyNotRedrivable)
+	}
+
+	conn, lockName, err := acquireApplyTargetLockConn(ctx, s.db, database, dbType, environment)
+	if err != nil {
+		return nil, err
+	}
+	defer releaseApplyTargetLockConn(ctx, conn, lockName, "redrive failed apply")
+
+	deployments, err := operationDeploymentsForApply(ctx, tx, apply.ID)
+	if err != nil {
+		return nil, err
+	}
+	deployments = append(deployments, deployment)
+	if err := checkNoActiveApplyForTargets(ctx, tx, database, dbType, environment, deployments, apply.ID); err != nil {
+		return nil, err
+	}
+	if err := rejectNonRedrivableOperations(ctx, tx, apply); err != nil {
+		return nil, err
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE tasks t
+		LEFT JOIN apply_operations ao ON ao.id = t.apply_operation_id
+		SET t.state = ?, t.error_message = '', t.completed_at = NULL, t.updated_at = NOW()
+		WHERE t.apply_id = ?
+			AND t.state IN (?, ?)
+			AND (t.apply_operation_id IS NULL OR ao.state = ?)
+	`, state.Task.FailedRetryable, apply.ID, state.Task.Failed, state.Task.Cancelled, state.ApplyOperation.Failed); err != nil {
+		return nil, fmt.Errorf("mark failed tasks retryable for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE apply_operations
+		SET state = ?, error_message = '', completed_at = NULL, updated_at = NOW(),
+		    lease_owner = '', lease_token = '', lease_acquired_at = NULL
+		WHERE apply_id = ? AND state = ?
+	`, state.ApplyOperation.FailedRetryable, apply.ID, state.ApplyOperation.Failed); err != nil {
+		return nil, fmt.Errorf("mark failed operations retryable for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+
+	result, err := tx.ExecContext(ctx, `
+		UPDATE applies
+		SET state = ?, error_message = '', attempt = 0, completed_at = NULL, updated_at = NOW(),
+		    lease_owner = '', lease_token = '', lease_acquired_at = NULL
+		WHERE id = ? AND state = ?
+	`, state.Apply.FailedRetryable, apply.ID, state.Apply.Failed)
+	if err != nil {
+		return nil, fmt.Errorf("mark apply %s retryable for redrive: %w", apply.ApplyIdentifier, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("read redrive rows affected for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if rows == 0 {
+		return nil, fmt.Errorf("apply %s changed before redrive: %w", apply.ApplyIdentifier, storage.ErrApplyNotRedrivable)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit redrive failed apply %s: %w", apply.ApplyIdentifier, err)
+	}
+
+	apply.State = state.Apply.FailedRetryable
+	apply.ErrorMessage = ""
+	apply.Attempt = 0
+	apply.CompletedAt = nil
+	apply.UpdatedAt = time.Now()
+	apply.LeaseOwner = ""
+	apply.LeaseToken = ""
+	apply.LeaseAcquiredAt = nil
+	return apply, nil
+}
+
+func rejectNonRedrivableOperations(ctx context.Context, tx *sql.Tx, apply *storage.Apply) error {
+	var count int
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM apply_operations
+		WHERE apply_id = ? AND state IN (?, ?, ?)
+	`, apply.ID, state.ApplyOperation.Stopped, state.ApplyOperation.Cancelled, state.ApplyOperation.Reverted).Scan(&count); err != nil {
+		return fmt.Errorf("check non-redrivable operations for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if count > 0 {
+		return fmt.Errorf("apply %s has %d stopped, cancelled, or reverted operation(s); create a new apply instead: %w", apply.ApplyIdentifier, count, storage.ErrApplyNotRedrivable)
+	}
+	return nil
+}
+
 func retryableExpirationReason(apply *storage.Apply) storage.RetryableExpirationReason {
 	if apply.Attempt >= maxRecoveryAttempts {
 		return storage.RetryableExpirationAttemptBudget

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -368,6 +368,33 @@ func checkNoActiveApplyForTargets(ctx context.Context, tx *sql.Tx, database, dbT
 	return fmt.Errorf("active apply exists for %s/%s/%s deployments %v: %w", database, dbType, environment, deployments, storage.ErrActiveApplyExists)
 }
 
+func checkNoActiveApplyForDatabase(ctx context.Context, tx *sql.Tx, database, dbType string, excludeApplyID int64) error {
+	statePredicate, stateArgs := nonTerminalApplyStatePredicate("state")
+	query := fmt.Sprintf(`
+		SELECT 1 FROM applies
+		WHERE database_name = ?
+		AND database_type = ?
+		AND %s
+	`, statePredicate)
+	args := []any{database, dbType}
+	args = append(args, stateArgs...)
+	if excludeApplyID > 0 {
+		query += " AND id != ?"
+		args = append(args, excludeApplyID)
+	}
+	query += " LIMIT 1"
+
+	var exists int
+	err := tx.QueryRowContext(ctx, query, args...).Scan(&exists)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("check active applies for %s/%s: %w", database, dbType, err)
+	}
+	return fmt.Errorf("active apply exists for %s/%s: %w", database, dbType, storage.ErrActiveApplyExists)
+}
+
 func applyLeaseFromContext(ctx context.Context, applyID int64) (storage.ApplyLease, bool, error) {
 	lease, ok := storage.ApplyLeaseFromContext(ctx)
 	if !ok {
@@ -1765,7 +1792,11 @@ func (s *applyStore) ExpireRetryable(ctx context.Context) ([]*storage.RetryableA
 // RedriveFailed transitions a recent permanently failed apply back onto the
 // retryable recovery path so operator drivers can claim and drive the
 // remaining failed work.
-func (s *applyStore) RedriveFailed(ctx context.Context, applyID int64) (*storage.Apply, error) {
+func (s *applyStore) RedriveFailed(ctx context.Context, applyID int64, lockID int64) (*storage.Apply, error) {
+	if lockID == 0 {
+		return nil, fmt.Errorf("redrive failed apply %d requires a lock: %w", applyID, storage.ErrApplyNotRedrivable)
+	}
+
 	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
 	if err != nil {
 		return nil, fmt.Errorf("begin redrive failed apply %d transaction: %w", applyID, err)
@@ -1804,6 +1835,9 @@ func (s *applyStore) RedriveFailed(ctx context.Context, applyID int64) (*storage
 	}
 	if !hasApplyTarget(database, dbType, environment) || deployment == "" {
 		return nil, fmt.Errorf("apply %s is missing target metadata for redrive: %w", apply.ApplyIdentifier, storage.ErrApplyNotRedrivable)
+	}
+	if err := checkNoActiveApplyForDatabase(ctx, tx, database, dbType, apply.ID); err != nil {
+		return nil, err
 	}
 
 	conn, lockName, err := acquireApplyTargetLockConn(ctx, s.db, database, dbType, environment)
@@ -1846,10 +1880,10 @@ func (s *applyStore) RedriveFailed(ctx context.Context, applyID int64) (*storage
 
 	result, err := tx.ExecContext(ctx, `
 		UPDATE applies
-		SET state = ?, error_message = '', attempt = 0, completed_at = NULL, updated_at = NOW(),
+		SET lock_id = ?, state = ?, error_message = '', attempt = 0, completed_at = NULL, updated_at = NOW(),
 		    lease_owner = '', lease_token = '', lease_acquired_at = NULL
 		WHERE id = ? AND state = ?
-	`, state.Apply.FailedRetryable, apply.ID, state.Apply.Failed)
+	`, lockID, state.Apply.FailedRetryable, apply.ID, state.Apply.Failed)
 	if err != nil {
 		return nil, fmt.Errorf("mark apply %s retryable for redrive: %w", apply.ApplyIdentifier, err)
 	}
@@ -1866,6 +1900,7 @@ func (s *applyStore) RedriveFailed(ctx context.Context, applyID int64) (*storage
 	}
 
 	apply.State = state.Apply.FailedRetryable
+	apply.LockID = lockID
 	apply.ErrorMessage = ""
 	apply.Attempt = 0
 	apply.CompletedAt = nil

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -2689,10 +2689,11 @@ func TestApplyStore_RedriveFailed(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	redriven, err := store.Applies().RedriveFailed(ctx, apply.ID)
+	redriven, err := store.Applies().RedriveFailed(ctx, apply.ID, lock.ID)
 	require.NoError(t, err)
 	require.NotNil(t, redriven)
 	assert.Equal(t, state.Apply.FailedRetryable, redriven.State)
+	assert.Equal(t, lock.ID, redriven.LockID)
 	assert.Zero(t, redriven.Attempt)
 	assert.Empty(t, redriven.ErrorMessage)
 	assert.Nil(t, redriven.CompletedAt)
@@ -2724,6 +2725,33 @@ func TestApplyStore_RedriveFailed(t *testing.T) {
 	assert.NotNil(t, completedOp.CompletedAt)
 }
 
+func TestApplyStore_RedriveFailedRejectsActiveApplyForDatabase(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_redrive_active_database", 523, state.Apply.Failed, "staging")
+	now := time.Now()
+	apply.Deployment = "region-a"
+	apply.CompletedAt = &now
+	require.NoError(t, store.Applies().Update(ctx, apply))
+	_, err := testDB.ExecContext(ctx, `UPDATE applies SET deployment = ?, completed_at = ? WHERE id = ?`, apply.Deployment, now, apply.ID)
+	require.NoError(t, err)
+
+	active := createTestApplyWithStateEnvDeployment(t, store, lock, "apply_redrive_active_database_blocker", 524, state.Apply.Running, "production", "region-b")
+	require.NotNil(t, active)
+
+	redriven, err := store.Applies().RedriveFailed(ctx, apply.ID, lock.ID)
+	require.ErrorIs(t, err, storage.ErrActiveApplyExists)
+	assert.Nil(t, redriven)
+
+	reloaded, err := store.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, reloaded)
+	assert.Equal(t, state.Apply.Failed, reloaded.State)
+}
+
 func TestApplyStore_RedriveFailedRejectsOldFailure(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
@@ -2738,7 +2766,7 @@ func TestApplyStore_RedriveFailedRejectsOldFailure(t *testing.T) {
 	_, err := testDB.ExecContext(ctx, `UPDATE applies SET deployment = ?, completed_at = ? WHERE id = ?`, apply.Deployment, completedAt, apply.ID)
 	require.NoError(t, err)
 
-	redriven, err := store.Applies().RedriveFailed(ctx, apply.ID)
+	redriven, err := store.Applies().RedriveFailed(ctx, apply.ID, lock.ID)
 	require.ErrorIs(t, err, storage.ErrApplyNotRedrivable)
 	assert.Nil(t, redriven)
 }
@@ -2788,7 +2816,7 @@ func TestApplyStore_RedriveFailedRejectsNonRedrivableOperation(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			redriven, err := store.Applies().RedriveFailed(ctx, apply.ID)
+			redriven, err := store.Applies().RedriveFailed(ctx, apply.ID, lock.ID)
 			require.ErrorIs(t, err, storage.ErrApplyNotRedrivable)
 			assert.Nil(t, redriven)
 

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -2629,6 +2629,177 @@ func TestApplyStore_ExpireRetryableTerminalizesRetryableOperations(t *testing.T)
 	assert.Equal(t, state.ApplyOperation.WaitingForCutover, parkedOp.State, "a healthy successor parked at the cutover barrier must be left untouched")
 }
 
+// TestApplyStore_RedriveFailed verifies that deliberate redrive reopens a
+// recent failed apply while preserving completed work as already done.
+func TestApplyStore_RedriveFailed(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_redrive_failed", 520, state.Apply.Failed, "staging")
+	now := time.Now()
+	apply.Attempt = maxRecoveryAttempts
+	apply.Deployment = "region-a"
+	apply.ErrorMessage = "retry budget exhausted"
+	apply.CompletedAt = &now
+	require.NoError(t, store.Applies().Update(ctx, apply))
+	_, err := testDB.ExecContext(ctx, `UPDATE applies SET deployment = ? WHERE id = ?`, apply.Deployment, apply.ID)
+	require.NoError(t, err)
+
+	_, err = store.Tasks().Create(ctx, &storage.Task{
+		TaskIdentifier: "task_redrive_failed",
+		ApplyID:        apply.ID,
+		PlanID:         apply.PlanID,
+		Database:       apply.Database,
+		DatabaseType:   apply.DatabaseType,
+		Engine:         storage.EngineSpirit,
+		Environment:    apply.Environment,
+		State:          state.Task.Failed,
+		ErrorMessage:   "copy failed",
+		TableName:      "orders",
+		Options:        []byte("{}"),
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	})
+	require.NoError(t, err)
+	_, err = store.Tasks().Create(ctx, &storage.Task{
+		TaskIdentifier: "task_redrive_completed",
+		ApplyID:        apply.ID,
+		PlanID:         apply.PlanID,
+		Database:       apply.Database,
+		DatabaseType:   apply.DatabaseType,
+		Engine:         storage.EngineSpirit,
+		Environment:    apply.Environment,
+		State:          state.Task.Completed,
+		TableName:      "customers",
+		Options:        []byte("{}"),
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		CompletedAt:    &now,
+	})
+	require.NoError(t, err)
+
+	failedOpID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Failed, ErrorMessage: "copy failed",
+	})
+	require.NoError(t, err)
+	completedOpID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b", State: state.ApplyOperation.Completed, CompletedAt: &now,
+	})
+	require.NoError(t, err)
+
+	redriven, err := store.Applies().RedriveFailed(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, redriven)
+	assert.Equal(t, state.Apply.FailedRetryable, redriven.State)
+	assert.Zero(t, redriven.Attempt)
+	assert.Empty(t, redriven.ErrorMessage)
+	assert.Nil(t, redriven.CompletedAt)
+
+	failedTask, err := store.Tasks().Get(ctx, "task_redrive_failed")
+	require.NoError(t, err)
+	require.NotNil(t, failedTask)
+	assert.Equal(t, state.Task.FailedRetryable, failedTask.State)
+	assert.Empty(t, failedTask.ErrorMessage)
+	assert.Nil(t, failedTask.CompletedAt)
+
+	completedTask, err := store.Tasks().Get(ctx, "task_redrive_completed")
+	require.NoError(t, err)
+	require.NotNil(t, completedTask)
+	assert.Equal(t, state.Task.Completed, completedTask.State)
+	assert.NotNil(t, completedTask.CompletedAt)
+
+	failedOp, err := store.ApplyOperations().Get(ctx, failedOpID)
+	require.NoError(t, err)
+	require.NotNil(t, failedOp)
+	assert.Equal(t, state.ApplyOperation.FailedRetryable, failedOp.State)
+	assert.Empty(t, failedOp.ErrorMessage)
+	assert.Nil(t, failedOp.CompletedAt)
+
+	completedOp, err := store.ApplyOperations().Get(ctx, completedOpID)
+	require.NoError(t, err)
+	require.NotNil(t, completedOp)
+	assert.Equal(t, state.ApplyOperation.Completed, completedOp.State)
+	assert.NotNil(t, completedOp.CompletedAt)
+}
+
+func TestApplyStore_RedriveFailedRejectsOldFailure(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_redrive_old_failed", 521, state.Apply.Failed, "staging")
+	completedAt := time.Now().AddDate(0, 0, -storage.RedriveFailureFreshnessDays-1)
+	apply.Deployment = "region-a"
+	apply.CompletedAt = &completedAt
+	require.NoError(t, store.Applies().Update(ctx, apply))
+	_, err := testDB.ExecContext(ctx, `UPDATE applies SET deployment = ?, completed_at = ? WHERE id = ?`, apply.Deployment, completedAt, apply.ID)
+	require.NoError(t, err)
+
+	redriven, err := store.Applies().RedriveFailed(ctx, apply.ID)
+	require.ErrorIs(t, err, storage.ErrApplyNotRedrivable)
+	assert.Nil(t, redriven)
+}
+
+func TestApplyStore_RedriveFailedRejectsNonRedrivableOperation(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		operationState string
+		taskState      string
+	}{
+		{name: "stopped", operationState: state.ApplyOperation.Stopped, taskState: state.Task.Stopped},
+		{name: "cancelled", operationState: state.ApplyOperation.Cancelled, taskState: state.Task.Cancelled},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearTables(t)
+			ctx := t.Context()
+			store := New(testDB)
+
+			lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+			apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_redrive_"+tc.name+"_operation", 522, state.Apply.Failed, "staging")
+			now := time.Now()
+			apply.Deployment = "region-a"
+			apply.CompletedAt = &now
+			require.NoError(t, store.Applies().Update(ctx, apply))
+			_, err := testDB.ExecContext(ctx, `UPDATE applies SET deployment = ? WHERE id = ?`, apply.Deployment, apply.ID)
+			require.NoError(t, err)
+
+			operationID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+				ApplyID: apply.ID, Deployment: "region-a", State: tc.operationState, CompletedAt: &now,
+			})
+			require.NoError(t, err)
+			_, err = store.Tasks().Create(ctx, &storage.Task{
+				TaskIdentifier:   "task_redrive_" + tc.name + "_operation",
+				ApplyID:          apply.ID,
+				ApplyOperationID: &operationID,
+				PlanID:           apply.PlanID,
+				Database:         apply.Database,
+				DatabaseType:     apply.DatabaseType,
+				Engine:           storage.EngineSpirit,
+				Environment:      apply.Environment,
+				State:            tc.taskState,
+				TableName:        "orders",
+				Options:          []byte("{}"),
+				CreatedAt:        now,
+				UpdatedAt:        now,
+				CompletedAt:      &now,
+			})
+			require.NoError(t, err)
+
+			redriven, err := store.Applies().RedriveFailed(ctx, apply.ID)
+			require.ErrorIs(t, err, storage.ErrApplyNotRedrivable)
+			assert.Nil(t, redriven)
+
+			task, err := store.Tasks().Get(ctx, "task_redrive_"+tc.name+"_operation")
+			require.NoError(t, err)
+			require.NotNil(t, task)
+			assert.Equal(t, tc.taskState, task.State)
+		})
+	}
+}
+
 func TestApplyStore_FindMissingSummaryComment_ExcludesAppliesWithoutGitHubDestination(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -332,10 +332,11 @@ type ApplyStore interface {
 	// RedriveFailed transitions a recent permanently failed apply back onto the
 	// retryable recovery path. Completed work remains completed; failed tasks and
 	// operation rows become failed_retryable so operator drivers can claim and
-	// drive only the remaining work. The transition re-checks active-apply
-	// exclusivity under the apply target lock because it makes a terminal apply
-	// active again.
-	RedriveFailed(ctx context.Context, applyID int64) (*Apply, error)
+	// drive only the remaining work. The caller must pass the logical lock row it
+	// owns for the target; the transition stores that lock_id and re-checks
+	// active-apply exclusivity under the apply target lock because it makes a
+	// terminal apply active again.
+	RedriveFailed(ctx context.Context, applyID int64, lockID int64) (*Apply, error)
 
 	// FindMissingSummaryComment returns GitHub-backed applies that should have
 	// a terminal summary comment but only have a progress comment. Used by

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -7,6 +7,11 @@ import (
 	"time"
 )
 
+// RedriveFailureFreshnessDays bounds deliberate redrive of terminal failed
+// applies. Older failures should be handled by creating a fresh apply from a
+// fresh plan so stale execution context is not reactivated unexpectedly.
+const RedriveFailureFreshnessDays = 1
+
 // Storage provides access to all stores.
 type Storage interface {
 	// Locks returns the lock store.
@@ -323,6 +328,14 @@ type ApplyStore interface {
 	// retry budget or recovery freshness window to permanent failed. Returns the
 	// applies updated.
 	ExpireRetryable(ctx context.Context) ([]*RetryableApplyExpiration, error)
+
+	// RedriveFailed transitions a recent permanently failed apply back onto the
+	// retryable recovery path. Completed work remains completed; failed tasks and
+	// operation rows become failed_retryable so operator drivers can claim and
+	// drive only the remaining work. The transition re-checks active-apply
+	// exclusivity under the apply target lock because it makes a terminal apply
+	// active again.
+	RedriveFailed(ctx context.Context, applyID int64) (*Apply, error)
 
 	// FindMissingSummaryComment returns GitHub-backed applies that should have
 	// a terminal summary comment but only have a progress comment. Used by


### PR DESCRIPTION
## Why
Failed schema changes currently become terminal once their retry budget is exhausted, even when only part of the original work failed and the desired schema is still unchanged. A CLI-only redrive path lets an operator deliberately retry that same failed work without creating a replacement apply or replaying completed work.

## What
- Add `schemabot redrive <apply-id>` as a guarded recovery command for terminal failed applies
- Reconstruct the remaining redrivable work from failed storage rows, then require a fresh plan to match it exactly
- Reopen the original apply only after the plan match succeeds; completed tasks and operations stay completed
- Require database lock ownership before re-planning, with `--force` matching existing lock takeover semantics
- Reject cancelled, stale, drifted, or concurrently active database work

```text
Original apply state                  Redrive validation
────────────────────                  ──────────────────
completed task ───────────────┐       stored failed rows ─────┐
completed operation ──────────┼──▶    expected remaining work  ├── exact match? ── yes ──▶ reopen failed rows
failed task / operation ──────┘       fresh re-plan ───────────┘                    no  ──▶ leave failed
```

```text
After successful redrive
────────────────────────
completed work        stays completed
failed tasks          failed_retryable
failed operations     failed_retryable
parent apply          failed_retryable with reset retry budget
```

## Risk Assessment
Medium — this adds a new operator control path that can move terminal failed applies back to active retryable states. The path is CLI-only, guarded by lock ownership, freshness limits, active-apply checks, and exact re-plan matching before storage state changes.

Generated with Amp
