### PR TITLE
feat(github): repository-level webhook dispatch for a shared App

### DIFF
--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -281,6 +281,18 @@ If `webhook-secret` is set in the config, SchemaBot validates the `X-Hub-Signatu
 
 If the secret is not set, signature validation is skipped (useful for local development).
 
+## Repository-level Webhooks (optional)
+
+A single deployment can also accept deliveries from a **repository-level webhook** (a webhook configured directly on a repo, rather than on the GitHub App). This lets several SchemaBot deployments that share one GitHub App all receive the same repo's events. Set a separate secret for these deliveries:
+
+```yaml
+github:
+  webhook-secret: "env:GITHUB_WEBHOOK_SECRET"           # App-installed deliveries
+  repo-webhook-secret: "env:GITHUB_REPO_WEBHOOK_SECRET" # repository-level deliveries
+```
+
+When `repo-webhook-secret` is set, deliveries whose `X-GitHub-Hook-Installation-Target-Type` header is `repository` are HMAC-verified against this secret. Such deliveries carry no installation id in their payload, so SchemaBot resolves the App's installation for the repo via the App JWT and caches it. Leave `repo-webhook-secret` unset to disable this path; App-installed deliveries are unaffected either way.
+
 ## Troubleshooting
 
 **Webhook not receiving events**: Check that the webhook URL is reachable from GitHub. Use the **Recent Deliveries** tab on your GitHub App's settings page to see delivery attempts and response codes.

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -247,6 +247,16 @@ type GitHubConfig struct {
 	// Supports secret references: env:VAR, file:/path, secretsmanager:name#key.
 	WebhookSecret string `yaml:"webhook-secret"`
 
+	// RepoWebhookSecret is the HMAC secret for validating repository-level
+	// webhook deliveries (registered directly on a repo, as opposed to the
+	// App's own webhook). When set, the handler additionally accepts
+	// repository-targeted deliveries verified against this secret and resolves
+	// the App's installation per repo, since such deliveries carry no
+	// installation id in the payload. Leave empty to disable repo-webhook
+	// dispatch (the default). Supports secret references: env:VAR, file:/path,
+	// secretsmanager:name#key.
+	RepoWebhookSecret string `yaml:"repo-webhook-secret,omitempty"`
+
 	// CheckName is the base name for aggregate GitHub Check Runs published by
 	// this App. Environment-scoped deployments append the environment in
 	// parentheses, for example "SchemaBot (staging)".
@@ -329,6 +339,13 @@ func (g *GitHubConfig) ResolvePrivateKey() (string, error) {
 // ResolveWebhookSecret resolves the webhook secret value using the secrets resolver.
 func (g *GitHubConfig) ResolveWebhookSecret() (string, error) {
 	return secrets.Resolve(g.WebhookSecret, "")
+}
+
+// ResolveRepoWebhookSecret resolves the repository-level webhook HMAC secret,
+// supporting env:/file:/secretsmanager: references. Empty when repo-webhook
+// dispatch is not configured.
+func (g *GitHubConfig) ResolveRepoWebhookSecret() (string, error) {
+	return secrets.Resolve(g.RepoWebhookSecret, "")
 }
 
 // GitHubAppConfig is one entry in ServerConfig.Apps. It carries the same

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -35,6 +35,9 @@ const schemaDiscoveryConcurrency = 10
 // Production uses *Client (JWT auth via ghinstallation); tests use a fake with httptest.
 type GitHubClientFactory interface {
 	ForInstallation(installationID int64) (*InstallationClient, error)
+	// InstallationIDForRepo resolves the App's installation id for a repo,
+	// needed for repo-level webhook deliveries that carry no installation id.
+	InstallationIDForRepo(ctx context.Context, repo string) (int64, error)
 }
 
 // Client handles GitHub App-level operations and creates per-installation clients.
@@ -69,6 +72,14 @@ type Client struct {
 	// every call.
 	installationsMu sync.Mutex
 	installations   map[int64]*InstallationClient
+
+	// repoInstallations caches the App's installation id for a repository,
+	// resolved via the App JWT. Repo-level webhook deliveries (unlike
+	// App-installed webhook deliveries) carry no installation id in the
+	// payload, so repo-webhook dispatch must look it up. A GitHub App installs
+	// once per account/org, so the id is stable per repo and safe to memoise.
+	repoInstallationsMu sync.Mutex
+	repoInstallations   map[string]int64
 
 	// checkStatusSingleflight coalesces concurrent GetPRCheckStatuses
 	// calls for the same (repo, sha) into a single upstream request via
@@ -132,6 +143,7 @@ func NewClient(appID int64, privateKey []byte, logger *slog.Logger, opts ...Clie
 		privateKey:              privateKey,
 		logger:                  logger,
 		installations:           make(map[int64]*InstallationClient),
+		repoInstallations:       make(map[string]int64),
 		checkStatusSingleflight: NewCheckStatusSingleflight(),
 	}
 	for _, opt := range opts {
@@ -237,6 +249,48 @@ func (c *Client) ForInstallation(installationID int64) (*InstallationClient, err
 	c.logger.Info("constructed installation client",
 		"installation_id", installationID, "app_slug", slug)
 	return ic, nil
+}
+
+// InstallationIDForRepo resolves this App's installation id for repo (in
+// "owner/name" form) via the App JWT, caching the result. Repo-level webhook
+// deliveries carry no installation id in the payload — only App-installed
+// webhook deliveries do — so repo-webhook dispatch uses this to obtain the id
+// needed to mint an installation client for API calls.
+func (c *Client) InstallationIDForRepo(ctx context.Context, repo string) (int64, error) {
+	c.repoInstallationsMu.Lock()
+	if id, ok := c.repoInstallations[repo]; ok {
+		c.repoInstallationsMu.Unlock()
+		return id, nil
+	}
+	c.repoInstallationsMu.Unlock()
+
+	owner, name := splitRepo(repo)
+	if owner == "" || name == "" {
+		return 0, fmt.Errorf("resolve installation for %q: repository must be in owner/name form", repo)
+	}
+
+	appBaseTransport := newGitHubRateLimitTransport(newGitHubMetricsTransport(http.DefaultTransport, 0, c.loadAppSlug))
+	appTransport, err := ghinstallation.NewAppsTransport(appBaseTransport, c.appID, c.privateKey)
+	if err != nil {
+		return 0, fmt.Errorf("create app transport to resolve installation for %s: %w", repo, err)
+	}
+	appClient := gh.NewClient(&http.Client{Transport: appTransport, Timeout: 10 * time.Second})
+	appClient.DisableRateLimitCheck = true
+
+	installation, _, err := appClient.Apps.FindRepositoryInstallation(ctx, owner, name)
+	if err != nil {
+		return 0, fmt.Errorf("find installation for %s: %w", repo, err)
+	}
+	id := installation.GetID()
+	if id == 0 {
+		return 0, fmt.Errorf("find installation for %s: GitHub returned installation id 0", repo)
+	}
+
+	c.repoInstallationsMu.Lock()
+	c.repoInstallations[repo] = id
+	c.repoInstallationsMu.Unlock()
+	c.logger.Info("resolved GitHub App installation for repo", "repo", repo, "installation_id", id)
+	return id, nil
 }
 
 // NewInstallationClient creates an InstallationClient from a pre-configured go-github client.

--- a/pkg/github/client_installation_test.go
+++ b/pkg/github/client_installation_test.go
@@ -1,0 +1,39 @@
+package github
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A previously-resolved installation id is served from cache without minting an
+// App JWT or calling GitHub — repo-webhook deliveries for an already-seen repo
+// must not pay a network round trip per event.
+func TestInstallationIDForRepoCacheHit(t *testing.T) {
+	c := &Client{
+		repoInstallations: map[string]int64{"octocat/hello-world": 42},
+		logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	id, err := c.InstallationIDForRepo(t.Context(), "octocat/hello-world")
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), id)
+}
+
+// A repo string that is not in "owner/name" form is rejected before any GitHub
+// call, with an error naming the offending value so the cause is obvious from
+// logs alone.
+func TestInstallationIDForRepoInvalidForm(t *testing.T) {
+	c := &Client{
+		repoInstallations: map[string]int64{},
+		logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	_, err := c.InstallationIDForRepo(t.Context(), "noslash")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "owner/name form")
+	assert.Contains(t, err.Error(), "noslash")
+}

--- a/pkg/github/clientset_test.go
+++ b/pkg/github/clientset_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +11,8 @@ import (
 type stubFactory struct{}
 
 func (stubFactory) ForInstallation(int64) (*InstallationClient, error) { return nil, nil }
+
+func (stubFactory) InstallationIDForRepo(context.Context, string) (int64, error) { return 0, nil }
 
 func TestClientSet_For(t *testing.T) {
 	t.Run("returns registered factory", func(t *testing.T) {

--- a/pkg/serve/serve.go
+++ b/pkg/serve/serve.go
@@ -604,12 +604,19 @@ func buildSingleAppWebhookRuntime(serverConfig *api.ServerConfig, svc *api.Servi
 		return webhookRuntime{}, fmt.Errorf("GitHub App is configured but webhook secret is empty — set github.webhook-secret to secure the /webhook endpoint")
 	}
 
+	repoWebhookSecret, err := serverConfig.GitHub.ResolveRepoWebhookSecret()
+	if err != nil {
+		return webhookRuntime{}, fmt.Errorf("resolve GitHub repo-webhook secret: %w", err)
+	}
+
 	appID := serverConfig.GitHub.ResolveAppID()
 	ghClient := ghclient.NewClient(appID, []byte(ghPrivateKey), logger,
 		ghclient.WithTrustedCheckAppSlugs(serverConfig.GitHub.TrustedCheckAppSlugs))
-	handler := webhook.NewHandler(svc, ghClient, []byte(ghWebhookSecret), logger)
+	handler := webhook.NewHandler(svc, ghClient, []byte(ghWebhookSecret), logger,
+		webhook.WithRepoWebhookSecret([]byte(repoWebhookSecret)))
 	logger.Info("GitHub webhook endpoint registered",
-		"app_id", appID, "trusted_check_app_slugs", serverConfig.GitHub.TrustedCheckAppSlugs)
+		"app_id", appID, "trusted_check_app_slugs", serverConfig.GitHub.TrustedCheckAppSlugs,
+		"repo_webhook_dispatch", repoWebhookSecret != "")
 	return webhookRuntime{
 		handler:                         handler,
 		reconcileMissingSummaryComments: handler.ReconcileMissingSummaryComments,

--- a/pkg/webhook/check_run.go
+++ b/pkg/webhook/check_run.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 )
@@ -23,7 +24,7 @@ type checkRunPayload struct {
 	} `json:"installation"`
 }
 
-func (h *Handler) handleCheckRun(w http.ResponseWriter, body []byte) {
+func (h *Handler) handleCheckRun(ctx context.Context, w http.ResponseWriter, body []byte) {
 	var payload checkRunPayload
 	if err := json.Unmarshal(body, &payload); err != nil {
 		h.writeError(w, http.StatusBadRequest, "invalid check_run payload")
@@ -40,7 +41,7 @@ func (h *Handler) handleCheckRun(w http.ResponseWriter, body []byte) {
 		return
 	}
 
-	installationID := payload.Installation.ID
+	installationID := h.effectiveInstallationID(ctx, payload.Installation.ID)
 	if installationID == 0 {
 		h.writeError(w, http.StatusBadRequest, "missing installation ID in webhook payload")
 		return

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -50,15 +50,16 @@ const defaultAppName = "default"
 //	                                                       naming for Apps)
 //	X-GitHub-Hook-Installation-Target-ID:   <app_id>
 //
-// The Target-Type value "repository" is only sent for repository-level
-// webhooks (registered directly on a repo, distinct from App-installed
-// webhooks); SchemaBot does not handle those. The single example in
-// https://docs.github.com/en/webhooks/webhook-events-and-payloads
-// happens to be a repository webhook, which is a known source of
-// confusion. Verified against a live SchemaBot App delivery: header
-// values were Target-Type "integration" and Target-ID equal to the
-// SchemaBot App ID — i.e., never the repository ID, regardless of the
-// underlying event type.
+// The Target-Type value "repository" is sent for repository-level webhooks
+// (registered directly on a repo, distinct from App-installed webhooks).
+// SchemaBot handles those only in the opt-in repo-webhook dispatch mode
+// (when repoWebhookSecret is set); otherwise they are rejected. The single
+// example in https://docs.github.com/en/webhooks/webhook-events-and-payloads
+// happens to be a repository webhook, which is a known source of confusion.
+// Verified against a live SchemaBot App delivery: for App-installed
+// deliveries the header values were Target-Type "integration" and Target-ID
+// equal to the SchemaBot App ID — i.e., never the repository ID, regardless
+// of the underlying event type.
 const (
 	headerHookTargetID   = "X-GitHub-Hook-Installation-Target-ID"
 	headerHookTargetType = "X-GitHub-Hook-Installation-Target-Type"

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -65,6 +65,7 @@ const (
 	headerDeliveryID     = "X-GitHub-Delivery"
 	headerSignature256   = "X-Hub-Signature-256"
 	hookTargetTypeApp    = "integration"
+	hookTargetTypeRepo   = "repository"
 	maxWebhookBodyBytes  = 10 << 20
 )
 
@@ -92,29 +93,52 @@ type Handler struct {
 	// single-secret behavior.
 	webhookAppByID map[int64]string
 
+	// repoWebhookSecret, when non-empty, enables repository-level webhook
+	// dispatch: deliveries with target type "repository" are HMAC-verified
+	// against this secret and their App installation is resolved per repo
+	// (such deliveries carry no installation id in the payload). Empty
+	// disables repo-webhook dispatch and leaves the App-webhook paths
+	// (single- and multi-App) unchanged.
+	repoWebhookSecret []byte
+
 	logger                     *slog.Logger
 	priorEnvCheckMaxAttempts   int
 	priorEnvCheckRetryInterval time.Duration
+}
+
+// HandlerOption configures optional Handler behavior at construction. Options
+// are variadic and backward-compatible: existing callers that pass none are
+// unaffected.
+type HandlerOption func(*Handler)
+
+// WithRepoWebhookSecret enables repository-level webhook dispatch by setting the
+// HMAC secret used to verify repository-targeted deliveries. Empty is a no-op.
+func WithRepoWebhookSecret(secret []byte) HandlerOption {
+	return func(h *Handler) {
+		if len(secret) > 0 {
+			h.repoWebhookSecret = secret
+		}
+	}
 }
 
 // NewHandler creates a new webhook handler for the legacy single-App
 // configuration. The provided factory is registered in the internal
 // ClientSet under the "default" App name so per-repo client resolution
 // works uniformly with the multi-App path used by NewHandlerWithDispatch.
-func NewHandler(service *api.Service, ghClient github.GitHubClientFactory, webhookSecret []byte, logger *slog.Logger) *Handler {
-	return NewHandlerWithClientSet(service, github.NewSingleClientSet(defaultAppName, ghClient), webhookSecret, logger)
+func NewHandler(service *api.Service, ghClient github.GitHubClientFactory, webhookSecret []byte, logger *slog.Logger, opts ...HandlerOption) *Handler {
+	return NewHandlerWithClientSet(service, github.NewSingleClientSet(defaultAppName, ghClient), webhookSecret, logger, opts...)
 }
 
 // NewHandlerWithClientSet creates a new webhook handler from an
 // already-built single-App ClientSet. The provided webhook secret is
 // associated with the defaultAppName entry and verified directly on every
 // request (legacy single-secret mode).
-func NewHandlerWithClientSet(service *api.Service, ghClients github.ClientSet, webhookSecret []byte, logger *slog.Logger) *Handler {
+func NewHandlerWithClientSet(service *api.Service, ghClients github.ClientSet, webhookSecret []byte, logger *slog.Logger, opts ...HandlerOption) *Handler {
 	secrets := map[string][]byte{}
 	if len(webhookSecret) > 0 {
 		secrets[defaultAppName] = webhookSecret
 	}
-	return NewHandlerWithDispatch(service, ghClients, secrets, nil, logger)
+	return NewHandlerWithDispatch(service, ghClients, secrets, nil, logger, opts...)
 }
 
 // NewHandlerWithDispatch creates a new webhook handler with header-keyed
@@ -126,7 +150,7 @@ func NewHandlerWithClientSet(service *api.Service, ghClients github.ClientSet, w
 // handler will require the header, reject unknown App IDs, and HMAC-verify
 // against the resolved App's secret only. Pass an empty/nil webhookAppByID
 // for legacy single-secret behavior (used internally by NewHandler).
-func NewHandlerWithDispatch(service *api.Service, ghClients github.ClientSet, webhookSecretsByApp map[string][]byte, webhookAppByID map[int64]string, logger *slog.Logger) *Handler {
+func NewHandlerWithDispatch(service *api.Service, ghClients github.ClientSet, webhookSecretsByApp map[string][]byte, webhookAppByID map[int64]string, logger *slog.Logger, opts ...HandlerOption) *Handler {
 	h := &Handler{
 		service:                    service,
 		ghClients:                  ghClients,
@@ -135,6 +159,9 @@ func NewHandlerWithDispatch(service *api.Service, ghClients github.ClientSet, we
 		logger:                     logger,
 		priorEnvCheckMaxAttempts:   defaultPriorEnvCheckMaxAttempts,
 		priorEnvCheckRetryInterval: defaultPriorEnvCheckRetryInterval,
+	}
+	for _, opt := range opts {
+		opt(h)
 	}
 
 	// Register recovery callback so the operator can attach comment observers
@@ -418,19 +445,24 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Cross-check that the App that signed the webhook is the App that
 	// owns this repository in config. A signed delivery for a repo owned
 	// by a different App is a config drift or hostile install — fail
-	// closed before any handler runs.
-	if err := h.verifySignedAppOwnsRepo(repo, appName); err != nil {
-		h.logger.Warn("webhook rejected: signing App does not own repo",
-			"app_name", appName,
-			"app_id", appID,
-			"delivery_id", r.Header.Get(headerDeliveryID),
-			"event", eventType,
-			"action", action,
-			"repo", repo,
-			"error", err)
-		metrics.RecordWebhookEvent(r.Context(), metricAppName(appName), eventType, action, repo, "app_repo_mismatch")
-		h.writeError(w, http.StatusUnauthorized, "invalid webhook dispatch")
-		return
+	// closed before any handler runs. Repo-level webhook deliveries are
+	// attributed to the single shared App rather than a per-repo App, so this
+	// per-repo-App ownership check does not apply to them; the repo allowlist
+	// (enforced per handler) is the authorization boundary in that mode.
+	if !h.repoWebhookTargeted(r) {
+		if err := h.verifySignedAppOwnsRepo(repo, appName); err != nil {
+			h.logger.Warn("webhook rejected: signing App does not own repo",
+				"app_name", appName,
+				"app_id", appID,
+				"delivery_id", r.Header.Get(headerDeliveryID),
+				"event", eventType,
+				"action", action,
+				"repo", repo,
+				"error", err)
+			metrics.RecordWebhookEvent(r.Context(), metricAppName(appName), eventType, action, repo, "app_repo_mismatch")
+			h.writeError(w, http.StatusUnauthorized, "invalid webhook dispatch")
+			return
+		}
 	}
 
 	ctx, span := otel.Tracer("schemabot").Start(r.Context(), "webhook",
@@ -452,12 +484,30 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	metricApp := metricAppName(appName)
 
+	// Repo-level webhook deliveries carry no installation id in the payload, so
+	// resolve the shared App's installation for the repo and stash it on the
+	// context for downstream handlers. Only for repos this deployment manages;
+	// others are rejected by the per-handler allowlist anyway. Fail closed (500)
+	// so GitHub redelivers if resolution fails transiently.
+	if h.repoWebhookTargeted(r) && repo != "" && h.isRepoAllowed(repo) {
+		installationID, err := h.resolveRepoWebhookInstallation(ctx, repo)
+		if err != nil {
+			h.logger.Error("failed to resolve installation for repo-level webhook",
+				"repo", repo, "event", eventType, "action", action,
+				"delivery_id", r.Header.Get(headerDeliveryID), "error", err)
+			metrics.RecordWebhookEvent(ctx, metricApp, eventType, action, repo, "installation_resolution_failed")
+			h.writeError(w, http.StatusInternalServerError, "failed to resolve installation for repository webhook")
+			return
+		}
+		ctx = withResolvedInstallationID(ctx, installationID)
+	}
+
 	switch eventType {
 	case "issue_comment":
 		h.handleIssueComment(ctx, metricApp, w, body)
 		metrics.RecordWebhookEvent(ctx, metricApp, eventType, action, repo, "processed")
 	case "check_run":
-		h.handleCheckRun(w, body)
+		h.handleCheckRun(ctx, w, body)
 		metrics.RecordWebhookEvent(ctx, metricApp, eventType, action, repo, "processed")
 	case "pull_request":
 		h.handlePullRequest(ctx, metricApp, w, body)
@@ -493,6 +543,19 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // configured secret (when set) and reports the App name as defaultAppName.
 func (h *Handler) authenticateWebhook(r *http.Request, body []byte) (appName string, appID int64, status string, ok bool) {
 	signature := r.Header.Get(headerSignature256)
+
+	// Repository-level webhook dispatch: when configured, a delivery whose
+	// target type is "repository" is verified against the repo-webhook secret.
+	// The shared App provides API identity (its installation is resolved per
+	// repo downstream); events are delivered by repo webhooks, not the App
+	// webhook. Falls through to App-webhook handling for "integration"
+	// deliveries so a deployment can run both during the cutover.
+	if h.repoWebhookTargeted(r) {
+		if !verifyHMAC(signature, body, h.repoWebhookSecret) {
+			return defaultAppName, 0, "invalid_signature", false
+		}
+		return defaultAppName, 0, "", true
+	}
 
 	if len(h.webhookAppByID) > 0 {
 		targetType := r.Header.Get(headerHookTargetType)
@@ -557,6 +620,63 @@ func (h *Handler) verifySignedAppOwnsRepo(repo, signedAppName string) error {
 		return fmt.Errorf("repo %q is configured to be owned by app %q but webhook was signed by app %q", repo, expected.Name, signedAppName)
 	}
 	return nil
+}
+
+// repoWebhookTargeted reports whether this delivery is a repository-level
+// webhook that repo-webhook dispatch should handle: repo-webhook mode is
+// configured and the delivery carries the "repository" hook target type.
+func (h *Handler) repoWebhookTargeted(r *http.Request) bool {
+	return len(h.repoWebhookSecret) > 0 &&
+		strings.EqualFold(r.Header.Get(headerHookTargetType), hookTargetTypeRepo)
+}
+
+// installationIDContextKey carries an installation id resolved out of band
+// (repo-webhook dispatch, whose deliveries omit the payload installation id).
+type installationIDContextKey struct{}
+
+// withResolvedInstallationID returns a context carrying an out-of-band-resolved
+// installation id for downstream handlers.
+func withResolvedInstallationID(ctx context.Context, id int64) context.Context {
+	return context.WithValue(ctx, installationIDContextKey{}, id)
+}
+
+// effectiveInstallationID returns the payload-supplied installation id when
+// present, otherwise the id resolved out of band and stashed on the context by
+// repo-webhook dispatch. Returns 0 when neither is available, which callers
+// already treat as a missing-installation error.
+func (h *Handler) effectiveInstallationID(ctx context.Context, payloadID int64) int64 {
+	if payloadID != 0 {
+		return payloadID
+	}
+	if id, ok := ctx.Value(installationIDContextKey{}).(int64); ok {
+		return id
+	}
+	return 0
+}
+
+// isRepoAllowed reports whether the repository is permitted by config. Mirrors
+// the per-handler allowlist check so repo-webhook dispatch can skip installation
+// resolution for repos this deployment does not manage.
+func (h *Handler) isRepoAllowed(repo string) bool {
+	return h.service == nil || h.service.Config().IsRepoAllowed(repo)
+}
+
+// resolveRepoWebhookInstallation resolves the shared App's installation id for
+// repo so a repo-level webhook delivery (which carries no installation id) can
+// mint an installation client downstream.
+func (h *Handler) resolveRepoWebhookInstallation(ctx context.Context, repo string) (int64, error) {
+	factory, err := h.factoryForRepo(repo)
+	if err != nil {
+		return 0, fmt.Errorf("resolve client factory for repo %s: %w", repo, err)
+	}
+	id, err := factory.InstallationIDForRepo(ctx, repo)
+	if err != nil {
+		return 0, fmt.Errorf("resolve installation for repo %s: %w", repo, err)
+	}
+	if id == 0 {
+		return 0, fmt.Errorf("resolved installation id 0 for repo %s", repo)
+	}
+	return id, nil
 }
 
 // metricAppName normalizes the App name for the webhook events counter so

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -68,10 +68,13 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 		return
 	}
 
-	var installationID int64
+	var payloadInstallationID int64
 	if payload.Installation != nil {
-		installationID = payload.Installation.ID
+		payloadInstallationID = payload.Installation.ID
 	}
+	// Repo-level webhook deliveries carry no installation id in the payload; the
+	// dispatcher resolves it and stashes it on the context.
+	installationID := h.effectiveInstallationID(ctx, payloadInstallationID)
 
 	repo := payload.Repository.FullName
 	pr := payload.Issue.Number

--- a/pkg/webhook/merge_group.go
+++ b/pkg/webhook/merge_group.go
@@ -60,7 +60,7 @@ func (h *Handler) handleMergeGroup(ctx context.Context, metricApp string, w http
 
 	repo := payload.Repository.FullName
 	headSHA := payload.MergeGroup.HeadSHA
-	installationID := payload.Installation.ID
+	installationID := h.effectiveInstallationID(ctx, payload.Installation.ID)
 	if installationID == 0 {
 		h.writeError(w, http.StatusBadRequest, "missing installation ID in merge_group payload")
 		return

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -44,13 +44,17 @@ func (h *Handler) handlePullRequest(ctx context.Context, metricApp string, w htt
 		return
 	}
 
+	// Repo-level webhook deliveries carry no installation id in the payload; the
+	// dispatcher resolves it and stashes it on the context.
+	installationID := h.effectiveInstallationID(ctx, payload.Installation.ID)
+
 	// Route PR actions
 	switch payload.Action {
 	case "opened", "synchronize", "reopened":
 		// proceed to auto-plan below
 	case "closed":
-		h.goSafe(payload.Repository.FullName, payload.PullRequest.Number, payload.Installation.ID, func() {
-			h.handlePRClosed(payload.Repository.FullName, payload.PullRequest.Number, payload.Installation.ID)
+		h.goSafe(payload.Repository.FullName, payload.PullRequest.Number, installationID, func() {
+			h.handlePRClosed(payload.Repository.FullName, payload.PullRequest.Number, installationID)
 		})
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "PR close cleanup started"})
 		return
@@ -61,7 +65,6 @@ func (h *Handler) handlePullRequest(ctx context.Context, metricApp string, w htt
 		return
 	}
 
-	installationID := payload.Installation.ID
 	if installationID == 0 {
 		h.writeError(w, http.StatusBadRequest, "missing installation ID in webhook payload")
 		return

--- a/pkg/webhook/repo_webhook_dispatch_test.go
+++ b/pkg/webhook/repo_webhook_dispatch_test.go
@@ -1,0 +1,166 @@
+package webhook
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/api"
+	ghclient "github.com/block/schemabot/pkg/github"
+)
+
+func repoWebhookSig(secret, body []byte) string {
+	mac := hmac.New(sha256.New, secret)
+	mac.Write(body)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func repoWebhookRequest(t *testing.T, targetType string, body []byte) *http.Request {
+	t.Helper()
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/webhook", strings.NewReader(string(body)))
+	if targetType != "" {
+		r.Header.Set(headerHookTargetType, targetType)
+	}
+	return r
+}
+
+// Repo-webhook dispatch only engages for repository-targeted deliveries and
+// only when a repo-webhook secret is configured; App-webhook deliveries
+// ("integration") and unconfigured deployments are unaffected.
+func TestRepoWebhookTargeted(t *testing.T) {
+	body := []byte(`{}`)
+	configured := &Handler{repoWebhookSecret: []byte("s"), logger: testLogger()}
+	unconfigured := &Handler{logger: testLogger()}
+
+	assert.True(t, configured.repoWebhookTargeted(repoWebhookRequest(t, "repository", body)))
+	assert.True(t, configured.repoWebhookTargeted(repoWebhookRequest(t, "Repository", body)), "target type is case-insensitive")
+	assert.False(t, configured.repoWebhookTargeted(repoWebhookRequest(t, "integration", body)), "App-webhook deliveries are not repo-webhook")
+	assert.False(t, configured.repoWebhookTargeted(repoWebhookRequest(t, "", body)))
+	assert.False(t, unconfigured.repoWebhookTargeted(repoWebhookRequest(t, "repository", body)), "no repo-webhook secret means no repo-webhook dispatch")
+}
+
+// The payload-supplied installation id always wins; the out-of-band id resolved
+// for repo-webhook deliveries (which carry no installation id) is the fallback.
+func TestEffectiveInstallationID(t *testing.T) {
+	h := &Handler{logger: testLogger()}
+	ctx := t.Context()
+
+	assert.Equal(t, int64(7), h.effectiveInstallationID(ctx, 7), "payload id is used when present")
+	assert.Equal(t, int64(99), h.effectiveInstallationID(withResolvedInstallationID(ctx, 99), 0), "resolved id used when payload is 0")
+	assert.Equal(t, int64(7), h.effectiveInstallationID(withResolvedInstallationID(ctx, 99), 7), "payload id takes precedence over resolved id")
+	assert.Equal(t, int64(0), h.effectiveInstallationID(ctx, 0), "0 when neither is available")
+}
+
+// A repository-targeted delivery is authenticated against the repo-webhook
+// secret and attributed to the single shared App; a bad signature is rejected.
+func TestAuthenticateWebhook_RepoWebhookMode(t *testing.T) {
+	secret := []byte("repo-secret")
+	h := &Handler{repoWebhookSecret: secret, logger: testLogger()}
+	body := []byte(`{"action":"opened","repository":{"full_name":"octocat/hello-world"}}`)
+
+	valid := repoWebhookRequest(t, hookTargetTypeRepo, body)
+	valid.Header.Set(headerSignature256, repoWebhookSig(secret, body))
+	name, _, status, ok := h.authenticateWebhook(valid, body)
+	require.True(t, ok)
+	assert.Equal(t, defaultAppName, name)
+	assert.Empty(t, status)
+
+	bad := repoWebhookRequest(t, hookTargetTypeRepo, body)
+	bad.Header.Set(headerSignature256, repoWebhookSig([]byte("wrong-secret"), body))
+	_, _, status, ok = h.authenticateWebhook(bad, body)
+	assert.False(t, ok)
+	assert.Equal(t, "invalid_signature", status)
+}
+
+// repoWebhookIssueComment builds a repository-targeted issue_comment delivery
+// signed with the repo-webhook secret. It deliberately omits the installation
+// object: repository-level webhook payloads carry no installation id, so the
+// handler must resolve it out of band before any command runs.
+func repoWebhookIssueComment(t *testing.T, comment string, repoSecret []byte) *http.Request {
+	t.Helper()
+	payload := map[string]any{
+		"action": "created",
+		"comment": map[string]any{
+			"id":   42,
+			"body": comment,
+			"user": map[string]any{"login": "testuser", "type": "User"},
+		},
+		"issue": map[string]any{
+			"number":       1,
+			"pull_request": map[string]any{"url": "https://api.github.com/repos/octocat/hello-world/pulls/1"},
+		},
+		"repository": map[string]any{"full_name": "octocat/hello-world"},
+	}
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/webhook", strings.NewReader(string(body)))
+	req.Header.Set("X-GitHub-Event", "issue_comment")
+	req.Header.Set(headerHookTargetType, hookTargetTypeRepo)
+	req.Header.Set(headerSignature256, repoWebhookSig(repoSecret, body))
+	return req
+}
+
+// A repository-targeted delivery resolves its installation id out of band and
+// injects it onto the request context so command handlers can act on the PR —
+// even though the payload carries no installation object. The "help" command
+// posts a comment via the resolved installation client, proving the full path:
+// repo-secret auth → installation resolution → context injection → handler.
+func TestServeHTTPRepoWebhookResolvesInstallation(t *testing.T) {
+	client, mux := setupGitHubServer(t)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+	})
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/comments/42/reactions", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+	factory := &fakeClientFactory{client: installClient}
+	service := api.New(nil, &api.ServerConfig{Repos: map[string]api.RepoConfig{"octocat/hello-world": {}}}, nil, testLogger())
+	secret := []byte("repo-secret")
+	h := &Handler{
+		service:           service,
+		ghClients:         ghclient.NewSingleClientSet(defaultAppName, factory),
+		logger:            testLogger(),
+		repoWebhookSecret: secret,
+	}
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, repoWebhookIssueComment(t, "schemabot help", secret))
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "help posted")
+}
+
+// If the installation id cannot be resolved for a repository-targeted delivery,
+// the handler must fail closed with 500 rather than proceed without an
+// installation client. GitHub retries on 5xx, so a transient resolution failure
+// is recoverable; silently dropping the event is not.
+func TestServeHTTPRepoWebhookResolutionFailureFailsClosed(t *testing.T) {
+	factory := &fakeClientFactory{installIDErr: errors.New("github unavailable")}
+	service := api.New(nil, &api.ServerConfig{Repos: map[string]api.RepoConfig{"octocat/hello-world": {}}}, nil, testLogger())
+	secret := []byte("repo-secret")
+	h := &Handler{
+		service:           service,
+		ghClients:         ghclient.NewSingleClientSet(defaultAppName, factory),
+		logger:            testLogger(),
+		repoWebhookSecret: secret,
+	}
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, repoWebhookIssueComment(t, "schemabot help", secret))
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}

--- a/pkg/webhook/testhelpers_test.go
+++ b/pkg/webhook/testhelpers_test.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -20,10 +21,26 @@ import (
 // fakeClientFactory returns a pre-built InstallationClient for any installation ID.
 type fakeClientFactory struct {
 	client *ghclient.InstallationClient
+	// repoInstallationID is returned by InstallationIDForRepo. Zero defaults to
+	// 12345 so repo-webhook dispatch tests resolve a non-zero installation id.
+	repoInstallationID int64
+	// installIDErr, when set, makes InstallationIDForRepo fail — used to
+	// exercise the fail-closed path of repo-webhook dispatch.
+	installIDErr error
 }
 
 func (f *fakeClientFactory) ForInstallation(_ int64) (*ghclient.InstallationClient, error) {
 	return f.client, nil
+}
+
+func (f *fakeClientFactory) InstallationIDForRepo(_ context.Context, _ string) (int64, error) {
+	if f.installIDErr != nil {
+		return 0, f.installIDErr
+	}
+	if f.repoInstallationID != 0 {
+		return f.repoInstallationID, nil
+	}
+	return 12345, nil
 }
 
 // setupGitHubServer creates an httptest server and a go-github client pointed at it.


### PR DESCRIPTION
## Why this matters
A single shared GitHub App can't fan its app-level webhook out to many independent SchemaBot deployments running in separate accounts. Repository-level webhooks (one per deployment, each with its own HMAC secret) are how a shared App reaches them — this is the foundation for multiple deployments contributing to one aggregate Check Run per environment, instead of one App and one check per deployment.

## What it does
Adds an opt-in repository-level webhook dispatch mode, inert unless `github.repo-webhook-secret` is configured:

- Accepts deliveries whose `X-GitHub-Hook-Installation-Target-Type` is `repository`, HMAC-verified against the repo-webhook secret.
- Resolves the App's installation for the repo via the App JWT (`Apps.FindRepositoryInstallation`, cached) and injects it on the request context — repository-level deliveries carry no installation id in the payload, unlike App-installed deliveries.
- Skips the App-ownership cross-check for repo-target deliveries (it only applies to App-installed deliveries) while still gating on the existing repo allowlist.
- Fails closed: if the installation can't be resolved, the delivery is rejected with 500 rather than processed without an installation client.

Existing single- and multi-App webhook paths are unchanged.

## Northstar
First building block toward folding several deployments' status into one required check per environment, reducing required-check sprawl on shared repositories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
