### PR TITLE
feat(tern): shard-aware fail-closed drift guard on materialize

### DIFF
--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -1505,11 +1505,15 @@ func (c *LocalClient) materializeApplyRequestPlan(ctx context.Context, req *tern
 		return nil, fmt.Errorf("materialize plan %s: apply request carried no DDL changes or schema files", req.PlanId)
 	}
 
-	// The dispatch carries the reviewed plan's DDL verbatim, so the materialized
-	// plan is the reviewed plan — no re-plan-and-compare here. Drift between when
-	// the plan was reviewed and when it applies is reconciled the same way on
-	// every path: replanAndFilterTasks re-plans against live schema at apply/resume
-	// and drops or updates work, and the engine validates each change at execution.
+	// A non-primary deployment never planned locally, so materializing the
+	// primary's reviewed DDL could silently replay it against a deployment whose
+	// schema has drifted. Recompute this deployment's own diff against its live
+	// schema and refuse unless it exactly matches the dispatched (reviewed) DDL,
+	// keeping unreviewed DDL from being applied. The comparison is shard-aware: a
+	// shard-scoped dispatch is checked against the re-plan restricted to its shard.
+	if err := c.verifyMaterializedPlanMatchesLiveSchema(ctx, req, schemaFiles); err != nil {
+		return nil, fmt.Errorf("materialize plan %s: %w", req.PlanId, err)
+	}
 
 	target := req.Target
 	if target == "" {

--- a/pkg/tern/local_plan_drift.go
+++ b/pkg/tern/local_plan_drift.go
@@ -1,0 +1,243 @@
+package tern
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/block/schemabot/pkg/ddl"
+	"github.com/block/schemabot/pkg/engine"
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/schema"
+)
+
+// driftChangeKey identifies a single table DDL change for drift comparison. Two
+// changes are the same iff they target the same namespace, shard, and table with
+// the same operation and canonicalized DDL. The shard is part of the key because
+// a sharded engine emits one change set per shard and the same table repeats
+// across shards: keying without it would conflate a change on one shard with a
+// different change on another.
+type driftChangeKey struct {
+	namespace string
+	shard     string
+	table     string
+	operation string
+	ddl       string
+}
+
+// driftChangeMultiset counts table DDL changes by key so duplicate changes are
+// compared exactly (set equality would silently tolerate a duplicated change).
+type driftChangeMultiset map[driftChangeKey]int
+
+// verifyMaterializedPlanMatchesLiveSchema fails closed unless the reviewed DDL a
+// dispatch carries exactly matches what this deployment would independently plan
+// against its own live schema. A non-primary deployment never planned locally,
+// so materializing the primary's reviewed DDL could silently replay it against a
+// deployment whose schema has drifted; recomputing the local diff and requiring
+// an exact match keeps non-primary drift from being applied unreviewed.
+//
+// The comparison is shard-aware. A sharded engine's work is dispatched one
+// apply_operation per shard, so a request that carries a target shard is scoped
+// to that single shard: the reviewed DDL is compared against this deployment's
+// re-plan restricted to the same shard. A request with no target shard is a
+// whole-deployment (or non-sharded) apply, compared against the re-plan's
+// non-sharded changes.
+func (c *LocalClient) verifyMaterializedPlanMatchesLiveSchema(ctx context.Context, req *ternv1.ApplyRequest, schemaFiles schema.SchemaFiles) error {
+	shardScoped := len(req.TargetShards) > 0
+	targetShard := ""
+	if shardScoped {
+		shard, err := dispatchTargetShard(req.TargetShards)
+		if err != nil {
+			return fmt.Errorf("drift guard: %w", err)
+		}
+		targetShard = shard
+	}
+
+	result, err := c.planWithEngine(ctx, &ternv1.PlanRequest{
+		Database:    c.config.Database,
+		Type:        c.config.Type,
+		Environment: req.Environment,
+		Target:      req.Target,
+	}, c.config.Database, schemaFiles)
+	if err != nil {
+		return fmt.Errorf("recompute local plan: %w", err)
+	}
+
+	recomputed, err := c.driftMultisetFromPlanResult(result, shardScoped, targetShard)
+	if err != nil {
+		return fmt.Errorf("recomputed plan: %w", err)
+	}
+	dispatched, err := c.driftMultisetFromApplyRequest(req.DdlChanges, targetShard)
+	if err != nil {
+		return fmt.Errorf("dispatched plan: %w", err)
+	}
+	if err := compareDriftMultisets(recomputed, dispatched); err != nil {
+		return fmt.Errorf("local schema has drifted from the reviewed plan (database %q, target %q): %w", c.config.Database, req.Target, err)
+	}
+
+	// VSchema changes are namespace-level, not shard-scoped, and travel on the
+	// whole-deployment dispatch — a shard-scoped DDL dispatch never carries them
+	// (VSchema is applied by a separate task-less finalizer). So parity is only
+	// meaningful for a whole-deployment materialize.
+	if !shardScoped {
+		if err := compareVSchemaParity(vschemaNamespacesFromPlanResult(c, result), vschemaNamespacesFromApplyRequest(c, req.DdlChanges)); err != nil {
+			return fmt.Errorf("local vschema has drifted from the reviewed plan (database %q, target %q): %w", c.config.Database, req.Target, err)
+		}
+	}
+	return nil
+}
+
+// driftMultisetFromPlanResult builds the table DDL multiset this deployment
+// would plan against its own live schema, restricted to the dispatch's shard
+// scope. A shard-scoped dispatch covers exactly one shard, so other shards'
+// remaining changes are not part of this comparison; a whole-deployment dispatch
+// covers only the non-sharded changes. VSchema changes carry no table DDL and
+// are compared separately, so they are excluded here.
+func (c *LocalClient) driftMultisetFromPlanResult(result *engine.PlanResult, shardScoped bool, targetShard string) (driftChangeMultiset, error) {
+	ms := driftChangeMultiset{}
+	for _, sc := range result.Changes {
+		shard := sc.Shard.Name
+		if shardScoped {
+			if shard != targetShard {
+				continue
+			}
+		} else if shard != "" {
+			continue
+		}
+		ns := c.planNamespace(sc.Namespace)
+		for _, tc := range sc.TableChanges {
+			canon, err := canonicalDDLForDrift(tc.DDL)
+			if err != nil {
+				return nil, fmt.Errorf("table %q: %w", tc.Table, err)
+			}
+			ms[driftChangeKey{ns, shard, tc.Table, ddl.StatementTypeToOp(tc.Operation), canon}]++
+		}
+	}
+	return ms, nil
+}
+
+// driftMultisetFromApplyRequest builds the table DDL multiset the dispatch
+// request carries as the reviewed, authoritative plan. The dispatched changes
+// are flat (the TableChange proto carries no shard), so they are keyed to the
+// dispatch's target shard, which is "" for a whole-deployment apply. VSchema
+// changes are compared separately and excluded here. Nil entries are corrupt
+// input and fail closed.
+func (c *LocalClient) driftMultisetFromApplyRequest(changes []*ternv1.TableChange, targetShard string) (driftChangeMultiset, error) {
+	ms := driftChangeMultiset{}
+	for _, ch := range changes {
+		if ch == nil {
+			return nil, fmt.Errorf("dispatch request carried a nil table change")
+		}
+		if ch.ChangeType == ternv1.ChangeType_CHANGE_TYPE_VSCHEMA {
+			continue
+		}
+		op, err := materializedTableChangeOperation(ch)
+		if err != nil {
+			return nil, err
+		}
+		canon, err := canonicalDDLForDrift(ch.Ddl)
+		if err != nil {
+			return nil, fmt.Errorf("table %q: %w", ch.TableName, err)
+		}
+		ms[driftChangeKey{c.planNamespace(ch.Namespace), targetShard, ch.TableName, op, canon}]++
+	}
+	return ms, nil
+}
+
+// canonicalDDLForDrift normalizes a DDL statement for comparison and fails
+// closed if it cannot be parsed — ddl.Canonicalize returns the input unchanged
+// on a parse failure, so an unparseable statement would otherwise compare by raw
+// text and could mask drift.
+func canonicalDDLForDrift(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("empty DDL")
+	}
+	if _, _, err := ddl.ClassifyStatement(raw); err != nil {
+		return "", fmt.Errorf("unparseable DDL: %w", err)
+	}
+	return ddl.Canonicalize(raw), nil
+}
+
+// compareDriftMultisets reports drift unless the recomputed and dispatched table
+// DDL multisets are exactly equal.
+func compareDriftMultisets(recomputed, dispatched driftChangeMultiset) error {
+	var missing, unexpected []string
+	for key, want := range dispatched {
+		if recomputed[key] < want {
+			missing = append(missing, formatDriftKey(key))
+		}
+	}
+	for key, have := range recomputed {
+		if have > dispatched[key] {
+			unexpected = append(unexpected, formatDriftKey(key))
+		}
+	}
+	if len(missing) == 0 && len(unexpected) == 0 {
+		return nil
+	}
+	sort.Strings(missing)
+	sort.Strings(unexpected)
+	return fmt.Errorf("reviewed changes this deployment would not plan: %v; changes this deployment would plan that were not reviewed: %v", missing, unexpected)
+}
+
+// formatDriftKey renders a drift key for an operator-facing message. The
+// canonicalized DDL is included because the multiset keys on it: two changes for
+// the same namespace/shard/table/operation that differ only in DDL must render
+// differently or the message would list identical-looking entries on both sides
+// and hide what actually drifted. The shard is shown only when set so
+// non-sharded messages stay uncluttered.
+func formatDriftKey(k driftChangeKey) string {
+	loc := fmt.Sprintf("%s.%s", k.namespace, k.table)
+	if k.shard != "" {
+		loc = fmt.Sprintf("%s[%s].%s", k.namespace, k.shard, k.table)
+	}
+	return fmt.Sprintf("%s/%s (%s)", loc, k.operation, k.ddl)
+}
+
+// vschemaNamespacesFromPlanResult returns the namespaces the recomputed plan
+// detected a vschema change for.
+func vschemaNamespacesFromPlanResult(c *LocalClient, result *engine.PlanResult) map[string]bool {
+	out := map[string]bool{}
+	for _, sc := range result.Changes {
+		if sc.Metadata["vschema_changed"] == "true" {
+			out[c.planNamespace(sc.Namespace)] = true
+		}
+	}
+	return out
+}
+
+// vschemaNamespacesFromApplyRequest returns the namespaces the dispatch request
+// carries a vschema change for.
+func vschemaNamespacesFromApplyRequest(c *LocalClient, changes []*ternv1.TableChange) map[string]bool {
+	out := map[string]bool{}
+	for _, ch := range changes {
+		if ch != nil && ch.ChangeType == ternv1.ChangeType_CHANGE_TYPE_VSCHEMA {
+			out[c.planNamespace(ch.Namespace)] = true
+		}
+	}
+	return out
+}
+
+// compareVSchemaParity reports drift unless the recomputed and dispatched sets
+// of vschema-changed namespaces are identical.
+func compareVSchemaParity(recomputed, dispatched map[string]bool) error {
+	var missing, unexpected []string
+	for ns := range dispatched {
+		if !recomputed[ns] {
+			missing = append(missing, ns)
+		}
+	}
+	for ns := range recomputed {
+		if !dispatched[ns] {
+			unexpected = append(unexpected, ns)
+		}
+	}
+	if len(missing) == 0 && len(unexpected) == 0 {
+		return nil
+	}
+	sort.Strings(missing)
+	sort.Strings(unexpected)
+	return fmt.Errorf("reviewed vschema changes this deployment would not plan: %v; vschema changes this deployment would plan that were not reviewed: %v", missing, unexpected)
+}

