### PR TITLE
feat(github): surface skip-revert finalization as a skipping_revert state

### DIFF
--- a/pkg/cmd/commands/watch_tui_view.go
+++ b/pkg/cmd/commands/watch_tui_view.go
@@ -161,9 +161,9 @@ func (m WatchModel) progressView() string {
 		b.WriteString("\n\n")
 		b.WriteString("🚫 Schema change cancelled.\n")
 		b.WriteString("The deploy request has been cancelled. Start a new apply to retry.\n")
-	case state.IsState(m.state, state.Apply.RevertWindow):
+	case state.IsState(m.state, state.Apply.RevertWindow, state.Apply.SkippingRevert):
 		b.WriteString("\n\n")
-		if m.skipRevertTriggered || (m.metadata != nil && m.metadata["revert_skipped"] == "true") {
+		if state.IsState(m.state, state.Apply.SkippingRevert) || m.skipRevertTriggered || (m.metadata != nil && m.metadata["revert_skipped"] == "true") {
 			elapsed := ""
 			if !m.skipRevertAt.IsZero() {
 				elapsed = fmt.Sprintf(" (%ds)", int(time.Since(m.skipRevertAt).Seconds()))

--- a/pkg/cmd/internal/templates/progress.go
+++ b/pkg/cmd/internal/templates/progress.go
@@ -552,6 +552,15 @@ func FormatTableProgressWithActivity(t TableProgress, activityBar, activityLabel
 		b.WriteString("\n")
 		b.WriteString(FormatShardProgress(t.Shards))
 		return b.String()
+	case state.Apply.SkippingRevert:
+		bar := ui.ProgressBarWaitingCutover() // yellow — complete, revert window closing
+		fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s ✓ Complete (finalizing)\n", t.TableName, bar)
+		if t.DDL != "" {
+			b.WriteString(formatProgressDDL(t.DDL))
+		}
+		b.WriteString("\n")
+		b.WriteString(FormatShardProgress(t.Shards))
+		return b.String()
 	case state.Apply.Cancelled:
 		if t.PercentComplete > 0 || t.RowsCopied > 0 {
 			cancelledPercent := ui.RowCopyDisplayPercent(t.PercentComplete, t.RowsCopied)
@@ -1199,6 +1208,8 @@ func stateColorFunc(s string) func(string) string {
 		return colorWrap(ANSIRed)
 	case state.Apply.RevertWindow:
 		return colorWrap(ANSIYellow)
+	case state.Apply.SkippingRevert:
+		return colorWrap(ANSICyan)
 	default:
 		return nil
 	}

--- a/pkg/state/apply.go
+++ b/pkg/state/apply.go
@@ -23,6 +23,7 @@ var Apply = struct {
 	Recovering        string
 	CuttingOver       string
 	RevertWindow      string
+	SkippingRevert    string
 	Completed         string
 	Failed            string
 	FailedRetryable   string
@@ -49,6 +50,7 @@ var Apply = struct {
 	Recovering:        "recovering",
 	CuttingOver:       "cutting_over",
 	RevertWindow:      "revert_window",
+	SkippingRevert:    "skipping_revert",
 	Completed:         "completed",
 	Failed:            "failed",
 	FailedRetryable:   "failed_retryable",

--- a/pkg/state/metadata.go
+++ b/pkg/state/metadata.go
@@ -66,6 +66,9 @@ var applyMetadata = map[string]ApplyStateInfo{
 	Apply.RevertWindow: {
 		Label: "Revert window",
 	},
+	Apply.SkippingRevert: {
+		Label: "Skipping revert",
+	},
 	Apply.Completed: {
 		Label:    "Completed",
 		Terminal: true,

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -1617,9 +1617,10 @@ func (c *GRPCClient) triggerRemoteOperationCutover(ctx context.Context, apply *s
 		return false, c.reconcileTerminalRemoteProgress(ctx, apply, resp.Tables, now, scope)
 	}
 	switch {
-	case state.IsState(remoteState, state.Apply.CuttingOver), state.IsState(remoteState, state.Apply.RevertWindow):
-		// A prior driver already started the swap, or the engine is in the
-		// post-cutover revert window. Do not re-send Cutover; poll to terminal.
+	case state.IsState(remoteState, state.Apply.CuttingOver), state.IsState(remoteState, state.Apply.RevertWindow), state.IsState(remoteState, state.Apply.SkippingRevert):
+		// A prior driver already started the swap, the engine is in the post-cutover
+		// revert window, or skip-revert is finalizing. Do not re-send Cutover; poll
+		// to terminal.
 		apply.State = remoteState
 		return true, nil
 	case state.IsState(remoteState, state.Apply.WaitingForCutover):
@@ -2954,6 +2955,8 @@ func applyProgressRank(applyState string) int {
 		return 9
 	case state.Apply.RevertWindow:
 		return 10
+	case state.Apply.SkippingRevert:
+		return 11
 	default:
 		return 0
 	}

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -583,7 +583,11 @@ func (c *LocalClient) pollForCompletionAtomic(ctx context.Context, apply *storag
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 
-	ps := &atomicPollState{lastProgressLog: time.Now()}
+	// Seed revertSkipped from the durable signal so a driver that picks this apply
+	// up after a restart treats skip-revert as already accepted: it won't re-attempt
+	// SkipRevert, and it keeps surfacing skipping_revert while finalization is in
+	// flight rather than falling back to revert_window.
+	ps := &atomicPollState{lastProgressLog: time.Now(), revertSkipped: apply.RevertSkippedAt != nil}
 
 	for {
 		select {

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -782,7 +782,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 			c.markRevertSkipped(ctx, apply)
 		}
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventSkipRevertTriggered, storage.LogSourceSchemaBot,
-			"Skip-revert triggered (--skip-revert)", state.Apply.RevertWindow, "")
+			"Skip-revert triggered (--skip-revert)", state.Apply.RevertWindow, state.Apply.SkippingRevert)
 		ps.revertSkipped = true
 	}
 
@@ -805,7 +805,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 					c.logger.Warn("failed to complete skip-revert control request", "apply_id", apply.ApplyIdentifier, "error", err)
 				}
 				c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventSkipRevertTriggered, storage.LogSourceSchemaBot,
-					fmt.Sprintf("Skip-revert triggered by user%s", callerApplyLogSuffix(controlRequestCaller(pending))), state.Apply.RevertWindow, "")
+					fmt.Sprintf("Skip-revert triggered by user%s", callerApplyLogSuffix(controlRequestCaller(pending))), state.Apply.RevertWindow, state.Apply.SkippingRevert)
 			}
 		}
 	}
@@ -823,7 +823,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 			} else {
 				c.markRevertSkipped(ctx, apply)
 				c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventSkipRevertTriggered, storage.LogSourceSchemaBot,
-					"Revert window expired, skip-revert triggered", state.Apply.RevertWindow, "")
+					"Revert window expired, skip-revert triggered", state.Apply.RevertWindow, state.Apply.SkippingRevert)
 			}
 			ps.revertSkipped = true
 		}
