### PR TITLE
feat(github): post SchemaBot checks on merge queue entries

### DIFF
--- a/docs/check-runs.md
+++ b/docs/check-runs.md
@@ -13,6 +13,7 @@
 - [Internal Records](#internal-records)
 - [Lifecycle](#lifecycle)
   - [Pull Request Events](#pull-request-events)
+  - [Merge Queue Events](#merge-queue-events)
   - [Auto-Plan](#auto-plan)
   - [Apply](#apply)
   - [Rollback](#rollback)
@@ -330,6 +331,27 @@ SchemaBot listens to these GitHub `pull_request` webhook actions:
 | `closed` | PR was closed or merged. | Release locks held by the PR and delete internal check records. In-flight applies continue in Tern. |
 
 Other `pull_request` actions are ignored by the check-run lifecycle.
+
+### Merge Queue Events
+
+When a repository uses a GitHub merge queue, branch protection re-evaluates the
+required checks against the queue's synthetic merge-group head commit — a new
+commit that combines the queued pull requests — not the PR head SHA. SchemaBot
+only publishes its checks on PR head SHAs, so without handling `merge_group` the
+required SchemaBot check would never appear on the merge-group commit and the
+queue entry would block indefinitely.
+
+| Action | Meaning | SchemaBot behavior |
+| --- | --- | --- |
+| `checks_requested` | A PR entered the merge queue; GitHub asks for checks on the merge-group head SHA. | Publish a passing aggregate check on the merge-group head SHA — one per gated environment, using the same check names as the PR-head aggregates. |
+| `destroyed` | A PR left the merge queue. | Ignored; no check is needed on any commit. |
+
+Publishing a passing check is safe because SchemaBot applies and gates schema
+changes *before* a PR can enter the queue: branch protection already required
+the PR-head check to pass, so the merge group sits strictly downstream of an
+already-completed, already-gated apply. A repository SchemaBot does not manage,
+or one with check publishing disabled, gets no merge-group check because its
+check is not required there.
 
 ### Auto-Plan
 

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -64,6 +64,7 @@ Under **Repository permissions**, grant:
 | **Commit statuses** | Read | Read legacy commit statuses for the `require_passing_checks` gate |
 | **Contents** | Read | Read `schemabot.yaml`, schema files, CODEOWNERS, and commit refs |
 | **Issues** | Read & Write | Post PR comments and add reactions |
+| **Merge queues** | Read | Receive `merge_group` events so SchemaBot can publish its checks on merge-queue commits (only needed if a repo uses a merge queue) |
 | **Metadata** | Read | Required (granted automatically) |
 | **Pull requests** | Read & Write | Fetch PR info, changed files, and reviews |
 
@@ -78,6 +79,9 @@ Under **Organization permissions**, grant:
 | Event | Purpose |
 |-------|---------|
 | **Issue comment** | Receive `schemabot plan`, `schemabot help`, etc. from PR comments |
+| **Merge group** | Publish a passing SchemaBot check on a merge-queue commit so a required SchemaBot check does not block the merge queue (only needed if a repo uses a merge queue) |
+
+Subscribe to **Merge group**, not **Merge queue entry** — the two are distinct events, and SchemaBot handles only `merge_group`. The **Merge group** event requires the **Merge queues: Read** repository permission above. Because that is a new permission, adding it to an existing App marks the App as requesting new permissions, which an org or repository admin must approve on each installation before it takes effect.
 
 Future phases will also use **Check run** (action buttons) and **Pull request** (auto-plan on open/sync).
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -640,6 +640,7 @@ var knownWebhookEvents = map[string]bool{
 	"pull_request_review":         true,
 	"pull_request_review_comment": true,
 	"check_run":                   true,
+	"merge_group":                 true,
 	"ping":                        true,
 	"push":                        true,
 }
@@ -649,6 +650,7 @@ var knownWebhookActions = map[string]bool{
 	"assigned":               true,
 	"auto_merge_disabled":    true,
 	"auto_merge_enabled":     true,
+	"checks_requested":       true,
 	"closed":                 true,
 	"completed":              true,
 	"converted_to_draft":     true,
@@ -656,6 +658,7 @@ var knownWebhookActions = map[string]bool{
 	"deleted":                true,
 	"demilestoned":           true,
 	"dequeued":               true,
+	"destroyed":              true,
 	"dismissed":              true,
 	"edited":                 true,
 	"enqueued":               true,

--- a/pkg/webhook/check_aggregate.go
+++ b/pkg/webhook/check_aggregate.go
@@ -38,6 +38,34 @@ func (h *Handler) aggregateCheckNameForRepo(repo string) string {
 	return config.GitHubCheckNameBaseForRepo(repo)
 }
 
+// aggregateCheckTarget pairs an aggregate Check Run name with the environment
+// it represents (aggregateSentinel when this instance is not environment-scoped).
+type aggregateCheckTarget struct {
+	name        string
+	environment string
+}
+
+// aggregateCheckTargetsForRepo returns the aggregate Check Run name(s) this
+// instance publishes for repo: one per allowed environment, or a single
+// non-environment-scoped name when AllowedEnvironments is empty. Callers that
+// publish aggregates on any commit (PR head or merge-group head) must use these
+// names so branch protection's required-check names always match.
+func (h *Handler) aggregateCheckTargetsForRepo(repo string) []aggregateCheckTarget {
+	base := h.aggregateCheckNameForRepo(repo)
+	config, ok := h.serverConfig()
+	if !ok || len(config.AllowedEnvironments) == 0 {
+		return []aggregateCheckTarget{{name: base, environment: aggregateSentinel}}
+	}
+	targets := make([]aggregateCheckTarget, 0, len(config.AllowedEnvironments))
+	for _, env := range config.AllowedEnvironments {
+		targets = append(targets, aggregateCheckTarget{
+			name:        aggregateCheckNameForEnv(base, env),
+			environment: env,
+		})
+	}
+	return targets
+}
+
 func (h *Handler) configuredDatabaseEnvironments(database string) ([]string, error) {
 	config, ok := h.serverConfig()
 	if !ok {

--- a/pkg/webhook/check_publisher.go
+++ b/pkg/webhook/check_publisher.go
@@ -282,8 +282,6 @@ func (h *Handler) postPassingAggregates(ctx context.Context, client *ghclient.In
 		return
 	}
 
-	config := h.service.Config()
-	checkNameBase := h.aggregateCheckNameForRepo(repo)
 	storedChecks, err := h.service.Storage().Checks().GetByPR(ctx, repo, pr)
 	if err != nil {
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
@@ -295,25 +293,7 @@ func (h *Handler) postPassingAggregates(ctx context.Context, client *ghclient.In
 		return
 	}
 
-	type envCheck struct {
-		name        string
-		environment string
-	}
-
-	var checks []envCheck
-	if len(config.AllowedEnvironments) > 0 {
-		for _, env := range config.AllowedEnvironments {
-			checks = append(checks, envCheck{
-				name:        aggregateCheckNameForEnv(checkNameBase, env),
-				environment: env,
-			})
-		}
-	} else {
-		checks = append(checks, envCheck{
-			name:        checkNameBase,
-			environment: aggregateSentinel,
-		})
-	}
+	checks := h.aggregateCheckTargetsForRepo(repo)
 
 	h.logger.Debug("posting passing aggregates", "repo", repo, "pr", pr, "head_sha", headSHA, "count", len(checks))
 

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -462,6 +462,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "pull_request":
 		h.handlePullRequest(ctx, metricApp, w, body)
 		metrics.RecordWebhookEvent(ctx, metricApp, eventType, action, repo, "processed")
+	case "merge_group":
+		h.handleMergeGroup(ctx, metricApp, w, body)
+		metrics.RecordWebhookEvent(ctx, metricApp, eventType, action, repo, "processed")
 	default:
 		h.logger.Info("webhook ignored",
 			"reason", "unsupported_event_type",

--- a/pkg/webhook/merge_group.go
+++ b/pkg/webhook/merge_group.go
@@ -1,0 +1,151 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/metrics"
+)
+
+// mergeGroupPayload is the subset of the GitHub merge_group webhook payload
+// SchemaBot needs. GitHub fires this event when a pull request enters or leaves
+// a repository's merge queue.
+type mergeGroupPayload struct {
+	Action     string `json:"action"`
+	MergeGroup struct {
+		HeadSHA string `json:"head_sha"`
+	} `json:"merge_group"`
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+	Installation struct {
+		ID int64 `json:"id"`
+	} `json:"installation"`
+}
+
+// handleMergeGroup responds to merge_group webhook events so SchemaBot's
+// required Check Runs do not wedge a repository's merge queue.
+//
+// A merge queue tests queued pull requests combined, on a synthetic head
+// commit, before they land on the base branch. Branch protection re-evaluates
+// the same required checks against that merge-group head SHA — but SchemaBot
+// only ever publishes its checks on PR head SHAs, so without this handler the
+// required SchemaBot check would never appear on the merge-group commit and the
+// queue entry would block indefinitely.
+//
+// Posting a passing check is correct: SchemaBot applies schema changes before a
+// PR merges, and branch protection already required the PR-head check to pass
+// before the PR could enter the queue. The merge group sits strictly downstream
+// of an already-completed, already-gated apply, so there is nothing left to
+// verify on the combined commit.
+func (h *Handler) handleMergeGroup(ctx context.Context, metricApp string, w http.ResponseWriter, body []byte) {
+	var payload mergeGroupPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		h.writeError(w, http.StatusBadRequest, "invalid merge_group payload")
+		return
+	}
+
+	// GitHub sends "checks_requested" when a PR joins the queue and "destroyed"
+	// when it leaves. Only checks_requested needs a check run on the new SHA.
+	if payload.Action != "checks_requested" {
+		h.logger.Debug("merge_group action ignored",
+			"action", payload.Action, "repo", payload.Repository.FullName)
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "merge_group action ignored"})
+		return
+	}
+
+	repo := payload.Repository.FullName
+	headSHA := payload.MergeGroup.HeadSHA
+	installationID := payload.Installation.ID
+	if installationID == 0 {
+		h.writeError(w, http.StatusBadRequest, "missing installation ID in merge_group payload")
+		return
+	}
+	if headSHA == "" {
+		h.writeError(w, http.StatusBadRequest, "missing merge_group head_sha in merge_group payload")
+		return
+	}
+
+	// A repo SchemaBot does not manage gets no check — its check is not required
+	// on that repo, so there is nothing to unblock.
+	if h.service != nil && !h.service.Config().IsRepoAllowed(repo) {
+		h.logger.Warn("merge_group webhook from unregistered repository",
+			"repo", repo, "head_sha", headSHA, "installation_id", installationID)
+		metrics.RecordUnregisteredRepositoryWebhook(ctx, metricApp, "merge_group", payload.Action, repo)
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "repository not registered"})
+		return
+	}
+
+	// When check publishing is disabled for this repo, SchemaBot's check is not
+	// required either, so skipping the merge-group check is correct.
+	if !h.shouldPublishChecks(ctx, repo, "merge_group_check") {
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "check publishing disabled"})
+		return
+	}
+
+	postCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+
+	client, err := h.clientForRepo(repo, installationID)
+	if err != nil {
+		h.logger.Error("failed to create GitHub client for merge_group check",
+			"repo", repo, "head_sha", headSHA, "installation_id", installationID, "error", err)
+		h.writeError(w, http.StatusInternalServerError, "failed to initialize GitHub client")
+		return
+	}
+
+	if err := h.postMergeGroupChecks(postCtx, client, repo, headSHA); err != nil {
+		// Return 500 so GitHub redelivers. The merge queue blocks until the check
+		// is posted, so a transient failure must be retried, not dropped.
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:  "merge_group_check",
+			Repository: repo,
+			Status:     "error",
+		})
+		h.logger.Error("failed to post merge_group checks",
+			"repo", repo, "head_sha", headSHA, "error", err)
+		h.writeError(w, http.StatusInternalServerError, "failed to post merge_group checks")
+		return
+	}
+
+	h.writeJSON(w, http.StatusOK, map[string]string{"message": "merge_group checks posted"})
+}
+
+// postMergeGroupChecks publishes a passing aggregate Check Run on the
+// merge-group head SHA for each environment this instance gates, reusing the
+// same check names as the PR-head aggregates so branch protection's required
+// checks always match.
+func (h *Handler) postMergeGroupChecks(ctx context.Context, client *ghclient.InstallationClient, repo, headSHA string) error {
+	const (
+		title   = "Schema changes verified before merge queue"
+		summary = "Schema changes in queued pull requests are applied and verified by SchemaBot before they enter the merge queue, so no additional verification is required for this merge group."
+	)
+
+	for _, target := range h.aggregateCheckTargetsForRepo(repo) {
+		opts := ghclient.CheckRunOptions{
+			Name:       target.name,
+			Status:     checkStatusCompleted,
+			Conclusion: checkConclusionSuccess,
+			Output: &ghclient.CheckRunOutput{
+				Title:   title,
+				Summary: summary,
+			},
+		}
+		if _, err := client.CreateCheckRun(ctx, repo, headSHA, opts); err != nil {
+			return fmt.Errorf("create merge_group check %q on %s: %w", target.name, headSHA, err)
+		}
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:   "merge_group_check",
+			Repository:  repo,
+			Environment: target.environment,
+			Status:      "success",
+		})
+		h.logger.Info("merge_group check posted",
+			"repo", repo, "head_sha", headSHA, "check_name", target.name, "environment", target.environment)
+	}
+	return nil
+}

--- a/pkg/webhook/merge_group.go
+++ b/pkg/webhook/merge_group.go
@@ -135,8 +135,24 @@ func (h *Handler) postMergeGroupChecks(ctx context.Context, client *ghclient.Ins
 				Summary: summary,
 			},
 		}