--- a/pkg/tern/local_plan_drift.go
+++ b/pkg/tern/local_plan_drift.go
@@ -10,6 +10,7 @@ import (
 	"github.com/block/schemabot/pkg/engine"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/schema"
+	"github.com/block/spirit/pkg/statement"
 )
 
 // driftChangeKey identifies a single table DDL change for drift comparison. Two
@@ -145,17 +146,24 @@ func (c *LocalClient) driftMultisetFromApplyRequest(changes []*ternv1.TableChang
 	return ms, nil
 }
 
-// canonicalDDLForDrift normalizes a DDL statement for comparison and fails
-// closed if it cannot be parsed — ddl.Canonicalize returns the input unchanged
-// on a parse failure, so an unparseable statement would otherwise compare by raw
-// text and could mask drift.
+// canonicalDDLForDrift normalizes a single DDL statement for comparison and
+// fails closed if it cannot be parsed or carries more than one statement.
+// ddl.Canonicalize returns the input unchanged on a parse failure, so an
+// unparseable statement would otherwise compare by raw text and could mask
+// drift. It also canonicalizes only the first statement, so a multi-statement
+// payload ("ALTER ...; ALTER ...") would silently drop the trailing statements
+// and mask drift on them — reject anything that is not exactly one statement.
 func canonicalDDLForDrift(raw string) (string, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return "", fmt.Errorf("empty DDL")
 	}
