### PR TITLE
feat(observability): log the engine-call boundary for revert and skip-revert

### DIFF
--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -1267,9 +1267,11 @@ func (c *LocalClient) Revert(ctx context.Context, req *ternv1.RevertRequest) (*t
 	if err != nil {
 		return nil, fmt.Errorf("build revert request for task %s: %w", task.TaskIdentifier, err)
 	}
+	c.logger.Info("sending revert request to engine", task.LogAttrs()...)
 	if _, err = eng.Revert(ctx, controlReq); err != nil {
 		return nil, fmt.Errorf("revert failed: %w", err)
 	}
+	c.logger.Info("engine accepted the revert request", task.LogAttrs()...)
 	return &ternv1.RevertResponse{Accepted: true}, nil
 }
 
@@ -1284,9 +1286,11 @@ func (c *LocalClient) SkipRevert(ctx context.Context, req *ternv1.SkipRevertRequ
 	if err != nil {
 		return nil, fmt.Errorf("build skip-revert request for task %s: %w", task.TaskIdentifier, err)
 	}
+	c.logger.Info("sending skip-revert request to engine", task.LogAttrs()...)
 	if _, err = eng.SkipRevert(ctx, controlReq); err != nil {
 		return nil, fmt.Errorf("skip revert failed: %w", err)
 	}
+	c.logger.Info("engine accepted the skip-revert request", task.LogAttrs()...)
 	return &ternv1.SkipRevertResponse{Accepted: true}, nil
 }
 


### PR DESCRIPTION
## Why this matters

The revert-window finalization path had one silent spot: the synchronous `LocalClient.Revert` and `SkipRevert` methods called the engine to undo or finalize a schema change with no log lines, while every sibling path (the API handler, the driver poll loop, the durable control-request processor) logs richly. During an incident that left a blind spot on exactly the operation an operator is watching.

## What it does

Logs when each control operation is sent to the engine and when the engine accepts it, with the task triage attributes (`LogAttrs`).

## How it moves toward northstar

Closes the last unlogged step on the revert/skip-revert path so the full finalization lifecycle is traceable from logs alone.