-		if _, err := client.CreateCheckRun(ctx, repo, headSHA, opts); err != nil {
-			return fmt.Errorf("create merge_group check %q on %s: %w", target.name, headSHA, err)
+		// Reuse an existing run for this name on the merge-group SHA so a webhook
+		// redelivery updates it rather than creating a duplicate Check Run. The
+		// lookup fails closed when the App slug is unknown; on that error fall
+		// back to creating, which is the safe (if untidy) outcome.
+		existing, _, findErr := client.FindCheckRunByName(ctx, repo, headSHA, target.name)
+		if findErr != nil {
+			h.logger.Warn("could not look up existing merge_group check; creating a new one",
+				"repo", repo, "head_sha", headSHA, "check_name", target.name, "error", findErr)
+		}
+		switch {
+		case findErr == nil && existing != nil:
+			if err := client.UpdateCheckRun(ctx, repo, existing.ID, opts); err != nil {
+				return fmt.Errorf("update merge_group check %q on %s: %w", target.name, headSHA, err)
+			}
+		default:
+			if _, err := client.CreateCheckRun(ctx, repo, headSHA, opts); err != nil {
+				return fmt.Errorf("create merge_group check %q on %s: %w", target.name, headSHA, err)
+			}
 		}
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
 			Operation:   "merge_group_check",

--- a/pkg/webhook/merge_group_test.go
+++ b/pkg/webhook/merge_group_test.go
@@ -1,0 +1,190 @@
+package webhook
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/api"
+	ghclient "github.com/block/schemabot/pkg/github"
+)
+
+// buildMergeGroupWebhookRequest constructs a merge_group webhook POST request.
+func buildMergeGroupWebhookRequest(t *testing.T, action, headSHA string, secret []byte) *http.Request {
+	t.Helper()
+	if action == "" {
+		action = "checks_requested"
+	}
+	if headSHA == "" {
+		headSHA = "mergesha123"
+	}
+
+	payload := map[string]any{
+		"action": action,
+		"merge_group": map[string]any{
+			"head_sha": headSHA,
+		},
+		"repository": map[string]any{
+			"full_name": "octocat/hello-world",
+		},
+		"installation": map[string]any{
+			"id": 12345,
+		},
+	}
+
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/webhook", strings.NewReader(string(body)))
+	req.Header.Set("X-GitHub-Event", "merge_group")
+
+	if len(secret) > 0 {
+		mac := hmac.New(sha256.New, secret)
+		mac.Write(body)
+		req.Header.Set("X-Hub-Signature-256", "sha256="+hex.EncodeToString(mac.Sum(nil)))
+	}
+
+	return req
+}
+
+type createdCheckRun struct {
+	Name       string `json:"name"`
+	HeadSHA    string `json:"head_sha"`
+	Status     string `json:"status"`
+	Conclusion string `json:"conclusion"`
+}
+
+func mergeGroupTestHandler(t *testing.T, allowedEnvironments []string, repos map[string]api.RepoConfig) (*Handler, chan createdCheckRun) {
+	t.Helper()
+	client, mux := setupGitHubServer(t)
+	created := make(chan createdCheckRun, 10)
+	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		var c createdCheckRun
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&c))
+		created <- c
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 555})
+	})
+
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+	service := api.New(nil, &api.ServerConfig{
+		AllowedEnvironments: allowedEnvironments,
+		Repos:               repos,
+	}, nil, testLogger())
+
+	h := &Handler{
+		service:   service,
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: installClient}),
+		logger:    testLogger(),
+	}
+	return h, created
+}
+
+// A merge queue evaluates the same required checks against the queue's
+// synthetic merge-group head commit, not the PR head. Because SchemaBot applies
+// and gates schema changes before a PR can enter the queue, it posts a passing
+// aggregate check on the merge-group head SHA — one per gated environment, with
+// the same names as the PR-head aggregates — so a required SchemaBot check does
+// not block the merge queue forever.
+func TestWebhookMergeGroupPostsPassingChecks(t *testing.T) {
+	h, created := mergeGroupTestHandler(t,
+		[]string{"staging", "production"},
+		map[string]api.RepoConfig{"octocat/hello-world": {}},
+	)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, buildMergeGroupWebhookRequest(t, "checks_requested", "mergesha123", nil))
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "merge_group checks posted")
+
+	got := map[string]createdCheckRun{}
+	for range []int{0, 1} {
+		select {
+		case c := <-created:
+			got[c.Name] = c
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for merge_group check run")
+		}
+	}
+
+	require.Len(t, got, 2)
+	for _, name := range []string{"SchemaBot (staging)", "SchemaBot (production)"} {
+		c, ok := got[name]
+		require.True(t, ok, "expected a check run named %q", name)
+		assert.Equal(t, "mergesha123", c.HeadSHA)
+		assert.Equal(t, "completed", c.Status)
+		assert.Equal(t, "success", c.Conclusion)
+	}
+}
+
+// GitHub fires merge_group with "destroyed" when a PR leaves the queue. That
+// action needs no check run on any commit, so SchemaBot ignores it.
+func TestWebhookMergeGroupIgnoresNonChecksRequested(t *testing.T) {
+	h, created := mergeGroupTestHandler(t, nil, map[string]api.RepoConfig{"octocat/hello-world": {}})
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, buildMergeGroupWebhookRequest(t, "destroyed", "mergesha123", nil))
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "merge_group action ignored")
+
+	select {
+	case c := <-created:
+		t.Fatalf("unexpected check run created for destroyed action: %q", c.Name)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// A merge_group event for a repository SchemaBot does not manage gets no check:
+// SchemaBot's check is not required on that repo, so there is nothing to unblock.
+func TestWebhookMergeGroupRejectsUnregisteredRepo(t *testing.T) {
+	h, created := mergeGroupTestHandler(t, nil, map[string]api.RepoConfig{"org/allowed-repo": {}})
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, buildMergeGroupWebhookRequest(t, "checks_requested", "mergesha123", nil))
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "repository not registered")
+
+	select {
+	case c := <-created:
+		t.Fatalf("unexpected check run created for unregistered repo: %q", c.Name)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// With no environment scoping configured, SchemaBot publishes a single
+// non-environment-scoped aggregate check on the merge-group head SHA.
+func TestWebhookMergeGroupSingleAggregateWhenNoEnvScoping(t *testing.T) {
+	h, created := mergeGroupTestHandler(t, nil, map[string]api.RepoConfig{"octocat/hello-world": {}})
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, buildMergeGroupWebhookRequest(t, "checks_requested", "mergesha123", nil))
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case c := <-created:
+		assert.Equal(t, "SchemaBot", c.Name)
+		assert.Equal(t, "mergesha123", c.HeadSHA)
+		assert.Equal(t, "success", c.Conclusion)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for merge_group check run")
+	}
+
+	select {
+	case c := <-created:
+		t.Fatalf("expected exactly one aggregate check, got extra: %q", c.Name)
+	case <-time.After(100 * time.Millisecond):
+	}
+}