-	if _, _, err := ddl.ClassifyStatement(raw); err != nil {
+	results, err := statement.Classify(raw)
+	if err != nil {
 		return "", fmt.Errorf("unparseable DDL: %w", err)
+	}
+	if len(results) != 1 {
+		return "", fmt.Errorf("expected exactly one DDL statement, got %d", len(results))
 	}
 	return ddl.Canonicalize(raw), nil
 }

--- a/pkg/tern/local_plan_drift_guard_test.go
+++ b/pkg/tern/local_plan_drift_guard_test.go
@@ -1,0 +1,275 @@
+package tern
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/engine"
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/spirit/pkg/statement"
+)
+
+// alterUsersEmailShardPlan is the recomputed plan for a sharded engine: the same
+// reviewed ALTER on a single named shard, used by the shard-scoped drift tests.
+func alterUsersEmailShardPlan(shard string) *engine.PlanResult {
+	return &engine.PlanResult{
+		Changes: []engine.SchemaChange{{
+			Namespace: "testapp",
+			Shard:     engine.Shard{Name: shard},
+			TableChanges: []engine.TableChange{{
+				Table:     "users",
+				Operation: statement.StatementAlterTable,
+				DDL:       "ALTER TABLE `users` ADD COLUMN `email` varchar(255)",
+			}},
+		}},
+	}
+}
+
+// A non-primary deployment whose recomputed local plan exactly matches the
+// reviewed DDL materializes the plan: there is no drift to block.
+func TestDriftGuard_MatchMaterializes(t *testing.T) {
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }, createID: 5}
+	c := newPlanMaterializeClientWithPlan(store, alterUsersEmailPlan())
+
+	got, err := c.planForApplyRequest(t.Context(), &ternv1.ApplyRequest{
+		PlanId: "plan_ok",
+		DdlChanges: []*ternv1.TableChange{
+			{TableName: "users", Ddl: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER, Namespace: "testapp"},
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, int64(5), got.ID)
+}
+
+// Whitespace and quoting differences between the recomputed DDL and the reviewed
+// DDL are normalized away by canonicalization, so they are not drift.
+func TestDriftGuard_CanonicalizationTolerant(t *testing.T) {
+	recomputed := &engine.PlanResult{Changes: []engine.SchemaChange{{
+		Namespace: "testapp",
+		TableChanges: []engine.TableChange{{
+			Table:     "users",
+			Operation: statement.StatementAlterTable,
+			DDL:       "ALTER TABLE users ADD COLUMN email varchar(255)",
+		}},
+	}}}
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }, createID: 6}
+	c := newPlanMaterializeClientWithPlan(store, recomputed)
+
+	_, err := c.planForApplyRequest(t.Context(), &ternv1.ApplyRequest{
+		PlanId: "plan_canon",
+		DdlChanges: []*ternv1.TableChange{
+			{TableName: "users", Ddl: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER, Namespace: "testapp"},
+		},
+	})
+
+	require.NoError(t, err)
+}
+
+// A reviewed change this deployment would not plan (local schema already has the
+// column) fails closed rather than replaying unreviewed DDL.
+func TestDriftGuard_MissingReviewedChangeFailsClosed(t *testing.T) {
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }}
+	c := newPlanMaterializeClientWithPlan(store, &engine.PlanResult{}) // recomputes no changes
+
+	_, err := c.planForApplyRequest(t.Context(), &ternv1.ApplyRequest{
+		PlanId: "plan_drift",
+		DdlChanges: []*ternv1.TableChange{
+			{TableName: "users", Ddl: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER, Namespace: "testapp"},
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "drifted")
+	assert.Nil(t, store.created, "must not materialize a drifted plan")
+}
+
+// A change this deployment would plan that was never reviewed (local schema is
+// behind the desired files in a way the primary did not see) fails closed.
+func TestDriftGuard_UnexpectedLocalChangeFailsClosed(t *testing.T) {
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }}
+	c := newPlanMaterializeClientWithPlan(store, alterUsersEmailPlan())
+
+	_, err := c.planForApplyRequest(t.Context(), &ternv1.ApplyRequest{
+		PlanId: "plan_extra",
+		DdlChanges: []*ternv1.TableChange{
+			{TableName: "orders", Ddl: "CREATE TABLE `orders` (`id` bigint)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_CREATE, Namespace: "testapp"},
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "drifted")
+}
+
+// Different DDL for the same table/operation is drift even though the
+// namespace/table/action triple matches.
+func TestDriftGuard_DifferentDDLSameTableFailsClosed(t *testing.T) {
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }}
+	c := newPlanMaterializeClientWithPlan(store, alterUsersEmailPlan())
+
+	_, err := c.planForApplyRequest(t.Context(), &ternv1.ApplyRequest{
+		PlanId: "plan_diff_ddl",
+		DdlChanges: []*ternv1.TableChange{
+			{TableName: "users", Ddl: "ALTER TABLE `users` ADD COLUMN `phone` varchar(255)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER, Namespace: "testapp"},
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "drifted")
+}
+
+// A shard-scoped apply is drift-checked against this deployment's re-plan
+// restricted to the dispatch's shard. When the reviewed DDL matches that shard's
+// recomputed change, the plan materializes.
+func TestDriftGuard_ShardScopedMatchMaterializes(t *testing.T) {
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }, createID: 8}
+	c := newPlanMaterializeClientWithPlan(store, alterUsersEmailShardPlan("-80"))
+
+	got, err := c.planForApplyRequest(t.Context(), &ternv1.ApplyRequest{
+		PlanId:       "plan_shard_ok",
+		TargetShards: []string{"-80"},
+		DdlChanges: []*ternv1.TableChange{
+			{TableName: "users", Ddl: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER, Namespace: "testapp"},
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, int64(8), got.ID)
+}
+
+// A shard-scoped apply whose reviewed DDL targets one shard but whose live
+// re-plan only needs the change on a different shard fails closed: the targeted
+// shard has drifted from the reviewed plan.
+func TestDriftGuard_ShardScopedWrongShardFailsClosed(t *testing.T) {
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }}
+	c := newPlanMaterializeClientWithPlan(store, alterUsersEmailShardPlan("80-"))
+
+	_, err := c.planForApplyRequest(t.Context(), &ternv1.ApplyRequest{
+		PlanId:       "plan_shard_drift",
+		TargetShards: []string{"-80"},
+		DdlChanges: []*ternv1.TableChange{
+			{TableName: "users", Ddl: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER, Namespace: "testapp"},
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "drifted")
+	assert.Nil(t, store.created, "must not materialize a drifted shard plan")
+}
+
+// More than one target shard is a malformed dispatch (the per-shard fan-out
+// emits one shard per operation), so the guard fails closed.
+func TestDriftGuard_MultipleTargetShardsFailsClosed(t *testing.T) {
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }}
+	c := newPlanMaterializeClientWithPlan(store, alterUsersEmailShardPlan("-80"))
+
+	_, err := c.planForApplyRequest(t.Context(), &ternv1.ApplyRequest{
+		PlanId:       "plan_shard_multi",
+		TargetShards: []string{"-80", "80-"},
+		DdlChanges: []*ternv1.TableChange{
+			{TableName: "users", Ddl: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER, Namespace: "testapp"},
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "shard")
+}
+
+// A vschema change the reviewed plan carries but this deployment would not plan
+// is drift, even when the table DDL matches exactly.
+func TestDriftGuard_VSchemaParityFailsClosed(t *testing.T) {
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }}
+	// Recomputed plan has the table change but no vschema change.
+	c := newPlanMaterializeClientWithPlan(store, alterUsersEmailPlan())
+
+	_, err := c.planForApplyRequest(t.Context(), &ternv1.ApplyRequest{
+		PlanId: "plan_vschema",
+		DdlChanges: []*ternv1.TableChange{
+			{TableName: "users", Ddl: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER, Namespace: "testapp"},
+			{TableName: "VSchema: testapp", ChangeType: ternv1.ChangeType_CHANGE_TYPE_VSCHEMA, Namespace: "testapp"},
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "vschema")
+}
+
+// A matching vschema change on both sides is not drift.
+func TestDriftGuard_VSchemaParityMatches(t *testing.T) {
+	recomputed := &engine.PlanResult{Changes: []engine.SchemaChange{{
+		Namespace: "testapp",
+		Metadata:  map[string]string{"vschema_changed": "true"},
+	}}}
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }, createID: 9}
+	c := newPlanMaterializeClientWithPlan(store, recomputed)
+
+	_, err := c.planForApplyRequest(t.Context(), &ternv1.ApplyRequest{
+		PlanId: "plan_vschema_ok",
+		DdlChanges: []*ternv1.TableChange{
+			{TableName: "VSchema: testapp", ChangeType: ternv1.ChangeType_CHANGE_TYPE_VSCHEMA, Namespace: "testapp"},
+		},
+		SchemaFiles: map[string]*ternv1.SchemaFiles{
+			"testapp": {Files: map[string]string{vSchemaArtifactName: `{"sharded":true}`}},
+		},
+	})
+
+	require.NoError(t, err)
+}
+
+// An engine failure during recompute surfaces as an error: the guard never
+// fails open when it cannot recompute.
+func TestDriftGuard_RecomputeErrorFailsClosed(t *testing.T) {
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }}
+	c := newPlanMaterializeClient(store)
+	c.config.TargetDSN = "user:pass@tcp(127.0.0.1:3306)/testapp"
+	c.spiritEngine = fakePlanEngine{
+		planFn: func(ctx context.Context, _ *engine.PlanRequest) (*engine.PlanResult, error) {
+			return nil, errors.New("engine boom")
+		},
+	}
+
+	_, err := c.planForApplyRequest(t.Context(), &ternv1.ApplyRequest{
+		PlanId: "plan_engine_err",
+		DdlChanges: []*ternv1.TableChange{
+			{TableName: "users", Ddl: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER, Namespace: "testapp"},
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "recompute local plan")
+}
+
+// canonicalDDLForDrift must fail closed on DDL it cannot parse: ddl.Canonicalize
+// returns its input unchanged on a parse failure, so without this guard an
+// unparseable statement would silently compare by raw text and could mask drift.
+func TestCanonicalDDLForDrift_FailsClosed(t *testing.T) {
+	t.Run("unparseable DDL is rejected", func(t *testing.T) {
+		_, err := canonicalDDLForDrift("this is not valid sql")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unparseable DDL")
+	})
+
+	t.Run("empty DDL is rejected", func(t *testing.T) {
+		_, err := canonicalDDLForDrift("   ")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty DDL")
+	})
+
+	t.Run("parseable DDL is canonicalized", func(t *testing.T) {
+		// Whitespace and unquoted identifiers normalize to the same canonical form
+		// regardless of incidental formatting, so equivalent DDL compares equal.
+		spaced, err := canonicalDDLForDrift("ALTER TABLE   users   ADD COLUMN email varchar(255)")
+		require.NoError(t, err)
+		quoted, err := canonicalDDLForDrift("ALTER TABLE `users` ADD COLUMN `email` varchar(255)")
+		require.NoError(t, err)
+		assert.Equal(t, quoted, spaced)
+		assert.NotEmpty(t, spaced)
+	})
+}

--- a/pkg/tern/local_plan_drift_guard_test.go
+++ b/pkg/tern/local_plan_drift_guard_test.go
@@ -262,6 +262,15 @@ func TestCanonicalDDLForDrift_FailsClosed(t *testing.T) {
 		assert.Contains(t, err.Error(), "empty DDL")
 	})
 
