### PR TITLE
feat(auth): refresh expired CLI tokens without re-login

### DIFF
--- a/pkg/cmd/client/config.go
+++ b/pkg/cmd/client/config.go
@@ -280,6 +280,15 @@ func profileToken(profile *Profile, endpointFlag string) string {
 // is not sent with a token that lapses mid-flight.
 const tokenRefreshSkew = 60 * time.Second
 
+// unixExpiry converts a token expiry to the stored Unix-seconds form, returning
+// 0 ("unknown, do not proactively refresh") when the provider omits an expiry.
+func unixExpiry(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	return t.Unix()
+}
+
 // ResolveBearerToken resolves the Bearer token like ResolveToken, but renews an
 // expired profile-cached token when a refresh token and OIDC settings are
 // present, persisting the rotated token. Flag/env tokens are returned as-is.
@@ -321,7 +330,7 @@ func ResolveBearerToken(ctx context.Context, tokenFlag, endpointFlag, profileFla
 		return token, nil
 	}
 	if profile.RefreshToken == "" || profile.OIDC == nil {
-		return token, fmt.Errorf("token for profile %q has expired; run `schemabot login`", profileName)
+		return token, fmt.Errorf("token for profile %q is expired or about to expire and cannot be refreshed; run `schemabot login`", profileName)
 	}
 
 	result, err := RefreshToken(ctx, LoginConfig{Issuer: profile.OIDC.Issuer, ClientID: profile.OIDC.ClientID}, profile.RefreshToken)
@@ -333,9 +342,9 @@ func ResolveBearerToken(ctx context.Context, tokenFlag, endpointFlag, profileFla
 	if result.RefreshToken != "" {
 		profile.RefreshToken = result.RefreshToken
 	}
-	if !result.Expiry.IsZero() {
-		profile.TokenExpiry = result.Expiry.Unix()
-	}
+	// Always set expiry, clearing it when the provider omits one, so a stale
+	// value can't make every subsequent command refresh immediately.
+	profile.TokenExpiry = unixExpiry(result.Expiry)
 	cfg.Profiles[profileName] = profile
 	if err := SaveConfig(cfg); err != nil {
 		// The refreshed token is usable for this run even if it could not be saved.

--- a/pkg/cmd/client/config.go
+++ b/pkg/cmd/client/config.go
@@ -1,11 +1,13 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"runtime"
+	"time"
 
 	"github.com/block/spirit/pkg/utils"
 	"gopkg.in/yaml.v3"
@@ -24,6 +26,10 @@ type Profile struct {
 	// `schemabot login`. Scoping it to a profile keeps a token bound to the
 	// server it was issued for, so it is never sent to a different endpoint.
 	Token string `yaml:"token,omitempty"`
+	// RefreshToken renews Token without another browser login. TokenExpiry is the
+	// Unix time (seconds) Token expires; 0 means unknown (no proactive refresh).
+	RefreshToken string `yaml:"refresh_token,omitempty"`
+	TokenExpiry  int64  `yaml:"token_expiry,omitempty"`
 	// OIDC holds the public-client settings `schemabot login` uses to run the
 	// browser auth-code flow for this profile's server. Optional; absent until a
 	// server has OIDC enabled.
@@ -103,7 +109,7 @@ func LoadConfig() (*Config, error) {
 // configHasToken reports whether any profile carries a cached token.
 func configHasToken(cfg *Config) bool {
 	for _, p := range cfg.Profiles {
-		if p.Token != "" {
+		if p.Token != "" || p.RefreshToken != "" {
 			return true
 		}
 	}
@@ -250,18 +256,92 @@ func ResolveToken(tokenFlag, endpointFlag, profileFlag string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if profile.Token == "" {
-		return "", nil
-	}
+	return profileToken(profile, endpointFlag), nil
+}
 
+// profileToken returns the cached token to send to endpointFlag, or "" when no
+// token is cached or an endpoint override points away from the profile's own
+// endpoint — a token must never be sent to a server it was not issued for.
+func profileToken(profile *Profile, endpointFlag string) string {
+	if profile.Token == "" {
+		return ""
+	}
 	endpointOverride := endpointFlag
 	if endpointOverride == "" {
 		endpointOverride = os.Getenv("SCHEMABOT_ENDPOINT")
 	}
 	if endpointOverride != "" && trimSlash(endpointOverride) != trimSlash(profile.Endpoint) {
+		return ""
+	}
+	return profile.Token
+}
+
+// tokenRefreshSkew renews a token slightly before its real expiry so a request
+// is not sent with a token that lapses mid-flight.
+const tokenRefreshSkew = 60 * time.Second
+
+// ResolveBearerToken resolves the Bearer token like ResolveToken, but renews an
+// expired profile-cached token when a refresh token and OIDC settings are
+// present, persisting the rotated token. Flag/env tokens are returned as-is.
+//
+// Error contract for the caller: a non-empty token with a non-nil error is a
+// non-fatal warning (the returned token is the best available — e.g. a stale
+// token when refresh failed — so the command can still run and the user can
+// re-authenticate); an empty token with a non-nil error is a hard failure.
+func ResolveBearerToken(ctx context.Context, tokenFlag, endpointFlag, profileFlag string) (string, error) {
+	if tokenFlag != "" {
+		return tokenFlag, nil
+	}
+	if env := os.Getenv("SCHEMABOT_TOKEN"); env != "" {
+		return env, nil
+	}
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		return "", err
+	}
+	profileName := ResolveProfileName(cfg, profileFlag)
+	profile, ok := cfg.Profiles[profileName]
+	if !ok {
+		// Mirror GetProfile: an explicitly requested missing profile is an error;
+		// an unrequested missing profile simply has no token.
+		if profileFlag != "" || os.Getenv("SCHEMABOT_PROFILE") != "" {
+			return "", fmt.Errorf("unknown profile %q", profileName)
+		}
 		return "", nil
 	}
-	return profile.Token, nil
+
+	token := profileToken(&profile, endpointFlag)
+	if token == "" {
+		return "", nil
+	}
+
+	// Refresh only when the expiry is known and (nearly) reached.
+	if profile.TokenExpiry == 0 || time.Until(time.Unix(profile.TokenExpiry, 0)) > tokenRefreshSkew {
+		return token, nil
+	}
+	if profile.RefreshToken == "" || profile.OIDC == nil {
+		return token, fmt.Errorf("token for profile %q has expired; run `schemabot login`", profileName)
+	}
+
+	result, err := RefreshToken(ctx, LoginConfig{Issuer: profile.OIDC.Issuer, ClientID: profile.OIDC.ClientID}, profile.RefreshToken)
+	if err != nil {
+		return token, fmt.Errorf("could not refresh the token for profile %q (run `schemabot login`): %w", profileName, err)
+	}
+
+	profile.Token = result.IDToken
+	if result.RefreshToken != "" {
+		profile.RefreshToken = result.RefreshToken
+	}
+	if !result.Expiry.IsZero() {
+		profile.TokenExpiry = result.Expiry.Unix()
+	}
+	cfg.Profiles[profileName] = profile
+	if err := SaveConfig(cfg); err != nil {
+		// The refreshed token is usable for this run even if it could not be saved.
+		return result.IDToken, fmt.Errorf("could not persist the refreshed token for profile %q: %w", profileName, err)
+	}
+	return result.IDToken, nil
 }
 
 func trimSlash(s string) string {

--- a/pkg/cmd/client/login_test.go
+++ b/pkg/cmd/client/login_test.go
@@ -31,19 +31,21 @@ type fakeOIDC struct {
 	stateOverride string // when set, echo this state instead of the request's
 	authError     string // when set, redirect with ?error=<authError>
 
-	idToken      string
-	accessToken  string
-	refreshToken string
-	omitIDToken  bool // when true, the token response omits the id_token
+	idToken          string
+	refreshedIDToken string // id_token returned for the refresh_token grant
+	accessToken      string
+	refreshToken     string
+	omitIDToken      bool // when true, the token response omits the id_token
 }
 
 func newFakeOIDC(t *testing.T) *fakeOIDC {
 	t.Helper()
 	f := &fakeOIDC{
-		challenges:   map[string]string{},
-		idToken:      "header.payload.signature",
-		accessToken:  "test-access-token",
-		refreshToken: "test-refresh-token",
+		challenges:       map[string]string{},
+		idToken:          "header.payload.signature",
+		refreshedIDToken: "refreshed.payload.signature",
+		accessToken:      "test-access-token",
+		refreshToken:     "test-refresh-token",
 	}
 
 	mux := http.NewServeMux()
@@ -99,6 +101,25 @@ func (f *fakeOIDC) handleToken(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "bad form", http.StatusBadRequest)
 		return
 	}
+	if r.Form.Get("grant_type") == "refresh_token" {
+		if r.Form.Get("refresh_token") == "" {
+			http.Error(w, `{"error":"invalid_grant"}`, http.StatusBadRequest)
+			return
+		}
+		body := map[string]any{
+			"access_token":  f.accessToken,
+			"token_type":    "Bearer",
+			"refresh_token": f.refreshToken,
+			"expires_in":    3600,
+		}
+		if !f.omitIDToken {
+			body["id_token"] = f.refreshedIDToken
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+		return
+	}
+
 	code := r.Form.Get("code")
 	verifier := r.Form.Get("code_verifier")
 

--- a/pkg/cmd/client/refresh.go
+++ b/pkg/cmd/client/refresh.go
@@ -1,0 +1,54 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"golang.org/x/oauth2"
+)
+
+// RefreshToken exchanges a refresh token for a fresh set of tokens at the
+// issuer's token endpoint, using the same public client as login. It returns the
+// new ID token plus the rotated refresh token and expiry when the provider
+// issues them, so a cached session can be renewed without another browser
+// round-trip. RedirectPort is unused for the refresh grant.
+func RefreshToken(ctx context.Context, cfg LoginConfig, refreshToken string) (*LoginResult, error) {
+	if cfg.Issuer == "" {
+		return nil, errors.New("refresh: issuer is required")
+	}
+	if cfg.ClientID == "" {
+		return nil, errors.New("refresh: client ID is required")
+	}
+	if refreshToken == "" {
+		return nil, errors.New("refresh: refresh token is required")
+	}
+
+	provider, err := oidc.NewProvider(ctx, cfg.Issuer)
+	if err != nil {
+		return nil, fmt.Errorf("discover OIDC provider %s: %w", cfg.Issuer, err)
+	}
+
+	oauthCfg := &oauth2.Config{
+		ClientID: cfg.ClientID,
+		Endpoint: provider.Endpoint(),
+	}
+	// TokenSource performs the refresh_token grant on the first Token() call.
+	token, err := oauthCfg.TokenSource(ctx, &oauth2.Token{RefreshToken: refreshToken}).Token()
+	if err != nil {
+		return nil, fmt.Errorf("refresh token at %s: %w", cfg.Issuer, err)
+	}
+
+	rawID, ok := token.Extra("id_token").(string)
+	if !ok || rawID == "" {
+		return nil, errors.New("refresh response did not include an id_token")
+	}
+
+	return &LoginResult{
+		IDToken:      rawID,
+		AccessToken:  token.AccessToken,
+		RefreshToken: token.RefreshToken,
+		Expiry:       token.Expiry,
+	}, nil
+}

--- a/pkg/cmd/client/refresh_test.go
+++ b/pkg/cmd/client/refresh_test.go
@@ -65,7 +65,7 @@ func TestResolveBearerToken(t *testing.T) {
 			Profiles: map[string]Profile{"default": {
 				Endpoint:     "https://schemabot.example",
 				Token:        "stale-token",
-				RefreshToken: "test-refresh-token",
+				RefreshToken: "old-refresh-token",
 				TokenExpiry:  time.Now().Add(-time.Hour).Unix(),
 				OIDC:         &OIDCLogin{Issuer: f.issuer(), ClientID: "cli-client"},
 			}},
@@ -75,10 +75,12 @@ func TestResolveBearerToken(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, f.refreshedIDToken, tok)
 
-		// The rotated token and a fresh expiry are persisted for the next command.
+		// The rotated ID token, the rotated refresh token, and a fresh expiry are
+		// all persisted for the next command.
 		reloaded, err := LoadConfig()
 		require.NoError(t, err)
 		assert.Equal(t, f.refreshedIDToken, reloaded.Profiles["default"].Token)
+		assert.Equal(t, f.refreshToken, reloaded.Profiles["default"].RefreshToken)
 		assert.Greater(t, reloaded.Profiles["default"].TokenExpiry, time.Now().Unix())
 	})
 

--- a/pkg/cmd/client/refresh_test.go
+++ b/pkg/cmd/client/refresh_test.go
@@ -1,0 +1,101 @@
+package client
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRefreshToken(t *testing.T) {
+	t.Run("exchanges refresh token for a new id token", func(t *testing.T) {
+		f := newFakeOIDC(t)
+		result, err := RefreshToken(t.Context(), LoginConfig{Issuer: f.issuer(), ClientID: "cli-client"}, "test-refresh-token")
+		require.NoError(t, err)
+		assert.Equal(t, f.refreshedIDToken, result.IDToken)
+		assert.Equal(t, f.refreshToken, result.RefreshToken)
+		assert.False(t, result.Expiry.IsZero())
+	})
+
+	t.Run("validates required input before any network call", func(t *testing.T) {
+		_, err := RefreshToken(t.Context(), LoginConfig{ClientID: "c"}, "r")
+		assert.ErrorContains(t, err, "issuer")
+		_, err = RefreshToken(t.Context(), LoginConfig{Issuer: "https://i"}, "r")
+		assert.ErrorContains(t, err, "client ID")
+		_, err = RefreshToken(t.Context(), LoginConfig{Issuer: "https://i", ClientID: "c"}, "")
+		assert.ErrorContains(t, err, "refresh token")
+	})
+}
+
+func TestResolveBearerToken(t *testing.T) {
+	t.Run("flag and env take precedence and never refresh", func(t *testing.T) {
+		writeConfig(t, &Config{Profiles: map[string]Profile{"default": {Token: "from-profile"}}}, 0o600)
+		t.Setenv("SCHEMABOT_TOKEN", "")
+		tok, err := ResolveBearerToken(t.Context(), "from-flag", "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "from-flag", tok)
+
+		t.Setenv("SCHEMABOT_TOKEN", "from-env")
+		tok, err = ResolveBearerToken(t.Context(), "", "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "from-env", tok)
+	})
+
+	t.Run("unexpired token is returned as-is", func(t *testing.T) {
+		t.Setenv("SCHEMABOT_TOKEN", "")
+		writeConfig(t, &Config{
+			DefaultProfile: "default",
+			Profiles: map[string]Profile{"default": {
+				Endpoint:    "https://schemabot.example",
+				Token:       "still-valid",
+				TokenExpiry: time.Now().Add(time.Hour).Unix(),
+			}},
+		}, 0o600)
+		tok, err := ResolveBearerToken(t.Context(), "", "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "still-valid", tok)
+	})
+
+	t.Run("expired token is refreshed and persisted", func(t *testing.T) {
+		t.Setenv("SCHEMABOT_TOKEN", "")
+		f := newFakeOIDC(t)
+		writeConfig(t, &Config{
+			DefaultProfile: "default",
+			Profiles: map[string]Profile{"default": {
+				Endpoint:     "https://schemabot.example",
+				Token:        "stale-token",
+				RefreshToken: "test-refresh-token",
+				TokenExpiry:  time.Now().Add(-time.Hour).Unix(),
+				OIDC:         &OIDCLogin{Issuer: f.issuer(), ClientID: "cli-client"},
+			}},
+		}, 0o600)
+
+		tok, err := ResolveBearerToken(t.Context(), "", "", "")
+		require.NoError(t, err)
+		assert.Equal(t, f.refreshedIDToken, tok)
+
+		// The rotated token and a fresh expiry are persisted for the next command.
+		reloaded, err := LoadConfig()
+		require.NoError(t, err)
+		assert.Equal(t, f.refreshedIDToken, reloaded.Profiles["default"].Token)
+		assert.Greater(t, reloaded.Profiles["default"].TokenExpiry, time.Now().Unix())
+	})
+
+	t.Run("expired token with no refresh token returns stale token and a warning", func(t *testing.T) {
+		t.Setenv("SCHEMABOT_TOKEN", "")
+		writeConfig(t, &Config{
+			DefaultProfile: "default",
+			Profiles: map[string]Profile{"default": {
+				Endpoint:    "https://schemabot.example",
+				Token:       "stale-token",
+				TokenExpiry: time.Now().Add(-time.Hour).Unix(),
+			}},
+		}, 0o600)
+
+		tok, err := ResolveBearerToken(t.Context(), "", "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expired")
+		assert.Equal(t, "stale-token", tok, "stale token is still returned so the command can run and re-login can fix it")
+	})
+}

--- a/pkg/cmd/commands/login.go
+++ b/pkg/cmd/commands/login.go
@@ -88,6 +88,9 @@ func (cmd *LoginCmd) Run(g *Globals) error {
 	// without another browser login.
 	profile.Token = result.IDToken
 	profile.RefreshToken = result.RefreshToken
+	// Clear expiry when the provider omits one so a stale value can't make the
+	// new token look immediately expired to the refresh path.
+	profile.TokenExpiry = 0
 	if !result.Expiry.IsZero() {
 		profile.TokenExpiry = result.Expiry.Unix()
 	}

--- a/pkg/cmd/commands/login.go
+++ b/pkg/cmd/commands/login.go
@@ -84,8 +84,13 @@ func (cmd *LoginCmd) Run(g *Globals) error {
 
 	// Cache the ID token: it carries the user identity and groups the server's
 	// OIDC authorizer validates, and its aud is the CLI client ID the server is
-	// configured to accept.
+	// configured to accept. The refresh token and expiry let the CLI renew it
+	// without another browser login.
 	profile.Token = result.IDToken
+	profile.RefreshToken = result.RefreshToken
+	if !result.Expiry.IsZero() {
+		profile.TokenExpiry = result.Expiry.Unix()
+	}
 	cfg.Profiles[profileName] = profile
 	if err := client.SaveConfig(cfg); err != nil {
 		return fmt.Errorf("save token to profile %q: %w", profileName, err)

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -64,12 +65,19 @@ func main() {
 	cli.Commit = commit
 	cli.Date = date
 
-	// Authenticate every API request with the resolved Bearer token. Empty when
-	// no token is configured, which is correct against a server with auth off.
-	token, err := client.ResolveToken(cli.Token, cli.Endpoint, cli.Profile)
+	// Authenticate every API request with the resolved Bearer token, renewing an
+	// expired cached token first. Empty when no token is configured, which is
+	// correct against a server with auth off.
+	token, err := client.ResolveBearerToken(context.Background(), cli.Token, cli.Endpoint, cli.Profile)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "\033[31mError: %v\033[0m\n", err)
-		os.Exit(1)
+		// Per ResolveBearerToken's contract: an empty token with an error is a hard
+		// failure; a non-empty token with an error is a non-fatal warning (the
+		// returned token is still usable and re-login can fix it).
+		if token == "" {
+			fmt.Fprintf(os.Stderr, "\033[31mError: %v\033[0m\n", err)
+			os.Exit(1)
+		}
+		fmt.Fprintf(os.Stderr, "\033[33mWarning: %v\033[0m\n", err)
 	}
 	client.SetAuthToken(token)
 

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/alecthomas/kong"
 
@@ -68,7 +69,12 @@ func main() {
 	// Authenticate every API request with the resolved Bearer token, renewing an
 	// expired cached token first. Empty when no token is configured, which is
 	// correct against a server with auth off.
-	token, err := client.ResolveBearerToken(context.Background(), cli.Token, cli.Endpoint, cli.Profile)
+	// Bound the resolution so a slow or unreachable issuer during a token refresh
+	// can't hang the CLI at startup. Cancel as soon as it returns rather than via
+	// defer, since the os.Exit below would skip a deferred cancel.
+	authCtx, cancelAuth := context.WithTimeout(context.Background(), 30*time.Second)
+	token, err := client.ResolveBearerToken(authCtx, cli.Token, cli.Endpoint, cli.Profile)
+	cancelAuth()
 	if err != nil {
 		// Per ResolveBearerToken's contract: an empty token with an error is a hard
 		// failure; a non-empty token with an error is a non-fatal warning (the


### PR DESCRIPTION
Completes the CLI OIDC flow: an expired cached token is renewed automatically before each command, so users don't have to re-run `schemabot login` every session.

**What it does**
- `schemabot login` now persists the refresh token and expiry on the profile (a stored refresh token also triggers the config-permission check).
- `RefreshToken` exchanges a refresh token for a fresh ID token at the issuer's `refresh_token` grant, reusing the public client.
- `ResolveBearerToken` renews a cached token that is within the refresh skew of expiry and persists the rotated token; flag/env tokens are used as-is, and tokens with unknown expiry are left untouched.

**Failure handling**
Refresh failure is non-fatal: the resolver returns the stale token plus a warning so the command still runs and the user can re-authenticate. Only a hard config error (e.g. unknown profile) blocks.

```
schemabot <cmd>
  └─ resolve token ─ expired? ─ yes ─ refresh_token grant ─ ok ─ persist + use new token
                       │                                     └─ fail ─ warn + use stale token
                       └─ no ─ use cached token
```

Lands dark — only exercised once a profile is logged into an OIDC-enabled server.