--- a/pkg/webhook/merge_group_test.go
+++ b/pkg/webhook/merge_group_test.go
@@ -163,6 +163,63 @@ func TestWebhookMergeGroupRejectsUnregisteredRepo(t *testing.T) {
 	}
 }
 
+// A webhook redelivery for the same merge group must not create a duplicate
+// Check Run. When SchemaBot's App slug is known it finds the run it already
+// published on the merge-group head SHA and updates it in place.
+func TestWebhookMergeGroupUpdatesExistingCheck(t *testing.T) {
+	client, mux := setupGitHubServer(t)
+	updated := make(chan int64, 4)
+	created := make(chan string, 4)
+	mux.HandleFunc("GET /repos/octocat/hello-world/commits/mergesha123/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"total_count": 1,
+			"check_runs": []map[string]any{
+				{"id": 7, "name": "SchemaBot (production)", "status": "completed", "conclusion": "success", "app": map[string]any{"slug": "schemabot"}},
+			},
+		})
+	})
+	mux.HandleFunc("PATCH /repos/octocat/hello-world/check-runs/7", func(w http.ResponseWriter, _ *http.Request) {
+		updated <- 7
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 7})
+	})
+	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		var c createdCheckRun
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&c))
+		created <- c.Name
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 555})
+	})
+
+	installClient := ghclient.NewInstallationClientWithSlug(client, testLogger(), "schemabot")
+	service := api.New(nil, &api.ServerConfig{
+		AllowedEnvironments: []string{"production"},
+		Repos:               map[string]api.RepoConfig{"octocat/hello-world": {}},
+	}, nil, testLogger())
+	h := &Handler{
+		service:   service,
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: installClient}),
+		logger:    testLogger(),
+	}
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, buildMergeGroupWebhookRequest(t, "checks_requested", "mergesha123", nil))
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case id := <-updated:
+		assert.Equal(t, int64(7), id)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected the existing check run to be updated")
+	}
+
+	select {
+	case name := <-created:
+		t.Fatalf("expected an update, not a new check run: %q", name)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
 // With no environment scoping configured, SchemaBot publishes a single
 // non-environment-scoped aggregate check on the merge-group head SHA.
 func TestWebhookMergeGroupSingleAggregateWhenNoEnvScoping(t *testing.T) {


### PR DESCRIPTION
## Why this matters

When a repository uses a GitHub merge queue, branch protection re-evaluates the required checks against the queue's **merge-group head commit** — a synthetic commit that combines the queued pull requests — not the PR head SHA. SchemaBot only published its checks on PR head SHAs and ignored `merge_group` events, so a required SchemaBot check would never appear on the merge-group commit. The queue entry would then wait forever for a check that never arrives, blocking every PR behind it. This makes it unsafe to mark a SchemaBot check *required* on any repo that uses a merge queue.

## What it does

Handle the `merge_group` webhook:

- On `checks_requested`, publish a passing aggregate Check Run on the merge-group head SHA — one per gated environment, reusing the exact check names SchemaBot publishes on the PR head so branch protection's required-check names always match.
- On `destroyed` (PR left the queue), do nothing — no check is needed on any commit.
- Repositories SchemaBot does not manage, or those with check publishing disabled, get no merge-group check, because the SchemaBot check is not required there.

```text
PR enters merge queue
        |
        v
merge_group / checks_requested  (new synthetic head SHA)
        |
        v
publish passing aggregate per gated env on the merge-group head SHA
        |
        v
queue entry's required SchemaBot check is satisfied
```

Publishing a passing check is correct because SchemaBot applies and gates schema changes *before* a PR can enter the queue: branch protection already required the PR-head check to pass, so the merge group sits strictly downstream of an already-completed, already-gated apply. To keep that guarantee, the merge-group check name derivation is shared with the PR-head aggregate path (`aggregateCheckTargetsForRepo`) so the two cannot drift, and a failure to publish returns 500 so GitHub redelivers rather than leaving the queue silently blocked.

## How it moves toward the north star

A SchemaBot Check Run is a tier-0 safety gate, but it is only an effective gate once it can be marked *required*. Merge queues are increasingly the default merge path on large shared repositories; without `merge_group` handling, "required SchemaBot check" and "merge queue" are mutually exclusive. This closes that gap so the safety gate holds under the merge-queue workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)