### PR TITLE
fix(config): accept deprecated driver keys to prevent crashloop

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -622,7 +622,7 @@ The operator is part of Tern orchestration. The API service starts it on server 
 
 Each operator driver runs immediately on startup, then polls every 10 seconds. The driver claims at most one apply per tick and resumes it through the Tern client for that apply's deployment and environment. Fresh applies also send a best-effort wake signal after their apply and task rows are committed, so a driver can claim them immediately instead of waiting for the next poll tick.
 
-`drivers` controls operator concurrency. The default is four drivers, so an untuned server can still make progress across independent databases and environments concurrently. More drivers help larger installations with many independent schema changes because each driver can claim and resume a different target during the same operator tick.
+`drivers` controls operator concurrency (the deprecated `operator_workers` and `scheduler_workers` aliases are still accepted with a deprecation warning). The default is four drivers, so an untuned server can still make progress across independent databases and environments concurrently. More drivers help larger installations with many independent schema changes because each driver can claim and resume a different target during the same operator tick.
 
 In a multi-pod deployment, every SchemaBot pod runs its own operator. Each operator has its own configurable driver pool, and every driver coordinates through shared storage before resuming an apply. When a recovered apply came from a PR comment, the driver attaches a reconstructed `ProgressObserver` before calling `ResumeApply()` so the resumed progress poller can keep updating PR comments.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -271,6 +271,8 @@ Increase `drivers` when one SchemaBot server should make operator progress acros
 
 A driver claim means selecting one stale apply and refreshing its heartbeat in the same storage transaction. That heartbeat refresh is the driver's lease while it reloads state and drives the apply to a terminal state.
 
+> **Deprecated:** the previous `operator_workers` and `scheduler_workers` keys still work as aliases for `drivers` and are honored with a deprecation warning. Set only one of the three. The aliases will be removed once deployed configs no longer set them.
+
 ## Pending Drops
 
 For MySQL databases executed by the Spirit engine, `DROP TABLE` statements are

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -108,6 +108,23 @@ type ServerConfig struct {
 	// SKIP LOCKED to prevent races. Defaults to DefaultDrivers.
 	Drivers int `yaml:"drivers"`
 
+	// OperatorWorkers is the deprecated alias for Drivers. It is kept so existing
+	// config files that still set operator_workers continue to load (the YAML
+	// decoder runs with KnownFields(true) and would otherwise reject the unknown
+	// key, crashlooping the server). Validate() folds it into Drivers when the
+	// new key is unset and logs a deprecation warning. Remove once deployed
+	// configs no longer set this key.
+	//
+	// Deprecated: use drivers.
+	OperatorWorkers int `yaml:"operator_workers,omitempty"`
+
+	// SchedulerWorkers is the original deprecated alias for Drivers, predating
+	// operator_workers. It is kept for the same KnownFields(true) reason and is
+	// folded into Drivers by Validate() with a deprecation warning.
+	//
+	// Deprecated: use drivers.
+	SchedulerWorkers int `yaml:"scheduler_workers,omitempty"`
+
 	// OperatorClaimOperations switches drivers to claim work at the
 	// apply_operations (per-deployment) level via FindNextApplyOperation instead
 	// of the apply level via FindNextApply. While every apply still owns exactly
@@ -737,8 +754,44 @@ func LoadServerConfigFromFile(path string) (*ServerConfig, error) {
 	return &config, nil
 }
 
+// resolveDeprecatedDrivers folds the deprecated operator_workers and
+// scheduler_workers keys into drivers. When only a deprecated key is set it is
+// honored and a deprecation warning is logged; setting more than one of the
+// three keys is rejected so the effective value is never ambiguous.
+func (c *ServerConfig) resolveDeprecatedDrivers() error {
+	set := 0
+	if c.Drivers != 0 {
+		set++
+	}
+	if c.OperatorWorkers != 0 {
+		set++
+	}
+	if c.SchedulerWorkers != 0 {
+		set++
+	}
+	if set > 1 {
+		return fmt.Errorf("set only one of drivers, operator_workers, or scheduler_workers (operator_workers and scheduler_workers are deprecated)")
+	}
+
+	if c.OperatorWorkers != 0 {
+		slog.Warn("operator_workers is deprecated; use drivers", "operator_workers", c.OperatorWorkers)
+		c.Drivers = c.OperatorWorkers
+		c.OperatorWorkers = 0
+	}
+	if c.SchedulerWorkers != 0 {
+		slog.Warn("scheduler_workers is deprecated; use drivers", "scheduler_workers", c.SchedulerWorkers)
+		c.Drivers = c.SchedulerWorkers
+		c.SchedulerWorkers = 0
+	}
+	return nil
+}
+
 // Validate checks the configuration for required fields and consistency.
 func (c *ServerConfig) Validate() error {
+	if err := c.resolveDeprecatedDrivers(); err != nil {
+		return err
+	}
+
 	// The database registry is required for the control plane and for a
 	// single-database data plane. A data plane configured with a target_resolver
 	// resolves opaque targets dynamically and has no database registry, so it is

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -123,6 +123,46 @@ repos:
 	assert.False(t, cfg.AreChecksEnabled("org/repo"))
 }
 
+// Deployed configs predating the driver rename still set the deprecated
+// scheduler_workers / operator_workers keys. The strict YAML decoder
+// (KnownFields(true)) must accept them so the server loads instead of
+// crashlooping, and the value must fold into drivers so operator intent is
+// preserved.
+func TestLoadServerConfigFromFile_DeprecatedDriverKeys(t *testing.T) {
+	cases := []struct {
+		name string
+		key  string
+	}{
+		{name: "scheduler_workers", key: "scheduler_workers"},
+		{name: "operator_workers", key: "operator_workers"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			configPath := filepath.Join(dir, "config.yaml")
+			content := tc.key + `: 4
+databases:
+  testapp:
+    type: mysql
+    environments:
+      staging:
+        target: testapp-staging
+        deployment: default
+tern_deployments:
+  default:
+    staging: "tern-staging:9090"
+`
+			require.NoError(t, os.WriteFile(configPath, []byte(content), 0644), "write config file")
+
+			cfg, err := LoadServerConfigFromFile(configPath)
+			require.NoError(t, err, "deprecated %s must not crashloop the loader", tc.key)
+			assert.Equal(t, 4, cfg.Drivers, "deprecated %s must fold into drivers", tc.key)
+			assert.Equal(t, 0, cfg.OperatorWorkers)
+			assert.Equal(t, 0, cfg.SchedulerWorkers)
+		})
+	}
+}
+
 func TestLoadServerConfigFromFile_DSNFrom(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.yaml")

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -28,6 +28,25 @@ func TestDriversConfig(t *testing.T) {
 		config := &ServerConfig{Drivers: 3}
 		assert.Equal(t, 3, config.Drivers)
 	})
