### PR TITLE
feat(storage): add ReapplyFailed for requeuing failed schema changes

### DIFF
--- a/pkg/storage/errors.go
+++ b/pkg/storage/errors.go
@@ -29,6 +29,9 @@ var (
 	// for the same database, type, and environment.
 	ErrActiveApplyExists = errors.New("active apply already exists")
 
+	// ErrApplyNotReappliable is returned when a failed apply cannot be reapplied.
+	ErrApplyNotReappliable = errors.New("apply is not reappliable")
+
 	// ErrApplyLeaseLost is returned when an operator-owned write no longer
 	// matches the apply lease token stored by the latest operator claimant.
 	ErrApplyLeaseLost = errors.New("apply lease lost")

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -1762,6 +1762,135 @@ func (s *applyStore) ExpireRetryable(ctx context.Context) ([]*storage.RetryableA
 	return expirations, nil
 }
 
+// ReapplyFailed transitions a recent permanently failed apply back onto the
+// retryable recovery path so operator drivers can claim and drive the
+// remaining failed work.
+func (s *applyStore) ReapplyFailed(ctx context.Context, applyID int64) (*storage.Apply, error) {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
+	if err != nil {
+		return nil, fmt.Errorf("begin reapply failed apply %d transaction: %w", applyID, err)
+	}
+	defer rollbackTx(ctx, tx, "reapply failed apply")
+
+	row := tx.QueryRowContext(ctx, `
+		SELECT `+applyColumns+`
+		FROM applies
+		WHERE id = ?
+		FOR UPDATE
+	`, applyID)
+	apply, err := scanApply(row)
+	if err != nil {
+		return nil, fmt.Errorf("load apply %d for reapply: %w", applyID, err)
+	}
+	if apply == nil {
+		return nil, storage.ErrApplyNotFound
+	}
+	if !state.IsState(apply.State, state.Apply.Failed) {
+		return nil, fmt.Errorf("apply %s is %s; only failed applies can be reapplied: %w", apply.ApplyIdentifier, apply.State, storage.ErrApplyNotReappliable)
+	}
+	if apply.CompletedAt == nil {
+		return nil, fmt.Errorf("apply %s has no failure completion time; create a new apply instead: %w", apply.ApplyIdentifier, storage.ErrApplyNotReappliable)
+	}
+	if apply.CompletedAt.Before(time.Now().AddDate(0, 0, -storage.ReapplyFailureFreshnessDays)) {
+		return nil, fmt.Errorf("apply %s failed more than %d day(s) ago; create a new apply instead: %w", apply.ApplyIdentifier, storage.ReapplyFailureFreshnessDays, storage.ErrApplyNotReappliable)
+	}
+
+	database, dbType, environment, deployment := apply.Database, apply.DatabaseType, apply.Environment, apply.Deployment
+	if !hasApplyTarget(database, dbType, environment) || deployment == "" {
+		database, dbType, environment, deployment, err = applyTargetForUpdate(ctx, tx, apply)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if !hasApplyTarget(database, dbType, environment) || deployment == "" {
+		return nil, fmt.Errorf("apply %s is missing target metadata for reapply: %w", apply.ApplyIdentifier, storage.ErrApplyNotReappliable)
+	}
+
+	conn, lockName, err := acquireApplyTargetLockConn(ctx, s.db, database, dbType, environment)
+	if err != nil {
+		return nil, err
+	}
+	defer releaseApplyTargetLockConn(ctx, conn, lockName, "reapply failed apply")
+
+	deployments, err := operationDeploymentsForApply(ctx, tx, apply.ID)
+	if err != nil {
+		return nil, err
+	}
+	deployments = append(deployments, deployment)
+	if err := checkNoActiveApplyForTargets(ctx, tx, database, dbType, environment, deployments, apply.ID); err != nil {
+		return nil, err
+	}
+	if err := rejectNonReappliableOperations(ctx, tx, apply); err != nil {
+		return nil, err
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE tasks t
+		LEFT JOIN apply_operations ao ON ao.id = t.apply_operation_id
+		SET t.state = ?, t.error_message = '', t.completed_at = NULL, t.updated_at = NOW()
+		WHERE t.apply_id = ?
+			AND t.state IN (?, ?)
+			AND (t.apply_operation_id IS NULL OR ao.state = ?)
+	`, state.Task.FailedRetryable, apply.ID, state.Task.Failed, state.Task.Cancelled, state.ApplyOperation.Failed); err != nil {
+		return nil, fmt.Errorf("mark failed tasks retryable for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE apply_operations
+		SET state = ?, error_message = '', completed_at = NULL, updated_at = NOW(),
+		    lease_owner = '', lease_token = '', lease_acquired_at = NULL
+		WHERE apply_id = ? AND state = ?
+	`, state.ApplyOperation.FailedRetryable, apply.ID, state.ApplyOperation.Failed); err != nil {
+		return nil, fmt.Errorf("mark failed operations retryable for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+
+	result, err := tx.ExecContext(ctx, `
+		UPDATE applies
+		SET state = ?, error_message = '', attempt = 0, completed_at = NULL, updated_at = NOW(),
+		    lease_owner = '', lease_token = '', lease_acquired_at = NULL
+		WHERE id = ? AND state = ?
+	`, state.Apply.FailedRetryable, apply.ID, state.Apply.Failed)
+	if err != nil {
+		return nil, fmt.Errorf("mark apply %s retryable for reapply: %w", apply.ApplyIdentifier, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("read reapply rows affected for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if rows == 0 {
+		return nil, fmt.Errorf("apply %s changed before reapply: %w", apply.ApplyIdentifier, storage.ErrApplyNotReappliable)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit reapply failed apply %s: %w", apply.ApplyIdentifier, err)
+	}
+
+	apply.State = state.Apply.FailedRetryable
+	apply.ErrorMessage = ""
+	apply.Attempt = 0
+	apply.CompletedAt = nil
+	apply.UpdatedAt = time.Now()
+	apply.LeaseOwner = ""
+	apply.LeaseToken = ""
+	apply.LeaseAcquiredAt = nil
+	return apply, nil
+}
+
+func rejectNonReappliableOperations(ctx context.Context, tx *sql.Tx, apply *storage.Apply) error {
+	var count int
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM apply_operations
+		WHERE apply_id = ? AND state IN (?, ?, ?)
+	`, apply.ID, state.ApplyOperation.Stopped, state.ApplyOperation.Cancelled, state.ApplyOperation.Reverted).Scan(&count); err != nil {
+		return fmt.Errorf("check non-reappliable operations for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if count > 0 {
+		return fmt.Errorf("apply %s has %d stopped, cancelled, or reverted operation(s); create a new apply instead: %w", apply.ApplyIdentifier, count, storage.ErrApplyNotReappliable)
+	}
+	return nil
+}
+
 func retryableExpirationReason(apply *storage.Apply) storage.RetryableExpirationReason {
 	if apply.Attempt >= maxRecoveryAttempts {
 		return storage.RetryableExpirationAttemptBudget

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -1826,8 +1826,8 @@ func (s *applyStore) ReapplyFailed(ctx context.Context, applyID int64) (*storage
 
 	if _, err := tx.ExecContext(ctx, `
 		UPDATE tasks t
-		LEFT JOIN apply_operations ao ON ao.id = t.apply_operation_id
-		SET t.state = ?, t.error_message = '', t.completed_at = NULL, t.updated_at = NOW()
+		LEFT JOIN apply_operations ao ON ao.id = t.apply_operation_id AND ao.apply_id = t.apply_id
+		SET t.state = ?, t.error_message = NULL, t.completed_at = NULL, t.updated_at = NOW()
 		WHERE t.apply_id = ?
 			AND t.state IN (?, ?)
 			AND (t.apply_operation_id IS NULL OR ao.state = ?)
@@ -1837,7 +1837,7 @@ func (s *applyStore) ReapplyFailed(ctx context.Context, applyID int64) (*storage
 
 	if _, err := tx.ExecContext(ctx, `
 		UPDATE apply_operations
-		SET state = ?, error_message = '', completed_at = NULL, updated_at = NOW(),
+		SET state = ?, error_message = NULL, completed_at = NULL, updated_at = NOW(),
 		    lease_owner = '', lease_token = '', lease_acquired_at = NULL
 		WHERE apply_id = ? AND state = ?
 	`, state.ApplyOperation.FailedRetryable, apply.ID, state.ApplyOperation.Failed); err != nil {

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -2629,6 +2629,177 @@ func TestApplyStore_ExpireRetryableTerminalizesRetryableOperations(t *testing.T)
 	assert.Equal(t, state.ApplyOperation.WaitingForCutover, parkedOp.State, "a healthy successor parked at the cutover barrier must be left untouched")
 }
 
+// TestApplyStore_ReapplyFailed verifies that deliberate reapply reopens a
+// recent failed apply while preserving completed work as already done.
+func TestApplyStore_ReapplyFailed(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_reapply_failed", 520, state.Apply.Failed, "staging")
+	now := time.Now()
+	apply.Attempt = maxRecoveryAttempts
+	apply.Deployment = "region-a"
+	apply.ErrorMessage = "retry budget exhausted"
+	apply.CompletedAt = &now
+	require.NoError(t, store.Applies().Update(ctx, apply))
+	_, err := testDB.ExecContext(ctx, `UPDATE applies SET deployment = ? WHERE id = ?`, apply.Deployment, apply.ID)
+	require.NoError(t, err)
+
+	_, err = store.Tasks().Create(ctx, &storage.Task{
+		TaskIdentifier: "task_reapply_failed",
+		ApplyID:        apply.ID,
+		PlanID:         apply.PlanID,
+		Database:       apply.Database,
+		DatabaseType:   apply.DatabaseType,
+		Engine:         storage.EngineSpirit,
+		Environment:    apply.Environment,
+		State:          state.Task.Failed,
+		ErrorMessage:   "copy failed",
+		TableName:      "orders",
+		Options:        []byte("{}"),
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	})
+	require.NoError(t, err)
+	_, err = store.Tasks().Create(ctx, &storage.Task{
+		TaskIdentifier: "task_reapply_completed",
+		ApplyID:        apply.ID,
+		PlanID:         apply.PlanID,
+		Database:       apply.Database,
+		DatabaseType:   apply.DatabaseType,
+		Engine:         storage.EngineSpirit,
+		Environment:    apply.Environment,
+		State:          state.Task.Completed,
+		TableName:      "customers",
+		Options:        []byte("{}"),
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		CompletedAt:    &now,
+	})
+	require.NoError(t, err)
+
+	failedOpID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-a", State: state.ApplyOperation.Failed, ErrorMessage: "copy failed",
+	})
+	require.NoError(t, err)
+	completedOpID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: apply.ID, Deployment: "region-b", State: state.ApplyOperation.Completed, CompletedAt: &now,
+	})
+	require.NoError(t, err)
+
+	reapplied, err := store.Applies().ReapplyFailed(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, reapplied)
+	assert.Equal(t, state.Apply.FailedRetryable, reapplied.State)
+	assert.Zero(t, reapplied.Attempt)
+	assert.Empty(t, reapplied.ErrorMessage)
+	assert.Nil(t, reapplied.CompletedAt)
+
+	failedTask, err := store.Tasks().Get(ctx, "task_reapply_failed")
+	require.NoError(t, err)
+	require.NotNil(t, failedTask)
+	assert.Equal(t, state.Task.FailedRetryable, failedTask.State)
+	assert.Empty(t, failedTask.ErrorMessage)
+	assert.Nil(t, failedTask.CompletedAt)
+
+	completedTask, err := store.Tasks().Get(ctx, "task_reapply_completed")
+	require.NoError(t, err)
+	require.NotNil(t, completedTask)
+	assert.Equal(t, state.Task.Completed, completedTask.State)
+	assert.NotNil(t, completedTask.CompletedAt)
+
+	failedOp, err := store.ApplyOperations().Get(ctx, failedOpID)
+	require.NoError(t, err)
+	require.NotNil(t, failedOp)
+	assert.Equal(t, state.ApplyOperation.FailedRetryable, failedOp.State)
+	assert.Empty(t, failedOp.ErrorMessage)
+	assert.Nil(t, failedOp.CompletedAt)
+
+	completedOp, err := store.ApplyOperations().Get(ctx, completedOpID)
+	require.NoError(t, err)
+	require.NotNil(t, completedOp)
+	assert.Equal(t, state.ApplyOperation.Completed, completedOp.State)
+	assert.NotNil(t, completedOp.CompletedAt)
+}
+
+func TestApplyStore_ReapplyFailedRejectsOldFailure(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_reapply_old_failed", 521, state.Apply.Failed, "staging")
+	completedAt := time.Now().AddDate(0, 0, -storage.ReapplyFailureFreshnessDays-1)
+	apply.Deployment = "region-a"
+	apply.CompletedAt = &completedAt
+	require.NoError(t, store.Applies().Update(ctx, apply))
+	_, err := testDB.ExecContext(ctx, `UPDATE applies SET deployment = ?, completed_at = ? WHERE id = ?`, apply.Deployment, completedAt, apply.ID)
+	require.NoError(t, err)
+
+	reapplied, err := store.Applies().ReapplyFailed(ctx, apply.ID)
+	require.ErrorIs(t, err, storage.ErrApplyNotReappliable)
+	assert.Nil(t, reapplied)
+}
+
+func TestApplyStore_ReapplyFailedRejectsNonReappliableOperation(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		operationState string
+		taskState      string
+	}{
+		{name: "stopped", operationState: state.ApplyOperation.Stopped, taskState: state.Task.Stopped},
+		{name: "cancelled", operationState: state.ApplyOperation.Cancelled, taskState: state.Task.Cancelled},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearTables(t)
+			ctx := t.Context()
+			store := New(testDB)
+
+			lock := createTestLock(t, store, "testdb", storage.DatabaseTypeMySQL, "staging")
+			apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_reapply_"+tc.name+"_operation", 522, state.Apply.Failed, "staging")
+			now := time.Now()
+			apply.Deployment = "region-a"
+			apply.CompletedAt = &now
+			require.NoError(t, store.Applies().Update(ctx, apply))
+			_, err := testDB.ExecContext(ctx, `UPDATE applies SET deployment = ? WHERE id = ?`, apply.Deployment, apply.ID)
+			require.NoError(t, err)
+
+			operationID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+				ApplyID: apply.ID, Deployment: "region-a", State: tc.operationState, CompletedAt: &now,
+			})
+			require.NoError(t, err)
+			_, err = store.Tasks().Create(ctx, &storage.Task{
+				TaskIdentifier:   "task_reapply_" + tc.name + "_operation",
+				ApplyID:          apply.ID,
+				ApplyOperationID: &operationID,
+				PlanID:           apply.PlanID,
+				Database:         apply.Database,
+				DatabaseType:     apply.DatabaseType,
+				Engine:           storage.EngineSpirit,
+				Environment:      apply.Environment,
+				State:            tc.taskState,
+				TableName:        "orders",
+				Options:          []byte("{}"),
+				CreatedAt:        now,
+				UpdatedAt:        now,
+				CompletedAt:      &now,
+			})
+			require.NoError(t, err)
+
+			reapplied, err := store.Applies().ReapplyFailed(ctx, apply.ID)
+			require.ErrorIs(t, err, storage.ErrApplyNotReappliable)
+			assert.Nil(t, reapplied)
+
+			task, err := store.Tasks().Get(ctx, "task_reapply_"+tc.name+"_operation")
+			require.NoError(t, err)
+			require.NotNil(t, task)
+			assert.Equal(t, tc.taskState, task.State)
+		})
+	}
+}
+
 func TestApplyStore_FindMissingSummaryComment_ExcludesAppliesWithoutGitHubDestination(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -7,6 +7,11 @@ import (
 	"time"
 )
 
+// ReapplyFailureFreshnessDays bounds deliberate reapply of terminal failed
+// applies. Older failures should be handled by creating a fresh apply from a
+// fresh plan so stale execution context is not reactivated unexpectedly.
+const ReapplyFailureFreshnessDays = 1
+
 // Storage provides access to all stores.
 type Storage interface {
 	// Locks returns the lock store.
@@ -323,6 +328,14 @@ type ApplyStore interface {
 	// retry budget or recovery freshness window to permanent failed. Returns the
 	// applies updated.
 	ExpireRetryable(ctx context.Context) ([]*RetryableApplyExpiration, error)
+
+	// ReapplyFailed transitions a recent permanently failed apply back onto the
+	// retryable recovery path. Completed work remains completed; failed tasks and
+	// operation rows become failed_retryable so operator drivers can claim and
+	// drive only the remaining work. The transition re-checks active-apply
+	// exclusivity under the apply target lock because it makes a terminal apply
+	// active again.
+	ReapplyFailed(ctx context.Context, applyID int64) (*Apply, error)
 
 	// FindMissingSummaryComment returns GitHub-backed applies that should have
 	// a terminal summary comment but only have a progress comment. Used by


### PR DESCRIPTION
## Why
Operators need to retry a recently failed schema change without re-authoring it. The foundation is a storage method that requeues a failed apply for a fresh attempt.

## What
- Add `ReapplyFailed`, which requeues a failed apply for a fresh attempt.
- Add the `ErrApplyNotReappliable` sentinel for applies that aren't eligible.
- Add the interface entry + storage tests.

## Risk Assessment
Low — additive storage method with no callers yet. The endpoint, lock-ownership enforcement, and CLI land in stacked follow-ups.

This is PR 1 of 4 splitting the reapply feature (storage → API → lock ownership → CLI). Supersedes the combined PR.

---
*PR authored with Claude Code (Opus 4.8).*
