### PR TITLE
Bump spirit to @main

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.43.3
-	github.com/block/spirit v0.15.2-0.20260625160741-3bd8ca93a47b
+	github.com/block/spirit v0.15.2-0.20260629112820-8f451ff83766
 	github.com/bradleyfalzon/ghinstallation/v2 v2.18.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/block/spirit v0.15.2-0.20260625160741-3bd8ca93a47b h1:8LFTfrv1giEGCbWEEvEK9gZ0UB1U7DFbHhrKs80aNL4=
-github.com/block/spirit v0.15.2-0.20260625160741-3bd8ca93a47b/go.mod h1:ku7mCCKx7Wk4QrMa/mHnsqQhZkoUD2vdBkpjJEDk4lY=
+github.com/block/spirit v0.15.2-0.20260629112820-8f451ff83766 h1:zMEF7E4k886bl2uaHaVQQQJZEc5rjQM1hP3W2haPoGs=
+github.com/block/spirit v0.15.2-0.20260629112820-8f451ff83766/go.mod h1:ku7mCCKx7Wk4QrMa/mHnsqQhZkoUD2vdBkpjJEDk4lY=
 github.com/block/tidb/pkg/parser v0.0.0-20260506200501-e528fd979fc8 h1:+OfdTacrEyjlqcRUpBFX9uJ6ROBq6cUjwY4DClhnsdU=
 github.com/block/tidb/pkg/parser v0.0.0-20260506200501-e528fd979fc8/go.mod h1:zDLDsfNBU5+L6T4J9/OgWAHc/WZvMUjbpgHqQ/t3yKo=
 github.com/block/vitess v0.0.0-20260601162944-8318a748ceb1 h1:dnHGiR/N1+X2EM1FGzL4548iCzJcIAnhcMbEt026xHQ=


### PR DESCRIPTION
Bumps the `github.com/block/spirit` dependency to the latest `main` (`8f451ff`).

Updated via `go get github.com/block/spirit@main && go mod tidy`. Only `go.mod`/`go.sum` change; `go build ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)