### PR TITLE
feat(github): aggregate-check config (leader/participant + expected tenants)

### DIFF
--- a/pkg/api/aggregate_config.go
+++ b/pkg/api/aggregate_config.go
@@ -1,0 +1,154 @@
+package api
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Aggregate-check roles for a repository. In a multi-tenant aggregate check,
+// several SchemaBot deployments coordinate one shared Check Run per environment
+// through GitHub: exactly one deployment is the leader, the rest are
+// participants.
+const (
+	// AggregateRoleLeader marks a deployment as the sole creator and writer of a
+	// repository's aggregate Check Run. The leader folds every participating
+	// tenant's reported state into the single check.
+	AggregateRoleLeader = "leader"
+
+	// AggregateRoleParticipant marks a deployment that reports only its own state
+	// for a repository and never writes the aggregate check.
+	AggregateRoleParticipant = "participant"
+)
+
+// AggregateConfig configures this deployment's role in a multi-tenant aggregate
+// check for one repository. It is set under repos.<repo>.aggregate. When unset,
+// the repository uses the standard single-deployment check behavior.
+type AggregateConfig struct {
+	// Role is this deployment's role for the repo: "leader" or "participant".
+	Role string `yaml:"role"`
+
+	// ExpectedTenants is the set of tenants expected to participate on this repo,
+	// each with the repo-relative directory prefixes it manages (same matching as
+	// databases.<db>.allowed_dirs — directory prefixes, not globs). It is required
+	// for, and only meaningful to, a leader: it is the fail-closed safety contract
+	// for the aggregate fold. A leader's database config cannot know other tenants'
+	// databases, so this is the only place the leader learns which tenants to
+	// expect — at tenant granularity, with the path prefixes used to decide which
+	// tenants a given PR touches. Must be empty for a participant.
+	ExpectedTenants []ExpectedTenant `yaml:"expected_tenants,omitempty"`
+}
+
+// ExpectedTenant names a tenant expected to participate on a repository and the
+// repo-relative directory prefixes it manages there. The leader uses these
+// prefixes against a PR's changed files to decide which tenants must report
+// before the aggregate check can pass.
+type ExpectedTenant struct {
+	Tenant string   `yaml:"tenant"`
+	Paths  []string `yaml:"paths"`
+}
+
+func (a *AggregateConfig) isLeader() bool {
+	return a != nil && a.Role == AggregateRoleLeader
+}
+
+// AggregateRoleForRepo returns this deployment's configured aggregate role for
+// repo ("leader" or "participant"), or "" if the repo has no aggregate config.
+func (c *ServerConfig) AggregateRoleForRepo(repo string) string {
+	if c == nil {
+		return ""
+	}
+	repoConfig, ok := c.Repos[repo]
+	if !ok || repoConfig.Aggregate == nil {
+		return ""
+	}
+	return repoConfig.Aggregate.Role
+}
+
+// IsAggregateLeaderForRepo reports whether this deployment is the aggregate-check
+// leader (the sole check writer) for repo.
+func (c *ServerConfig) IsAggregateLeaderForRepo(repo string) bool {
+	return c.AggregateRoleForRepo(repo) == AggregateRoleLeader
+}
+
+// ExpectedTenantsForPR returns the tenants expected to report on repo for a PR
+// touching changedFiles: the subset of the repo's expected-tenant set whose
+// managed path prefixes cover at least one changed file. This is the fail-closed
+// contract for the aggregate fold — every returned tenant must report
+// terminal-success before the check can pass. Returns nil when this deployment
+// is not the leader for repo, since only the leader holds the expected set.
+func (c *ServerConfig) ExpectedTenantsForPR(repo string, changedFiles []string) []string {
+	if c == nil {
+		return nil
+	}
+	repoConfig, ok := c.Repos[repo]
+	if !ok || !repoConfig.Aggregate.isLeader() {
+		return nil
+	}
+	var expected []string
+	for _, tenant := range repoConfig.Aggregate.ExpectedTenants {
+		if anyPathCovered(tenant.Paths, changedFiles) {
+			expected = append(expected, tenant.Tenant)
+		}
+	}
+	return expected
+}
+
+// anyPathCovered reports whether any changed file falls under one of dirs, using
+// the same directory-prefix matching as databases.<db>.allowed_dirs.
+func anyPathCovered(dirs, changedFiles []string) bool {
+	for _, file := range changedFiles {
+		if schemaPathAllowed(dirs, file) {
+			return true
+		}
+	}
+	return false
+}
+
+// validateAggregateConfig validates a repository's aggregate config. A leader
+// must carry a non-empty, well-formed expected-tenant set; a participant must
+// not (only the leader holds it). Fails closed on any ambiguity so a
+// misconfiguration cannot silently weaken the gate.
+func validateAggregateConfig(repo string, agg *AggregateConfig) error {
+	if agg == nil {
+		return nil
+	}
+
+	switch agg.Role {
+	case AggregateRoleLeader, AggregateRoleParticipant:
+	case "":
+		return fmt.Errorf("repos.%s.aggregate.role is required (must be %q or %q)", repo, AggregateRoleLeader, AggregateRoleParticipant)
+	default:
+		return fmt.Errorf("repos.%s.aggregate.role %q is invalid (must be %q or %q)", repo, agg.Role, AggregateRoleLeader, AggregateRoleParticipant)
+	}
+
+	if agg.Role == AggregateRoleParticipant {
+		if len(agg.ExpectedTenants) > 0 {
+			return fmt.Errorf("repos.%s.aggregate.expected_tenants must be empty for role %q (only the leader holds the expected-tenant set)", repo, AggregateRoleParticipant)
+		}
+		return nil
+	}
+
+	if len(agg.ExpectedTenants) == 0 {
+		return fmt.Errorf("repos.%s.aggregate.expected_tenants is required for role %q", repo, AggregateRoleLeader)
+	}
+	seen := make(map[string]struct{}, len(agg.ExpectedTenants))
+	for _, tenant := range agg.ExpectedTenants {
+		name := strings.TrimSpace(tenant.Tenant)
+		if name == "" {
+			return fmt.Errorf("repos.%s.aggregate.expected_tenants contains an entry with an empty tenant", repo)
+		}
+		if _, ok := seen[name]; ok {
+			return fmt.Errorf("repos.%s.aggregate.expected_tenants contains duplicate tenant %q", repo, name)
+		}
+		seen[name] = struct{}{}
+		if len(tenant.Paths) == 0 {
+			return fmt.Errorf("repos.%s.aggregate.expected_tenants[%q].paths is empty", repo, name)
+		}
+		for _, p := range tenant.Paths {
+			if _, err := normalizeSchemaPath(p); err != nil {
+				return fmt.Errorf("repos.%s.aggregate.expected_tenants[%q].paths contains invalid value %q: %w", repo, name, p, err)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/api/aggregate_config_test.go
+++ b/pkg/api/aggregate_config_test.go
@@ -1,0 +1,148 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func leaderConfig() *ServerConfig {
+	return &ServerConfig{
+		Repos: map[string]RepoConfig{
+			"octocat/shared-repo": {
+				Aggregate: &AggregateConfig{
+					Role: AggregateRoleLeader,
+					ExpectedTenants: []ExpectedTenant{
+						{Tenant: "tenant-a", Paths: []string{"services/a"}},
+						{Tenant: "tenant-b", Paths: []string{"services/b"}},
+						{Tenant: "tenant-c", Paths: []string{"services/c"}},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestAggregateRoleAccessors(t *testing.T) {
+	c := &ServerConfig{
+		Repos: map[string]RepoConfig{
+			"octocat/shared-repo": {Aggregate: &AggregateConfig{Role: AggregateRoleLeader, ExpectedTenants: []ExpectedTenant{{Tenant: "tenant-b", Paths: []string{"services/b"}}}}},
+			"octocat/other-repo":  {Aggregate: &AggregateConfig{Role: AggregateRoleParticipant}},
+			"octocat/plain":       {},
+		},
+	}
+
+	assert.Equal(t, AggregateRoleLeader, c.AggregateRoleForRepo("octocat/shared-repo"))
+	assert.Equal(t, AggregateRoleParticipant, c.AggregateRoleForRepo("octocat/other-repo"))
+	assert.Empty(t, c.AggregateRoleForRepo("octocat/plain"), "no aggregate config means no role")
+	assert.Empty(t, c.AggregateRoleForRepo("octocat/unknown"), "unknown repo means no role")
+
+	assert.True(t, c.IsAggregateLeaderForRepo("octocat/shared-repo"))
+	assert.False(t, c.IsAggregateLeaderForRepo("octocat/other-repo"), "participant is not the leader")
+	assert.False(t, c.IsAggregateLeaderForRepo("octocat/plain"))
+}
+
+// The leader derives the per-PR expected-tenant set from the path prefixes its
+// expected tenants manage intersected with the PR's changed files — without
+// needing to know any tenant's databases.
+func TestExpectedTenantsForPR(t *testing.T) {
+	c := leaderConfig()
+
+	t.Run("single tenant touched", func(t *testing.T) {
+		got := c.ExpectedTenantsForPR("octocat/shared-repo", []string{"services/b/schema/orders.sql"})
+		assert.Equal(t, []string{"tenant-b"}, got)
+	})
+
+	t.Run("multiple tenants touched", func(t *testing.T) {
+		got := c.ExpectedTenantsForPR("octocat/shared-repo", []string{
+			"services/a/schema/users.sql",
+			"services/b/schema/orders.sql",
+		})
+		assert.ElementsMatch(t, []string{"tenant-a", "tenant-b"}, got)
+	})
+
+	t.Run("no tenant paths touched", func(t *testing.T) {
+		got := c.ExpectedTenantsForPR("octocat/shared-repo", []string{"docs/README.md", "services/z/x.sql"})
+		assert.Empty(t, got)
+	})
+
+	t.Run("not the leader returns nil", func(t *testing.T) {
+		participant := &ServerConfig{Repos: map[string]RepoConfig{
+			"octocat/shared-repo": {Aggregate: &AggregateConfig{Role: AggregateRoleParticipant}},
+		}}
+		assert.Nil(t, participant.ExpectedTenantsForPR("octocat/shared-repo", []string{"services/b/x.sql"}))
+	})
+
+	t.Run("no aggregate config returns nil", func(t *testing.T) {
+		plain := &ServerConfig{Repos: map[string]RepoConfig{"octocat/shared-repo": {}}}
+		assert.Nil(t, plain.ExpectedTenantsForPR("octocat/shared-repo", []string{"services/b/x.sql"}))
+	})
+}
+
+func TestValidateAggregateConfig(t *testing.T) {
+	t.Run("nil is allowed", func(t *testing.T) {
+		require.NoError(t, validateAggregateConfig("octocat/r", nil))
+	})
+
+	t.Run("valid leader", func(t *testing.T) {
+		require.NoError(t, validateAggregateConfig("octocat/r", &AggregateConfig{
+			Role:            AggregateRoleLeader,
+			ExpectedTenants: []ExpectedTenant{{Tenant: "tenant-b", Paths: []string{"services/b"}}},
+		}))
+	})
+
+	t.Run("valid participant", func(t *testing.T) {
+		require.NoError(t, validateAggregateConfig("octocat/r", &AggregateConfig{Role: AggregateRoleParticipant}))
+	})
+
+	cases := []struct {
+		name    string
+		agg     *AggregateConfig
+		wantErr string
+	}{
+		{"empty role", &AggregateConfig{Role: ""}, "role is required"},
+		{"invalid role", &AggregateConfig{Role: "boss"}, "is invalid"},
+		{
+			"participant with expected_tenants",
+			&AggregateConfig{Role: AggregateRoleParticipant, ExpectedTenants: []ExpectedTenant{{Tenant: "x", Paths: []string{"a"}}}},
+			"must be empty for role",
+		},
+		{"leader without expected_tenants", &AggregateConfig{Role: AggregateRoleLeader}, "expected_tenants is required"},
+		{
+			"leader with empty tenant",
+			&AggregateConfig{Role: AggregateRoleLeader, ExpectedTenants: []ExpectedTenant{{Tenant: "  ", Paths: []string{"a"}}}},
+			"empty tenant",
+		},
+		{
+			"leader with duplicate tenant",
+			&AggregateConfig{Role: AggregateRoleLeader, ExpectedTenants: []ExpectedTenant{
+				{Tenant: "tenant-b", Paths: []string{"a"}},
+				{Tenant: "tenant-b", Paths: []string{"b"}},
+			}},
+			"duplicate tenant",
+		},
+		{
+			"leader with empty paths",
+			&AggregateConfig{Role: AggregateRoleLeader, ExpectedTenants: []ExpectedTenant{{Tenant: "tenant-b"}}},
+			"paths is empty",
+		},
+		{
+			"leader with absolute path",
+			&AggregateConfig{Role: AggregateRoleLeader, ExpectedTenants: []ExpectedTenant{{Tenant: "tenant-b", Paths: []string{"/etc"}}}},
+			"invalid value",
+		},
+		{
+			"leader with escaping path",
+			&AggregateConfig{Role: AggregateRoleLeader, ExpectedTenants: []ExpectedTenant{{Tenant: "tenant-b", Paths: []string{"../secrets"}}}},
+			"invalid value",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateAggregateConfig("octocat/r", tc.agg)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -709,6 +709,12 @@ type RepoConfig struct {
 	// while only the legacy single-App GitHub field is configured is
 	// rejected at config load to fail closed on misconfiguration.
 	GitHubApp string `yaml:"github_app,omitempty"`
+
+	// Aggregate configures this deployment's role in a multi-tenant aggregate
+	// check for the repository (leader vs participant, and — for a leader — the
+	// set of tenants expected to report). Nil means the repository uses the
+	// standard single-deployment check behavior.
+	Aggregate *AggregateConfig `yaml:"aggregate,omitempty"`
 }
 
 // DeploymentTarget is one entry in EnvironmentConfig.Deployments. It carries
@@ -892,6 +898,12 @@ func (c *ServerConfig) Validate() error {
 			if endpoints[env] == "" {
 				return fmt.Errorf("database %q environment %q deployment %q has no endpoint", name, env, envConfig.Deployment)
 			}
+		}
+	}
+
+	for repo, repoConfig := range c.Repos {
+		if err := validateAggregateConfig(repo, repoConfig.Aggregate); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
## Why this matters
For several SchemaBot deployments to coordinate one shared Check Run per environment on a repository, exactly one of them (the leader) must fold the others' state, and it must know which tenants to expect — at tenant granularity, without needing any other tenant's database config. This adds the configuration that expresses that role and expectation. It is inert: no behavior changes until later changes consume it.

## What it does
Adds `repos.<repo>.aggregate`:

```yaml
repos:
  octocat/shared-repo:
    aggregate:
      role: leader            # or: participant
      expected_tenants:       # leader-only; the fail-closed safety contract
        - { tenant: tenant-a, paths: ["services/a"] }
        - { tenant: tenant-b, paths: ["services/b"] }
```

- `role`: `leader` (sole creator/writer of the aggregate check) or `participant` (reports only its own state).
- `expected_tenants`: for a leader, the tenants expected to report, each with the repo-relative directory prefixes it manages — reusing the existing `allowed_dirs` directory-prefix matching, so no new dependency.
- Accessors: `AggregateRoleForRepo`, `IsAggregateLeaderForRepo`, and `ExpectedTenantsForPR(repo, changedFiles)` — the subset of expected tenants whose paths cover a PR's changed files. This is how the leader decides which tenants must report, using path prefixes alone — it never needs another tenant's databases.
- Validation fails closed: a leader must carry a well-formed, de-duplicated expected-tenant set; a participant must not carry one.

## Northstar
Configuration foundation for a leader-folded aggregate check that collapses per-tenant required checks on shared repositories into one row per environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
