### PR TITLE
feat(auth): add `schemabot login` command for the OIDC browser flow

### DIFF
--- a/pkg/cmd/client/config.go
+++ b/pkg/cmd/client/config.go
@@ -150,10 +150,6 @@ func SaveConfig(cfg *Config) error {
 	return nil
 }
 
-// GetProfile returns the profile to use based on:
-// 1. Explicit profile flag
-// 2. SCHEMABOT_PROFILE environment variable
-// 3. Default profile from config
 // ResolveProfileName returns the active profile name using the standard
 // precedence: the --profile flag, then SCHEMABOT_PROFILE, then the configured
 // default profile, then "default". It does not check that the profile exists.
@@ -170,6 +166,10 @@ func ResolveProfileName(cfg *Config, profileFlag string) string {
 	return "default"
 }
 
+// GetProfile loads and returns the resolved profile (see ResolveProfileName for
+// the name precedence, which includes the final fallback to "default"). An
+// explicitly requested profile (via --profile or SCHEMABOT_PROFILE) that does
+// not exist is an error; an unrequested missing profile yields an empty Profile.
 func GetProfile(profileFlag string) (*Profile, error) {
 	cfg, err := LoadConfig()
 	if err != nil {

--- a/pkg/cmd/client/config.go
+++ b/pkg/cmd/client/config.go
@@ -24,6 +24,20 @@ type Profile struct {
 	// `schemabot login`. Scoping it to a profile keeps a token bound to the
 	// server it was issued for, so it is never sent to a different endpoint.
 	Token string `yaml:"token,omitempty"`
+	// OIDC holds the public-client settings `schemabot login` uses to run the
+	// browser auth-code flow for this profile's server. Optional; absent until a
+	// server has OIDC enabled.
+	OIDC *OIDCLogin `yaml:"oidc,omitempty"`
+}
+
+// OIDCLogin holds the OIDC public-client settings for `schemabot login`. The
+// values mirror the server's OIDC provider registration: the issuer URL, the
+// CLI public client ID, and the loopback port of the redirect URI registered
+// for that client.
+type OIDCLogin struct {
+	Issuer       string `yaml:"issuer"`
+	ClientID     string `yaml:"client_id"`
+	RedirectPort int    `yaml:"redirect_port,omitempty"`
 }
 
 // ConfigPath returns the path to the config file (~/.schemabot/config.yaml).
@@ -140,27 +154,32 @@ func SaveConfig(cfg *Config) error {
 // 1. Explicit profile flag
 // 2. SCHEMABOT_PROFILE environment variable
 // 3. Default profile from config
+// ResolveProfileName returns the active profile name using the standard
+// precedence: the --profile flag, then SCHEMABOT_PROFILE, then the configured
+// default profile, then "default". It does not check that the profile exists.
+func ResolveProfileName(cfg *Config, profileFlag string) string {
+	if profileFlag != "" {
+		return profileFlag
+	}
+	if env := os.Getenv("SCHEMABOT_PROFILE"); env != "" {
+		return env
+	}
+	if cfg.DefaultProfile != "" {
+		return cfg.DefaultProfile
+	}
+	return "default"
+}
+
 func GetProfile(profileFlag string) (*Profile, error) {
 	cfg, err := LoadConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	// Determine which profile to use.
-	// Track whether the user explicitly requested a profile (flag or env),
-	// so we can error if it doesn't exist instead of silently falling back.
-	profileName := profileFlag
-	explicit := profileFlag != ""
-	if profileName == "" {
-		profileName = os.Getenv("SCHEMABOT_PROFILE")
-		explicit = profileName != ""
-	}
-	if profileName == "" {
-		profileName = cfg.DefaultProfile
-	}
-	if profileName == "" {
-		profileName = "default"
-	}
+	// Track whether the user explicitly requested a profile (flag or env), so we
+	// can error if it doesn't exist instead of silently falling back.
+	explicit := profileFlag != "" || os.Getenv("SCHEMABOT_PROFILE") != ""
+	profileName := ResolveProfileName(cfg, profileFlag)
 
 	profile, ok := cfg.Profiles[profileName]
 	if !ok {

--- a/pkg/cmd/commands/login.go
+++ b/pkg/cmd/commands/login.go
@@ -42,8 +42,17 @@ func (cmd *LoginCmd) Run(g *Globals) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
+	// Log in against an already-configured profile: the token is bound to the
+	// profile's endpoint, so refuse to cache one on a missing or endpoint-less
+	// profile (which would otherwise create a dangling, unusable entry).
 	profileName := client.ResolveProfileName(cfg, g.Profile)
-	profile := cfg.Profiles[profileName]
+	profile, ok := cfg.Profiles[profileName]
+	if !ok {
+		return fmt.Errorf("profile %q is not configured; run `schemabot configure` to set its endpoint before logging in", profileName)
+	}
+	if profile.Endpoint == "" {
+		return fmt.Errorf("profile %q has no endpoint; run `schemabot configure` to set it before logging in", profileName)
+	}
 
 	loginCfg, err := resolveLoginConfig(cmd.Issuer, cmd.ClientID, cmd.RedirectPort, &profile)
 	if err != nil {
@@ -73,9 +82,6 @@ func (cmd *LoginCmd) Run(g *Globals) error {
 	// configured to accept.
 	profile.Token = result.IDToken
 	cfg.Profiles[profileName] = profile
-	if cfg.DefaultProfile == "" {
-		cfg.DefaultProfile = profileName
-	}
 	if err := client.SaveConfig(cfg); err != nil {
 		return fmt.Errorf("save token to profile %q: %w", profileName, err)
 	}
@@ -145,11 +151,16 @@ func openBrowser(url string) error {
 	default:
 		name, args = "xdg-open", []string{url}
 	}
-	// Background, not the login context: the launcher forks the browser and
-	// returns immediately, so the launch must not be killed when the login flow's
-	// deadline fires.
-	if err := exec.CommandContext(context.Background(), name, args...).Start(); err != nil {
+	// Background, not the login context: the launcher hands off to the browser
+	// and exits, so the launch must not be killed when the login deadline fires.
+	launcher := exec.CommandContext(context.Background(), name, args...)
+	if err := launcher.Start(); err != nil {
 		return fmt.Errorf("launch browser via %s: %w", name, err)
+	}
+	// The launcher exits as soon as it dispatches to the browser; we don't need
+	// its result, so release the process handle rather than waiting on it.
+	if err := launcher.Process.Release(); err != nil {
+		return fmt.Errorf("release browser launcher process: %w", err)
 	}
 	return nil
 }

--- a/pkg/cmd/commands/login.go
+++ b/pkg/cmd/commands/login.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -28,6 +30,7 @@ type LoginCmd struct {
 	Issuer       string `help:"OIDC issuer URL (overrides the profile's oidc.issuer)"`
 	ClientID     string `name:"client-id" help:"OIDC public client ID for the CLI (overrides the profile's oidc.client_id)"`
 	RedirectPort int    `name:"redirect-port" help:"Loopback port for the OIDC redirect URI (overrides the profile's oidc.redirect_port)"`
+	NoBrowser    bool   `name:"no-browser" help:"Print the login URL instead of opening a browser (for headless or remote sessions)"`
 
 	// Test seams: nil in production, where they default to the real
 	// implementations below.
@@ -61,7 +64,10 @@ func (cmd *LoginCmd) Run(g *Globals) error {
 
 	open := cmd.openBrowser
 	if open == nil {
-		open = openBrowser
+		open = launchBrowser
+		if cmd.NoBrowser {
+			open = printAuthURL
+		}
 	}
 	loginFn := cmd.loginFn
 	if loginFn == nil {
@@ -71,7 +77,6 @@ func (cmd *LoginCmd) Run(g *Globals) error {
 	ctx, cancel := context.WithTimeout(context.Background(), loginTimeout)
 	defer cancel()
 
-	fmt.Fprintf(os.Stderr, "Opening your browser to log in to %s…\n", loginCfg.Issuer)
 	result, err := loginFn(ctx, loginCfg, open)
 	if err != nil {
 		return fmt.Errorf("log in to %s: %w", loginCfg.Issuer, err)
@@ -86,7 +91,11 @@ func (cmd *LoginCmd) Run(g *Globals) error {
 		return fmt.Errorf("save token to profile %q: %w", profileName, err)
 	}
 
-	fmt.Printf("Logged in. Token cached for profile %q.\n", profileName)
+	if who := userFromIDToken(result.IDToken); who != "" {
+		fmt.Printf("Logged in as %s. Token cached for profile %q.\n", who, profileName)
+	} else {
+		fmt.Printf("Logged in. Token cached for profile %q.\n", profileName)
+	}
 	return nil
 }
 
@@ -135,11 +144,19 @@ func resolveLoginConfig(flagIssuer, flagClientID string, flagRedirectPort int, p
 	}, nil
 }
 
-// openBrowser opens the system browser at the authorization URL and also prints
-// it, so the user can complete login by pasting the URL if the browser does not
-// launch (e.g. over SSH).
-func openBrowser(url string) error {
-	fmt.Fprintf(os.Stderr, "If your browser does not open, visit this URL to continue:\n  %s\n", url)
+// printAuthURL prints the authorization URL for the user to open manually. It is
+// the --no-browser opener and the fallback the launcher reuses, so the user can
+// always complete login by pasting the URL (e.g. on a headless or remote host).
+func printAuthURL(url string) error {
+	fmt.Fprintf(os.Stderr, "Open this URL in your browser to log in:\n\n  %s\n\n", url)
+	return nil
+}
+
+// launchBrowser prints the authorization URL and opens it in the system browser.
+func launchBrowser(url string) error {
+	if err := printAuthURL(url); err != nil {
+		return err
+	}
 
 	var name string
 	var args []string
@@ -163,4 +180,35 @@ func openBrowser(url string) error {
 		return fmt.Errorf("release browser launcher process: %w", err)
 	}
 	return nil
+}
+
+// userFromIDToken extracts a human-readable identifier from the ID token for the
+// "logged in as" confirmation. It is best-effort and display-only — the server
+// verifies the token — so an unparseable token yields an empty string and the
+// caller simply omits the name.
+func userFromIDToken(idToken string) string {
+	parts := strings.Split(idToken, ".")
+	if len(parts) < 2 {
+		return ""
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return ""
+	}
+	var claims struct {
+		Email string `json:"email"`
+		Name  string `json:"name"`
+		Sub   string `json:"sub"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return ""
+	}
+	switch {
+	case claims.Email != "":
+		return claims.Email
+	case claims.Name != "":
+		return claims.Name
+	default:
+		return claims.Sub
+	}
 }

--- a/pkg/cmd/commands/login.go
+++ b/pkg/cmd/commands/login.go
@@ -1,0 +1,155 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/block/schemabot/pkg/cmd/client"
+)
+
+// loginTimeout bounds the whole interactive login, including the wait for the
+// user to authenticate in the browser.
+const loginTimeout = 5 * time.Minute
+
+// defaultRedirectPort is the loopback port used for the OIDC redirect when the
+// profile and flags do not set one. It must match a redirect URI registered for
+// the CLI public client, so an operator can override it per profile.
+const defaultRedirectPort = 8765
+
+// LoginCmd logs in via OIDC (browser auth-code + PKCE) and caches the resulting
+// token on the active profile, so subsequent commands authenticate to an
+// auth-enabled server without a manually supplied --token.
+type LoginCmd struct {
+	Issuer       string `help:"OIDC issuer URL (overrides the profile's oidc.issuer)"`
+	ClientID     string `name:"client-id" help:"OIDC public client ID for the CLI (overrides the profile's oidc.client_id)"`
+	RedirectPort int    `name:"redirect-port" help:"Loopback port for the OIDC redirect URI (overrides the profile's oidc.redirect_port)"`
+
+	// Test seams: nil in production, where they default to the real
+	// implementations below.
+	loginFn     func(context.Context, client.LoginConfig, client.BrowserOpener) (*client.LoginResult, error)
+	openBrowser client.BrowserOpener
+}
+
+// Run executes the login command.
+func (cmd *LoginCmd) Run(g *Globals) error {
+	cfg, err := client.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	profileName := client.ResolveProfileName(cfg, g.Profile)
+	profile := cfg.Profiles[profileName]
+
+	loginCfg, err := resolveLoginConfig(cmd.Issuer, cmd.ClientID, cmd.RedirectPort, &profile)
+	if err != nil {
+		return err
+	}
+
+	open := cmd.openBrowser
+	if open == nil {
+		open = openBrowser
+	}
+	loginFn := cmd.loginFn
+	if loginFn == nil {
+		loginFn = client.Login
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), loginTimeout)
+	defer cancel()
+
+	fmt.Fprintf(os.Stderr, "Opening your browser to log in to %s…\n", loginCfg.Issuer)
+	result, err := loginFn(ctx, loginCfg, open)
+	if err != nil {
+		return fmt.Errorf("log in to %s: %w", loginCfg.Issuer, err)
+	}
+
+	// Cache the ID token: it carries the user identity and groups the server's
+	// OIDC authorizer validates, and its aud is the CLI client ID the server is
+	// configured to accept.
+	profile.Token = result.IDToken
+	cfg.Profiles[profileName] = profile
+	if cfg.DefaultProfile == "" {
+		cfg.DefaultProfile = profileName
+	}
+	if err := client.SaveConfig(cfg); err != nil {
+		return fmt.Errorf("save token to profile %q: %w", profileName, err)
+	}
+
+	fmt.Printf("Logged in. Token cached for profile %q.\n", profileName)
+	return nil
+}
+
+// resolveLoginConfig merges login settings from flags (highest precedence) and
+// the profile's oidc block, applying the default redirect port, and fails when a
+// required value is missing.
+func resolveLoginConfig(flagIssuer, flagClientID string, flagRedirectPort int, profile *client.Profile) (client.LoginConfig, error) {
+	var oidc client.OIDCLogin
+	if profile != nil && profile.OIDC != nil {
+		oidc = *profile.OIDC
+	}
+
+	issuer := flagIssuer
+	if issuer == "" {
+		issuer = oidc.Issuer
+	}
+	clientID := flagClientID
+	if clientID == "" {
+		clientID = oidc.ClientID
+	}
+	port := flagRedirectPort
+	if port == 0 {
+		port = oidc.RedirectPort
+	}
+	if port == 0 {
+		port = defaultRedirectPort
+	}
+
+	var missing []string
+	if issuer == "" {
+		missing = append(missing, "issuer")
+	}
+	if clientID == "" {
+		missing = append(missing, "client ID")
+	}
+	if len(missing) > 0 {
+		return client.LoginConfig{}, fmt.Errorf(
+			"OIDC %s not configured for this profile; set it under `oidc:` in the profile or pass --issuer/--client-id",
+			strings.Join(missing, " and "))
+	}
+
+	return client.LoginConfig{
+		Issuer:       issuer,
+		ClientID:     clientID,
+		RedirectPort: port,
+	}, nil
+}
+
+// openBrowser opens the system browser at the authorization URL and also prints
+// it, so the user can complete login by pasting the URL if the browser does not
+// launch (e.g. over SSH).
+func openBrowser(url string) error {
+	fmt.Fprintf(os.Stderr, "If your browser does not open, visit this URL to continue:\n  %s\n", url)
+
+	var name string
+	var args []string
+	switch runtime.GOOS {
+	case "darwin":
+		name, args = "open", []string{url}
+	case "windows":
+		name, args = "rundll32", []string{"url.dll,FileProtocolHandler", url}
+	default:
+		name, args = "xdg-open", []string{url}
+	}
+	// Background, not the login context: the launcher forks the browser and
+	// returns immediately, so the launch must not be killed when the login flow's
+	// deadline fires.
+	if err := exec.CommandContext(context.Background(), name, args...).Start(); err != nil {
+		return fmt.Errorf("launch browser via %s: %w", name, err)
+	}
+	return nil
+}

--- a/pkg/cmd/commands/login_test.go
+++ b/pkg/cmd/commands/login_test.go
@@ -2,12 +2,39 @@ package commands
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"testing"
 
 	"github.com/block/schemabot/pkg/cmd/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// fakeIDToken builds a syntactically valid (unsigned) JWT carrying the given
+// claims, for exercising display-only claim parsing.
+func fakeIDToken(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+	payload, err := json.Marshal(claims)
+	require.NoError(t, err)
+	return header + "." + base64.RawURLEncoding.EncodeToString(payload) + "."
+}
+
+func TestUserFromIDToken(t *testing.T) {
+	t.Run("prefers email", func(t *testing.T) {
+		tok := fakeIDToken(t, map[string]any{"email": "dev@example.com", "name": "Dev", "sub": "abc"})
+		assert.Equal(t, "dev@example.com", userFromIDToken(tok))
+	})
+	t.Run("falls back to name then sub", func(t *testing.T) {
+		assert.Equal(t, "Dev", userFromIDToken(fakeIDToken(t, map[string]any{"name": "Dev", "sub": "abc"})))
+		assert.Equal(t, "abc", userFromIDToken(fakeIDToken(t, map[string]any{"sub": "abc"})))
+	})
+	t.Run("malformed token yields empty", func(t *testing.T) {
+		assert.Empty(t, userFromIDToken("not-a-jwt"))
+		assert.Empty(t, userFromIDToken(""))
+	})
+}
 
 func TestResolveLoginConfig(t *testing.T) {
 	t.Run("flags override profile", func(t *testing.T) {
@@ -75,11 +102,12 @@ func TestLoginCmdRunCachesToken(t *testing.T) {
 	}
 	require.NoError(t, client.SaveConfig(seed))
 
+	idToken := fakeIDToken(t, map[string]any{"email": "dev@example.com"})
 	var gotCfg client.LoginConfig
 	cmd := &LoginCmd{
 		loginFn: func(_ context.Context, lc client.LoginConfig, _ client.BrowserOpener) (*client.LoginResult, error) {
 			gotCfg = lc
-			return &client.LoginResult{IDToken: "jwt-xyz"}, nil
+			return &client.LoginResult{IDToken: idToken}, nil
 		},
 		openBrowser: func(string) error { return nil },
 	}
@@ -92,7 +120,7 @@ func TestLoginCmdRunCachesToken(t *testing.T) {
 
 	reloaded, err := client.LoadConfig()
 	require.NoError(t, err)
-	assert.Equal(t, "jwt-xyz", reloaded.Profiles["default"].Token)
+	assert.Equal(t, idToken, reloaded.Profiles["default"].Token)
 }
 
 // Without OIDC settings on the profile and no flags, login fails with a clear

--- a/pkg/cmd/commands/login_test.go
+++ b/pkg/cmd/commands/login_test.go
@@ -119,3 +119,27 @@ func TestLoginCmdRunMissingOIDCErrors(t *testing.T) {
 	assert.Contains(t, err.Error(), "OIDC")
 	assert.False(t, browserOpened)
 }
+
+// Logging in against a profile that does not exist fails clearly instead of
+// caching a token on a dangling profile with no endpoint.
+func TestLoginCmdRunUnknownProfileErrors(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("SCHEMABOT_PROFILE", "")
+	require.NoError(t, client.SaveConfig(&client.Config{
+		Profiles: map[string]client.Profile{"other": {Endpoint: "https://other.example"}},
+	}))
+
+	browserOpened := false
+	cmd := &LoginCmd{
+		loginFn: func(context.Context, client.LoginConfig, client.BrowserOpener) (*client.LoginResult, error) {
+			t.Fatal("login should not be attempted for an unconfigured profile")
+			return nil, nil
+		},
+		openBrowser: func(string) error { browserOpened = true; return nil },
+	}
+
+	err := cmd.Run(&Globals{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not configured")
+	assert.False(t, browserOpened)
+}

--- a/pkg/cmd/commands/login_test.go
+++ b/pkg/cmd/commands/login_test.go
@@ -1,0 +1,121 @@
+package commands
+
+import (
+	"context"
+	"testing"
+
+	"github.com/block/schemabot/pkg/cmd/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveLoginConfig(t *testing.T) {
+	t.Run("flags override profile", func(t *testing.T) {
+		profile := &client.Profile{OIDC: &client.OIDCLogin{Issuer: "https://profile.example", ClientID: "profile-client", RedirectPort: 1111}}
+		got, err := resolveLoginConfig("https://flag.example", "flag-client", 2222, profile)
+		require.NoError(t, err)
+		assert.Equal(t, "https://flag.example", got.Issuer)
+		assert.Equal(t, "flag-client", got.ClientID)
+		assert.Equal(t, 2222, got.RedirectPort)
+	})
+
+	t.Run("profile used when flags empty", func(t *testing.T) {
+		profile := &client.Profile{OIDC: &client.OIDCLogin{Issuer: "https://profile.example", ClientID: "profile-client", RedirectPort: 1111}}
+		got, err := resolveLoginConfig("", "", 0, profile)
+		require.NoError(t, err)
+		assert.Equal(t, "https://profile.example", got.Issuer)
+		assert.Equal(t, "profile-client", got.ClientID)
+		assert.Equal(t, 1111, got.RedirectPort)
+	})
+
+	t.Run("default redirect port when none set", func(t *testing.T) {
+		profile := &client.Profile{OIDC: &client.OIDCLogin{Issuer: "https://profile.example", ClientID: "profile-client"}}
+		got, err := resolveLoginConfig("", "", 0, profile)
+		require.NoError(t, err)
+		assert.Equal(t, defaultRedirectPort, got.RedirectPort)
+	})
+
+	t.Run("missing issuer errors", func(t *testing.T) {
+		profile := &client.Profile{OIDC: &client.OIDCLogin{ClientID: "profile-client"}}
+		_, err := resolveLoginConfig("", "", 0, profile)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "issuer")
+	})
+
+	t.Run("missing client ID errors", func(t *testing.T) {
+		profile := &client.Profile{OIDC: &client.OIDCLogin{Issuer: "https://profile.example"}}
+		_, err := resolveLoginConfig("", "", 0, profile)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "client ID")
+	})
+
+	t.Run("no oidc config and no flags errors with both", func(t *testing.T) {
+		_, err := resolveLoginConfig("", "", 0, &client.Profile{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "issuer")
+		assert.Contains(t, err.Error(), "client ID")
+	})
+}
+
+// Logging in caches the ID token on the resolved profile so later commands
+// authenticate without a manually supplied --token, and the resolved OIDC
+// settings flow from the profile into the login flow.
+func TestLoginCmdRunCachesToken(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("SCHEMABOT_PROFILE", "")
+
+	seed := &client.Config{
+		DefaultProfile: "default",
+		Profiles: map[string]client.Profile{
+			"default": {
+				Endpoint: "https://schemabot.example",
+				OIDC:     &client.OIDCLogin{Issuer: "https://issuer.example", ClientID: "cli-client", RedirectPort: 9999},
+			},
+		},
+	}
+	require.NoError(t, client.SaveConfig(seed))
+
+	var gotCfg client.LoginConfig
+	cmd := &LoginCmd{
+		loginFn: func(_ context.Context, lc client.LoginConfig, _ client.BrowserOpener) (*client.LoginResult, error) {
+			gotCfg = lc
+			return &client.LoginResult{IDToken: "jwt-xyz"}, nil
+		},
+		openBrowser: func(string) error { return nil },
+	}
+
+	require.NoError(t, cmd.Run(&Globals{}))
+
+	assert.Equal(t, "https://issuer.example", gotCfg.Issuer)
+	assert.Equal(t, "cli-client", gotCfg.ClientID)
+	assert.Equal(t, 9999, gotCfg.RedirectPort)
+
+	reloaded, err := client.LoadConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "jwt-xyz", reloaded.Profiles["default"].Token)
+}
+
+// Without OIDC settings on the profile and no flags, login fails with a clear
+// configuration error rather than opening a browser.
+func TestLoginCmdRunMissingOIDCErrors(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("SCHEMABOT_PROFILE", "")
+	require.NoError(t, client.SaveConfig(&client.Config{
+		DefaultProfile: "default",
+		Profiles:       map[string]client.Profile{"default": {Endpoint: "https://schemabot.example"}},
+	}))
+
+	browserOpened := false
+	cmd := &LoginCmd{
+		loginFn: func(context.Context, client.LoginConfig, client.BrowserOpener) (*client.LoginResult, error) {
+			t.Fatal("login should not be attempted when OIDC is unconfigured")
+			return nil, nil
+		},
+		openBrowser: func(string) error { browserOpened = true; return nil },
+	}
+
+	err := cmd.Run(&Globals{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "OIDC")
+	assert.False(t, browserOpened)
+}

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -45,6 +45,7 @@ type CLI struct {
 	Preview    commands.PreviewCmd    `cmd:"" help:"Preview CLI output templates (for development)"`
 	FixLint    commands.FixLintCmd    `cmd:"" name:"fix-lint" help:"Auto-fix lint issues in schema files"`
 	Configure  commands.ConfigureCmd  `cmd:"" help:"Configure CLI settings (endpoint, profiles)"`
+	Login      commands.LoginCmd      `cmd:"" help:"Log in via OIDC and cache a token for the active profile"`
 	Settings   commands.SettingsCmd   `cmd:"" help:"View or update schema change settings"`
 	Serve      commands.ServeCmd      `cmd:"" help:"Start the SchemaBot HTTP API server"`
 }


### PR DESCRIPTION
Adds the interactive `schemabot login` command on top of the PKCE login helper, so a user can authenticate to an auth-enabled server once and have subsequent commands use the cached token.

**What it does**
- Resolves the OIDC issuer, client ID, and loopback redirect port from the active profile's `oidc:` block, with `--issuer` / `--client-id` / `--redirect-port` overrides.
- Runs the browser authorization-code + PKCE flow, then caches the resulting ID token on the profile so later commands authenticate without a manual `--token`.
- Cross-platform browser opener that also prints the URL, so login still works headless / over SSH.
- Fails with a clear configuration error (no browser launch) when OIDC isn't set up for the profile.

Also adds the `oidc:` profile block and a `ResolveProfileName` helper.

Lands dark — does nothing until a profile is pointed at an OIDC-enabled server.

---
*PR opened by Claude Code (Opus 4.8).*