+
+	t.Run("deprecated operator_workers folds into drivers", func(t *testing.T) {
+		config := &ServerConfig{OperatorWorkers: 2}
+		require.NoError(t, config.resolveDeprecatedDrivers())
+		assert.Equal(t, 2, config.Drivers)
+		assert.Equal(t, 0, config.OperatorWorkers)
+	})
+
+	t.Run("deprecated scheduler_workers folds into drivers", func(t *testing.T) {
+		config := &ServerConfig{SchedulerWorkers: 2}
+		require.NoError(t, config.resolveDeprecatedDrivers())
+		assert.Equal(t, 2, config.Drivers)
+		assert.Equal(t, 0, config.SchedulerWorkers)
+	})
+
+	t.Run("setting multiple keys is rejected", func(t *testing.T) {
+		config := &ServerConfig{Drivers: 4, OperatorWorkers: 2}
+		assert.Error(t, config.resolveDeprecatedDrivers())
+	})
 }
 
 // recordingApplyOperationStore records the state-mutating call made by


### PR DESCRIPTION
## Summary
The server config decoder runs with `KnownFields(true)`, so any unknown YAML key is a hard parse error before validation runs. A prior cleanup removed the `operator_workers` / `scheduler_workers` aliases, but deployed configs still set them — so on rollout the config fails to load and the server crashloops.

## What
Re-accept both deprecated keys: restore the struct fields (so the strict decoder no longer rejects them) and the fold logic in `Validate()`, which maps the legacy value into `drivers`, logs a deprecation warning, and rejects setting more than one of the three keys.

## Why
A config knob removal must not be able to crashloop a running fleet whose configs haven't been migrated yet. Folding (rather than ignoring) the legacy key preserves the operator's intended concurrency value. `KnownFields(true)` stays strict for genuine typos. The aliases can be removed again once deployed configs no longer set them.

## Before / after

```text
config: scheduler_workers: 4
  BEFORE                              AFTER
  KnownFields(true) decode           field is known → decode OK
    └─ ✗ "parse config file"           └─ Validate(): fold → drivers=4
         └─ 💥 crashloop on rollout         + warn "deprecated; use drivers"
```

A regression test loads a real config setting each legacy key end-to-end and asserts it folds to `drivers=4` instead of failing.
