### PR TITLE
refactor(tern): dedupe control-apply, resume-operation, and GitHub contents helpers

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -1166,34 +1166,40 @@ func (ic *InstallationClient) FetchFileContent(ctx context.Context, repo, filePa
 const maxGitHubDirEntries = 1000
 
 func (ic *InstallationClient) fetchDirectoryContents(ctx context.Context, repo, dirPath, ref string) ([]*gh.RepositoryContent, error) {
-	owner, repoName := splitRepo(repo)
-	opts := &gh.RepositoryContentGetOptions{Ref: ref}
-	readResult, err := retryGitHubUnavailableRead(ctx, ic.logger, "fetch directory content", []any{"repo", repo, "path", dirPath, "ref", ref}, func(ctx context.Context) (struct {
-		fileContent      *gh.RepositoryContent
-		directoryContent []*gh.RepositoryContent
-	}, error) {
-		fileContent, directoryContent, _, err := ic.client.Repositories.GetContents(ctx, owner, repoName, dirPath, opts)
-		if err != nil {
-			return struct {
-				fileContent      *gh.RepositoryContent
-				directoryContent []*gh.RepositoryContent
-			}{}, fmt.Errorf("fetch directory content at %s: %w", dirPath, classifyGitHubAPIError(err))
-		}
-		return struct {
-			fileContent      *gh.RepositoryContent
-			directoryContent []*gh.RepositoryContent
-		}{fileContent: fileContent, directoryContent: directoryContent}, nil
-	})
+	result, err := ic.getRepositoryContents(ctx, repo, dirPath, ref, "fetch directory content")
 	if err != nil {
 		return nil, err
 	}
-	if readResult.fileContent != nil {
+	if result.fileContent != nil {
 		return nil, fmt.Errorf("expected directory at %s, found file", dirPath)
 	}
-	if len(readResult.directoryContent) >= maxGitHubDirEntries {
+	if len(result.directoryContent) >= maxGitHubDirEntries {
 		return nil, fmt.Errorf("list schema directory %s in repo %s ref %s reached GitHub Contents API limit: %w", dirPath, repo, ref, ErrDirListingCapped)
 	}
-	return readResult.directoryContent, nil
+	return result.directoryContent, nil
+}
+
+// repositoryContents bundles the two-shaped result of the GitHub Contents API:
+// GetContents returns a file when the path is a file and a directory listing
+// when it is a directory, with the other value nil.
+type repositoryContents struct {
+	fileContent      *gh.RepositoryContent
+	directoryContent []*gh.RepositoryContent
+}
+
+// getRepositoryContents performs a retried GitHub Contents API read at
+// contentPath on ref, returning both the file and directory results. operation
+// labels the read for retry logs and error context.
+func (ic *InstallationClient) getRepositoryContents(ctx context.Context, repo, contentPath, ref, operation string) (repositoryContents, error) {
+	owner, repoName := splitRepo(repo)
+	opts := &gh.RepositoryContentGetOptions{Ref: ref}
+	return retryGitHubUnavailableRead(ctx, ic.logger, operation, []any{"repo", repo, "path", contentPath, "ref", ref}, func(ctx context.Context) (repositoryContents, error) {
+		fileContent, directoryContent, _, err := ic.client.Repositories.GetContents(ctx, owner, repoName, contentPath, opts)
+		if err != nil {
+			return repositoryContents{}, fmt.Errorf("%s at %s: %w", operation, contentPath, classifyGitHubAPIError(err))
+		}
+		return repositoryContents{fileContent: fileContent, directoryContent: directoryContent}, nil
+	})
 }
 
 // GitHubFile represents a file fetched from GitHub API.

--- a/pkg/github/schema.go
+++ b/pkg/github/schema.go
@@ -133,28 +133,11 @@ func validateEnvironmentPathSegment(environment string) error {
 }
 
 func (ic *InstallationClient) fetchRepositoryContents(ctx context.Context, repo, filePath, ref string) (*gh.RepositoryContent, []*gh.RepositoryContent, error) {
-	owner, repoName := splitRepo(repo)
-	opts := &gh.RepositoryContentGetOptions{Ref: ref}
-	readResult, err := retryGitHubUnavailableRead(ctx, ic.logger, "fetch repository content", []any{"repo", repo, "path", filePath, "ref", ref}, func(ctx context.Context) (struct {
-		fileContent      *gh.RepositoryContent
-		directoryContent []*gh.RepositoryContent
-	}, error) {
-		fileContent, directoryContent, _, err := ic.client.Repositories.GetContents(ctx, owner, repoName, filePath, opts)
-		if err != nil {
-			return struct {
-				fileContent      *gh.RepositoryContent
-				directoryContent []*gh.RepositoryContent
-			}{}, fmt.Errorf("fetch repository content at %s: %w", filePath, classifyGitHubAPIError(err))
-		}
-		return struct {
-			fileContent      *gh.RepositoryContent
-			directoryContent []*gh.RepositoryContent
-		}{fileContent: fileContent, directoryContent: directoryContent}, nil
-	})
+	result, err := ic.getRepositoryContents(ctx, repo, filePath, ref, "fetch repository content")
 	if err != nil {
 		return nil, nil, err
 	}
-	return readResult.fileContent, readResult.directoryContent, nil
+	return result.fileContent, result.directoryContent, nil
 }
 
 func resolveSchemaRootSymlinkTarget(configDir, symlinkPath, target string) (string, error) {

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -25,7 +25,7 @@ func (c *LocalClient) Cutover(ctx context.Context, req *ternv1.CutoverRequest) (
 // stop and start are routed to the apply owner.
 func (c *LocalClient) requestCutover(ctx context.Context, req *ternv1.CutoverRequest, caller string) (*ternv1.CutoverResponse, error) {
 	c.logger.Info("Cutover requested", "database", c.config.Database, "type", c.config.Type, "apply_id", req.ApplyId, "environment", req.Environment, "caller", caller)
-	apply, err := c.resolveCutoverApply(ctx, req)
+	apply, err := c.resolveControlApply(ctx, req.ApplyId, "cutover")
 	if err != nil {
 		return nil, err
 	}
@@ -35,16 +35,18 @@ func (c *LocalClient) requestCutover(ctx context.Context, req *ternv1.CutoverReq
 	return c.queueCutoverRequest(ctx, apply, caller)
 }
 
-// resolveCutoverApply finds the apply a cutover request targets, by apply
-// identifier when provided or by the database's active task otherwise.
-func (c *LocalClient) resolveCutoverApply(ctx context.Context, req *ternv1.CutoverRequest) (*storage.Apply, error) {
-	if req.ApplyId != "" {
-		apply, err := c.storage.Applies().GetByApplyIdentifier(ctx, req.ApplyId)
+// resolveControlApply finds the apply a control request targets, by apply
+// identifier when provided or by the database's active task otherwise. The
+// operation label names the control verb in errors and logs. Returns
+// (nil, nil) when no apply id is given and the database has no active task.
+func (c *LocalClient) resolveControlApply(ctx context.Context, applyID, operation string) (*storage.Apply, error) {
+	if applyID != "" {
+		apply, err := c.storage.Applies().GetByApplyIdentifier(ctx, applyID)
 		if err != nil {
-			return nil, fmt.Errorf("load apply %s before cutover: %w", req.ApplyId, err)
+			return nil, fmt.Errorf("load apply %s before %s: %w", applyID, operation, err)
 		}
 		if apply == nil {
-			return nil, fmt.Errorf("load apply %s before cutover: %w", req.ApplyId, storage.ErrApplyNotFound)
+			return nil, fmt.Errorf("load apply %s before %s: %w", applyID, operation, storage.ErrApplyNotFound)
 		}
 		return apply, nil
 	}
@@ -54,15 +56,15 @@ func (c *LocalClient) resolveCutoverApply(ctx context.Context, req *ternv1.Cutov
 		return nil, err
 	}
 	if task == nil {
-		c.logger.Info("cutover request found no active task", "database", c.config.Database, "type", c.config.Type)
+		c.logger.Info(operation+" request found no active task", "database", c.config.Database, "type", c.config.Type)
 		return nil, nil
 	}
 	apply, err := c.storage.Applies().Get(ctx, task.ApplyID)
 	if err != nil {
-		return nil, fmt.Errorf("load apply %d before cutover: %w", task.ApplyID, err)
+		return nil, fmt.Errorf("load apply %d before %s: %w", task.ApplyID, operation, err)
 	}
 	if apply == nil {
-		return nil, fmt.Errorf("load apply %d before cutover: %w", task.ApplyID, storage.ErrApplyNotFound)
+		return nil, fmt.Errorf("load apply %d before %s: %w", task.ApplyID, operation, storage.ErrApplyNotFound)
 	}
 	return apply, nil
 }
@@ -339,7 +341,7 @@ func (c *LocalClient) requestStop(ctx context.Context, req *ternv1.StopRequest, 
 		c.logger.Warn("stop rejected because this engine supports cancel instead", "database", c.config.Database, "type", c.config.Type, "apply_id", req.ApplyId)
 		return nil, fmt.Errorf("stop not supported for this schema change; use cancel to permanently cancel it")
 	}
-	apply, err := c.resolveStopApply(ctx, req)
+	apply, err := c.resolveControlApply(ctx, req.ApplyId, "stop")
 	if err != nil {
 		return nil, err
 	}
@@ -390,36 +392,6 @@ func (c *LocalClient) requestStop(ctx context.Context, req *ternv1.StopRequest, 
 	}
 	c.wakeOperatorForControlRequest(apply)
 	return &ternv1.StopResponse{Accepted: true}, nil
-}
-
-func (c *LocalClient) resolveStopApply(ctx context.Context, req *ternv1.StopRequest) (*storage.Apply, error) {
-	if req.ApplyId != "" {
-		apply, err := c.storage.Applies().GetByApplyIdentifier(ctx, req.ApplyId)
-		if err != nil {
-			return nil, fmt.Errorf("load apply %s before stop: %w", req.ApplyId, err)
-		}
-		if apply == nil {
-			return nil, fmt.Errorf("load apply %s before stop: %w", req.ApplyId, storage.ErrApplyNotFound)
-		}
-		return apply, nil
-	}
-
-	task, err := c.getActiveTaskForDatabase(ctx, c.config.Database)
-	if err != nil {
-		return nil, err
-	}
-	if task == nil {
-		c.logger.Info("stop request found no active task", "database", c.config.Database, "type", c.config.Type)
-		return nil, nil
-	}
-	apply, err := c.storage.Applies().Get(ctx, task.ApplyID)
-	if err != nil {
-		return nil, fmt.Errorf("load apply %d before stop: %w", task.ApplyID, err)
-	}
-	if apply == nil {
-		return nil, fmt.Errorf("load apply %d before stop: %w", task.ApplyID, storage.ErrApplyNotFound)
-	}
-	return apply, nil
 }
 
 func (c *LocalClient) stopOwnedApply(ctx context.Context, req *ternv1.StopRequest, caller string) (*ternv1.StopResponse, error) {

--- a/pkg/tern/routing_client.go
+++ b/pkg/tern/routing_client.go
@@ -275,24 +275,20 @@ func (c *RoutingClient) ResumeApply(ctx context.Context, apply *storage.Apply) e
 
 // ResumeApplyOperation starts or resumes one operation for a stored apply.
 func (c *RoutingClient) ResumeApplyOperation(ctx context.Context, apply *storage.Apply, applyOperationID int64) error {
-	if apply == nil {
-		return fmt.Errorf("stored apply is required for routing")
-	}
-	operation, err := c.loadApplyOperation(ctx, apply, applyOperationID)
-	if err != nil {
-		return err
-	}
-	client, err := c.clientForDeployment(ctx, operation.Deployment, apply.Environment)
-	if err != nil {
-		return fmt.Errorf("get client for apply %q operation %d deployment %q environment %q: %w", apply.ApplyIdentifier, applyOperationID, operation.Deployment, apply.Environment, err)
-	}
-	c.attachObserver(client, apply.ID)
-	return client.ResumeApplyOperation(ctx, operationScopedApply(apply, operation), applyOperationID)
+	return c.resumeApplyOperation(ctx, apply, applyOperationID, Client.ResumeApplyOperation)
 }
 
 // ResumeApplyOperationCutover drives one parked operation through its cutover
 // phase, routing to the deployment's client just like ResumeApplyOperation.
 func (c *RoutingClient) ResumeApplyOperationCutover(ctx context.Context, apply *storage.Apply, applyOperationID int64) error {
+	return c.resumeApplyOperation(ctx, apply, applyOperationID, Client.ResumeApplyOperationCutover)
+}
+
+// resumeApplyOperation resolves the deployment client that owns one operation of
+// a stored apply, attaches any registered observer, and dispatches the resume to
+// it on an operation-scoped copy of the apply. dispatch selects the resume phase
+// (start/resume vs cutover) to run on the resolved client.
+func (c *RoutingClient) resumeApplyOperation(ctx context.Context, apply *storage.Apply, applyOperationID int64, dispatch func(Client, context.Context, *storage.Apply, int64) error) error {
 	if apply == nil {
 		return fmt.Errorf("stored apply is required for routing")
 	}
@@ -305,7 +301,7 @@ func (c *RoutingClient) ResumeApplyOperationCutover(ctx context.Context, apply *
 		return fmt.Errorf("get client for apply %q operation %d deployment %q environment %q: %w", apply.ApplyIdentifier, applyOperationID, operation.Deployment, apply.Environment, err)
 	}
 	c.attachObserver(client, apply.ID)
-	return client.ResumeApplyOperationCutover(ctx, operationScopedApply(apply, operation), applyOperationID)
+	return dispatch(client, ctx, operationScopedApply(apply, operation), applyOperationID)
 }
 
 // Endpoint returns a descriptive endpoint for the routing wrapper.


### PR DESCRIPTION
## Summary

Three near-identical copy-pasted blocks are collapsed into shared helpers, each parameterized by the single varying piece. Fully behavior-preserving: error messages and log strings are byte-identical to before, so operator triage output is unchanged.

## What

- `pkg/tern/local_control.go` — `resolveCutoverApply` / `resolveStopApply` collapse into one `resolveControlApply(ctx, applyID, operation)`; the two single-use wrappers are inlined at their call sites.
- `pkg/github` — extract `getRepositoryContents` + a named `repositoryContents` struct; `fetchRepositoryContents` and `fetchDirectoryContents` delegate to it, removing the 4×-repeated inline anonymous struct in each.
- `pkg/tern/routing_client.go` — `ResumeApplyOperation` / `ResumeApplyOperationCutover` collapse into `resumeApplyOperation(..., dispatch)`, selecting the resume phase via a `Client.X` method expression.

## Why

Each pair/trio differed only by an operation verb, a resume phase, or a content path. Extracting the varying piece keeps one source of truth for the shared control flow (load/resolve → attach observer → dispatch) while preserving every error and log string verbatim.