@@ -868,6 +868,15 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		apply.State = state.DeriveApplyState([]string{newState})
 	} else if derived, ok := c.deriveAggregateApplyState(ctx, apply, tasks); ok {
 		apply.State = derived
+	}
+	// Once skip-revert has been accepted, PlanetScale keeps reporting
+	// complete_pending_revert (which derives to revert_window) until it finishes
+	// discarding the staged revert. Surface that finalization as skipping_revert so
+	// the comment and CLI stop offering a resumable revert window and show that the
+	// change is being made permanent. It clears on its own: when the engine reports
+	// complete the aggregate derives completed and this override no longer applies.
+	if ps.revertSkipped && state.IsState(apply.State, state.Apply.RevertWindow) {
+		apply.State = state.Apply.SkippingRevert
 	}
 	apply.UpdatedAt = now
 	freshApply, err := c.storage.Applies().Get(ctx, apply.ID)

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -156,6 +156,8 @@ func writeApplyHeader(sb *strings.Builder, data ApplyStatusCommentData) {
 		writeEnvironmentTitle(sb, "Schema Change In Progress", data.Environment)
 	case state.Apply.RevertWindow:
 		writeEnvironmentTitle(sb, "Schema Change Applied (Pending Revert)", data.Environment)
+	case state.Apply.SkippingRevert:
+		writeEnvironmentTitle(sb, "Skipping Revert — Finalizing", data.Environment)
 	case state.Apply.Completed:
 		writeEnvironmentTitle(sb, "✅ Schema Change Applied", data.Environment)
 	case state.Apply.Failed:
@@ -817,6 +819,9 @@ func writeApplyFooter(sb *strings.Builder, data ApplyStatusCommentData) {
 	case state.Apply.RevertWindow:
 		writeFooterAction(sb, "To revert:", fmt.Sprintf("schemabot revert %s -e %s", data.ApplyID, data.Environment))
 		fmt.Fprintf(sb, "\nTo skip revert and keep changes:\n```\nschemabot skip-revert %s -e %s\n```\n", data.ApplyID, data.Environment)
+	case state.Apply.SkippingRevert:
+		sb.WriteString("\n---\n\n")
+		sb.WriteString("Skip-revert was requested — closing the revert window and making this schema change permanent. This can no longer be reverted.\n")
 	}
 }
 

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -1725,3 +1725,26 @@ func TestRenderApplyStatusComment_RevertWindow(t *testing.T) {
 	assert.Contains(t, result, "schemabot revert apply-abc123 -e staging")
 	assert.Contains(t, result, "schemabot skip-revert apply-abc123 -e staging")
 }
