### PR TITLE
fix(github): fail closed when a managed schema dir loses its config

### DIFF
--- a/pkg/api/source_policy.go
+++ b/pkg/api/source_policy.go
@@ -154,6 +154,26 @@ func (c *ServerConfig) SchemaPathAllowedForRepo(repo, schemaPath string) bool {
 	return false
 }
 
+// DatabaseForSchemaPath returns the name of the database whose allowed_dirs
+// covers schemaPath for a repository permitted to manage it, and whether one was
+// found. It is the inverse of the source-policy authorization check: given a
+// schema file with no in-repo config, it answers "which managed database owns
+// this directory" so operators get a precise message.
+func (c *ServerConfig) DatabaseForSchemaPath(repo, schemaPath string) (string, bool) {
+	if c == nil {
+		return "", false
+	}
+	for name, dbConfig := range c.Databases {
+		if len(dbConfig.AllowedDirs) == 0 || !databaseAllowsRepo(dbConfig, repo) {
+			continue
+		}
+		if schemaPathAllowed(dbConfig.AllowedDirs, schemaPath) {
+			return name, true
+		}
+	}
+	return "", false
+}
+
 func (d DatabaseConfig) hasSourcePolicy() bool {
 	return len(d.AllowedRepos) > 0 || len(d.AllowedDirs) > 0
 }

--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -174,7 +174,7 @@ func (ic *InstallationClient) FindConfigByDatabaseName(ctx context.Context, repo
 		return nil, "", fmt.Errorf("fetch PR files: %w", err)
 	}
 
-	prConfigs, err := ic.findAllConfigsForPRFiles(ctx, repo, prInfo.HeadSHA, files)
+	prConfigs, err := ic.FindConfigsForPRFiles(ctx, repo, prInfo.HeadSHA, files)
 	if err != nil {
 		return nil, "", fmt.Errorf("find configs for PR: %w", err)
 	}
