### PR TITLE
fix(api): route LocalClient cancel through a durable owner-routed request

### DIFF
--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -332,7 +332,75 @@ func (c *LocalClient) Stop(ctx context.Context, req *ternv1.StopRequest) (*ternv
 
 // Cancel terminates an in-progress schema change permanently.
 func (c *LocalClient) Cancel(ctx context.Context, req *ternv1.CancelRequest) (*ternv1.CancelResponse, error) {
-	return c.cancelOwnedApply(ctx, req, "")
+	return c.requestCancel(ctx, req, "")
+}
+
+// requestCancel records a durable, owner-routed cancel control request rather than
+// cancelling inline. A Cancel RPC can land on any pod, but only the lease owner
+// driving the apply holds the in-process engine state — so the request is queued
+// for the owning driver (processPendingCancelControlRequest) to claim and execute
+// the engine cancel plus the terminal transitions on the pod that owns the apply.
+// This mirrors requestStop's delivery; cancel keeps its own terminate semantics.
+func (c *LocalClient) requestCancel(ctx context.Context, req *ternv1.CancelRequest, caller string) (*ternv1.CancelResponse, error) {
+	c.logger.Info("Cancel requested", "database", c.config.Database, "type", c.config.Type, "apply_id", req.ApplyId)
+	apply, err := c.resolveControlApply(ctx, req.ApplyId, "cancel")
+	if err != nil {
+		return nil, err
+	}
+	if apply == nil {
+		return nil, fmt.Errorf("no active schema change")
+	}
+
+	// A terminal apply (other than stopped, which a driver can still cancel) has
+	// no work to cancel; reject synchronously rather than queue a no-op request.
+	if state.IsTerminalApplyState(apply.State) && !state.IsState(apply.State, state.Apply.Stopped) {
+		c.logger.Warn("cancel rejected: schema change is already terminal",
+			"apply_id", apply.ApplyIdentifier, "state", apply.State)
+		return nil, fmt.Errorf("schema change %s is already terminal (state: %s)", apply.ApplyIdentifier, apply.State)
+	}
+
+	if revertWindow, err := c.applyHasRevertWindowTask(ctx, apply); err != nil {
+		return nil, err
+	} else if revertWindow {
+		c.logger.Warn("cancel rejected: schema change is in the revert window and has already cut over",
+			"apply_id", apply.ApplyIdentifier, "state", apply.State)
+		return nil, errors.New(revertWindowStopRejectionMessage(apply.ApplyIdentifier))
+	}
+
+	controlStore := c.storage.ControlRequests()
+	if controlStore == nil {
+		return nil, fmt.Errorf("control request store is not available")
+	}
+	requestedBy := caller
+	if requestedBy == "" {
+		requestedBy = "tern-grpc"
+	}
+	_, alreadyPending, err := controlStore.RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationCancel,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: requestedBy,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("record cancel control request for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if alreadyPending {
+		c.logger.Info("cancel request already pending for apply owner",
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"requested_by", requestedBy)
+	} else {
+		c.logger.Info("cancel request queued for apply owner",
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"requested_by", requestedBy)
+		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventCancelRequested, storage.LogSourceSchemaBot,
+			fmt.Sprintf("Cancel request queued for apply owner%s", callerApplyLogSuffix(requestedBy)), "", "")
+	}
+	c.wakeOperatorForControlRequest(apply)
+	return &ternv1.CancelResponse{Accepted: true}, nil
 }
 
 func (c *LocalClient) requestStop(ctx context.Context, req *ternv1.StopRequest, caller string) (*ternv1.StopResponse, error) {

--- a/pkg/tern/local_control_test.go
+++ b/pkg/tern/local_control_test.go
@@ -200,6 +200,7 @@ func newVitessControlTestClient(apply *storage.Apply, tasks []*storage.Task, res
 			tasks:           &controlTestTaskStore{tasks: tasks},
 			applyLogs:       &controlTestApplyLogStore{},
 			applyOperations: &controlTestApplyOperationStore{data: resumeState},
+			controlRequests: &testControlRequestStore{},
 		},
 		planetscaleEngine: eng,
 		logger:            slog.Default(),
@@ -300,6 +301,54 @@ func TestLocalClient_StopQueuesStopRequestForApplyOwner(t *testing.T) {
 	assert.Equal(t, state.Task.Running, task.State)
 	assert.Equal(t, state.Apply.Running, apply.State)
 	controlReq, err := client.storage.ControlRequests().GetPending(t.Context(), apply.ID, storage.ControlOperationStop)
+	require.NoError(t, err)
+	require.NotNil(t, controlReq)
+	assert.Equal(t, "tern-grpc", controlReq.RequestedBy)
+	assert.Equal(t, apply.ApplyIdentifier, wakeApplyID)
+	assert.Equal(t, apply.Database, wakeDatabase)
+	assert.Equal(t, apply.Environment, wakeEnvironment)
+}
+
+// External Cancel records durable intent in shared storage instead of cancelling
+// inline. A Cancel RPC can land on any replica, but only the lease owner driving
+// the apply holds the in-process engine state — so a non-owner replica records a
+// pending cancel request for the owning driver to claim, without touching the
+// engine or mutating cancelled state itself. This keeps cancel from depending on
+// the request happening to hit the owner pod.
+func TestLocalClient_CancelQueuesCancelRequestForApplyOwner(t *testing.T) {
+	apply := &storage.Apply{
+		ID:              42,
+		ApplyIdentifier: "apply-vitess-cancel-queued",
+		State:           state.Apply.Running,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeVitess,
+		Environment:     "staging",
+	}
+	task := &storage.Task{
+		ID:             7,
+		ApplyID:        apply.ID,
+		TaskIdentifier: "task-vitess-cancel-queued",
+		Database:       "testdb",
+		Namespace:      "testdb",
+		State:          state.Task.Running,
+	}
+	eng := &controlCaptureEngine{}
+	client := newVitessControlTestClient(apply, []*storage.Task{task}, nil, eng)
+	var wakeApplyID, wakeDatabase, wakeEnvironment string
+	client.config.WakeOperator = func(applyIdentifier, database, environment string) {
+		wakeApplyID = applyIdentifier
+		wakeDatabase = database
+		wakeEnvironment = environment
+	}
+
+	resp, err := client.Cancel(t.Context(), &ternv1.CancelRequest{ApplyId: apply.ApplyIdentifier})
+
+	require.NoError(t, err)
+	assert.True(t, resp.Accepted)
+	assert.Nil(t, eng.cancelReq, "external cancel must not cancel the local engine directly")
+	assert.Equal(t, state.Task.Running, task.State, "external cancel must not mutate task state inline")
+	assert.Equal(t, state.Apply.Running, apply.State, "external cancel must not mutate apply state inline")
+	controlReq, err := client.storage.ControlRequests().GetPending(t.Context(), apply.ID, storage.ControlOperationCancel)
 	require.NoError(t, err)
 	require.NotNil(t, controlReq)
 	assert.Equal(t, "tern-grpc", controlReq.RequestedBy)


### PR DESCRIPTION
## Why
`LocalClient.Cancel` cancelled inline on whichever pod received the RPC — it called `getEngine()` and the engine cancel directly. On an instance-local, multi-pod data plane, a Cancel landing on a pod that is **not** the lease owner driving the apply has no in-process engine state, so the cancel errored and the schema change kept running until the request happened to hit the owner pod. Cancel must not depend on which pod receives it.

## What
Route cancel through the same durable, owner-routed path the other control operations use.

- `Cancel` now records a pending cancel control request and wakes the operator (mirroring the stop delivery path) instead of touching the engine inline. The owning driver claims the request and runs the engine cancel plus the terminal transitions on the pod that owns the apply, regardless of which pod received the RPC.
- The HTTP/API cancel already queued the same control request, so both entry points now converge on one owner-routed implementation — no second inline path.
- Cancel keeps its terminate semantics (it is not a stop): the producer preserves the revert-window, already-terminal, and no-active-schema-change rejections; the owner-side executor is unchanged.

```diagram
Cancel RPC ─▶ any pod ─▶ record pending cancel request + wake operator
                                      │
                          owning driver claims it
                                      ▼
                     engine cancel + terminal transitions
                          (on the pod that owns the apply)
```

## Risk Assessment
Low–medium — changes the cancel delivery mechanism, not its semantics. The durable consumer path already exists and is exercised; the producer keeps the existing rejection guards. Covered by a new test for the non-owner-pod case plus the existing owner-side cancel and pending-request tests.

---
*PR authored with Claude Code (Opus 4.8).*
