### PR TITLE
fix(api): harden host:port assembly for IPv6 and portless hosts

### DIFF
--- a/pkg/inventory/connection_assembler.go
+++ b/pkg/inventory/connection_assembler.go
@@ -63,13 +63,8 @@ func (a MySQLConnectionAssembler) Assemble(host string, _ map[string]string, cre
 	if creds == nil {
 		return "", nil, fmt.Errorf("mysql connection requires credentials")
 	}
-	// Append the default port only when the host has none. net.SplitHostPort
-	// errors when no port is present, including for bare IPv6 addresses; in that
-	// case net.JoinHostPort adds the required brackets.
 	if a.DefaultPort != "" {
-		if _, _, err := net.SplitHostPort(host); err != nil {
-			host = net.JoinHostPort(host, a.DefaultPort)
-		}
+		host = hostWithDefaultPort(host, a.DefaultPort)
 	}
 	cfg := mysql.NewConfig()
 	cfg.User = creds.Username
@@ -80,6 +75,32 @@ func (a MySQLConnectionAssembler) Assemble(host string, _ map[string]string, cre
 		cfg.Params = maps.Clone(a.Params)
 	}
 	return cfg.FormatDSN(), maps.Clone(a.Metadata), nil
+}
+
+// hostWithDefaultPort returns host with defaultPort appended when host carries
+// no port, and host unchanged when it already specifies one. It is robust to
+// every form a resolved endpoint may take:
+//
+//   - "host" / "1.2.3.4"        -> "host:port"        (bare host gains the port)
+//   - "host:3306"               -> "host:3306"        (existing port preserved)
+//   - "host:"                   -> "host:port"        (empty port filled in)
+//   - "2001:db8::1"             -> "[2001:db8::1]:port" (bare IPv6 bracketed)
+//   - "[2001:db8::1]"           -> "[2001:db8::1]:port" (bracketed IPv6 gains port)
+//   - "[2001:db8::1]:3306"      -> "[2001:db8::1]:3306" (existing port preserved)
+//
+// net.SplitHostPort succeeds with an empty port for a trailing colon, and a
+// bracketed IPv6 literal with no port already carries the brackets that
+// net.JoinHostPort would add again — so the raw host must be unwrapped before
+// rejoining to avoid a double-bracketed, undialable address.
+func hostWithDefaultPort(host, defaultPort string) string {
+	if h, port, err := net.SplitHostPort(host); err == nil {
+		if port != "" {
+			return host
+		}
+		return net.JoinHostPort(h, defaultPort)
+	}
+	bare := strings.TrimSuffix(strings.TrimPrefix(host, "["), "]")
+	return net.JoinHostPort(bare, defaultPort)
 }
 
 // Metadata keys the Vitess (PlanetScale) engine reads from a resolved Target.

--- a/pkg/inventory/connection_assembler_test.go
+++ b/pkg/inventory/connection_assembler_test.go
@@ -66,6 +66,30 @@ func TestMySQLConnectionAssemblerKeepsBracketedIPv6Port(t *testing.T) {
 	assert.Equal(t, "[2001:db8::1]:3307", cfg.Addr)
 }
 
+// A bracketed IPv6 literal with no port already carries the brackets; the
+// default port must be appended without bracketing a second time.
+func TestMySQLConnectionAssemblerAppendsPortToBracketedIPv6WithoutPort(t *testing.T) {
+	a := MySQLConnectionAssembler{DefaultPort: "3306"}
+
+	dsn, _, err := a.Assemble("[2001:db8::1]", nil, &Credentials{Username: "ddl", Password: "secret"})
+	require.NoError(t, err)
+	cfg, err := mysql.ParseDSN(dsn)
+	require.NoError(t, err)
+	assert.Equal(t, "[2001:db8::1]:3306", cfg.Addr)
+}
+
+// A host with a trailing colon parses with an empty port; the default port
+// fills it in rather than leaving an undialable address.
+func TestMySQLConnectionAssemblerFillsEmptyPort(t *testing.T) {
+	a := MySQLConnectionAssembler{DefaultPort: "3306"}
+
+	dsn, _, err := a.Assemble("orders.example:", nil, &Credentials{Username: "ddl", Password: "secret"})
+	require.NoError(t, err)
+	cfg, err := mysql.ParseDSN(dsn)
+	require.NoError(t, err)
+	assert.Equal(t, "orders.example:3306", cfg.Addr)
+}
+
 func TestMySQLConnectionAssemblerRequiresHost(t *testing.T) {
 	_, _, err := MySQLConnectionAssembler{}.Assemble("", nil, &Credentials{Username: "ddl", Password: "secret"})
 	require.Error(t, err)


### PR DESCRIPTION
## Why this matters

A resolved MySQL endpoint can arrive in host forms the connection assembler mishandled, producing an undialable DSN — a confusing dial/parse failure rather than a clear error.

## What it does

The MySQL connection assembler decided whether to append the default port from whether `net.SplitHostPort` returned an error, which broke two cases:

- A **bracketed IPv6 literal with no port** (`[2001:db8::1]`) got bracketed a second time into `[[2001:db8::1]]:3306`.
- A **trailing-colon host** (`host:`) parsed with an empty port and was left unchanged.

Both now route through a `hostWithDefaultPort` helper that unwraps a bracketed host before rejoining and fills an empty port. Bare hosts, IPv4, existing ports, and bare IPv6 are unaffected. Adds focused tests for the two previously-broken forms.

## How it moves toward northstar

Hardens the engine-agnostic target-resolution path so IPv6 and edge-form endpoints connect reliably as inventory-driven resolution widens.