+	t.Run("multi-statement DDL is rejected", func(t *testing.T) {
+		// ddl.Canonicalize only canonicalizes the first statement, so a
+		// multi-statement payload would silently drop the trailing statements
+		// and mask drift on them. It must fail closed instead.
+		_, err := canonicalDDLForDrift("ALTER TABLE `users` ADD COLUMN `email` varchar(255); ALTER TABLE `users` ADD COLUMN `phone` varchar(255)")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exactly one DDL statement")
+	})
+
 	t.Run("parseable DDL is canonicalized", func(t *testing.T) {
 		// Whitespace and unquoted identifiers normalize to the same canonical form
 		// regardless of incidental formatting, so equivalent DDL compares equal.


### PR DESCRIPTION
## Summary

Restores the materialize-time drift guard that was removed in #535, this time shard-aware. A non-primary deployment that never planned locally must not silently apply the primary's reviewed DDL against a schema that has drifted; this re-adds the fail-closed check, now compatible with per-shard apply fan-out.

## What

- Recompute this deployment's own diff against its live schema at materialize time and refuse unless it exactly matches the dispatched (reviewed) DDL, compared as an exact multiset keyed by `(namespace, shard, table, operation, canonical DDL)`.
- A shard-scoped dispatch is compared against the re-plan restricted to its shard; a whole-deployment dispatch against the non-sharded changes. VSchema parity is checked per namespace for whole-deployment applies.
- DDL that cannot be parsed, a nil change, or a malformed multi-shard dispatch all fail closed.

## Why

#535 deleted the guard because it rejected shard-scoped applies, which were incompatible with per-shard fan-out. The interim reconciliation (re-plan at apply/resume) is not fail-closed: it silently completes drifted tables or applies locally recomputed DDL that no reviewer saw, breaking the "what gets applied is what was reviewed" boundary on every non-primary deployment. Making the comparator shard-aware lets the guard return.

        materialize remote plan (non-primary, no local plan)
                          |
                          v
          re-plan THIS deployment vs its live schema
          (restricted to the dispatch's shard scope)
                          |
               exact multiset match vs reviewed DDL?
                 |- yes -> materialize -> apply
                 |- no  -> FAIL CLOSED (never persisted, never applied)
