### PR TITLE
feat(control): accept paused in stop + reconciliation, reject in start

### DIFF
--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -1720,6 +1720,8 @@ func startNotAllowedForState(apply *storage.Apply) error {
 		return controlConflictf("schema change is cutting over; start is not allowed")
 	case state.IsState(apply.State, state.Apply.RevertWindow):
 		return controlConflictf("schema change is in revert window; use revert or skip-revert instead of start")
+	case state.IsState(apply.State, state.Apply.Paused):
+		return controlConflictf("schema change is paused after a failed deployment; use release to continue the remaining deployments or stop to abandon them")
 	case state.IsState(apply.State, state.Apply.FailedRetryable):
 		return controlConflictf("schema change is waiting for operator retry; start is not allowed")
 	case state.IsState(apply.State, state.Apply.Failed):

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -4645,6 +4645,11 @@ func TestStartHandler(t *testing.T) {
 				wantMessage: "use revert or skip-revert",
 			},
 			{
+				name:        "paused",
+				applyState:  state.Apply.Paused,
+				wantMessage: "paused after a failed deployment; use release",
+			},
+			{
 				name:        "preparing branch",
 				applyState:  state.Apply.PreparingBranch,
 				wantMessage: "setup state preparing_branch",

--- a/pkg/cmd/commands/stop.go
+++ b/pkg/cmd/commands/stop.go
@@ -49,7 +49,7 @@ func (cmd *StopCmd) Run(g *Globals) error {
 		fmt.Println("Schema change already stopped")
 		return nil
 	}
-	if !state.IsState(curState, state.Apply.Running, state.Apply.RunningDegraded, state.Apply.CuttingOver, state.Apply.WaitingForDeploy, state.Apply.WaitingForCutover, state.Apply.Pending) {
+	if !state.IsState(curState, state.Apply.Running, state.Apply.RunningDegraded, state.Apply.Paused, state.Apply.CuttingOver, state.Apply.WaitingForDeploy, state.Apply.WaitingForCutover, state.Apply.Pending) {
 		return fmt.Errorf("cannot stop schema change in state: %s", curState)
 	}
 

--- a/pkg/state/apply_test.go
+++ b/pkg/state/apply_test.go
@@ -504,6 +504,11 @@ func TestDeriveRolloutApplyState_PausePolicy(t *testing.T) {
 			want:     Apply.Failed,
 		},
 		{
+			name:     "pause failure with later sibling stopped (stop chosen over release) settles failed",
+			children: []RolloutChild{rcPause(Apply.Failed), rcPause(Apply.Stopped)},
+			want:     Apply.Failed,
+		},
+		{
 			name:     "single pause failure with nothing to hold settles failed",
 			children: []RolloutChild{rcPause(Apply.Failed)},
 			want:     Apply.Failed,

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -1318,14 +1318,19 @@ func (s *applyStore) FindNextApplyForStopReconciliation(ctx context.Context, own
 	}
 	defer rollbackTx(ctx, tx, "claim apply for stop reconciliation")
 
-	// Parent eligibility: pending plus the active recovery-claimable states
-	// (claimableApplyStates); the resumable failed_retryable and stopped states
-	// are excluded because they have their own resume paths. pending is included
-	// so a stop requested before the first operation is ever claimed is not
-	// stranded — the claim gate refuses the pending ops, so reconciliation must
-	// own them; persistApplyClaim transitions a pending apply to running for the
-	// claim.
-	parentStates := append([]string{state.Apply.Pending}, claimableApplyStates()...)
+	// Parent eligibility: pending and paused plus the active recovery-claimable
+	// states (claimableApplyStates); the resumable failed_retryable and stopped
+	// states are excluded because they have their own resume paths. pending is
+	// included so a stop requested before the first operation is ever claimed is
+	// not stranded — the claim gate refuses the pending ops, so reconciliation
+	// must own them; persistApplyClaim transitions a pending apply to running for
+	// the claim. paused is included so an on_failure='pause' rollout that an
+	// operator stops (rather than releases) is terminalized: paused holds the
+	// later siblings pending behind the failed one, and paused is deliberately
+	// absent from claimableApplyStates (it needs an explicit human decision, not
+	// stale-heartbeat recovery), so without it here a stopped paused apply would
+	// strand its pending siblings forever.
+	parentStates := append([]string{state.Apply.Pending, state.Apply.Paused}, claimableApplyStates()...)
 	parentStatePlaceholders := placeholders(len(parentStates))
 
 	// A child operation in any of these states is being driven, or is a crashed

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -3257,6 +3257,51 @@ func TestApplyStore_FindNextApplyForStopReconciliation_ClaimsStrandedContinueApp
 	assert.Equal(t, state.Apply.Running, claimed.State, "reconciliation claim refreshes the lease without changing apply state")
 }
 
+// TestApplyStore_FindNextApplyForStopReconciliation_ClaimsStrandedPausedApply
+// verifies the trigger also covers on_failure "pause": a rollout held paused by
+// a failed earlier sibling (no release) with a pending stop and a pending
+// sibling is claimed here so the operator can stop the held siblings and settle
+// the apply failed. paused is deliberately absent from claimableApplyStates, so
+// without paused in the reconciliation parent eligibility a stopped paused apply
+// would strand its pending siblings forever.
+func TestApplyStore_FindNextApplyForStopReconciliation_ClaimsStrandedPausedApply(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_stop_recon_paused", 1, state.Apply.Paused, "staging")
+
+	failedID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Failed, OnFailure: storage.OnFailurePause,
+	})
+	require.NoError(t, err)
+	_, err = store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b", OnFailure: storage.OnFailurePause,
+	})
+	require.NoError(t, err)
+	// Backdate the failed row so it can't be mistaken for a fresh active op.
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE apply_operations SET updated_at = NOW() - INTERVAL 1 HOUR WHERE id = ?
+	`, failedID)
+	require.NoError(t, err)
+
+	_, _, err = store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationStop,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "operator",
+	})
+	require.NoError(t, err)
+
+	claimed, err := store.Applies().FindNextApplyForStopReconciliation(ctx, "test-operator")
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "a paused apply with a pending stop and pending siblings must be claimable for reconciliation")
+	assert.Equal(t, apply.ID, claimed.ID)
+	assert.Equal(t, "test-operator", claimed.LeaseOwner, "claim rotates the lease owner")
+	assert.Equal(t, state.Apply.Paused, claimed.State, "reconciliation claim refreshes the lease without changing apply state")
+}
+
 // TestApplyStore_FindNextApplyForStopReconciliation_SkipsApplyWithActiveOp
 // verifies the trigger defers to the operation-claim path whenever any operation
 // is active — whether freshly heartbeating or stale-and-crashed. That path drives


### PR DESCRIPTION
## Summary
Make `on_failure: pause` rollouts cleanly stoppable. The stop path (CLI + reconciliation) now accepts `paused`, so a stopped paused rollout's held siblings settle `failed` instead of stranding. `start` still rejects `paused`, now with explicit "use release or stop" guidance.

## What
- `pkg/cmd/commands/stop.go` — add `paused` to the stop CLI allowlist.
- `pkg/api/control_handlers.go` — `start` rejects `paused` with "use release to continue the remaining deployments or stop to abandon them".
- `pkg/storage/mysqlstore/applies.go` — add `paused` to `FindNextApplyForStopReconciliation` parent eligibility **only** (not the shared `claimableApplyStates()`, which is stale-recovery scope).
- Tests: start-handler rejection, stop-reconciliation claims a stranded paused parent, and the truth-table case where a paused failure + later-stopped sibling settles `failed`.

## Why
A paused rollout was `release`-able but not cleanly `stop`-pable: the CLI rejected stop on `paused`, `start` gave a generic "not stopped" error, and `paused` was missing from stop-reconciliation parent eligibility, so a pending stop could strand held siblings. `paused` is deliberately kept out of the shared claimable set because that set governs generic stale recovery, not local stop reconciliation.

## Before / after

```text
BEFORE
  paused rollout
    ├─ stop (CLI) ......... ✗ rejected ("not stopped")
    ├─ start .............. ✗ generic "not stopped" error
    └─ pending stop ...... parent paused not eligible for
                            stop-reconciliation → held siblings stranded

AFTER
  paused rollout
    ├─ stop (CLI) ......... ✓ accepted
    ├─ start .............. ✗ rejected, "use release or stop"
    └─ pending stop ...... reconciliation claims paused parent
                            → held siblings stopped → parent settles failed
```

## References
- Workstream: `on_failure: pause` (PAUSE-7); follows `#487, #541, #543, #544, #578, #580`