+
+// Once skip-revert is accepted the apply moves from revert_window to
+// skipping_revert while PlanetScale discards the staged revert. The comment must
+// show finalization is underway and stop offering revert/skip-revert, since the
+// change can no longer be reverted.
+func TestRenderApplyStatusComment_SkippingRevert(t *testing.T) {
+	data := ApplyStatusCommentData{
+		ApplyID:     "apply-abc123",
+		Database:    "testapp",
+		Environment: "staging",
+		State:       state.Apply.SkippingRevert,
+		Tables: []TableProgressData{
+			{TableName: "users", Status: state.Task.RevertWindow},
+		},
+	}
+
+	result := RenderApplyStatusComment(data)
+
+	assert.Contains(t, result, "Skipping Revert — Finalizing")
+	assert.Contains(t, result, "can no longer be reverted")
+	assert.NotContains(t, result, "schemabot revert apply-abc123 -e staging")
+	assert.NotContains(t, result, "schemabot skip-revert apply-abc123 -e staging")
+}


### PR DESCRIPTION
## Why
After skip-revert is accepted, the engine keeps reporting `complete_pending_revert` (which derives to `revert_window`) until it finishes discarding the staged revert. Until now the apply sat in `revert_window` the whole time — so the PR comment and CLI kept offering a resumable revert window and gave no sign that finalization was underway. That left a silent gap between `revert_window` and `completed` where an operator who hit skip-revert was staring at a frozen "revert window" with no feedback.

## What
Adds a `skipping_revert` apply state on the `revert_window → skipping_revert → completed` path.

- The data-plane drive overrides the derived state to `skipping_revert` once skip-revert is accepted and holds it while the engine still reports `complete_pending_revert`; it clears to `completed` on its own when the engine reports `complete`. The skip-revert apply-log events now record the `revert_window → skipping_revert` transition.
- The control plane ranks `skipping_revert` just above `revert_window` so remote progress is mirrored rather than regressed, and treats it like the revert window when deciding not to re-send cutover.
- The PR comment shows "Skipping Revert — Finalizing" and explains the change can no longer be reverted (no revert/skip-revert actions); the CLI and TUI render the finalization state.
- `revert` and `skip-revert` are already gated on `revert_window`, so both are correctly rejected once finalization starts.

```diagram
revert_window ──skip accepted──▶ skipping_revert ──engine reports complete──▶ completed
   (revert /                      (finalizing;                 (permanent)
    skip-revert                    no revert /
    offered)                       skip-revert)
```

## Risk Assessment
Low–medium — adds a new non-terminal apply state on a PlanetScale-only path. It is additive: the state only appears after skip-revert is accepted, clears itself when the engine completes, and `revert`/`skip-revert` gating is unchanged. Single-operation drives only; the multi-operation rollout projection is unaffected (no regression, just no new state there yet).

---
*PR authored with Claude Code (Opus 4.8).*