@@ -246,7 +246,7 @@ func (ic *InstallationClient) FindConfigForPR(ctx context.Context, repo string, 
 
 	var schemaFiles []string
 	for _, file := range files {
-		if isSchemaFile(file.Filename) {
+		if IsSchemaFile(file.Filename) {
 			schemaFiles = append(schemaFiles, file.Filename)
 		}
 	}
@@ -318,10 +318,14 @@ func (ic *InstallationClient) FindAllConfigsForPR(ctx context.Context, repo stri
 	if err != nil {
 		return nil, fmt.Errorf("fetch PR files: %w", err)
 	}
-	return ic.findAllConfigsForPRFiles(ctx, repo, prInfo.HeadSHA, files)
+	return ic.FindConfigsForPRFiles(ctx, repo, prInfo.HeadSHA, files)
 }
 
-func (ic *InstallationClient) findAllConfigsForPRFiles(ctx context.Context, repo, ref string, files []PRFile) ([]DiscoveredConfig, error) {
+// FindConfigsForPRFiles discovers the schemabot.yaml configs that manage the
+// given already-fetched PR files at ref. Callers that have the changed files in
+// hand use this directly to avoid re-listing them; FindAllConfigsForPR is the
+// convenience wrapper that fetches the files first.
+func (ic *InstallationClient) FindConfigsForPRFiles(ctx context.Context, repo, ref string, files []PRFile) ([]DiscoveredConfig, error) {
 	configsByPath := make(map[string]DiscoveredConfig)
 	for _, file := range files {
 		if !isConfigFile(file.Filename) {
@@ -390,7 +394,9 @@ func (ic *InstallationClient) FindConfigInRepo(ctx context.Context, repo string,
 	return nil, "", result.InvalidConfigs, fmt.Errorf("%w: %s", ErrMultipleConfigs, strings.Join(databases, ", "))
 }
 
-func isSchemaFile(filename string) bool {
+// IsSchemaFile reports whether filename is a SchemaBot-managed schema file
+// (a .sql DDL file or a vschema.json).
+func IsSchemaFile(filename string) bool {
 	return strings.HasSuffix(filename, ".sql") || strings.HasSuffix(filename, "vschema.json")
 }
 
@@ -406,7 +412,7 @@ func HasSchemaInputFiles(files []PRFile) bool {
 }
 
 func isSchemaInputFile(filename string) bool {
-	return isSchemaFile(filename) || isConfigFile(filename)
+	return IsSchemaFile(filename) || isConfigFile(filename)
 }
 
 func isConfigFile(filename string) bool {
@@ -420,7 +426,7 @@ func isRemovedPRFile(status string) bool {
 func filterSchemaFiles(files []string) []string {
 	var result []string
 	for _, file := range files {
-		if isSchemaFile(file) {
+		if IsSchemaFile(file) {
 			result = append(result, file)
 		}
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1031,6 +1031,7 @@ var knownStatusCheckOperations = map[string]bool{
 	"schema_config_discovery":              true,
 	"schema_config_source_policy":          true,
 	"schema_config_environment_validation": true,
+	"managed_dir_missing_config":           true,
 }
 
 var knownStatusCheckStatuses = map[string]bool{

--- a/pkg/webhook/auto_plan_integration_test.go
+++ b/pkg/webhook/auto_plan_integration_test.go
@@ -903,3 +903,138 @@ func TestE2EAutoPlanFailsWhenConfiguredEnvironmentsAreNotAllowed(t *testing.T) {
 	case <-time.After(500 * time.Millisecond):
 	}
 }
+
+// A PR that changes schema files under a directory the server config manages
+// (databases.<db>.allowed_dirs) but contains no schemabot.yaml must fail closed:
+// dropping or omitting the config cannot silently land DDL ungated. SchemaBot
+// publishes a blocking aggregate instead of a passing one. To offboard a
+// directory an operator removes it from allowed_dirs in the server config.
+func TestE2EAutoPlanManagedDirMissingConfigBlocks(t *testing.T) {
+	dbName := "webhook_autoplan_managed_dir_missing_config"
+	svc := setupE2EService(t, dbName)
+	dbConfig := svc.Config().Databases[dbName]
+	dbConfig.AllowedRepos = []string{"octocat/hello-world"}
+	dbConfig.AllowedDirs = []string{"schema"}
+	svc.Config().Databases[dbName] = dbConfig
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+	// Empty schemabotConfig: the schema directory is server-managed via
+	// allowed_dirs, but no schemabot.yaml resolves for it (as if removed).
+	result := setupFakeGitHubForPlan(t, mux, schemaFiles, "", dbName)
+
+	h := newE2EHandler(t, svc, client)
+
+	req := buildPRWebhookRequest(t, prWebhookPayloadOpts{
+		action:  "opened",
+		headSHA: "abc123",
+		headRef: "feature-branch",
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "schema change under managed directory has no config")
+
+	var aggregateCheck checkRunCapture
+	select {
+	case aggregateCheck = <-result.checkRuns:
+	case <-time.After(webhookIntegrationCheckRunDeadline):
+		t.Fatal("timed out waiting for managed-dir-missing-config aggregate check run")
+	}
+	assert.Equal(t, aggregateCheckName, aggregateCheck.Name)
+	assert.Equal(t, "completed", aggregateCheck.Status)
+	assert.Equal(t, "failure", aggregateCheck.Conclusion)
+	require.NotNil(t, aggregateCheck.Output)
+	assert.Contains(t, aggregateCheck.Output.Summary, "schemabot.yaml")
+	assert.Contains(t, aggregateCheck.Output.Summary, "allowed_dirs")
+
+	check, err := svc.Storage().Checks().Get(t.Context(), "octocat/hello-world", 1, aggregateSentinel, aggregateSentinel, aggregateSentinel)
+	require.NoError(t, err)
+	require.NotNil(t, check, "managed-dir-missing-config auto-plan must store a failing aggregate check")
+	assert.Equal(t, "abc123", check.HeadSHA)
+	assert.Equal(t, "completed", check.Status)
+	assert.Equal(t, "failure", check.Conclusion)
+	assert.Equal(t, "managed_dir_missing_config", check.BlockingReason)
+
+	plans, err := svc.Storage().Plans().GetByPR(t.Context(), "octocat/hello-world", 1)
+	require.NoError(t, err)
+	for _, plan := range plans {
+		assert.NotEqual(t, dbName, plan.Database, "a blocked auto-plan must not store a plan for the managed database")
+	}
+}
+
+// Moving a managed schema directory in one PR — the schemabot.yaml and its
+// schema files relocate together — must not be mistaken for an unmanaged schema
+// change. The destination files stay covered by the moved config, so auto-plan
+// proceeds normally instead of failing closed. Both the old and new directories
+// are in allowed_dirs, as for an operator-gated move.
+func TestE2EAutoPlanSchemaDirMoveNotBlocked(t *testing.T) {
+	dbName := "webhook_autoplan_schema_dir_move"
+	svc := setupE2EService(t, dbName)
+	dbConfig := svc.Config().Databases[dbName]
+	dbConfig.AllowedRepos = []string{"octocat/hello-world"}
+	dbConfig.AllowedDirs = []string{"schema", "old/schema"}
+	svc.Config().Databases[dbName] = dbConfig
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+	// The PR relocates the config and schema file out of old/schema; the moved
+	// config lands at schema/schemabot.yaml (served by the helper) and covers the
+	// new schema/<db>/users.sql.
+	prFiles := []*gh.CommitFile{
+		{Filename: new("old/schema/schemabot.yaml"), Status: new("removed")},
+		{Filename: new("old/schema/users.sql"), Status: new("removed")},
+		{Filename: new("schema/schemabot.yaml"), Status: new("added")},
+		{Filename: new("schema/" + dbName + "/users.sql"), Status: new("added")},
+	}
+	result := setupFakeGitHubForPlanWithPRFiles(t, mux, schemaFiles, schemabotConfig, dbName, prFiles)
+
+	h := newE2EHandler(t, svc, client)
+
+	req := buildPRWebhookRequest(t, prWebhookPayloadOpts{
+		action:  "opened",
+		headSHA: "abc123",
+		headRef: "feature-branch",
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "auto-plan started")
+
+	// A normal plan-with-changes check, not a fail-closed failure, proves the
+	// move was not mistaken for an unmanaged schema change.
+	select {
+	case cr := <-result.checkRuns:
+		assert.Contains(t, cr.Name, "SchemaBot")
+		assert.Equal(t, "action_required", cr.Conclusion)
+	case <-time.After(webhookIntegrationCheckRunDeadline):
+		t.Fatal("timed out waiting for check run")
+	}
+
+	check, err := svc.Storage().Checks().Get(t.Context(), "octocat/hello-world", 1, aggregateSentinel, aggregateSentinel, aggregateSentinel)
+	require.NoError(t, err)
+	if check != nil {
+		assert.NotEqual(t, "managed_dir_missing_config", check.BlockingReason, "a clean move must not be blocked as a missing-config change")
+	}
+}

--- a/pkg/webhook/check_runs.go
+++ b/pkg/webhook/check_runs.go
@@ -84,6 +84,18 @@ var configDiscoveryFailedBlock = checkBlockReason{
 	message:        "SchemaBot failed this check closed because it could not determine the managed schema configuration for this PR. Review the SchemaBot configuration and retry the check.",
 }
 
+// managedDirMissingConfigBlock is used when a PR changes schema files under a
+// directory the server config manages (databases.<db>.allowed_dirs) but no
+// schemabot.yaml resolves for them — for example because the PR removed the
+// config while keeping schema changes. The aggregate fails closed so dropping
+// the config cannot silently unmanage a server-owned schema directory; the
+// per-environment message naming the directories and databases is built at the
+// call site.
+var managedDirMissingConfigBlock = checkBlockReason{
+	blockingReason: "managed_dir_missing_config",
+	message:        "A schema change under a SchemaBot-managed directory has no schemabot.yaml config.",
+}
+
 // noAllowedConfiguredEnvironmentsBlock is used when schema files changed but
 // the server-configured environments for the database do not overlap this
 // service's allowed_environments. SchemaBot cannot safely plan the schema

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -142,13 +142,32 @@ func (h *Handler) shouldPostAutoPlanComment(ctx context.Context, client *ghclien
 }
 
 func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA string, installationID int64, source string, action string, beforeSHA string) string {
+	// Fetch the changed files once so the same list drives both config discovery
+	// and the server-managed-directory safety check below.
+	files, err := client.FetchPRFiles(ctx, repo, pr)
+	if err != nil {
+		h.logger.Error("failed to fetch PR files for auto-plan", "repo", repo, "pr", pr, "head_sha", headSHA, "source", source, "error", err)
+		h.postConfigDiscoveryFailure(ctx, client, repo, pr, headSHA, err)
+		return "config discovery failed"
+	}
+
 	// Discover all configs matching changed schema files in this PR
-	configs, err := client.FindAllConfigsForPR(ctx, repo, pr)
+	configs, err := client.FindConfigsForPRFiles(ctx, repo, headSHA, files)
 	if err != nil {
 		h.logger.Error("failed to discover configs for PR", "repo", repo, "pr", pr, "head_sha", headSHA, "source", source, "error", err)
 		h.postConfigDiscoveryFailure(ctx, client, repo, pr, headSHA, err)
 		return "config discovery failed"
 	}
+
+	// Fail closed when the PR changes schema files under a directory the server
+	// config manages but no schemabot.yaml resolves for them — e.g. the PR
+	// removed the config while keeping schema changes. Dropping the config must
+	// not silently unmanage a server-owned schema directory.
+	if unmanaged := h.unmanagedServerManagedSchemaChanges(repo, files, configs); len(unmanaged) > 0 {
+		h.failClosedOnUnmanagedSchemaDir(ctx, client, repo, pr, headSHA, source, unmanaged)
+		return "schema change under managed directory has no config"
+	}
+
 	configs = h.filterManagedDiscoveredConfigs(ctx, repo, pr, headSHA, source, configs)
 
 	// Collect database names from discovered configs

--- a/pkg/webhook/schema_source_guard.go
+++ b/pkg/webhook/schema_source_guard.go
@@ -1,0 +1,107 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+
+	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/metrics"
+)
+
+// unmanagedServerManagedSchemaChanges returns the changed schema files in the PR
+// that live under a directory the server config manages
+// (databases.<db>.allowed_dirs) but are not covered by any discovered
+// schemabot.yaml. A non-empty result means the PR is changing server-owned
+// schema with no managing config — for example because it removed the config
+// while keeping schema files.
+//
+// Returns nil when the repository has no server-side schema-directory allowlist
+// (open mode): the server has no authoritative managed-path knowledge there, so
+// this protection does not apply and discovery behaves as before. To offboard a
+// directory, an operator removes it from databases.<db>.allowed_dirs.
+func (h *Handler) unmanagedServerManagedSchemaChanges(repo string, files []ghclient.PRFile, configs []ghclient.DiscoveredConfig) []string {
+	config, ok := h.serverConfig()
+	if !ok || !config.RepoHasSchemaDirAllowlist(repo) {
+		return nil
+	}
+
+	var unmanaged []string
+	for _, f := range files {
+		if !ghclient.IsSchemaFile(f.Filename) {
+			continue
+		}
+		// A schema file being deleted is not an unmanaged change; only files
+		// present at the PR head can land DDL without a managing config.
+		if strings.EqualFold(f.Status, "removed") {
+			continue
+		}
+		if schemaFileCoveredByConfig(f.Filename, configs) {
+			continue
+		}
+		if config.SchemaPathAllowedForRepo(repo, f.Filename) {
+			unmanaged = append(unmanaged, f.Filename)
+		}
+	}
+	return unmanaged
+}
+
+// schemaFileCoveredByConfig reports whether filename resolves to one of the
+// discovered configs — i.e. a config's directory is an ancestor of (or equal
+// to) the file's directory, the same nearest-ancestor rule discovery uses.
+func schemaFileCoveredByConfig(filename string, configs []ghclient.DiscoveredConfig) bool {
+	dir := path.Dir(filename)
+	for _, cfg := range configs {
+		if dir == cfg.SchemaDir || strings.HasPrefix(dir, cfg.SchemaDir+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// failClosedOnUnmanagedSchemaDir publishes a blocking aggregate naming the
+// server-managed directories whose schemabot.yaml is missing and how to resolve
+// it: restore the config, or offboard the directory by removing it from
+// databases.<db>.allowed_dirs in the server config.
+func (h *Handler) failClosedOnUnmanagedSchemaDir(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA, source string, unmanagedFiles []string) {
+	h.logger.Warn("failing aggregate closed: schema change under server-managed directory has no schemabot.yaml",
+		"repo", repo, "pr", pr, "head_sha", headSHA, "source", source,
+		"files", strings.Join(unmanagedFiles, ","))
+	metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+		Operation:  "managed_dir_missing_config",
+		Repository: repo,
+		Status:     "blocked",
+	})
+
+	message := h.unmanagedSchemaDirMessage(repo, unmanagedFiles)
+	h.postFailingAggregatesWithBlock(ctx, client, repo, pr, headSHA,
+		h.aggregateMessagesForAllEnvironments(message), managedDirMissingConfigBlock)
+}
+
+// unmanagedSchemaDirMessage builds the operator-facing block message, naming
+// each unmanaged schema file and the managed database that owns its directory.
+func (h *Handler) unmanagedSchemaDirMessage(repo string, unmanagedFiles []string) string {
+	config, _ := h.serverConfig()
+
+	lines := make([]string, 0, len(unmanagedFiles))
+	for _, f := range unmanagedFiles {
+		db := "an unknown database"
+		if config != nil {
+			if name, ok := config.DatabaseForSchemaPath(repo, f); ok {
+				db = fmt.Sprintf("database `%s`", name)
+			}
+		}
+		lines = append(lines, fmt.Sprintf("- `%s` (%s)", f, db))
+	}
+	sort.Strings(lines)
+
+	return strings.Join([]string{
+		"This PR changes schema files under directories SchemaBot manages via server config, but no `schemabot.yaml` config resolves for them:",
+		"",
+		strings.Join(lines, "\n"),
+		"",
+		"Restore the `schemabot.yaml` config for these directories, or ask a SchemaBot operator to remove the directory from `allowed_dirs` in the server config to offboard it.",
+	}, "\n")
+}

--- a/pkg/webhook/schema_source_guard.go
+++ b/pkg/webhook/schema_source_guard.go
@@ -54,7 +54,9 @@ func (h *Handler) unmanagedServerManagedSchemaChanges(repo string, files []ghcli
 func schemaFileCoveredByConfig(filename string, configs []ghclient.DiscoveredConfig) bool {
 	dir := path.Dir(filename)
 	for _, cfg := range configs {
-		if dir == cfg.SchemaDir || strings.HasPrefix(dir, cfg.SchemaDir+"/") {
+		// A repo-root config (SchemaDir ".") is an ancestor of every directory,
+		// so it covers schema files anywhere in the repo.
+		if cfg.SchemaDir == "." || dir == cfg.SchemaDir || strings.HasPrefix(dir, cfg.SchemaDir+"/") {
 			return true
 		}
 	}

--- a/pkg/webhook/schema_source_guard_test.go
+++ b/pkg/webhook/schema_source_guard_test.go
@@ -1,0 +1,166 @@
+package webhook
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/api"
+	ghclient "github.com/block/schemabot/pkg/github"
+)
+
+func guardTestHandler(t *testing.T, databases map[string]api.DatabaseConfig) *Handler {
+	t.Helper()
+	service := api.New(nil, &api.ServerConfig{Databases: databases}, nil, testLogger())
+	return &Handler{service: service, logger: testLogger()}
+}
+
+// A directory listed in databases.<db>.allowed_dirs is server-managed. A PR that
+// changes schema files there must always be gated by SchemaBot, even if the
+// in-repo schemabot.yaml is missing or was removed — otherwise dropping the
+// config would silently land DDL ungated. unmanagedServerManagedSchemaChanges
+// is the detection that keeps that case failing closed.
+func TestUnmanagedServerManagedSchemaChanges(t *testing.T) {
+	const repo = "octocat/hello-world"
+	managed := map[string]api.DatabaseConfig{
+		"orders": {
+			Type:         "mysql",
+			AllowedRepos: []string{repo},
+			AllowedDirs:  []string{"db/orders/schema"},
+		},
+	}
+	coveringConfig := []ghclient.DiscoveredConfig{{SchemaDir: "db/orders/schema"}}
+	managedTwoDirs := map[string]api.DatabaseConfig{
+		"orders": {
+			Type:         "mysql",
+			AllowedRepos: []string{repo},
+			AllowedDirs:  []string{"db/orders/schema", "db/orders/v2"},
+		},
+	}
+
+	cases := []struct {
+		name      string
+		databases map[string]api.DatabaseConfig
+		files     []ghclient.PRFile
+		configs   []ghclient.DiscoveredConfig
+		want      []string
+	}{
+		{
+			name:      "managed dir, no config -> flagged",
+			databases: managed,
+			files:     []ghclient.PRFile{{Filename: "db/orders/schema/users.sql", Status: "modified"}},
+			want:      []string{"db/orders/schema/users.sql"},
+		},
+		{
+			name:      "managed dir descendant, no config -> flagged",
+			databases: managed,
+			files:     []ghclient.PRFile{{Filename: "db/orders/schema/sub/users.sql", Status: "added"}},
+			want:      []string{"db/orders/schema/sub/users.sql"},
+		},
+		{
+			name:      "managed dir, covered by config -> not flagged",
+			databases: managed,
+			files:     []ghclient.PRFile{{Filename: "db/orders/schema/users.sql", Status: "modified"}},
+			configs:   coveringConfig,
+			want:      nil,
+		},
+		{
+			name:      "managed dir descendant, covered by ancestor config -> not flagged",
+			databases: managed,
+			files:     []ghclient.PRFile{{Filename: "db/orders/schema/sub/users.sql", Status: "modified"}},
+			configs:   coveringConfig,
+			want:      nil,
+		},
+		{
+			name:      "removed schema file -> not flagged",
+			databases: managed,
+			files:     []ghclient.PRFile{{Filename: "db/orders/schema/users.sql", Status: "removed"}},
+			want:      nil,
+		},
+		{
+			name:      "outside managed dirs -> not flagged",
+			databases: managed,
+			files:     []ghclient.PRFile{{Filename: "db/other/schema/x.sql", Status: "modified"}},
+			want:      nil,
+		},
+		{
+			// Moving a schema directory: the old config and files are removed and
+			// the schema files reappear at the destination alongside the moved
+			// config. The destination files are covered by the moved config, so the
+			// move is not mistaken for an unmanaged schema change.
+			name:      "clean move with config moved alongside -> not flagged",
+			databases: managedTwoDirs,
+			files: []ghclient.PRFile{
+				{Filename: "db/orders/schema/schemabot.yaml", Status: "removed"},
+				{Filename: "db/orders/schema/users.sql", Status: "removed"},
+				{Filename: "db/orders/v2/users.sql", Status: "added"},
+			},
+			configs: []ghclient.DiscoveredConfig{{SchemaDir: "db/orders/v2"}},
+			want:    nil,
+		},
+		{
+			// Moving schema files to another server-managed directory without moving
+			// the config leaves the destination files uncovered, which fails closed.
+			name:      "move to managed dir without its config -> flagged",
+			databases: managedTwoDirs,
+			files: []ghclient.PRFile{
+				{Filename: "db/orders/schema/users.sql", Status: "removed"},
+				{Filename: "db/orders/v2/users.sql", Status: "added"},
+			},
+			want: []string{"db/orders/v2/users.sql"},
+		},
+		{
+			name:      "non-schema file -> not flagged",
+			databases: managed,
+			files:     []ghclient.PRFile{{Filename: "db/orders/schema/README.md", Status: "modified"}},
+			want:      nil,
+		},
+		{
+			name:      "open mode (no allowlist) -> not flagged",
+			databases: map[string]api.DatabaseConfig{"orders": {Type: "mysql"}},
+			files:     []ghclient.PRFile{{Filename: "db/orders/schema/users.sql", Status: "modified"}},
+			want:      nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := guardTestHandler(t, tc.databases)
+			got := h.unmanagedServerManagedSchemaChanges(repo, tc.files, tc.configs)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// The block message must name each unmanaged file and the managed database that
+// owns its directory so an operator knows exactly what to restore or offboard.
+func TestUnmanagedSchemaDirMessage(t *testing.T) {
+	const repo = "octocat/hello-world"
+	h := guardTestHandler(t, map[string]api.DatabaseConfig{
+		"orders": {Type: "mysql", AllowedRepos: []string{repo}, AllowedDirs: []string{"db/orders/schema"}},
+	})
+
+	msg := h.unmanagedSchemaDirMessage(repo, []string{"db/orders/schema/users.sql"})
+	assert.Contains(t, msg, "db/orders/schema/users.sql")
+	assert.Contains(t, msg, "database `orders`")
+	assert.Contains(t, msg, "allowed_dirs")
+	assert.Contains(t, msg, "schemabot.yaml")
+}
+
+func TestDatabaseForSchemaPath(t *testing.T) {
+	const repo = "octocat/hello-world"
+	cfg := &api.ServerConfig{Databases: map[string]api.DatabaseConfig{
+		"orders": {Type: "mysql", AllowedRepos: []string{repo}, AllowedDirs: []string{"db/orders/schema"}},
+	}}
+
+	name, ok := cfg.DatabaseForSchemaPath(repo, "db/orders/schema/users.sql")
+	require.True(t, ok)
+	assert.Equal(t, "orders", name)
+
+	_, ok = cfg.DatabaseForSchemaPath(repo, "db/other/schema/x.sql")
+	assert.False(t, ok)
+
+	_, ok = cfg.DatabaseForSchemaPath("other/repo", "db/orders/schema/users.sql")
+	assert.False(t, ok)
+}

--- a/pkg/webhook/schema_source_guard_test.go
+++ b/pkg/webhook/schema_source_guard_test.go
@@ -73,6 +73,16 @@ func TestUnmanagedServerManagedSchemaChanges(t *testing.T) {
 			want:      nil,
 		},
 		{
+			// A repo-root schemabot.yaml (SchemaDir ".") is an ancestor of every
+			// directory, so discovery resolves it for schema files in managed
+			// subdirectories — it must not be flagged as missing config.
+			name:      "root config covers managed subdir file -> not flagged",
+			databases: managed,
+			files:     []ghclient.PRFile{{Filename: "db/orders/schema/users.sql", Status: "modified"}},
+			configs:   []ghclient.DiscoveredConfig{{SchemaDir: "."}},
+			want:      nil,
+		},
+		{
 			name:      "removed schema file -> not flagged",
 			databases: managed,
 			files:     []ghclient.PRFile{{Filename: "db/orders/schema/users.sql", Status: "removed"}},


### PR DESCRIPTION
## Why this matters

A PR that changed schema files under a directory the server manages, but contained **no** `schemabot.yaml` — for example because the PR removed the config while keeping the `.sql` changes — posted a passing "No managed schema changes" aggregate and could merge green. That let DDL land with no SchemaBot gating: dropping the config silently unmanaged the directory. A safety gate that disappears the moment its config file is deleted isn't a safety gate.

## What it does

Treat the server-side `databases.<db>.allowed_dirs` / `allowed_repos` as the authoritative ownership boundary, rather than relying solely on in-repo config discovery. During auto-plan, any changed (non-removed) schema file under a server-managed directory that no discovered `schemabot.yaml` covers fails the aggregate **closed**, with a blocking reason that names the directory and the owning database.

```text
PR changes schema file under a server-managed dir
        |
        +-- a schemabot.yaml covers it ----> normal plan (unchanged)
        |
        +-- no config resolves ------------> aggregate fails closed
                                              (blocking_reason: managed_dir_missing_config)
```

- **Offboarding** stays an explicit operator action: remove the directory from `allowed_dirs` in the server config. It is intentionally privileged, not something a single PR author can do by deleting a file.
- **Moving a schema directory** is unaffected when the config relocates with its files — the destination files stay covered by the moved config, so a clean move plans normally. (Relocating to a different managed directory *without* the config fails closed, as it should.)
- **Open mode** (deployments with no `allowed_dirs` allowlist) is unaffected — there is no server-side managed-path knowledge to enforce, so discovery behaves exactly as before.

## How it moves toward the north star

SchemaBot's Check Run is a tier-0 safety gate, and a gate is only trustworthy if it can't be removed by the very change it's meant to guard. This closes a fail-open hole so the gate holds across onboarding, offboarding, and directory moves, with the server config as the single authoritative source of which directories are managed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)