### PR TITLE
feat(github): show the revert-window deadline in the PR comment

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -2677,6 +2677,8 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 **Status**: Revert window
 
+🔗 **Deploy request**: https://app.planetscale.com/acme/myapp/deploy-requests/42
+
 ⏳ **Revert window closes in**: 28m 30s
 
 ### Table Progress
@@ -2727,6 +2729,8 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 **Status**: Skipping revert
+
+🔗 **Deploy request**: https://app.planetscale.com/acme/myapp/deploy-requests/42
 
 ### Table Progress
 

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -2666,6 +2666,98 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 </details>
 
 <details>
+<summary><a name="revert-window"></a><strong>Revert Window</strong></summary>
+
+
+## Schema Change Applied (Pending Revert) — Staging
+
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
+
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: Revert window
+
+⏳ **Revert window closes in**: 28m 30s
+
+### Table Progress
+
+**`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✓ Complete (pending revert)
+
+```sql
+ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+```
+
+**`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✓ Complete (pending revert)
+
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
+```
+
+**`products`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✓ Complete (pending revert)
+
+```sql
+ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+```
+
+
+---
+
+To revert:
+```
+schemabot revert apply-a1b2c3d4e5f6 -e staging
+```
+
+To skip revert and keep changes:
+```
+schemabot skip-revert apply-a1b2c3d4e5f6 -e staging
+```
+
+_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
+
+</details>
+
+<details>
+<summary><a name="skipping-revert"></a><strong>Skipping Revert</strong></summary>
+
+
+## Skipping Revert — Finalizing — Staging
+
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
+
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: Skipping revert
+
+### Table Progress
+
+**`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✓ Complete (pending revert)
+
+```sql
+ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
+```
+
+**`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✓ Complete (pending revert)
+
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
+```
+
+**`products`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✓ Complete (pending revert)
+
+```sql
+ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
+```
+
+
+---
+
+Skip-revert was requested — closing the revert window and making this schema change permanent. This can no longer be reverted.
+
+_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
+
+</details>
+
+<details>
 <summary><a name="start-command-accepted"></a><strong>Start Command Accepted</strong></summary>
 
 

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -237,6 +237,9 @@ func previewCommentApplyFlowAllOutput() {
 		// Cutover states
 		{"WAITING FOR CUTOVER", func() { fmt.Print(webhooktemplates.PreviewCommentApplyWaitingForCutover()) }},
 		{"CUTTING OVER", func() { fmt.Print(webhooktemplates.PreviewCommentApplyCuttingOver()) }},
+		// Revert-window states (PlanetScale): deployed-but-revertable, then finalizing.
+		{"REVERT WINDOW", func() { fmt.Print(webhooktemplates.PreviewCommentApplyRevertWindow()) }},
+		{"SKIPPING REVERT", func() { fmt.Print(webhooktemplates.PreviewCommentApplySkippingRevert()) }},
 		{"START COMMAND ACCEPTED", func() { fmt.Print(webhooktemplates.PreviewCommentStartCommandAccepted()) }},
 		{"START COMMAND ALREADY PENDING", func() { fmt.Print(webhooktemplates.PreviewCommentStartCommandAlreadyRequested()) }},
 		{"CUTOVER COMMAND ACCEPTED", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAccepted()) }},

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -674,6 +674,20 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 	// updated metadata like deploy request URL or migration context).
 	if result.ResumeState != nil && resumeState != nil {
 		*resumeState = *result.ResumeState
+		// Persist the revert-window deadline so the PR comment and CLI can show
+		// time remaining. revertWindowDeadline derives it from the engine's
+		// deployed_at plus the configured window; merge it in key-preserving so
+		// engine fields the storage struct does not model survive the rewrite.
+		if result.State == engine.StateRevertWindow {
+			if deadline := c.revertWindowDeadline(result.ResumeState, ps.stateEnteredAt); !deadline.IsZero() {
+				if merged, err := setRevertExpiresAtMetadata(resumeState.Metadata, deadline); err != nil {
+					c.logger.Warn("failed to stamp revert_expires_at into resume metadata; comment will omit revert deadline",
+						append(apply.LogAttrs(), "error", err)...)
+				} else {
+					resumeState.Metadata = merged
+				}
+			}
+		}
 		if c.config.Type == storage.DatabaseTypeVitess {
 			if saveErr := c.saveEngineResumeState(ctx, apply, tasks, resumeState); saveErr != nil {
 				c.logger.Error("failed to save Vitess engine resume state from progress polling",

--- a/pkg/tern/state_converters.go
+++ b/pkg/tern/state_converters.go
@@ -289,6 +289,7 @@ type psMetadataForStorage struct {
 	DeferredDeploy   bool                  `json:"deferred_deploy,omitempty"`
 	VSchemaStatus    string                `json:"vschema_status,omitempty"`
 	VSchemaDiffs     []vschemaKeyspaceDiff `json:"vschema_diffs,omitempty"`
+	RevertExpiresAt  *time.Time            `json:"revert_expires_at,omitempty"`
 }
 
 // vschemaKeyspaceDiff mirrors the PlanetScale engine's per-keyspace VSchema diff
@@ -307,6 +308,31 @@ func decodePSMetadataForStorage(s string) (*psMetadataForStorage, error) {
 		return nil, err
 	}
 	return &m, nil
+}
+
+// setRevertExpiresAtMetadata returns the PlanetScale resume-state blob with
+// revert_expires_at set to expiresAt, preserving every other key. It merges at
+// the JSON-object level rather than re-encoding psMetadataForStorage so engine
+// fields the storage struct does not model (e.g. existing_migration_contexts)
+// survive the rewrite. The timestamp is normalized to UTC RFC3339 so the value
+// is stable across ticks and the comment/CLI parse it the same way.
+func setRevertExpiresAtMetadata(metadata string, expiresAt time.Time) (string, error) {
+	obj := map[string]json.RawMessage{}
+	if metadata != "" {
+		if err := json.Unmarshal([]byte(metadata), &obj); err != nil {
+			return "", fmt.Errorf("decode planetscale resume metadata to set revert_expires_at: %w", err)
+		}
+	}
+	encoded, err := json.Marshal(expiresAt.UTC().Format(time.RFC3339))
+	if err != nil {
+		return "", fmt.Errorf("encode revert_expires_at: %w", err)
+	}
+	obj["revert_expires_at"] = encoded
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return "", fmt.Errorf("re-encode planetscale resume metadata with revert_expires_at: %w", err)
+	}
+	return string(out), nil
 }
 
 // PSDisplayMetadata decodes a PlanetScale engine resume-state blob into the
@@ -342,6 +368,9 @@ func PSDisplayMetadata(resumeStateMetadata string) (map[string]string, error) {
 	}
 	if meta.DeferredDeploy {
 		set("deferred_deploy", "true")
+	}
+	if meta.RevertExpiresAt != nil {
+		set("revert_expires_at", meta.RevertExpiresAt.UTC().Format(time.RFC3339))
 	}
 	// Per-keyspace VSchema state. Mirrors the engine's live projection: every
 	// changed keyspace carries the deploy-level status, encoded as JSON so the

--- a/pkg/tern/state_converters.go
+++ b/pkg/tern/state_converters.go
@@ -313,9 +313,9 @@ func decodePSMetadataForStorage(s string) (*psMetadataForStorage, error) {
 // setRevertExpiresAtMetadata returns the PlanetScale resume-state blob with
 // revert_expires_at set to expiresAt, preserving every other key. It merges at
 // the JSON-object level rather than re-encoding psMetadataForStorage so engine
-// fields the storage struct does not model (e.g. existing_migration_contexts)
-// survive the rewrite. The timestamp is normalized to UTC RFC3339 so the value
-// is stable across ticks and the comment/CLI parse it the same way.
+// fields the storage struct does not model survive the rewrite. The timestamp
+// is normalized to UTC RFC3339 so the value is stable across ticks and the
+// comment/CLI parse it the same way.
 func setRevertExpiresAtMetadata(metadata string, expiresAt time.Time) (string, error) {
 	obj := map[string]json.RawMessage{}
 	if metadata != "" {

--- a/pkg/tern/state_converters_test.go
+++ b/pkg/tern/state_converters_test.go
@@ -74,11 +74,12 @@ func TestPSDisplayMetadata(t *testing.T) {
 }
 
 // setRevertExpiresAtMetadata must set revert_expires_at without dropping engine
-// fields the storage struct does not model (e.g. existing_migration_contexts) —
-// it merges at the JSON-object level rather than re-encoding the typed struct.
+// fields the storage struct does not model — it merges at the JSON-object level
+// rather than re-encoding the typed struct, so an arbitrary unmodeled key
+// survives.
 func TestSetRevertExpiresAtMetadata(t *testing.T) {
 	expires := time.Date(2026, 6, 29, 18, 30, 0, 0, time.UTC)
-	in := `{"branch_name":"b","existing_migration_contexts":{"commerce":{"started_at":"2026-06-29T18:00:00Z"}}}`
+	in := `{"branch_name":"b","unmodeled_engine_field":{"commerce":{"started_at":"2026-06-29T18:00:00Z"}}}`
 
 	out, err := setRevertExpiresAtMetadata(in, expires)
 	require.NoError(t, err)
@@ -86,7 +87,7 @@ func TestSetRevertExpiresAtMetadata(t *testing.T) {
 	var obj map[string]json.RawMessage
 	require.NoError(t, json.Unmarshal([]byte(out), &obj))
 	assert.JSONEq(t, `"2026-06-29T18:30:00Z"`, string(obj["revert_expires_at"]))
-	assert.Contains(t, obj, "existing_migration_contexts", "unmodeled engine field must survive the rewrite")
+	assert.Contains(t, obj, "unmodeled_engine_field", "unmodeled engine field must survive the rewrite")
 	assert.JSONEq(t, `"b"`, string(obj["branch_name"]))
 
 	// Surfaced back through the display projection.

--- a/pkg/tern/state_converters_test.go
+++ b/pkg/tern/state_converters_test.go
@@ -1,7 +1,9 @@
 package tern
 
 import (
+	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/block/schemabot/pkg/apitypes"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
@@ -63,6 +65,39 @@ func TestPSDisplayMetadata(t *testing.T) {
 	// Malformed JSON surfaces an error rather than silently dropping fields.
 	_, err = PSDisplayMetadata(`{not json`)
 	require.Error(t, err)
+
+	// A persisted revert_expires_at is surfaced for the revert-window countdown.
+	m, err = PSDisplayMetadata(`{"branch_name":"b","revert_expires_at":"2026-06-29T18:30:00Z"}`)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	assert.Equal(t, "2026-06-29T18:30:00Z", m["revert_expires_at"])
+}
+
+// setRevertExpiresAtMetadata must set revert_expires_at without dropping engine
+// fields the storage struct does not model (e.g. existing_migration_contexts) —
+// it merges at the JSON-object level rather than re-encoding the typed struct.
+func TestSetRevertExpiresAtMetadata(t *testing.T) {
+	expires := time.Date(2026, 6, 29, 18, 30, 0, 0, time.UTC)
+	in := `{"branch_name":"b","existing_migration_contexts":{"commerce":{"started_at":"2026-06-29T18:00:00Z"}}}`
+
+	out, err := setRevertExpiresAtMetadata(in, expires)
+	require.NoError(t, err)
+
+	var obj map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(out), &obj))
+	assert.JSONEq(t, `"2026-06-29T18:30:00Z"`, string(obj["revert_expires_at"]))
+	assert.Contains(t, obj, "existing_migration_contexts", "unmodeled engine field must survive the rewrite")
+	assert.JSONEq(t, `"b"`, string(obj["branch_name"]))
+
+	// Surfaced back through the display projection.
+	m, err := PSDisplayMetadata(out)
+	require.NoError(t, err)
+	assert.Equal(t, "2026-06-29T18:30:00Z", m["revert_expires_at"])
+
+	// Empty input starts a fresh object rather than erroring.
+	out, err = setRevertExpiresAtMetadata("", expires)
+	require.NoError(t, err)
+	assert.Contains(t, out, "revert_expires_at")
 }
 
 // The display map a data-plane progress poll returns round-trips through

--- a/pkg/webhook/apply.go
+++ b/pkg/webhook/apply.go
@@ -30,6 +30,7 @@ func buildApplyCommentData(apply *storage.Apply, tasks []*storage.Task, display 
 		ErrorMessage:     apply.ErrorMessage,
 		VSchemaChanges:   display.VSchema,
 		DeployRequestURL: display.DeployRequestURL,
+		RevertExpiresAt:  display.RevertExpiresAt,
 	}
 	if apply.StartedAt != nil {
 		data.StartedAt = apply.StartedAt.Format(time.RFC3339)
@@ -47,6 +48,10 @@ func buildApplyCommentData(apply *storage.Apply, tasks []*storage.Task, display 
 type operationDisplay struct {
 	VSchema          []apitypes.VSchemaChange
 	DeployRequestURL string
+	// RevertExpiresAt is the RFC3339 deadline when the revert window closes
+	// (PlanetScale only), surfaced so the comment can show time remaining. Empty
+	// outside the revert window.
+	RevertExpiresAt string
 }
 
 // resolveDisplayByOperation projects each operation's engine display state
@@ -84,8 +89,8 @@ func resolveDisplayByOperation(ctx context.Context, stor storage.Storage, apply 
 			slog.Warn("comment will omit VSchema status: failed to parse VSchema changes",
 				"apply_id", apply.ApplyIdentifier, "apply_operation_id", op.ID, "error", err)
 		}
-		od := operationDisplay{VSchema: changes, DeployRequestURL: display["deploy_request_url"]}
-		if len(od.VSchema) == 0 && od.DeployRequestURL == "" {
+		od := operationDisplay{VSchema: changes, DeployRequestURL: display["deploy_request_url"], RevertExpiresAt: display["revert_expires_at"]}
+		if len(od.VSchema) == 0 && od.DeployRequestURL == "" && od.RevertExpiresAt == "" {
 			continue
 		}
 		if byOp == nil {

--- a/pkg/webhook/multi_apply.go
+++ b/pkg/webhook/multi_apply.go
@@ -160,6 +160,7 @@ func buildDeploymentDetail(apply *storage.Apply, op *storage.ApplyOperation, tas
 		Tables:           tableProgressFromTasks(apply.Database, tasks, shardsByTable),
 		VSchemaChanges:   display.VSchema,
 		DeployRequestURL: display.DeployRequestURL,
+		RevertExpiresAt:  display.RevertExpiresAt,
 	}
 	if apply.StartedAt != nil {
 		data.StartedAt = apply.StartedAt.Format(time.RFC3339)

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -75,6 +75,12 @@ type ApplyStatusCommentData struct {
 	// request's own progress, which the comment does not otherwise surface. Empty
 	// for engines without a deploy request or before one is created.
 	DeployRequestURL string
+
+	// RevertExpiresAt is the RFC3339 deadline when the revert window closes
+	// (PlanetScale only). When set and the apply is in its revert window, the
+	// comment shows the time remaining before the change becomes permanent.
+	// Empty outside the revert window or for engines without one.
+	RevertExpiresAt string
 }
 
 // RenderApplyStatusComment renders a PR comment for the current apply status.
@@ -97,6 +103,12 @@ func renderApplyStatusComment(data ApplyStatusCommentData, includeLastUpdated bo
 	// Deploy-request link (PlanetScale) — the operator's entry point into the
 	// deploy request's own progress, which the comment does not otherwise surface.
 	writeDeployRequestLink(&sb, data)
+
+	// Revert-window countdown (PlanetScale) — how long until the change becomes
+	// permanent, so the operator knows the window to revert or skip.
+	if state.IsState(data.State, state.Apply.RevertWindow) {
+		writeRevertWindowDeadline(&sb, data.RevertExpiresAt)
+	}
 
 	// Cutover readiness summary
 	if data.State == state.Apply.WaitingForCutover || data.State == state.Apply.CuttingOver {
@@ -280,6 +292,25 @@ func writeStopOrCancelFooterAction(sb *strings.Builder, data ApplyStatusCommentD
 		prefix = cancelPrefix
 	}
 	writeFooterAction(sb, prefix, fmt.Sprintf("schemabot %s %s -e %s", command, data.ApplyID, data.Environment))
+}
+
+// writeRevertWindowDeadline writes the time remaining before the revert window
+// closes, when a deadline is known and still in the future. An unset or
+// past-due deadline renders nothing so the comment never shows a stale or
+// negative countdown.
+func writeRevertWindowDeadline(sb *strings.Builder, revertExpiresAt string) {
+	if revertExpiresAt == "" {
+		return
+	}
+	expires, err := time.Parse(time.RFC3339, revertExpiresAt)
+	if err != nil {
+		return
+	}
+	remaining := time.Until(expires)
+	if remaining <= 0 {
+		return
+	}
+	fmt.Fprintf(sb, "\n⏳ **Revert window closes in**: %s\n", formatDuration(remaining))
 }
 
 // writeCutoverSummary writes a readiness summary for cutover states,
@@ -1278,6 +1309,9 @@ func ApplyStatusFromProgress(resp *apitypes.ProgressResponse, requestedBy string
 		ErrorMessage: resp.ErrorMessage,
 		StartedAt:    resp.StartedAt,
 		CompletedAt:  resp.CompletedAt,
+	}
+	if resp.Metadata != nil {
+		data.RevertExpiresAt = resp.Metadata["revert_expires_at"]
 	}
 
 	if changes, err := apitypes.ParseVSchemaChanges(resp.Metadata); err != nil {

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -306,7 +306,8 @@ func writeRevertWindowDeadline(sb *strings.Builder, revertExpiresAt string) {
 	if err != nil {
 		return
 	}
-	remaining := time.Until(expires)
+	// NowFunc (not time.Now) so previews and tests render a deterministic countdown.
+	remaining := expires.Sub(NowFunc())
 	if remaining <= 0 {
 		return
 	}

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -1310,9 +1310,7 @@ func ApplyStatusFromProgress(resp *apitypes.ProgressResponse, requestedBy string
 		StartedAt:    resp.StartedAt,
 		CompletedAt:  resp.CompletedAt,
 	}
-	if resp.Metadata != nil {
-		data.RevertExpiresAt = resp.Metadata["revert_expires_at"]
-	}
+	data.RevertExpiresAt = resp.Metadata["revert_expires_at"]
 
 	if changes, err := apitypes.ParseVSchemaChanges(resp.Metadata); err != nil {
 		slog.Warn("failed to parse VSchema changes from progress metadata", "apply_id", resp.ApplyID, "error", err)

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -1787,3 +1787,29 @@ func TestRenderApplyStatusComment_SkippingRevert(t *testing.T) {
 	assert.NotContains(t, result, "schemabot revert apply-abc123 -e staging")
 	assert.NotContains(t, result, "schemabot skip-revert apply-abc123 -e staging")
 }
+
+// In the revert window the comment shows how long the operator has to revert or
+// skip before the change becomes permanent. A future deadline renders a
+// countdown; an absent or past-due deadline renders none rather than a stale or
+// negative value.
+func TestRenderApplyStatusComment_RevertWindowDeadline(t *testing.T) {
+	base := ApplyStatusCommentData{
+		ApplyID:     "apply-abc123",
+		Database:    "testapp",
+		Environment: "staging",
+		State:       state.Apply.RevertWindow,
+		Tables:      []TableProgressData{{TableName: "users", Status: state.Task.RevertWindow}},
+	}
+
+	withDeadline := base
+	withDeadline.RevertExpiresAt = time.Now().Add(20 * time.Minute).UTC().Format(time.RFC3339)
+	assert.Contains(t, RenderApplyStatusComment(withDeadline), "Revert window closes in")
+
+	// No deadline → no countdown line.
+	assert.NotContains(t, RenderApplyStatusComment(base), "Revert window closes in")
+
+	// Past-due deadline → no countdown line (never show a negative countdown).
+	pastDue := base
+	pastDue.RevertExpiresAt = time.Now().Add(-1 * time.Minute).UTC().Format(time.RFC3339)
+	assert.NotContains(t, RenderApplyStatusComment(pastDue), "Revert window closes in")
+}

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -1087,6 +1087,33 @@ func PreviewCommentApplyCuttingOver() string {
 	return RenderApplyStatusComment(sampleApplyData(state.Apply.CuttingOver, tables))
 }
 
+// PreviewCommentApplyRevertWindow renders a PlanetScale apply in its revert
+// window: the change is deployed but still revertable, with a countdown to when
+// it becomes permanent and the revert / skip-revert actions.
+func PreviewCommentApplyRevertWindow() string {
+	tables := sampleApplyTables()
+	for i := range tables {
+		tables[i].Status = state.Task.RevertWindow
+	}
+	data := sampleApplyData(state.Apply.RevertWindow, tables)
+	data.Engine = "PlanetScale"
+	data.RevertExpiresAt = NowFunc().Add(28*time.Minute + 30*time.Second).UTC().Format(time.RFC3339)
+	return RenderApplyStatusComment(data)
+}
+
+// PreviewCommentApplySkippingRevert renders a PlanetScale apply after skip-revert
+// was requested: the revert window is closing and the change is being made
+// permanent, so no revert / skip-revert actions are offered.
+func PreviewCommentApplySkippingRevert() string {
+	tables := sampleApplyTables()
+	for i := range tables {
+		tables[i].Status = state.Task.RevertWindow
+	}
+	data := sampleApplyData(state.Apply.SkippingRevert, tables)
+	data.Engine = "PlanetScale"
+	return RenderApplyStatusComment(data)
+}
+
 // =============================================================================
 // Multi-Deployment Apply Previews (MD-10)
 // =============================================================================

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -1097,6 +1097,7 @@ func PreviewCommentApplyRevertWindow() string {
 	}
 	data := sampleApplyData(state.Apply.RevertWindow, tables)
 	data.Engine = "PlanetScale"
+	data.DeployRequestURL = "https://app.planetscale.com/acme/myapp/deploy-requests/42"
 	data.RevertExpiresAt = NowFunc().Add(28*time.Minute + 30*time.Second).UTC().Format(time.RFC3339)
 	return RenderApplyStatusComment(data)
 }
@@ -1111,6 +1112,7 @@ func PreviewCommentApplySkippingRevert() string {
 	}
 	data := sampleApplyData(state.Apply.SkippingRevert, tables)
 	data.Engine = "PlanetScale"
+	data.DeployRequestURL = "https://app.planetscale.com/acme/myapp/deploy-requests/42"
 	return RenderApplyStatusComment(data)
 }
 


### PR DESCRIPTION
## Why
The revert window has a configured duration, but the PR comment never told the operator how long was left to revert or skip before the change becomes permanent. The deadline is computed in the drive (`deployed_at` + window) but wasn't surfaced anywhere the comment reads, so an operator deciding whether to revert had no sense of urgency or time budget.

## What
Mirror the revert-window deadline into the engine display metadata the comment already projects — the same pattern used for the deploy-request URL.

- The drive stamps `revert_expires_at` into the resume metadata while in the revert window, using a **key-preserving JSON merge** so engine fields the storage struct does not model (e.g. `existing_migration_contexts`) survive the rewrite.
- `PSDisplayMetadata` surfaces `revert_expires_at`; it threads through `operationDisplay` and `ApplyStatusCommentData` to the renderer (single- and multi-deployment builders, plus the progress-conversion path).
- The comment shows "⏳ **Revert window closes in**: <duration>" while in the revert window. An absent or past-due deadline renders nothing rather than a stale or negative countdown.

## Risk Assessment
Low — additive, PlanetScale-only, display-path change. No control flow or state transitions change. The key-preserving merge is covered by a test asserting an unmodeled engine field survives, and the countdown is covered for the future / absent / past-due cases.

---
*PR authored with Claude Code (Opus 4.8).*
