### PR TITLE
feat(github): surface paused rollouts in the deployment presentation

### DIFF
--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -237,16 +237,30 @@ func progressOperationResponseFromStorage(op *storage.ApplyOperation) *apitypes.
 	return resp
 }
 
-func (s *Service) progressOperationsForApply(ctx context.Context, apply *storage.Apply) ([]*apitypes.ProgressOperationResponse, map[int64]string, error) {
+func (s *Service) progressOperationsForApply(ctx context.Context, apply *storage.Apply) ([]*apitypes.ProgressOperationResponse, map[int64]string, []*storage.ApplyOperation, error) {
 	if apply == nil {
-		return nil, nil, fmt.Errorf("apply is required")
+		return nil, nil, nil, fmt.Errorf("apply is required")
 	}
 	ops, err := s.storage.ApplyOperations().ListByApply(ctx, apply.ID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("list apply operations for apply %d (%s): %w", apply.ID, apply.ApplyIdentifier, err)
+		return nil, nil, nil, fmt.Errorf("list apply operations for apply %d (%s): %w", apply.ID, apply.ApplyIdentifier, err)
 	}
 	responses, deploymentByOperationID := progressOperationsFromRows(ops)
-	return responses, deploymentByOperationID, nil
+	return responses, deploymentByOperationID, ops, nil
+}
+
+// resolveReleaseLatch best-effort reports whether a paused rollout has been
+// released open, for progress enrichment. Release state is observability, not
+// an apply safety gate, so a latch read failure is logged and treated as
+// unreleased (fail-closed) rather than failing the progress response.
+func (s *Service) resolveReleaseLatch(ctx context.Context, apply *storage.Apply, ops []*storage.ApplyOperation) bool {
+	released, err := storage.ReleaseLatched(ctx, s.storage, apply.ID, ops)
+	if err != nil {
+		s.logger.Warn("progress response will treat rollout as unreleased: failed to load release latch",
+			"apply_id", apply.ApplyIdentifier, "database", apply.Database, "environment", apply.Environment, "error", err)
+		return false
+	}
+	return released
 }
 
 // progressOperationsFromRows projects already-fetched operation rows into the
@@ -264,12 +278,12 @@ func progressOperationsFromRows(ops []*storage.ApplyOperation) ([]*apitypes.Prog
 	return responses, deploymentByOperationID
 }
 
-func (s *Service) bestEffortProgressOperations(ctx context.Context, apply *storage.Apply) ([]*apitypes.ProgressOperationResponse, map[int64]string) {
+func (s *Service) bestEffortProgressOperations(ctx context.Context, apply *storage.Apply) ([]*apitypes.ProgressOperationResponse, map[int64]string, bool) {
 	if apply == nil {
 		s.logger.Warn("progress response will omit per-deployment operations: apply is nil")
-		return nil, nil
+		return nil, nil, false
 	}
-	operations, deploymentByOperationID, err := s.progressOperationsForApply(ctx, apply)
+	operations, deploymentByOperationID, ops, err := s.progressOperationsForApply(ctx, apply)
 	if err != nil {
 		// Operation rows are observability enrichment, not an apply safety gate.
 		// Serve progress without the enrichment and log the storage uncertainty.
@@ -278,9 +292,9 @@ func (s *Service) bestEffortProgressOperations(ctx context.Context, apply *stora
 			"database", apply.Database,
 			"environment", apply.Environment,
 			"error", err)
-		return nil, nil
+		return nil, nil, false
 	}
-	return operations, deploymentByOperationID
+	return operations, deploymentByOperationID, s.resolveReleaseLatch(ctx, apply, ops)
 }
 
 // handleProgressByApplyID handles GET /api/progress/apply/{apply_id} requests.
@@ -392,6 +406,7 @@ func (s *Service) handleProgressByApplyID(w http.ResponseWriter, r *http.Request
 	// a storage error (already logged) just omits the per-deployment breakdown.
 	if opsErr == nil {
 		httpResp.Operations, _ = progressOperationsFromRows(ops)
+		httpResp.Released = s.resolveReleaseLatch(r.Context(), apply, ops)
 	}
 	httpResp.ApplyID = apply.ApplyIdentifier
 	httpResp.Database = apply.Database
@@ -983,8 +998,9 @@ func (s *Service) progressFromLocalStorage(ctx context.Context, apply *storage.A
 	}
 	overlayApplyOptions(httpResp, apply)
 	setRevertSkippedMetadata(httpResp, apply)
-	operations, deploymentByOperationID := s.bestEffortProgressOperations(ctx, apply)
+	operations, deploymentByOperationID, released := s.bestEffortProgressOperations(ctx, apply)
 	httpResp.Operations = operations
+	httpResp.Released = released
 	s.overlayStoredDisplayMetadata(ctx, httpResp, apply, deploymentByOperationID)
 
 	for _, task := range tasks {

--- a/pkg/api/progress_release_test.go
+++ b/pkg/api/progress_release_test.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// resolveReleaseLatch enriches the progress response with the apply-level
+// release latch so the CLI/TUI render a released pause as running degraded
+// rather than paused. It reads the latch only for a pause rollout and fails
+// closed on an unreleased or absent latch.
+func TestResolveReleaseLatch(t *testing.T) {
+	apply := &storage.Apply{ID: 5, ApplyIdentifier: "apply-rel", Environment: "staging"}
+	pauseOps := []*storage.ApplyOperation{
+		{ID: 1, State: state.ApplyOperation.Failed, OnFailure: storage.OnFailurePause},
+		{ID: 2, State: state.ApplyOperation.Pending, OnFailure: storage.OnFailurePause},
+	}
+
+	t.Run("released latch reports released for the projected apply", func(t *testing.T) {
+		control := &releaseLatchControlStore{release: &storage.ApplyControlRequest{
+			Operation: storage.ControlOperationRelease, Status: storage.ControlRequestCompleted,
+		}}
+		svc := newStopReconcileTestService(nil, nil, control)
+		assert.True(t, svc.resolveReleaseLatch(t.Context(), apply, pauseOps))
+		assert.True(t, control.queriedRelease)
+		assert.Equal(t, apply.ID, control.queriedApply)
+	})
+
+	t.Run("unreleased pause stays held", func(t *testing.T) {
+		control := &releaseLatchControlStore{release: nil}
+		svc := newStopReconcileTestService(nil, nil, control)
+		assert.False(t, svc.resolveReleaseLatch(t.Context(), apply, pauseOps))
+	})
+
+	t.Run("no pause operation never reads the latch", func(t *testing.T) {
+		control := &releaseLatchControlStore{release: &storage.ApplyControlRequest{
+			Operation: storage.ControlOperationRelease, Status: storage.ControlRequestCompleted,
+		}}
+		svc := newStopReconcileTestService(nil, nil, control)
+		haltOps := []*storage.ApplyOperation{{ID: 1, State: state.ApplyOperation.Failed}}
+		assert.False(t, svc.resolveReleaseLatch(t.Context(), apply, haltOps))
+		assert.False(t, control.queriedRelease)
+	})
+}

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -439,6 +439,11 @@ type ProgressResponse struct {
 	Volume       int32                        `json:"volume,omitempty"`   // Current volume setting (1-11)
 	Options      map[string]string            `json:"options,omitempty"`  // Apply options (defer_cutover, skip_revert, etc.)
 	Metadata     map[string]string            `json:"metadata,omitempty"` // Engine-specific data
+	// Released is true when an operator has released a paused rollout open via a
+	// release control request, so a deployment that failed under
+	// on_failure=pause no longer holds later deployments — the rollout proceeds
+	// like continue. Apply-level: it applies to every operation of the apply.
+	Released bool `json:"released,omitempty"`
 }
 
 // ProgressOperationResponse represents progress for one deployment operation.

--- a/pkg/cmd/commands/watch_tui.go
+++ b/pkg/cmd/commands/watch_tui.go
@@ -35,6 +35,7 @@ type WatchModel struct {
 	state         string
 	tables        []tableProgress
 	operations    []templates.ProgressOperation
+	released      bool // apply-level release latch: a released pause runs degraded, not paused
 	errorMsg      string
 	currentVolume int // Current volume (1-11)
 
@@ -110,6 +111,7 @@ type progressMsg struct {
 	state       string
 	tables      []tableProgress
 	operations  []templates.ProgressOperation
+	released    bool   // apply-level release latch: a released pause runs degraded, not paused
 	errorMsg    string // Human-readable error message
 	failed      bool   // true when the API call didn't return usable progress data
 	retryable   bool   // when failed, whether the TUI should keep polling
@@ -244,6 +246,7 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.tables = msg.tables
 		}
 		m.operations = msg.operations
+		m.released = msg.released
 		m.errorMsg = msg.errorMsg
 
 		// Timeout skip-revert if state hasn't transitioned after 10s.

--- a/pkg/cmd/commands/watch_tui_commands.go
+++ b/pkg/cmd/commands/watch_tui_commands.go
@@ -226,6 +226,7 @@ func parseProgressResult(result *apitypes.ProgressResponse) progressMsg {
 	msg := progressMsg{
 		state:       data.State,
 		operations:  data.Operations,
+		released:    data.Released,
 		errorMsg:    data.ErrorMessage,
 		volume:      int(result.Volume),
 		applyID:     result.ApplyID,

--- a/pkg/cmd/commands/watch_tui_view_multi.go
+++ b/pkg/cmd/commands/watch_tui_view_multi.go
@@ -34,8 +34,8 @@ func tuiOperationsForPresentation(ops []templates.ProgressOperation) []presentat
 			State:             op.State,
 			Barrier:           op.CutoverPolicy == storage.CutoverPolicyBarrier,
 			Parallel:          op.CutoverPolicy == storage.CutoverPolicyParallel,
-			HaltOnFailure:     op.OnFailure != storage.OnFailureContinue,
 			ContinueOnFailure: op.OnFailure == storage.OnFailureContinue,
+			PauseOnFailure:    op.OnFailure == storage.OnFailurePause,
 			Error:             op.ErrorMessage,
 		})
 	}

--- a/pkg/cmd/commands/watch_tui_view_multi.go
+++ b/pkg/cmd/commands/watch_tui_view_multi.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (m WatchModel) multiDeploymentProgressView() string {
-	model := presentation.Derive(tuiOperationsForPresentation(m.operations))
+	model := presentation.Derive(tuiOperationsForPresentation(m.operations, m.released))
 
 	var b strings.Builder
 	m.writeMultiDeploymentHeader(&b, model)
@@ -26,7 +26,11 @@ func (m WatchModel) multiDeploymentProgressView() string {
 	return b.String()
 }
 
-func tuiOperationsForPresentation(ops []templates.ProgressOperation) []presentation.Operation {
+// tuiOperationsForPresentation maps the watch model's progress operations to the
+// surface-neutral presentation inputs. released is the apply-level release latch:
+// a released pause behaves like continue, so the held siblings proceed and the
+// aggregate runs degraded instead of paused.
+func tuiOperationsForPresentation(ops []templates.ProgressOperation, released bool) []presentation.Operation {
 	presentationOps := make([]presentation.Operation, 0, len(ops))
 	for _, op := range ops {
 		presentationOps = append(presentationOps, presentation.Operation{
@@ -36,6 +40,7 @@ func tuiOperationsForPresentation(ops []templates.ProgressOperation) []presentat
 			Parallel:          op.CutoverPolicy == storage.CutoverPolicyParallel,
 			ContinueOnFailure: op.OnFailure == storage.OnFailureContinue,
 			PauseOnFailure:    op.OnFailure == storage.OnFailurePause,
+			Released:          released,
 			Error:             op.ErrorMessage,
 		})
 	}

--- a/pkg/cmd/internal/templates/progress_multi.go
+++ b/pkg/cmd/internal/templates/progress_multi.go
@@ -33,8 +33,8 @@ func progressOperationsForPresentation(ops []ProgressOperation) []presentation.O
 			State:             op.State,
 			Barrier:           op.CutoverPolicy == storage.CutoverPolicyBarrier,
 			Parallel:          op.CutoverPolicy == storage.CutoverPolicyParallel,
-			HaltOnFailure:     op.OnFailure != storage.OnFailureContinue,
 			ContinueOnFailure: op.OnFailure == storage.OnFailureContinue,
+			PauseOnFailure:    op.OnFailure == storage.OnFailurePause,
 			Error:             op.ErrorMessage,
 		})
 	}

--- a/pkg/cmd/internal/templates/progress_multi.go
+++ b/pkg/cmd/internal/templates/progress_multi.go
@@ -13,7 +13,7 @@ import (
 )
 
 func writeMultiDeploymentProgress(data ProgressData) {
-	model := presentation.Derive(progressOperationsForPresentation(data.Operations))
+	model := presentation.Derive(progressOperationsForPresentation(data.Operations, data.Released))
 
 	writeMultiDeploymentHeader(data, model)
 	writeMultiDeploymentFirstFailure(model.FirstFailure)
@@ -25,7 +25,11 @@ func writeMultiDeploymentProgress(data ProgressData) {
 	}
 }
 
-func progressOperationsForPresentation(ops []ProgressOperation) []presentation.Operation {
+// progressOperationsForPresentation maps the parsed progress operations to the
+// surface-neutral presentation inputs. released is the apply-level release latch
+// (from ProgressData.Released): a released pause behaves like continue, so the
+// held siblings proceed and the aggregate runs degraded instead of paused.
+func progressOperationsForPresentation(ops []ProgressOperation, released bool) []presentation.Operation {
 	presentationOps := make([]presentation.Operation, 0, len(ops))
 	for _, op := range ops {
 		presentationOps = append(presentationOps, presentation.Operation{
@@ -35,6 +39,7 @@ func progressOperationsForPresentation(ops []ProgressOperation) []presentation.O
 			Parallel:          op.CutoverPolicy == storage.CutoverPolicyParallel,
 			ContinueOnFailure: op.OnFailure == storage.OnFailureContinue,
 			PauseOnFailure:    op.OnFailure == storage.OnFailurePause,
+			Released:          released,
 			Error:             op.ErrorMessage,
 		})
 	}

--- a/pkg/cmd/internal/templates/progress_multi_test.go
+++ b/pkg/cmd/internal/templates/progress_multi_test.go
@@ -77,6 +77,31 @@ func TestWriteProgressMultiDeploymentContinueFailureShowsRunningDegraded(t *test
 	assert.NotContains(t, output, "Next: review failure")
 }
 
+// Under on_failure pause a failed deployment with a held sibling renders the
+// paused "release or stop" guidance; once the apply-level release latch is set
+// (Released), the same rollout renders running degraded instead — the CLI
+// applies the latch so it matches what the operator will claim next.
+func TestWriteProgressMultiDeploymentReleasedPauseRendersDegradedNotPaused(t *testing.T) {
+	data := ProgressData{
+		ApplyID:     "apply-paused",
+		Environment: "production",
+		State:       state.Apply.Paused,
+		Operations: []ProgressOperation{
+			{Deployment: "region-a", Target: "orders-a", State: state.ApplyOperation.Failed, CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailurePause, ErrorMessage: "duplicate column name 'region'"},
+			{Deployment: "region-b", Target: "orders-b", State: state.ApplyOperation.Pending, CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailurePause},
+		},
+	}
+
+	paused := captureStdout(t, func() { WriteProgress(data) })
+	assert.Contains(t, paused, "paused — region-a failed; release or stop")
+
+	data.State = state.Apply.RunningDegraded
+	data.Released = true
+	released := captureStdout(t, func() { WriteProgress(data) })
+	assert.NotContains(t, released, "paused — region-a failed; release or stop")
+	assert.Contains(t, released, "running (degraded)")
+}
+
 func TestWriteProgressSingleDeploymentDoesNotRenderMultiDeploymentAggregate(t *testing.T) {
 	data := ProgressData{
 		ApplyID:     "apply-single",

--- a/pkg/cmd/internal/templates/progress_parse.go
+++ b/pkg/cmd/internal/templates/progress_parse.go
@@ -30,6 +30,10 @@ type ProgressData struct {
 	Tables         []TableProgress
 	Options        map[string]string // Apply options (defer_cutover, skip_revert, etc.)
 	Metadata       map[string]string // Engine metadata (e.g., deploy_request_url, branch_name)
+	// Released is true when an operator has released a paused rollout open, so a
+	// deployment that failed under on_failure=pause no longer holds later
+	// deployments. Apply-level: it applies to every operation of the apply.
+	Released bool
 }
 
 // ProgressOperation represents progress for one deployment operation.
@@ -144,6 +148,7 @@ func ParseProgressResponse(result *apitypes.ProgressResponse) ProgressData {
 		CompletedAt:  result.CompletedAt,
 		Options:      result.Options,
 		Metadata:     result.Metadata,
+		Released:     result.Released,
 	}
 
 	for _, op := range result.Operations {

--- a/pkg/presentation/presentation.go
+++ b/pkg/presentation/presentation.go
@@ -5,11 +5,12 @@
 // expand/collapse are computed once and rendered identically everywhere.
 //
 // The derivation adds no persisted state. Labels such as "halted",
-// "ready for cutover — waiting for <deployment>", and "queued — next in order"
-// exist only here; they are projections of (operation state, earlier-sibling
-// states, resolved order, cutover_policy, halt_on_failure). The ordering
-// context is derived from the same gate FindNextApplyOperation evaluates, so the
-// presentation never contradicts what the operator will actually claim next.
+// "paused — <deployment> failed; release or stop", "ready for cutover — waiting
+// for <deployment>", and "queued — next in order" exist only here; they are
+// projections of (operation state, earlier-sibling states, resolved order,
+// cutover_policy, on_failure, release latch). The ordering context is derived
+// from the same gate FindNextApplyOperation evaluates, so the presentation never
+// contradicts what the operator will actually claim next.
 //
 // Vocabulary is deployment-facing only — the model never exposes the internal
 // "apply_operation" term.
@@ -49,19 +50,42 @@ type Operation struct {
 	// are mutually exclusive: the caller derives each from the same stored policy.
 	Parallel bool
 
-	// HaltOnFailure is the resolved halt-on-failure policy (the caller derefs the
-	// stored *bool, treating nil as true — the safe default). When false, a
-	// terminal-failed earlier sibling no longer blocks later deployments.
-	HaltOnFailure bool
-
 	// ContinueOnFailure is true only when the operation's on_failure policy is
-	// exactly "continue". The aggregate projection uses it to hold a rollout
-	// running_degraded past a continuable sibling failure; halt, pause, empty,
-	// and any unrecognized value must be false so the projection fails closed.
+	// exactly "continue". A terminal-failed earlier sibling no longer blocks
+	// later deployments and the aggregate is held running_degraded past the
+	// failure; halt, pause, empty, and any unrecognized value must be false so
+	// the projection fails closed.
 	ContinueOnFailure bool
+
+	// PauseOnFailure is true only when the operation's on_failure policy is
+	// exactly "pause". A terminal-failed earlier sibling holds later deployments
+	// for a human (rendered paused) until the rollout is released; once released
+	// the failure is treated like continue (see Released).
+	PauseOnFailure bool
+
+	// Released is true when a release control request has latched the apply open
+	// (the caller resolves it from storage.ApplyControlRequest.ReleasesPausedRollout
+	// at the boundary). It only has meaning alongside PauseOnFailure: a released
+	// pause behaves like continue, so the held siblings proceed and the aggregate
+	// runs degraded instead of paused. A failed release does not latch, so it
+	// leaves Released false (fail-closed).
+	Released bool
 
 	// Error is the operation's error detail, set when State is failed.
 	Error string
+}
+
+// continuesPastFailure reports whether a terminal-failed earlier sibling stops
+// blocking this deployment: on_failure=continue, or on_failure=pause once the
+// rollout is released. Mirrors the claim predicate's released-failure exemption.
+func (o Operation) continuesPastFailure() bool {
+	return o.ContinueOnFailure || (o.PauseOnFailure && o.Released)
+}
+
+// pausesOnFailure reports whether a terminal-failed earlier sibling holds this
+// deployment paused for a human: on_failure=pause and not yet released.
+func (o Operation) pausesOnFailure() bool {
+	return o.PauseOnFailure && !o.Released
 }
 
 // PresentationState is the semantic, render-time status of one deployment. It is
@@ -82,6 +106,7 @@ const (
 	StateQueuedNext
 	StateWaiting
 	StateHalted
+	StatePaused
 	StateFailed
 	StateRetrying
 	StateStopped
@@ -201,7 +226,8 @@ func Derive(ops []Operation) Apply {
 	for i, op := range ops {
 		children[i] = state.RolloutChild{
 			State:             op.State,
-			ContinueOnFailure: op.ContinueOnFailure,
+			ContinueOnFailure: op.continuesPastFailure(),
+			PauseOnFailure:    op.pausesOnFailure(),
 		}
 	}
 
@@ -287,12 +313,16 @@ func derivePending(d *Deployment, ops []Operation, i int) {
 		d.set(StateQueuedNext, "queued — next in order", "⏳", false)
 		return
 	}
-	if h := haltingBlocker(ops, i); h != nil {
+	if h, paused := blockingSibling(ops, i); h != nil {
+		if paused {
+			d.set(StatePaused, fmt.Sprintf("paused — %s failed; release or stop", h.Deployment), "⏸", true)
+			return
+		}
 		d.set(StateHalted, fmt.Sprintf("halted — %s %s", h.Deployment, haltedReason(h.State)), "⏸", true)
 		return
 	}
 	for j := range i {
-		if blocksPending(ops[j].State, op.Barrier, op.HaltOnFailure) {
+		if blocksPending(ops[j].State, op.Barrier, op.continuesPastFailure()) {
 			d.set(StateWaiting, fmt.Sprintf("waiting for %s", ops[j].Deployment), "⏳", false)
 			return
 		}
@@ -306,7 +336,7 @@ func derivePending(d *Deployment, ops []Operation, i int) {
 func deriveWaitingForCutover(d *Deployment, ops []Operation, i int) {
 	op := ops[i]
 	for j := range i {
-		if blocksCutover(ops[j].State, op.HaltOnFailure) {
+		if blocksCutover(ops[j].State, op.continuesPastFailure()) {
 			d.set(StateReadyForCutoverWaiting, fmt.Sprintf("ready for cutover — waiting for %s", ops[j].Deployment), "🟡", true)
 			return
 		}
@@ -314,30 +344,33 @@ func deriveWaitingForCutover(d *Deployment, ops []Operation, i int) {
 	d.set(StateReadyForCutoverNext, "ready for cutover — next in order", "🟢", true)
 }
 
-// haltingBlocker returns the earliest earlier sibling that halts the rollout for
-// a pending operation: a terminal-failed sibling (only when halt_on_failure is
-// on) or a cancelled/reverted sibling (which halt regardless, matching the
-// predicate's lack of an exemption for them).
-func haltingBlocker(ops []Operation, i int) *Operation {
-	halt := ops[i].HaltOnFailure
+// blockingSibling returns the earliest earlier sibling that holds the rollout
+// for a pending operation, and whether the hold is a human-gated pause rather
+// than a halt. A terminal-failed sibling holds unless the policy continues past
+// it (continue, or a released pause); when it does hold under on_failure=pause
+// the hold is a pause (paused=true). A cancelled/reverted sibling always halts,
+// matching the predicate's lack of an exemption for them.
+func blockingSibling(ops []Operation, i int) (blocker *Operation, paused bool) {
+	op := ops[i]
 	for j := range i {
 		switch ops[j].State {
 		case state.ApplyOperation.Failed:
-			if halt {
-				return &ops[j]
+			if op.continuesPastFailure() {
+				continue
 			}
+			return &ops[j], op.pausesOnFailure()
 		case state.ApplyOperation.Cancelled, state.ApplyOperation.Reverted:
-			return &ops[j]
+			return &ops[j], false
 		}
 	}
-	return nil
+	return nil, false
 }
 
 // blocksPending reports whether an earlier sibling in earlierState blocks a
 // pending operation from being claimed. It mirrors the SQL sibling gate in
 // FindNextApplyOperation exactly: the cutover_policy branch selects the
-// non-blocking set, then the halt_on_failure exemption is applied.
-func blocksPending(earlierState string, barrier, halt bool) bool {
+// non-blocking set, then the released-failure exemption is applied.
+func blocksPending(earlierState string, barrier, continuesPastFailure bool) bool {
 	var policyBlocks bool
 	if barrier {
 		policyBlocks = !isBarrierNonBlocking(earlierState)
@@ -347,9 +380,9 @@ func blocksPending(earlierState string, barrier, halt bool) bool {
 	if !policyBlocks {
 		return false
 	}
-	// halt_on_failure exemption: a terminal-failed earlier sibling stops blocking
-	// when the policy is off.
-	if !halt && earlierState == state.ApplyOperation.Failed {
+	// Released-failure exemption: a terminal-failed earlier sibling stops
+	// blocking when the policy continues past it (continue, or a released pause).
+	if continuesPastFailure && earlierState == state.ApplyOperation.Failed {
 		return false
 	}
 	return true
@@ -374,13 +407,13 @@ func isBarrierNonBlocking(s string) bool {
 
 // blocksCutover reports whether an earlier sibling in earlierState blocks a
 // later deployment's ordered cutover. Cutover is strictly ordered: an earlier
-// sibling blocks until it is completed, except a terminal-failed sibling under
-// halt_on_failure=false, which the rollout is configured to continue past.
-func blocksCutover(earlierState string, halt bool) bool {
+// sibling blocks until it is completed, except a terminal-failed sibling the
+// rollout is configured to continue past (continue, or a released pause).
+func blocksCutover(earlierState string, continuesPastFailure bool) bool {
 	if earlierState == state.ApplyOperation.Completed {
 		return false
 	}
-	if earlierState == state.ApplyOperation.Failed && !halt {
+	if earlierState == state.ApplyOperation.Failed && continuesPastFailure {
 		return false
 	}
 	return true
@@ -410,6 +443,8 @@ func aggregateLabel(s string) string {
 		return "running"
 	case state.Apply.RunningDegraded:
 		return "running (degraded)"
+	case state.Apply.Paused:
+		return "paused"
 	case state.Apply.WaitingForDeploy:
 		return "waiting for deploy"
 	case state.Apply.WaitingForCutover:
@@ -474,6 +509,7 @@ var summaryCategoryOrder = []struct {
 	{"waiting", []PresentationState{StateWaiting}},
 	{"queued", []PresentationState{StateQueuedNext}},
 	{"halted", []PresentationState{StateHalted}},
+	{"paused", []PresentationState{StatePaused}},
 	{"failed", []PresentationState{StateFailed}},
 	{"retrying", []PresentationState{StateRetrying}},
 	{"stopped", []PresentationState{StateStopped}},

--- a/pkg/presentation/presentation_test.go
+++ b/pkg/presentation/presentation_test.go
@@ -11,29 +11,39 @@ import (
 // so is the shared operation/apply state vocabulary (state.ApplyOperation == state.Apply).
 var so = state.ApplyOperation
 
-// rolling builds a rolling, halt-on-failure operation (the conservative defaults).
+// rolling builds a rolling, halt-on-failure operation (the conservative
+// defaults: both policy flags false).
 func rolling(dep, st string) Operation {
-	return Operation{Deployment: dep, State: st, Barrier: false, HaltOnFailure: true}
+	return Operation{Deployment: dep, State: st, Barrier: false}
 }
 
 // barrier builds a barrier, halt-on-failure operation.
 func barrier(dep, st string) Operation {
-	return Operation{Deployment: dep, State: st, Barrier: true, HaltOnFailure: true}
+	return Operation{Deployment: dep, State: st, Barrier: true}
 }
 
 // parallel builds a parallel, halt-on-failure operation. Under parallel the copy
 // phase has no earlier-sibling gate, so a pending parallel operation is never
 // shown waiting for or halted by an earlier sibling.
 func parallel(dep, st string) Operation {
-	return Operation{Deployment: dep, State: st, Parallel: true, HaltOnFailure: true}
+	return Operation{Deployment: dep, State: st, Parallel: true}
 }
 
-// continuing builds a rolling, on_failure=continue operation. HaltOnFailure and
-// ContinueOnFailure are exact complements at the real boundary mappers (both
-// derive from the same on_failure value), so a continue operation sets
-// HaltOnFailure false and ContinueOnFailure true together.
+// continuing builds a rolling, on_failure=continue operation.
 func continuing(dep, st string) Operation {
-	return Operation{Deployment: dep, State: st, HaltOnFailure: false, ContinueOnFailure: true}
+	return Operation{Deployment: dep, State: st, ContinueOnFailure: true}
+}
+
+// pausing builds a rolling, on_failure=pause operation with no release latch: a
+// terminal-failed earlier sibling holds it paused for a human.
+func pausing(dep, st string) Operation {
+	return Operation{Deployment: dep, State: st, PauseOnFailure: true}
+}
+
+// released builds a rolling, on_failure=pause operation whose apply has been
+// released: a terminal-failed earlier sibling is treated like continue.
+func released(dep, st string) Operation {
+	return Operation{Deployment: dep, State: st, PauseOnFailure: true, Released: true}
 }
 
 // TestDerive_Empty: an apply with no operations rolls up to pending with no
@@ -174,6 +184,30 @@ func TestDerivePending_Ordering(t *testing.T) {
 			label: "queued — next in order",
 		},
 		{
+			name:  "pause: earlier failed holds the rollout paused for a human",
+			ops:   []Operation{pausing("eu", so.Failed), pausing("us", so.Pending)},
+			want:  StatePaused,
+			label: "paused — eu failed; release or stop",
+		},
+		{
+			name:  "released pause: earlier failed no longer blocks, like continue",
+			ops:   []Operation{released("eu", so.Failed), released("us", so.Pending)},
+			want:  StateQueuedNext,
+			label: "queued — next in order",
+		},
+		{
+			name:  "pause: earlier cancelled halts rather than pauses",
+			ops:   []Operation{pausing("eu", so.Cancelled), pausing("us", so.Pending)},
+			want:  StateHalted,
+			label: "halted — eu cancelled",
+		},
+		{
+			name:  "pause naming picks the failed sibling over an in-flight one",
+			ops:   []Operation{pausing("eu", so.Failed), pausing("us", so.Running), pausing("au", so.Pending)},
+			want:  StatePaused,
+			label: "paused — eu failed; release or stop",
+		},
+		{
 			name:  "cancelled earlier halts regardless of halt flag",
 			ops:   []Operation{continuing("eu", so.Cancelled), continuing("us", so.Pending)},
 			want:  StateHalted,
@@ -235,6 +269,24 @@ func TestDeriveWaitingForCutover_Ordering(t *testing.T) {
 			ops: []Operation{
 				continuing("eu", so.Failed),
 				continuing("us", so.WaitingForCutover),
+			},
+			want:  StateReadyForCutoverNext,
+			label: "ready for cutover — next in order",
+		},
+		{
+			name: "pause: earlier failed still blocks cutover until released",
+			ops: []Operation{
+				pausing("eu", so.Failed),
+				pausing("us", so.WaitingForCutover),
+			},
+			want:  StateReadyForCutoverWaiting,
+			label: "ready for cutover — waiting for eu",
+		},
+		{
+			name: "released pause: earlier failed no longer blocks cutover",
+			ops: []Operation{
+				released("eu", so.Failed),
+				released("us", so.WaitingForCutover),
 			},
 			want:  StateReadyForCutoverNext,
 			label: "ready for cutover — next in order",
@@ -338,7 +390,7 @@ func TestDerive_StoppedAggregateNextAction(t *testing.T) {
 // error detail for the renderer.
 func TestDerive_FailedDeploymentCarriesError(t *testing.T) {
 	got := Derive([]Operation{
-		{Deployment: "eu", State: so.Failed, HaltOnFailure: true, Error: "lock wait timeout"},
+		{Deployment: "eu", State: so.Failed, Error: "lock wait timeout"},
 	})
 	require.Len(t, got.Deployments, 1)
 	assert.Equal(t, "lock wait timeout", got.Deployments[0].Error)
@@ -361,8 +413,8 @@ func TestDerive_FirstFailureNoneWhenHealthy(t *testing.T) {
 func TestDerive_FirstFailurePicksEarliestInOrder(t *testing.T) {
 	got := Derive([]Operation{
 		continuing("eu", so.Completed),
-		{Deployment: "us", State: so.Failed, HaltOnFailure: false, ContinueOnFailure: true, Error: "first boom"},
-		{Deployment: "au", State: so.Failed, HaltOnFailure: false, ContinueOnFailure: true, Error: "second boom"},
+		{Deployment: "us", State: so.Failed, ContinueOnFailure: true, Error: "first boom"},
+		{Deployment: "au", State: so.Failed, ContinueOnFailure: true, Error: "second boom"},
 	})
 	require.NotNil(t, got.FirstFailure)
 	assert.Equal(t, "us", got.FirstFailure.Deployment)
@@ -376,7 +428,7 @@ func TestDerive_FirstFailurePicksEarliestInOrder(t *testing.T) {
 // waiting for the terminal summary.
 func TestDerive_FirstFailureWhileSiblingStillRunning(t *testing.T) {
 	got := Derive([]Operation{
-		{Deployment: "eu", State: so.Failed, HaltOnFailure: false, ContinueOnFailure: true, Error: "boom"},
+		{Deployment: "eu", State: so.Failed, ContinueOnFailure: true, Error: "boom"},
 		continuing("us", so.Running),
 	})
 	assert.Equal(t, state.Apply.RunningDegraded, got.State)
@@ -397,6 +449,38 @@ func TestDerive_HaltFailureWithRunningSiblingStaysFailed(t *testing.T) {
 	})
 	assert.Equal(t, state.Apply.Failed, got.State)
 	assert.Equal(t, "failed", got.Label)
+}
+
+// TestDerive_PauseFailureWithPendingSiblingHoldsPaused: under on_failure pause an
+// earlier failure with later work still to run holds the aggregate paused for a
+// human, and the first failure is surfaced eagerly. The held sibling renders
+// paused with the release-or-stop label.
+func TestDerive_PauseFailureWithPendingSiblingHoldsPaused(t *testing.T) {
+	got := Derive([]Operation{
+		{Deployment: "eu", State: so.Failed, PauseOnFailure: true, Error: "boom"},
+		pausing("us", so.Pending),
+	})
+	assert.Equal(t, state.Apply.Paused, got.State)
+	assert.Equal(t, "paused", got.Label)
+	assert.Equal(t, StatePaused, got.Deployments[1].Presentation)
+	assert.Equal(t, "paused — eu failed; release or stop", got.Deployments[1].Label)
+	require.NotNil(t, got.FirstFailure)
+	assert.Equal(t, "eu", got.FirstFailure.Deployment)
+}
+
+// TestDerive_ReleasedPauseRunsDegradedLikeContinue: once an apply is released a
+// pause failure behaves like continue — the held siblings proceed and the
+// aggregate runs degraded rather than paused.
+func TestDerive_ReleasedPauseRunsDegradedLikeContinue(t *testing.T) {
+	got := Derive([]Operation{
+		{Deployment: "eu", State: so.Failed, PauseOnFailure: true, Released: true, Error: "boom"},
+		released("us", so.Running),
+	})
+	assert.Equal(t, state.Apply.RunningDegraded, got.State)
+	assert.Equal(t, "running (degraded)", got.Label)
+	assert.Equal(t, StateRunningCopy, got.Deployments[1].Presentation)
+	require.NotNil(t, got.FirstFailure)
+	assert.Equal(t, "eu", got.FirstFailure.Deployment)
 }
 
 // TestDerive_FirstFailureExcludesRetrying: a failed_retryable deployment is

--- a/pkg/storage/release_latch.go
+++ b/pkg/storage/release_latch.go
@@ -1,0 +1,45 @@
+package storage
+
+import (
+	"context"
+	"slices"
+)
+
+// AnyPauseOnFailure reports whether any operation uses the on_failure=pause
+// policy — the only policy whose projection depends on whether an operator has
+// released the rollout. It gates the release-latch read so an apply without a
+// pause operation never pays the read or risks an unrelated latch read error.
+func AnyPauseOnFailure(ops []*ApplyOperation) bool {
+	return slices.ContainsFunc(ops, func(op *ApplyOperation) bool {
+		return op.OnFailure == OnFailurePause
+	})
+}
+
+// ReleaseLatched reports whether a paused rollout has been released open,
+// resolving the boundary that the rollout projection and every presentation
+// surface gate on so they agree with what the operator will actually claim
+// next. It reads the release control request only when some operation uses
+// on_failure=pause — the only policy whose projection depends on release — so an
+// apply without a pause operation never touches the control-request store. It
+// fails closed: no pause operation, a nil store, or a non-latching release
+// request (no pending or completed release row, or a failed one) all leave it
+// false. Only a store read error is surfaced; callers fail closed on it. A
+// released pause behaves like continue (see
+// ApplyControlRequest.ReleasesPausedRollout).
+func ReleaseLatched(ctx context.Context, stor Storage, applyID int64, ops []*ApplyOperation) (bool, error) {
+	if !AnyPauseOnFailure(ops) {
+		return false, nil
+	}
+	if stor == nil {
+		return false, nil
+	}
+	requests := stor.ControlRequests()
+	if requests == nil {
+		return false, nil
+	}
+	req, err := requests.GetByOperation(ctx, applyID, ControlOperationRelease)
+	if err != nil {
+		return false, err
+	}
+	return req.ReleasesPausedRollout(), nil
+}

--- a/pkg/storage/release_latch_test.go
+++ b/pkg/storage/release_latch_test.go
@@ -1,0 +1,106 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeControlRequests returns a fixed release request (or error) from
+// GetByOperation, standing in for the durable control-request store.
+type fakeControlRequests struct {
+	ControlRequestStore
+	req    *ApplyControlRequest
+	err    error
+	called bool
+}
+
+func (f *fakeControlRequests) GetByOperation(_ context.Context, _ int64, _ ControlOperation) (*ApplyControlRequest, error) {
+	f.called = true
+	return f.req, f.err
+}
+
+// fakeStorage exposes only the ControlRequests accessor ReleaseLatched needs;
+// every other store is nil and would panic, keeping the test honest about the
+// access ReleaseLatched makes.
+type fakeStorage struct {
+	Storage
+	requests ControlRequestStore
+}
+
+func (f fakeStorage) ControlRequests() ControlRequestStore { return f.requests }
+
+func pauseOp() *ApplyOperation    { return &ApplyOperation{OnFailure: OnFailurePause} }
+func haltOp() *ApplyOperation     { return &ApplyOperation{} }
+func continueOp() *ApplyOperation { return &ApplyOperation{OnFailure: OnFailureContinue} }
+
+func TestAnyPauseOnFailure(t *testing.T) {
+	assert.False(t, AnyPauseOnFailure(nil))
+	assert.False(t, AnyPauseOnFailure([]*ApplyOperation{haltOp(), continueOp()}))
+	assert.True(t, AnyPauseOnFailure([]*ApplyOperation{haltOp(), pauseOp()}))
+}
+
+func TestReleaseLatched(t *testing.T) {
+	releaseReq := func(s ControlRequestStatus) *ApplyControlRequest {
+		return &ApplyControlRequest{Operation: ControlOperationRelease, Status: s}
+	}
+
+	t.Run("no pause operation never reads the store", func(t *testing.T) {
+		// A latched release row is present, but with no pause operation the read
+		// is skipped entirely and the rollout is unreleased.
+		reqs := &fakeControlRequests{req: releaseReq(ControlRequestCompleted)}
+		released, err := ReleaseLatched(t.Context(), fakeStorage{requests: reqs}, 1, []*ApplyOperation{haltOp(), continueOp()})
+		require.NoError(t, err)
+		assert.False(t, released)
+		assert.False(t, reqs.called, "store must not be consulted without a pause operation")
+	})
+
+	t.Run("nil storage fails closed", func(t *testing.T) {
+		released, err := ReleaseLatched(t.Context(), nil, 1, []*ApplyOperation{pauseOp()})
+		require.NoError(t, err)
+		assert.False(t, released)
+	})
+
+	t.Run("nil control-request store fails closed", func(t *testing.T) {
+		released, err := ReleaseLatched(t.Context(), fakeStorage{requests: nil}, 1, []*ApplyOperation{pauseOp()})
+		require.NoError(t, err)
+		assert.False(t, released)
+	})
+
+	t.Run("pending release latches open", func(t *testing.T) {
+		reqs := &fakeControlRequests{req: releaseReq(ControlRequestPending)}
+		released, err := ReleaseLatched(t.Context(), fakeStorage{requests: reqs}, 1, []*ApplyOperation{pauseOp()})
+		require.NoError(t, err)
+		assert.True(t, released)
+	})
+
+	t.Run("completed release latches open", func(t *testing.T) {
+		reqs := &fakeControlRequests{req: releaseReq(ControlRequestCompleted)}
+		released, err := ReleaseLatched(t.Context(), fakeStorage{requests: reqs}, 1, []*ApplyOperation{pauseOp()})
+		require.NoError(t, err)
+		assert.True(t, released)
+	})
+
+	t.Run("failed release does not latch", func(t *testing.T) {
+		reqs := &fakeControlRequests{req: releaseReq(ControlRequestFailed)}
+		released, err := ReleaseLatched(t.Context(), fakeStorage{requests: reqs}, 1, []*ApplyOperation{pauseOp()})
+		require.NoError(t, err)
+		assert.False(t, released)
+	})
+
+	t.Run("no release row stays paused", func(t *testing.T) {
+		reqs := &fakeControlRequests{req: nil}
+		released, err := ReleaseLatched(t.Context(), fakeStorage{requests: reqs}, 1, []*ApplyOperation{pauseOp()})
+		require.NoError(t, err)
+		assert.False(t, released)
+	})
+
+	t.Run("store read error is surfaced", func(t *testing.T) {
+		reqs := &fakeControlRequests{err: errors.New("boom")}
+		_, err := ReleaseLatched(t.Context(), fakeStorage{requests: reqs}, 1, []*ApplyOperation{pauseOp()})
+		require.Error(t, err)
+	})
+}

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -408,7 +408,7 @@ func (o *CommentObserver) statusCommentFromOps(apply *storage.Apply, ops []*stor
 			"apply_id", o.applyID, "error", opsErr)
 		return formatProgressComment(apply, tasks, shardsByTable)
 	}
-	return formatApplyStatusComment(apply, ops, tasks, o.resolveDisplay(apply, ops), shardsByTable)
+	return formatApplyStatusComment(apply, ops, o.resolveReleased(apply, ops), tasks, o.resolveDisplay(apply, ops), shardsByTable)
 }
 
 // resolveDisplay projects the apply's per-operation engine display state (VSchema
@@ -419,6 +419,16 @@ func (o *CommentObserver) resolveDisplay(apply *storage.Apply, ops []*storage.Ap
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	return resolveDisplayByOperation(ctx, o.stor, apply, ops)
+}
+
+// resolveReleased reports whether the apply's paused rollout has been released
+// open, for comment rendering. It uses a short, independent deadline so a slow
+// storage read degrades to an unreleased (paused) render rather than blocking
+// the update.
+func (o *CommentObserver) resolveReleased(apply *storage.Apply, ops []*storage.ApplyOperation) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	return releasedForApply(ctx, o.stor, apply, ops, o.logger)
 }
 
 // formatTerminalSummaryComment renders the apply's terminal summary comment,
@@ -447,7 +457,7 @@ func (o *CommentObserver) summaryCommentFromOps(apply *storage.Apply, ops []*sto
 			"apply_id", o.applyID, "error", opsErr)
 		return formatSummaryComment(apply, tasks, shardsByTable)
 	}
-	return formatApplySummaryComment(apply, ops, tasks, o.resolveDisplay(apply, ops), shardsByTable)
+	return formatApplySummaryComment(apply, ops, o.resolveReleased(apply, ops), tasks, o.resolveDisplay(apply, ops), shardsByTable)
 }
 
 func (o *CommentObserver) shouldDeferCutover(apply *storage.Apply) bool {

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -367,7 +367,8 @@ func (h *Handler) ReconcileMissingSummaryComments(ctx context.Context) {
 				"apply_id", apply.ApplyIdentifier, "error", err)
 			ops = nil
 		}
-		summaryBody := formatApplySummaryComment(apply, ops, tasks, resolveDisplayByOperation(ctx, h.service.Storage(), apply, ops), nil)
+		released := releasedForApply(ctx, h.service.Storage(), apply, ops, h.logger)
+		summaryBody := formatApplySummaryComment(apply, ops, released, tasks, resolveDisplayByOperation(ctx, h.service.Storage(), apply, ops), nil)
 		h.postAndTrackComment(ctx, apply.Repository, apply.PullRequest, apply.InstallationID, apply.ID, state.Comment.Summary, summaryBody)
 	}
 }

--- a/pkg/webhook/multi_apply.go
+++ b/pkg/webhook/multi_apply.go
@@ -1,12 +1,31 @@
 package webhook
 
 import (
+	"context"
 	"time"
 
 	"github.com/block/schemabot/pkg/presentation"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/webhook/templates"
 )
+
+// releasedForApply best-effort reports whether a paused rollout has been
+// released open, for comment rendering. Release state is presentation
+// enrichment, not an apply safety gate, so a latch read failure is logged and
+// treated as unreleased (fail-closed) rather than failing the comment. A
+// released pause behaves like continue, so the held siblings render as running
+// degraded instead of paused.
+func releasedForApply(ctx context.Context, stor storage.Storage, apply *storage.Apply, ops []*storage.ApplyOperation, logger interface {
+	Error(msg string, args ...any)
+}) bool {
+	released, err := storage.ReleaseLatched(ctx, stor, apply.ID, ops)
+	if err != nil {
+		logger.Error("comment will treat rollout as unreleased: failed to load release latch",
+			append(apply.LogAttrs(), "error", err)...)
+		return false
+	}
+	return released
+}
 
 // formatApplyStatusComment renders the progress/status PR comment for an apply,
 // choosing the layout from how many deployments the apply owns. The threshold is
@@ -18,17 +37,17 @@ import (
 // ops must be in resolved deployment order (as returned by
 // ApplyOperations().ListByApply); tasks are the apply's tasks across all
 // deployments, regrouped per operation for the multi-deployment layout.
-func formatApplyStatusComment(apply *storage.Apply, ops []*storage.ApplyOperation, tasks []*storage.Task, displayByOp map[int64]operationDisplay, shardsByTable map[string][]*storage.Task) string {
+func formatApplyStatusComment(apply *storage.Apply, ops []*storage.ApplyOperation, released bool, tasks []*storage.Task, displayByOp map[int64]operationDisplay, shardsByTable map[string][]*storage.Task) string {
 	// A sharded apply fans out across the shards of one keyspace within a single
 	// deployment, so it gets the shard-unit layout rather than the deployment-unit
 	// one — its operations differ by shard, not deployment.
 	if isShardedApply(ops) {
-		return templates.RenderShardedApplyComment(buildShardedApplyData(apply, ops, tasks))
+		return templates.RenderShardedApplyComment(buildShardedApplyData(apply, ops, released, tasks))
 	}
 	if len(ops) <= 1 {
 		return templates.RenderApplyStatusComment(buildApplyCommentData(apply, tasks, singleOpDisplay(ops, displayByOp), shardsByTable))
 	}
-	return templates.RenderMultiDeploymentApplyComment(buildMultiApplyData(apply, ops, tasks, displayByOp, shardsByTable))
+	return templates.RenderMultiDeploymentApplyComment(buildMultiApplyData(apply, ops, released, tasks, displayByOp, shardsByTable))
 }
 
 // formatApplySummaryComment renders the terminal summary PR comment for an apply,
@@ -41,17 +60,17 @@ func formatApplyStatusComment(apply *storage.Apply, ops []*storage.ApplyOperatio
 // ops must be in resolved deployment order (as returned by
 // ApplyOperations().ListByApply); tasks are the apply's tasks across all
 // deployments, regrouped per operation for the multi-deployment layout.
-func formatApplySummaryComment(apply *storage.Apply, ops []*storage.ApplyOperation, tasks []*storage.Task, displayByOp map[int64]operationDisplay, shardsByTable map[string][]*storage.Task) string {
+func formatApplySummaryComment(apply *storage.Apply, ops []*storage.ApplyOperation, released bool, tasks []*storage.Task, displayByOp map[int64]operationDisplay, shardsByTable map[string][]*storage.Task) string {
 	// The sharded layout is terminal-aware (header, footer, no last-updated line),
 	// so the same renderer serves the terminal summary; only the deployment-unit
 	// path has a distinct summary renderer.
 	if isShardedApply(ops) {
-		return templates.RenderShardedApplyComment(buildShardedApplyData(apply, ops, tasks))
+		return templates.RenderShardedApplyComment(buildShardedApplyData(apply, ops, released, tasks))
 	}
 	if len(ops) <= 1 {
 		return templates.RenderApplySummaryComment(buildApplyCommentData(apply, tasks, singleOpDisplay(ops, displayByOp), shardsByTable))
 	}
-	return templates.RenderMultiDeploymentApplySummaryComment(buildMultiApplyData(apply, ops, tasks, displayByOp, shardsByTable))
+	return templates.RenderMultiDeploymentApplySummaryComment(buildMultiApplyData(apply, ops, released, tasks, displayByOp, shardsByTable))
 }
 
 // singleOpDisplay returns the engine display projection for a zero/one-operation
@@ -67,10 +86,10 @@ func singleOpDisplay(ops []*storage.ApplyOperation, displayByOp map[int64]operat
 // buildMultiApplyData assembles the multi-deployment comment input: the derived
 // rollup plus each deployment's own single-deployment comment data, so each
 // deployment's section reuses the existing per-table renderer.
-func buildMultiApplyData(apply *storage.Apply, ops []*storage.ApplyOperation, tasks []*storage.Task, displayByOp map[int64]operationDisplay, shardsByTable map[string][]*storage.Task) templates.MultiDeploymentApplyData {
+func buildMultiApplyData(apply *storage.Apply, ops []*storage.ApplyOperation, released bool, tasks []*storage.Task, displayByOp map[int64]operationDisplay, shardsByTable map[string][]*storage.Task) templates.MultiDeploymentApplyData {
 	tasksByOp := groupTasksByOperation(tasks)
 
-	model := deriveApplyPresentation(ops)
+	model := deriveApplyPresentation(ops, released)
 	details := make(map[string]templates.ApplyStatusCommentData, len(ops))
 	for _, op := range ops {
 		details[op.Deployment] = buildDeploymentDetail(apply, op, tasksByOp[op.ID], displayByOp[op.ID], shardsByTable)
@@ -93,10 +112,11 @@ func buildMultiApplyData(apply *storage.Apply, ops []*storage.ApplyOperation, ta
 
 // deriveApplyPresentation maps the apply's operation rows to the surface-neutral
 // presentation inputs and derives the rollup. Rows are already in resolved order.
-func deriveApplyPresentation(ops []*storage.ApplyOperation) presentation.Apply {
+// released is the apply-level release latch applied to every operation.
+func deriveApplyPresentation(ops []*storage.ApplyOperation, released bool) presentation.Apply {
 	inputs := make([]presentation.Operation, 0, len(ops))
 	for _, op := range ops {
-		inputs = append(inputs, applyOperationToPresentation(op))
+		inputs = append(inputs, applyOperationToPresentation(op, released))
 	}
 	return presentation.Derive(inputs)
 }
@@ -108,8 +128,10 @@ func deriveApplyPresentation(ops []*storage.ApplyOperation) presentation.Apply {
 // ContinueOnFailure flag — true only when on_failure is exactly "continue" — and
 // the PauseOnFailure flag — true only when it is exactly "pause". Any other value
 // leaves both false (halt), the safe default the claim predicate and the
-// aggregate projection also assume.
-func applyOperationToPresentation(op *storage.ApplyOperation) presentation.Operation {
+// aggregate projection also assume. released is the apply-level release latch: a
+// released pause behaves like continue, so the held siblings run degraded
+// instead of paused.
+func applyOperationToPresentation(op *storage.ApplyOperation, released bool) presentation.Operation {
 	return presentation.Operation{
 		Deployment:        op.Deployment,
 		State:             op.State,
@@ -117,6 +139,7 @@ func applyOperationToPresentation(op *storage.ApplyOperation) presentation.Opera
 		Parallel:          op.CutoverPolicy == storage.CutoverPolicyParallel,
 		ContinueOnFailure: op.OnFailure == storage.OnFailureContinue,
 		PauseOnFailure:    op.OnFailure == storage.OnFailurePause,
+		Released:          released,
 		Error:             op.ErrorMessage,
 	}
 }

--- a/pkg/webhook/multi_apply.go
+++ b/pkg/webhook/multi_apply.go
@@ -104,19 +104,19 @@ func deriveApplyPresentation(ops []*storage.ApplyOperation) presentation.Apply {
 // applyOperationToPresentation maps one storage operation row to the neutral
 // presentation input, resolving the rollout-policy values at the boundary:
 // cutover_policy "barrier" becomes the Barrier flag and "parallel" becomes the
-// Parallel flag (the two are mutually exclusive), and on_failure becomes both
-// the HaltOnFailure flag — true unless on_failure is "continue" — and the
-// ContinueOnFailure flag — true only when on_failure is exactly "continue". Any
-// other value fails closed to halting, the safe default the claim predicate and
-// the aggregate projection also assume.
+// Parallel flag (the two are mutually exclusive), and on_failure becomes the
+// ContinueOnFailure flag — true only when on_failure is exactly "continue" — and
+// the PauseOnFailure flag — true only when it is exactly "pause". Any other value
+// leaves both false (halt), the safe default the claim predicate and the
+// aggregate projection also assume.
 func applyOperationToPresentation(op *storage.ApplyOperation) presentation.Operation {
 	return presentation.Operation{
 		Deployment:        op.Deployment,
 		State:             op.State,
 		Barrier:           op.CutoverPolicy == storage.CutoverPolicyBarrier,
 		Parallel:          op.CutoverPolicy == storage.CutoverPolicyParallel,
-		HaltOnFailure:     op.OnFailure != storage.OnFailureContinue,
 		ContinueOnFailure: op.OnFailure == storage.OnFailureContinue,
+		PauseOnFailure:    op.OnFailure == storage.OnFailurePause,
 		Error:             op.ErrorMessage,
 	}
 }

--- a/pkg/webhook/multi_apply_test.go
+++ b/pkg/webhook/multi_apply_test.go
@@ -22,7 +22,7 @@ func runningApply() *storage.Apply {
 // An apply with no operation rows (legacy, predating apply_operations) renders
 // the single-deployment comment unchanged — no aggregate header.
 func TestFormatApplyStatusComment_NoOperationsRendersSingle(t *testing.T) {
-	out := formatApplyStatusComment(runningApply(), nil, nil, nil, nil)
+	out := formatApplyStatusComment(runningApply(), nil, false, nil, nil, nil)
 	assert.Contains(t, out, "## Schema Change In Progress")
 	assert.NotContains(t, out, "**Deployments**:")
 }
@@ -33,7 +33,7 @@ func TestFormatApplyStatusComment_OneOperationRendersSingle(t *testing.T) {
 	ops := []*storage.ApplyOperation{
 		{ID: 1, Deployment: "eu", State: state.ApplyOperation.Running},
 	}
-	out := formatApplyStatusComment(runningApply(), ops, nil, nil, nil)
+	out := formatApplyStatusComment(runningApply(), ops, false, nil, nil, nil)
 	assert.NotContains(t, out, "**Deployments**:")
 	assert.NotContains(t, out, "- 🔄 eu")
 }
@@ -45,11 +45,28 @@ func TestFormatApplyStatusComment_MultipleOperationsRendersMulti(t *testing.T) {
 		{ID: 1, Deployment: "eu", State: state.ApplyOperation.Completed, CutoverPolicy: storage.CutoverPolicyBarrier},
 		{ID: 2, Deployment: "us", State: state.ApplyOperation.Running, CutoverPolicy: storage.CutoverPolicyBarrier},
 	}
-	out := formatApplyStatusComment(runningApply(), ops, nil, nil, nil)
+	out := formatApplyStatusComment(runningApply(), ops, false, nil, nil, nil)
 	assert.Contains(t, out, "## Schema Change In Progress")
 	assert.Contains(t, out, "**Deployments**: 1 completed, 1 running")
 	assert.Contains(t, out, "- ✅ eu — completed")
 	assert.Contains(t, out, "- 🔄 us — running table copy")
+}
+
+// An apply that failed under on_failure=pause with a held sibling renders the
+// paused "release or stop" guidance; once the operator releases it, the apply
+// renders running degraded instead — the boundary applies the apply-level
+// release latch so the comment matches what the operator will claim next.
+func TestFormatApplyStatusComment_ReleasedPauseRendersDegradedNotPaused(t *testing.T) {
+	ops := []*storage.ApplyOperation{
+		{ID: 1, Deployment: "eu", State: state.ApplyOperation.Failed, OnFailure: storage.OnFailurePause, ErrorMessage: "boom"},
+		{ID: 2, Deployment: "us", State: state.ApplyOperation.Pending, OnFailure: storage.OnFailurePause},
+	}
+
+	paused := formatApplyStatusComment(runningApply(), ops, false, nil, nil, nil)
+	assert.Contains(t, paused, "paused — eu failed; release or stop")
+
+	released := formatApplyStatusComment(runningApply(), ops, true, nil, nil, nil)
+	assert.NotContains(t, released, "paused — eu failed; release or stop")
 }
 
 func completedApply() *storage.Apply {
@@ -61,7 +78,7 @@ func completedApply() *storage.Apply {
 // An apply with no operation rows (legacy) renders the single-deployment summary
 // unchanged — no aggregate header.
 func TestFormatApplySummaryComment_NoOperationsRendersSingle(t *testing.T) {
-	out := formatApplySummaryComment(completedApply(), nil, nil, nil, nil)
+	out := formatApplySummaryComment(completedApply(), nil, false, nil, nil, nil)
 	assert.Contains(t, out, "## ✅ Schema Change Applied")
 	assert.NotContains(t, out, "**Deployments**:")
 }
@@ -72,7 +89,7 @@ func TestFormatApplySummaryComment_OneOperationRendersSingle(t *testing.T) {
 	ops := []*storage.ApplyOperation{
 		{ID: 1, Deployment: "eu", State: state.ApplyOperation.Completed},
 	}
-	out := formatApplySummaryComment(completedApply(), ops, nil, nil, nil)
+	out := formatApplySummaryComment(completedApply(), ops, false, nil, nil, nil)
 	assert.NotContains(t, out, "**Deployments**:")
 	assert.NotContains(t, out, "- ✅ eu")
 }
@@ -85,7 +102,7 @@ func TestFormatApplySummaryComment_MultipleOperationsRendersMulti(t *testing.T) 
 		{ID: 1, Deployment: "eu", State: state.ApplyOperation.Completed},
 		{ID: 2, Deployment: "us", State: state.ApplyOperation.Completed},
 	}
-	out := formatApplySummaryComment(completedApply(), ops, nil, nil, nil)
+	out := formatApplySummaryComment(completedApply(), ops, false, nil, nil, nil)
 	assert.Contains(t, out, "## ✅ Schema Change Applied")
 	assert.Contains(t, out, "**Deployments**: 2 completed")
 	assert.Contains(t, out, "- ✅ eu — completed")
@@ -103,7 +120,7 @@ func TestBuildMultiApplyData_RoutesTasksByOperation(t *testing.T) {
 		{ApplyOperationID: new(int64(2)), TableName: "orders", State: state.Task.Running},
 		{ApplyOperationID: new(int64(1)), TableName: "customers", State: state.Task.Running},
 	}
-	data := buildMultiApplyData(runningApply(), ops, tasks, nil, nil)
+	data := buildMultiApplyData(runningApply(), ops, false, tasks, nil, nil)
 
 	require.Len(t, data.Details["eu"].Tables, 1)
 	assert.Equal(t, "customers", data.Details["eu"].Tables[0].TableName)
@@ -133,7 +150,7 @@ func TestBuildMultiApplyData_ScopesShardsByOperation(t *testing.T) {
 		},
 	}
 
-	data := buildMultiApplyData(runningApply(), ops, tasks, nil, shardsByTable)
+	data := buildMultiApplyData(runningApply(), ops, false, tasks, nil, shardsByTable)
 
 	require.Len(t, data.Details["eu"].Tables, 1)
 	require.Len(t, data.Details["eu"].Tables[0].Shards, 1)
@@ -160,7 +177,7 @@ func TestBuildDeploymentDetail_UsesOperationStateAndError(t *testing.T) {
 func TestApplyOperationToPresentation_ResolvesPolicies(t *testing.T) {
 	halting := applyOperationToPresentation(&storage.ApplyOperation{
 		Deployment: "eu", State: state.ApplyOperation.Running, CutoverPolicy: storage.CutoverPolicyBarrier,
-	})
+	}, false)
 	assert.True(t, halting.Barrier)
 	assert.False(t, halting.ContinueOnFailure, "unset on_failure does not continue")
 	assert.False(t, halting.PauseOnFailure, "unset on_failure does not pause")
@@ -168,7 +185,7 @@ func TestApplyOperationToPresentation_ResolvesPolicies(t *testing.T) {
 	rolling := applyOperationToPresentation(&storage.ApplyOperation{
 		Deployment: "us", State: state.ApplyOperation.Running,
 		CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailureContinue,
-	})
+	}, false)
 	assert.False(t, rolling.Barrier)
 	assert.True(t, rolling.ContinueOnFailure)
 	assert.False(t, rolling.PauseOnFailure)
@@ -176,9 +193,19 @@ func TestApplyOperationToPresentation_ResolvesPolicies(t *testing.T) {
 	paused := applyOperationToPresentation(&storage.ApplyOperation{
 		Deployment: "au", State: state.ApplyOperation.Running,
 		CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailurePause,
-	})
+	}, false)
 	assert.True(t, paused.PauseOnFailure)
 	assert.False(t, paused.ContinueOnFailure)
+	assert.False(t, paused.Released, "unreleased pause stays held")
+
+	// A released pause carries the apply-level release latch, so it behaves like
+	// continue: held siblings proceed and the aggregate runs degraded, not paused.
+	released := applyOperationToPresentation(&storage.ApplyOperation{
+		Deployment: "au", State: state.ApplyOperation.Running,
+		CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailurePause,
+	}, true)
+	assert.True(t, released.PauseOnFailure)
+	assert.True(t, released.Released)
 }
 
 // Tasks without an apply_operation_id (legacy rows) are not attributable to a

--- a/pkg/webhook/multi_apply_test.go
+++ b/pkg/webhook/multi_apply_test.go
@@ -154,24 +154,31 @@ func TestBuildDeploymentDetail_UsesOperationStateAndError(t *testing.T) {
 }
 
 // The storage→presentation boundary resolves the rollout policies: barrier flips
-// the Barrier flag, and on_failure becomes the complementary HaltOnFailure /
-// ContinueOnFailure pair — continue only when on_failure is exactly "continue",
-// so an unset value resolves to halting (the safe default).
+// the Barrier flag, and on_failure becomes the ContinueOnFailure / PauseOnFailure
+// pair — each true only when on_failure is exactly that value, so an unset value
+// leaves both false (halt, the safe default).
 func TestApplyOperationToPresentation_ResolvesPolicies(t *testing.T) {
-	barrier := applyOperationToPresentation(&storage.ApplyOperation{
+	halting := applyOperationToPresentation(&storage.ApplyOperation{
 		Deployment: "eu", State: state.ApplyOperation.Running, CutoverPolicy: storage.CutoverPolicyBarrier,
 	})
-	assert.True(t, barrier.Barrier)
-	assert.True(t, barrier.HaltOnFailure, "unset on_failure resolves to halting")
-	assert.False(t, barrier.ContinueOnFailure, "unset on_failure does not continue")
+	assert.True(t, halting.Barrier)
+	assert.False(t, halting.ContinueOnFailure, "unset on_failure does not continue")
+	assert.False(t, halting.PauseOnFailure, "unset on_failure does not pause")
 
 	rolling := applyOperationToPresentation(&storage.ApplyOperation{
 		Deployment: "us", State: state.ApplyOperation.Running,
 		CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailureContinue,
 	})
 	assert.False(t, rolling.Barrier)
-	assert.False(t, rolling.HaltOnFailure)
 	assert.True(t, rolling.ContinueOnFailure)
+	assert.False(t, rolling.PauseOnFailure)
+
+	paused := applyOperationToPresentation(&storage.ApplyOperation{
+		Deployment: "au", State: state.ApplyOperation.Running,
+		CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailurePause,
+	})
+	assert.True(t, paused.PauseOnFailure)
+	assert.False(t, paused.ContinueOnFailure)
 }
 
 // Tasks without an apply_operation_id (legacy rows) are not attributable to a

--- a/pkg/webhook/sharded_apply.go
+++ b/pkg/webhook/sharded_apply.go
@@ -76,7 +76,7 @@ func isShardedApply(ops []*storage.ApplyOperation) bool {
 // ("waiting for `-40`", "halted — `-40` failed") reference shards. Finalizer
 // (VSchema) operations are not shard work and are omitted from the shard view;
 // their outcome is still reflected in the aggregate headline state.
-func buildShardedApplyData(apply *storage.Apply, ops []*storage.ApplyOperation, tasks []*storage.Task) templates.ShardedApplyData {
+func buildShardedApplyData(apply *storage.Apply, ops []*storage.ApplyOperation, released bool, tasks []*storage.Task) templates.ShardedApplyData {
 	tasksByOp := groupTasksByOperation(tasks)
 	// Tasks arrive in created_at DESC order with no id tiebreaker. Sort each
 	// operation's tasks by id so the joined DDL (and the change signature derived
@@ -126,7 +126,7 @@ func buildShardedApplyData(apply *storage.Apply, ops []*storage.ApplyOperation, 
 		Keyspace:    keyspace,
 		ApplyID:     apply.ApplyIdentifier,
 		RequestedBy: actorFromCaller(apply.Caller),
-		Shards:      shardStatuses(shardOrder, opsByShard, tasksByOp),
+		Shards:      shardStatuses(shardOrder, opsByShard, released, tasksByOp),
 		Cells:       cells,
 	}
 	if apply.StartedAt != nil {
@@ -142,7 +142,7 @@ func buildShardedApplyData(apply *storage.Apply, ops []*storage.ApplyOperation, 
 // aggregated to a single representative state, then the shards are projected
 // together through pkg/presentation (shard name as identity) so ordering labels
 // reference sibling shards.
-func shardStatuses(shardOrder []string, opsByShard map[string][]*storage.ApplyOperation, tasksByOp map[int64][]*storage.Task) []templates.ShardStatus {
+func shardStatuses(shardOrder []string, opsByShard map[string][]*storage.ApplyOperation, released bool, tasksByOp map[int64][]*storage.Task) []templates.ShardStatus {
 	inputs := make([]presentation.Operation, 0, len(shardOrder))
 	for _, shard := range shardOrder {
 		shardOps := opsByShard[shard]
@@ -155,6 +155,7 @@ func shardStatuses(shardOrder []string, opsByShard map[string][]*storage.ApplyOp
 			Parallel:          first.CutoverPolicy == storage.CutoverPolicyParallel,
 			ContinueOnFailure: first.OnFailure == storage.OnFailureContinue,
 			PauseOnFailure:    first.OnFailure == storage.OnFailurePause,
+			Released:          released,
 			Error:             errMsg,
 		})
 	}

--- a/pkg/webhook/sharded_apply.go
+++ b/pkg/webhook/sharded_apply.go
@@ -153,8 +153,8 @@ func shardStatuses(shardOrder []string, opsByShard map[string][]*storage.ApplyOp
 			State:             st,
 			Barrier:           first.CutoverPolicy == storage.CutoverPolicyBarrier,
 			Parallel:          first.CutoverPolicy == storage.CutoverPolicyParallel,
-			HaltOnFailure:     first.OnFailure != storage.OnFailureContinue,
 			ContinueOnFailure: first.OnFailure == storage.OnFailureContinue,
+			PauseOnFailure:    first.OnFailure == storage.OnFailurePause,
 			Error:             errMsg,
 		})
 	}

--- a/pkg/webhook/sharded_apply_test.go
+++ b/pkg/webhook/sharded_apply_test.go
@@ -22,7 +22,7 @@ func TestFormatApplyStatusComment_ShardedAttributionFromCaller(t *testing.T) {
 	oid := int64(1)
 	tasks := []*storage.Task{{ID: 1, ApplyID: 1, ApplyOperationID: &oid, Namespace: "cdb_resolute_sharded", TableName: "mutes", Shard: "-40", DDL: "ALTER TABLE `mutes` ADD INDEX a"}}
 
-	out := formatApplyStatusComment(apply, []*storage.ApplyOperation{op}, tasks, nil, nil)
+	out := formatApplyStatusComment(apply, []*storage.ApplyOperation{op}, false, tasks, nil, nil)
 
 	assert.Contains(t, out, "by @morgo at", "attribution shows the clean username")
 	assert.NotContains(t, out, "github:", "the raw structured caller is not rendered")
@@ -100,7 +100,7 @@ func TestFormatApplyStatusComment_ShardedFailedSurfacesError(t *testing.T) {
 	}
 	tasks := []*storage.Task{task(1, 1, "-40"), task(2, 2, "40-80"), task(3, 3, "80-c0"), task(4, 4, "c0-")}
 
-	out := formatApplyStatusComment(apply, ops, tasks, nil, nil)
+	out := formatApplyStatusComment(apply, ops, false, tasks, nil, nil)
 
 	assert.Contains(t, out, "❌ Schema Change Failed", "uses the shard-unit failed headline")
 	assert.Contains(t, out, "**Shards**:", "counts shards, not deployments")
@@ -127,7 +127,7 @@ func TestFormatApplyStatusComment_ShardedFailureFallsBackToTaskError(t *testing.
 	oid := int64(1)
 	tasks := []*storage.Task{{ID: 1, ApplyID: 1, ApplyOperationID: &oid, Namespace: "cdb_resolute_sharded", TableName: "mutes", Shard: "-40", DDL: "ALTER ...", ErrorMessage: gotZero}}
 
-	out := formatApplyStatusComment(apply, []*storage.ApplyOperation{op}, tasks, nil, nil)
+	out := formatApplyStatusComment(apply, []*storage.ApplyOperation{op}, false, tasks, nil, nil)
 
 	assert.Contains(t, out, gotZero, "the task error is surfaced when the operation row has none")
 }
@@ -150,7 +150,7 @@ func TestBuildShardedApplyData_DivergentGroupsByTable(t *testing.T) {
 	}
 	tasks := []*storage.Task{tk(1, 1, "mutes"), tk(2, 2, "mutes"), tk(3, 3, "blocks")}
 
-	data := buildShardedApplyData(apply, ops, tasks)
+	data := buildShardedApplyData(apply, ops, false, tasks)
 
 	assert.Equal(t, "ks", data.Keyspace)
 	require.Len(t, data.Cells, 3)
@@ -173,7 +173,7 @@ func TestBuildShardedApplyData_JoinsMultiTaskDDL(t *testing.T) {
 		{ID: 3, ApplyID: 1, ApplyOperationID: &oid, Namespace: "ks", TableName: "mutes", DDL: "ALTER TABLE `mutes` ADD INDEX b"},
 	}
 
-	data := buildShardedApplyData(apply, []*storage.ApplyOperation{op}, tasks)
+	data := buildShardedApplyData(apply, []*storage.ApplyOperation{op}, false, tasks)
 
 	require.Len(t, data.Cells, 1)
 	assert.Equal(t, "ALTER TABLE `mutes` ADD INDEX a\nALTER TABLE `mutes` ADD INDEX b", data.Cells[0].DDL,

--- a/pkg/webhook/templates/multi_apply_test.go
+++ b/pkg/webhook/templates/multi_apply_test.go
@@ -12,15 +12,15 @@ import (
 var so = state.ApplyOperation
 
 func barrierOp(dep, st string) presentation.Operation {
-	return presentation.Operation{Deployment: dep, State: st, Barrier: true, HaltOnFailure: true}
+	return presentation.Operation{Deployment: dep, State: st, Barrier: true}
 }
 
 func rollingOp(dep, st string) presentation.Operation {
-	return presentation.Operation{Deployment: dep, State: st, HaltOnFailure: true}
+	return presentation.Operation{Deployment: dep, State: st}
 }
 
 func continuingOp(dep, st string) presentation.Operation {
-	return presentation.Operation{Deployment: dep, State: st, HaltOnFailure: false, ContinueOnFailure: true}
+	return presentation.Operation{Deployment: dep, State: st, ContinueOnFailure: true}
 }
 
 // A barrier rollout mid-flight (one deployment parked ready for cutover, one
@@ -157,7 +157,7 @@ func TestRenderMultiDeploymentApplyComment_StartedAtUsesApplyStart(t *testing.T)
 // firstFailingOp builds a rolling, continue-policy operation carrying an error,
 // so a fan-out can fail one deployment and keep going.
 func firstFailingOp(dep, st, errMsg string) presentation.Operation {
-	return presentation.Operation{Deployment: dep, State: st, HaltOnFailure: false, ContinueOnFailure: true, Error: errMsg}
+	return presentation.Operation{Deployment: dep, State: st, ContinueOnFailure: true, Error: errMsg}
 }
 
 // A failed deployment's reason is lifted to the aggregate header so an operator
@@ -207,7 +207,7 @@ func TestRenderMultiDeploymentApplyComment_NoFirstFailureWhenHealthy(t *testing.
 func TestRenderMultiDeploymentApplySummaryComment_FirstFailureSurfacesError(t *testing.T) {
 	model := presentation.Derive([]presentation.Operation{
 		rollingOp("eu", so.Completed),
-		{Deployment: "us", State: so.Failed, HaltOnFailure: true, Error: "boom <script>"},
+		{Deployment: "us", State: so.Failed, Error: "boom <script>"},
 		rollingOp("au", so.Pending),
 	})
 	out := RenderMultiDeploymentApplySummaryComment(MultiDeploymentApplyData{
@@ -224,7 +224,7 @@ func TestRenderMultiDeploymentApplySummaryComment_FirstFailureSurfacesError(t *t
 // an escaped Markdown code span would.
 func TestRenderMultiDeploymentApplyComment_FirstFailureEscapesName(t *testing.T) {
 	model := presentation.Derive([]presentation.Operation{
-		{Deployment: "us&ca", State: so.Failed, HaltOnFailure: true, Error: "boom"},
+		{Deployment: "us&ca", State: so.Failed, Error: "boom"},
 	})
 	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{
 		Model:       model,

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -1115,10 +1115,10 @@ func sampleDeploymentDetail(database, applyState string, tables []TableProgressD
 // mid-flight: one deployment parked ready for cutover, one copying, two queued.
 func PreviewCommentMultiDeploymentApplyInProgress() string {
 	model := presentation.Derive([]presentation.Operation{
-		{Deployment: "eu", State: state.ApplyOperation.WaitingForCutover, Barrier: true, HaltOnFailure: true},
-		{Deployment: "us", State: state.ApplyOperation.Running, Barrier: true, HaltOnFailure: true},
-		{Deployment: "au", State: state.ApplyOperation.Pending, Barrier: true, HaltOnFailure: true},
-		{Deployment: "ca", State: state.ApplyOperation.Pending, Barrier: true, HaltOnFailure: true},
+		{Deployment: "eu", State: state.ApplyOperation.WaitingForCutover, Barrier: true},
+		{Deployment: "us", State: state.ApplyOperation.Running, Barrier: true},
+		{Deployment: "au", State: state.ApplyOperation.Pending, Barrier: true},
+		{Deployment: "ca", State: state.ApplyOperation.Pending, Barrier: true},
 	})
 
 	euTables := sampleApplyTables()
@@ -1153,10 +1153,10 @@ func PreviewCommentMultiDeploymentApplyInProgress() string {
 // deployments are halted, and the aggregate is failed with retry as next action.
 func PreviewCommentMultiDeploymentApplyFailed() string {
 	model := presentation.Derive([]presentation.Operation{
-		{Deployment: "eu", State: state.ApplyOperation.Completed, HaltOnFailure: true},
-		{Deployment: "us", State: state.ApplyOperation.Failed, HaltOnFailure: true, Error: PreviewErrorMiddleFailed},
-		{Deployment: "au", State: state.ApplyOperation.Pending, HaltOnFailure: true},
-		{Deployment: "ca", State: state.ApplyOperation.Pending, HaltOnFailure: true},
+		{Deployment: "eu", State: state.ApplyOperation.Completed},
+		{Deployment: "us", State: state.ApplyOperation.Failed, Error: PreviewErrorMiddleFailed},
+		{Deployment: "au", State: state.ApplyOperation.Pending},
+		{Deployment: "ca", State: state.ApplyOperation.Pending},
 	})
 
 	euTables := sampleApplyTables()
@@ -1191,9 +1191,9 @@ func PreviewCommentMultiDeploymentApplyFailed() string {
 // across all deployments — aggregate applied, no pending operator action.
 func PreviewCommentMultiDeploymentApplyCompleted() string {
 	model := presentation.Derive([]presentation.Operation{
-		{Deployment: "eu", State: state.ApplyOperation.Completed, HaltOnFailure: true},
-		{Deployment: "us", State: state.ApplyOperation.Completed, HaltOnFailure: true},
-		{Deployment: "au", State: state.ApplyOperation.Completed, HaltOnFailure: true},
+		{Deployment: "eu", State: state.ApplyOperation.Completed},
+		{Deployment: "us", State: state.ApplyOperation.Completed},
+		{Deployment: "au", State: state.ApplyOperation.Completed},
 	})
 
 	completedTables := func() []TableProgressData {
@@ -1224,9 +1224,9 @@ func PreviewCommentMultiDeploymentApplyCompleted() string {
 // deployment's terminal summary in its section.
 func PreviewCommentMultiDeploymentApplySummaryCompleted() string {
 	model := presentation.Derive([]presentation.Operation{
-		{Deployment: "eu", State: state.ApplyOperation.Completed, HaltOnFailure: true},
-		{Deployment: "us", State: state.ApplyOperation.Completed, HaltOnFailure: true},
-		{Deployment: "au", State: state.ApplyOperation.Completed, HaltOnFailure: true},
+		{Deployment: "eu", State: state.ApplyOperation.Completed},
+		{Deployment: "us", State: state.ApplyOperation.Completed},
+		{Deployment: "au", State: state.ApplyOperation.Completed},
 	})
 
 	completedTables := func() []TableProgressData {
@@ -1258,10 +1258,10 @@ func PreviewCommentMultiDeploymentApplySummaryCompleted() string {
 // error and retry guidance, and later deployments are halted.
 func PreviewCommentMultiDeploymentApplySummaryFailed() string {
 	model := presentation.Derive([]presentation.Operation{
-		{Deployment: "eu", State: state.ApplyOperation.Completed, HaltOnFailure: true},
-		{Deployment: "us", State: state.ApplyOperation.Failed, HaltOnFailure: true, Error: PreviewErrorMiddleFailed},
-		{Deployment: "au", State: state.ApplyOperation.Pending, HaltOnFailure: true},
-		{Deployment: "ca", State: state.ApplyOperation.Pending, HaltOnFailure: true},
+		{Deployment: "eu", State: state.ApplyOperation.Completed},
+		{Deployment: "us", State: state.ApplyOperation.Failed, Error: PreviewErrorMiddleFailed},
+		{Deployment: "au", State: state.ApplyOperation.Pending},
+		{Deployment: "ca", State: state.ApplyOperation.Pending},
 	})
 
 	euTables := sampleApplyTables()

--- a/pkg/webhook/templates/preview_sharded.go
+++ b/pkg/webhook/templates/preview_sharded.go
@@ -33,10 +33,10 @@ func PreviewCommentShardedApplyInProgress() string {
 		State: state.Apply.Running, Environment: "production", Database: "cdb_resolute",
 		Keyspace: "cdb_resolute_sharded", ApplyID: "apply-a1b2c3d4e5f6", RequestedBy: previewRequestedBy,
 		Shards: previewShardStatuses([]presentation.Operation{
-			{Deployment: "-40", State: state.ApplyOperation.Running, HaltOnFailure: true},
-			{Deployment: "40-80", State: state.ApplyOperation.Pending, HaltOnFailure: true},
-			{Deployment: "80-c0", State: state.ApplyOperation.Pending, HaltOnFailure: true},
-			{Deployment: "c0-", State: state.ApplyOperation.Pending, HaltOnFailure: true},
+			{Deployment: "-40", State: state.ApplyOperation.Running},
+			{Deployment: "40-80", State: state.ApplyOperation.Pending},
+			{Deployment: "80-c0", State: state.ApplyOperation.Pending},
+			{Deployment: "c0-", State: state.ApplyOperation.Pending},
 		}),
 		Cells: []ShardCell{previewMutesCell("-40"), previewMutesCell("40-80"), previewMutesCell("80-c0"), previewMutesCell("c0-")},
 	})
@@ -49,10 +49,10 @@ func PreviewCommentShardedApplyFailed() string {
 		State: state.Apply.Failed, Environment: "production", Database: "cdb_resolute",
 		Keyspace: "cdb_resolute_sharded", ApplyID: "apply-a1b2c3d4e5f6", RequestedBy: previewRequestedBy,
 		Shards: previewShardStatuses([]presentation.Operation{
-			{Deployment: "-40", State: state.ApplyOperation.Failed, HaltOnFailure: true, Error: "resolve shard primary for `-40`: context deadline exceeded"},
-			{Deployment: "40-80", State: state.ApplyOperation.Pending, HaltOnFailure: true},
-			{Deployment: "80-c0", State: state.ApplyOperation.Pending, HaltOnFailure: true},
-			{Deployment: "c0-", State: state.ApplyOperation.Pending, HaltOnFailure: true},
+			{Deployment: "-40", State: state.ApplyOperation.Failed, Error: "resolve shard primary for `-40`: context deadline exceeded"},
+			{Deployment: "40-80", State: state.ApplyOperation.Pending},
+			{Deployment: "80-c0", State: state.ApplyOperation.Pending},
+			{Deployment: "c0-", State: state.ApplyOperation.Pending},
 		}),
 		Cells: []ShardCell{previewMutesCell("-40"), previewMutesCell("40-80"), previewMutesCell("80-c0"), previewMutesCell("c0-")},
 	})
@@ -65,9 +65,9 @@ func PreviewCommentShardedApplyDivergent() string {
 		State: state.Apply.Running, Environment: "production", Database: "cdb_resolute",
 		Keyspace: "cdb_resolute_sharded", ApplyID: "apply-a1b2c3d4e5f6", RequestedBy: previewRequestedBy,
 		Shards: previewShardStatuses([]presentation.Operation{
-			{Deployment: "-40", State: state.ApplyOperation.Running, HaltOnFailure: true},
-			{Deployment: "40-80", State: state.ApplyOperation.Pending, HaltOnFailure: true},
-			{Deployment: "80-c0", State: state.ApplyOperation.Pending, HaltOnFailure: true},
+			{Deployment: "-40", State: state.ApplyOperation.Running},
+			{Deployment: "40-80", State: state.ApplyOperation.Pending},
+			{Deployment: "80-c0", State: state.ApplyOperation.Pending},
 		}),
 		Cells: []ShardCell{
 			previewMutesCell("-40"),


### PR DESCRIPTION
## Summary
Teaches the presentation layer (CLI progress, TUI, PR-comment webhook) to
distinguish a **paused** rollout from a halted or degraded one, so users see
"release or stop" guidance instead of a misleading failure.

## What
- Presentation `Operation` now carries `ContinueOnFailure` / `PauseOnFailure` /
  `Released` instead of the conflated `HaltOnFailure`.
- Aggregate derives paused vs released-pause from `state.RolloutChild`.
- Adds a `paused` deployment presentation state + labels
  (`paused — <deployment> failed; release or stop`).
- Pending/cutover gates mirror the released-failure exemption from the claim
  predicate so the presentation matches what the operator will actually do.
- Boundary mappings updated across webhook, CLI, and sharded webhook; preview
  and test fixtures updated to match.

## Why
PAUSE-1..4 made `paused` a real, projected rollout state with a release latch,
but every user-facing surface still collapsed it into halt/continue. Without
this, a paused rollout reads as a hard failure and hides the release/stop
choice the operator is actually waiting on.

## Before / after
```
Before:                              After:
╭───────────────────────────╮       ╭────────────────────────────────────╮
│ op.OnFailure = pause      │       │ op.OnFailure = pause               │
│        │                  │       │     │           │                  │
│        ▼                  │       │  released?    not released?        │
│  HaltOnFailure (conflated)│       │     │           │                  │
│        │                  │       │     ▼           ▼                  │
│        ▼                  │       │  continue    PauseOnFailure        │
│  "failed" / blocked       │       │  (degraded)  "paused — release or  │
│                           │       │              stop"  gates mirror   │
│                           │       │              claim exemption       │
╰───────────────────────────╯       ╰────────────────────────────────────╯
```
## References
PAUSE-5 in the on_failure:pause workstream (follows #487, #541, #543, #544).
