### PR TITLE
feat(github): TenantStateSource seam + tenant-state model

### DIFF
--- a/pkg/webhook/tenant_state.go
+++ b/pkg/webhook/tenant_state.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 )
 
 // tenantStateVersion is the schema version of the machine-readable tenant-state
@@ -41,9 +42,15 @@ type TenantDatabaseState struct {
 // authenticated RPC channel later).
 type TenantState struct {
 	Tenant string `json:"tenant"`
-	SHA    string `json:"sha"`
-	// Rollup is the tenant's overall state for the head SHA, folded from its
-	// databases. The leader maps it to the aggregate check conclusion.
+	// Environment scopes this block to one environment. A deployment may manage
+	// several environments (AllowedEnvironments), and the aggregate check is
+	// per-environment, so state is keyed by (tenant, environment): a tenant
+	// publishes one block per environment it participates in, and each
+	// environment's leader folds only the blocks for its own environment.
+	Environment string `json:"environment"`
+	SHA         string `json:"sha"`
+	// Rollup is the tenant's overall state for this environment at the head SHA,
+	// folded from its databases. The leader maps it to the check conclusion.
 	Rollup    string                `json:"rollup"`
 	Databases []TenantDatabaseState `json:"databases,omitempty"`
 }
@@ -84,11 +91,46 @@ func parseTenantStateBlock(commentBody string) (state TenantState, found bool, e
 		return TenantState{}, false, nil
 	}
 	version, convErr := strconv.Atoi(match[1])
-	if convErr != nil || version != tenantStateVersion {
-		return TenantState{}, true, fmt.Errorf("unsupported tenant-state block version %q (want %d)", match[1], tenantStateVersion)
+	if convErr != nil {
+		return TenantState{}, true, fmt.Errorf("malformed tenant-state block version %q: %w", match[1], convErr)
+	}
+	if version != tenantStateVersion {
+		return TenantState{}, true, fmt.Errorf("unsupported tenant-state block version %d (want %d)", version, tenantStateVersion)
 	}
 	if err := json.Unmarshal([]byte(match[2]), &state); err != nil {
 		return TenantState{}, true, fmt.Errorf("parse tenant-state block: %w", err)
 	}
+	if err := state.validate(); err != nil {
+		return TenantState{}, true, fmt.Errorf("invalid tenant-state block: %w", err)
+	}
 	return state, true, nil
+}
+
+// validate reports whether a parsed TenantState carries the fields a reader
+// requires to trust it. A syntactically valid but semantically empty block
+// (missing tenant, sha, rollup, or a database row missing its name or state)
+// must be rejected so a reader fails closed rather than treating it as a real
+// report.
+func (s TenantState) validate() error {
+	if strings.TrimSpace(s.Tenant) == "" {
+		return fmt.Errorf("missing tenant")
+	}
+	if strings.TrimSpace(s.Environment) == "" {
+		return fmt.Errorf("missing environment")
+	}
+	if strings.TrimSpace(s.SHA) == "" {
+		return fmt.Errorf("missing sha")
+	}
+	if strings.TrimSpace(s.Rollup) == "" {
+		return fmt.Errorf("missing rollup")
+	}
+	for i, db := range s.Databases {
+		if strings.TrimSpace(db.Database) == "" {
+			return fmt.Errorf("databases[%d] missing db", i)
+		}
+		if strings.TrimSpace(db.State) == "" {
+			return fmt.Errorf("databases[%d] (%s) missing state", i, db.Database)
+		}
+	}
+	return nil
 }

--- a/pkg/webhook/tenant_state.go
+++ b/pkg/webhook/tenant_state.go
@@ -1,0 +1,94 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+// tenantStateVersion is the schema version of the machine-readable tenant-state
+// block embedded in a per-tenant comment. The leader rejects blocks it cannot
+// parse (including unknown versions) and treats the tenant as not-reported,
+// which is fail-closed.
+const tenantStateVersion = 1
+
+// tenantStateMarker identifies the hidden HTML-comment block that carries a
+// tenant's machine-readable state inside an otherwise human-facing comment.
+const tenantStateMarker = "schemabot:state"
+
+// TenantDatabaseState is one (database) row of a tenant's reported state for a
+// pull request head SHA.
+type TenantDatabaseState struct {
+	Database string `json:"db"`
+	// Op is the DDL operation (for example "ALTER TABLE" or "CREATE TABLE").
+	// Optional; carried through for display.
+	Op string `json:"op,omitempty"`
+	// State is this database's state for the head SHA (for example running,
+	// applied, or failed). It is carried verbatim; the leader's fold maps it to
+	// an aggregate check conclusion.
+	State string `json:"state"`
+	// Detail is a short human-facing description (for example a DDL summary).
+	// Optional.
+	Detail string `json:"detail,omitempty"`
+}
+
+// TenantState is a single tenant's published, machine-readable state for a pull
+// request head SHA — the cross-tenant interface the leader folds into the one
+// aggregate check. It is transport-agnostic: a TenantStateSource yields these
+// regardless of how the tenant published them (PR comments today; an issue or an
+// authenticated RPC channel later).
+type TenantState struct {
+	Tenant string `json:"tenant"`
+	SHA    string `json:"sha"`
+	// Rollup is the tenant's overall state for the head SHA, folded from its
+	// databases. The leader maps it to the aggregate check conclusion.
+	Rollup    string                `json:"rollup"`
+	Databases []TenantDatabaseState `json:"databases,omitempty"`
+}
+
+// TenantStateSource yields every participating tenant's published state for a
+// pull request at a head SHA, independent of the underlying transport. The
+// leader fold reads through this seam so the transport (PR comments, a dedicated
+// issue, or a future RPC channel) can change without touching the fold, the
+// render, or the check.
+type TenantStateSource interface {
+	StatesForPR(ctx context.Context, repo string, pr int, headSHA string) ([]TenantState, error)
+}
+
+// tenantStateBlockRE matches the hidden tenant-state block. The payload is
+// captured up to the closing "-->" (not up to the first "}"), so nested JSON in
+// the databases array round-trips correctly.
+var tenantStateBlockRE = regexp.MustCompile(`(?s)<!--\s*` + regexp.QuoteMeta(tenantStateMarker) + `\s+v=(\d+)\s+(.*?)-->`)
+
+// renderTenantStateBlock serializes a tenant's state into the hidden
+// HTML-comment block embedded in its comment. The block is the machine-readable
+// source of truth; the human-facing summary is rendered separately.
+func renderTenantStateBlock(state TenantState) (string, error) {
+	payload, err := json.Marshal(state)
+	if err != nil {
+		return "", fmt.Errorf("marshal tenant state for %q: %w", state.Tenant, err)
+	}
+	return fmt.Sprintf("<!-- %s v=%d\n%s\n-->", tenantStateMarker, tenantStateVersion, payload), nil
+}
+
+// parseTenantStateBlock extracts and parses the tenant-state block from a
+// comment body. found is false when the comment carries no block (not an
+// error). A present-but-malformed or unsupported-version block returns an error
+// so the leader treats the tenant as not-reported (fail-closed) rather than
+// silently trusting a bad block.
+func parseTenantStateBlock(commentBody string) (state TenantState, found bool, err error) {
+	match := tenantStateBlockRE.FindStringSubmatch(commentBody)
+	if match == nil {
+		return TenantState{}, false, nil
+	}
+	version, convErr := strconv.Atoi(match[1])
+	if convErr != nil || version != tenantStateVersion {
+		return TenantState{}, true, fmt.Errorf("unsupported tenant-state block version %q (want %d)", match[1], tenantStateVersion)
+	}
+	if err := json.Unmarshal([]byte(match[2]), &state); err != nil {
+		return TenantState{}, true, fmt.Errorf("parse tenant-state block: %w", err)
+	}
+	return state, true, nil
+}

--- a/pkg/webhook/tenant_state_test.go
+++ b/pkg/webhook/tenant_state_test.go
@@ -10,9 +10,10 @@ import (
 
 func TestTenantStateBlockRoundTrip(t *testing.T) {
 	state := TenantState{
-		Tenant: "tenant-b",
-		SHA:    "abc1234",
-		Rollup: "pending",
+		Tenant:      "tenant-b",
+		Environment: "staging",
+		SHA:         "abc1234",
+		Rollup:      "pending",
 		Databases: []TenantDatabaseState{
 			{Database: "orders", Op: "ALTER TABLE", State: "running", Detail: "add column email"},
 			{Database: "ledger", Op: "CREATE TABLE", State: "applied"},
@@ -34,10 +35,11 @@ func TestTenantStateBlockRoundTrip(t *testing.T) {
 // brace.
 func TestParseTenantStateBlockEmbeddedInComment(t *testing.T) {
 	state := TenantState{
-		Tenant:    "tenant-b",
-		SHA:       "abc1234",
-		Rollup:    "pending",
-		Databases: []TenantDatabaseState{{Database: "orders", State: "running"}},
+		Tenant:      "tenant-b",
+		Environment: "staging",
+		SHA:         "abc1234",
+		Rollup:      "pending",
+		Databases:   []TenantDatabaseState{{Database: "orders", State: "running"}},
 	}
 	block, err := renderTenantStateBlock(state)
 	require.NoError(t, err)
@@ -49,6 +51,7 @@ func TestParseTenantStateBlockEmbeddedInComment(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, found)
 	assert.Equal(t, "tenant-b", got.Tenant)
+	assert.Equal(t, "staging", got.Environment)
 	assert.Equal(t, "abc1234", got.SHA)
 	require.Len(t, got.Databases, 1)
 	assert.Equal(t, "orders", got.Databases[0].Database)
@@ -79,11 +82,49 @@ func TestParseTenantStateBlockUnsupportedVersion(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported tenant-state block version")
 }
 
+// An out-of-range version is reported as a malformed version (a distinct,
+// actionable cause), not conflated with an unsupported one.
+func TestParseTenantStateBlockMalformedVersion(t *testing.T) {
+	comment := "<!-- " + tenantStateMarker + " v=99999999999999999999\n{\"tenant\":\"tenant-b\"}\n-->"
+	_, found, err := parseTenantStateBlock(comment)
+	assert.True(t, found)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "malformed tenant-state block version")
+}
+
+// A block whose JSON parses but is missing fields a reader needs to trust it
+// must be rejected (found=true, descriptive error) so the reader fails closed
+// instead of treating a semantically-empty block as a real report.
+func TestParseTenantStateBlockMissingRequiredFields(t *testing.T) {
+	cases := []struct {
+		name    string
+		json    string
+		wantErr string
+	}{
+		{"missing tenant", `{"environment":"staging","sha":"abc","rollup":"pending"}`, "missing tenant"},
+		{"missing environment", `{"tenant":"tenant-b","sha":"abc","rollup":"pending"}`, "missing environment"},
+		{"missing sha", `{"tenant":"tenant-b","environment":"staging","rollup":"pending"}`, "missing sha"},
+		{"missing rollup", `{"tenant":"tenant-b","environment":"staging","sha":"abc"}`, "missing rollup"},
+		{"database missing db", `{"tenant":"tenant-b","environment":"staging","sha":"abc","rollup":"pending","databases":[{"state":"running"}]}`, "missing db"},
+		{"database missing state", `{"tenant":"tenant-b","environment":"staging","sha":"abc","rollup":"pending","databases":[{"db":"orders"}]}`, "missing state"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			comment := "<!-- " + tenantStateMarker + " v=1\n" + tc.json + "\n-->"
+			_, found, err := parseTenantStateBlock(comment)
+			assert.True(t, found, "the marker was present")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid tenant-state block")
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
 // A no-changes report carries an empty databases list and still round-trips —
 // participants must publish this so the leader can distinguish "done, nothing to
 // do" from "not yet reported".
 func TestTenantStateBlockNoChanges(t *testing.T) {
-	state := TenantState{Tenant: "tenant-c", SHA: "abc1234", Rollup: "no_changes"}
+	state := TenantState{Tenant: "tenant-c", Environment: "production", SHA: "abc1234", Rollup: "no_changes"}
 	block, err := renderTenantStateBlock(state)
 	require.NoError(t, err)
 	assert.True(t, strings.Contains(block, "no_changes"))

--- a/pkg/webhook/tenant_state_test.go
+++ b/pkg/webhook/tenant_state_test.go
@@ -1,0 +1,96 @@
+package webhook
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTenantStateBlockRoundTrip(t *testing.T) {
+	state := TenantState{
+		Tenant: "tenant-b",
+		SHA:    "abc1234",
+		Rollup: "pending",
+		Databases: []TenantDatabaseState{
+			{Database: "orders", Op: "ALTER TABLE", State: "running", Detail: "add column email"},
+			{Database: "ledger", Op: "CREATE TABLE", State: "applied"},
+		},
+	}
+
+	block, err := renderTenantStateBlock(state)
+	require.NoError(t, err)
+
+	got, found, err := parseTenantStateBlock(block)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, state, got, "round-trip must preserve nested database rows")
+}
+
+// The block round-trips even when embedded in an otherwise human-facing comment
+// (the collapsed summary the writer adds around it), and nested JSON in the
+// databases array is captured up to the closing marker rather than the first
+// brace.
+func TestParseTenantStateBlockEmbeddedInComment(t *testing.T) {
+	state := TenantState{
+		Tenant:    "tenant-b",
+		SHA:       "abc1234",
+		Rollup:    "pending",
+		Databases: []TenantDatabaseState{{Database: "orders", State: "running"}},
+	}
+	block, err := renderTenantStateBlock(state)
+	require.NoError(t, err)
+
+	comment := "<details><summary>SchemaBot · tenant-b — 1 change pending</summary>\n\n" +
+		block + "\n\n| Database | State |\n|---|---|\n| orders | running |\n</details>"
+
+	got, found, err := parseTenantStateBlock(comment)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "tenant-b", got.Tenant)
+	assert.Equal(t, "abc1234", got.SHA)
+	require.Len(t, got.Databases, 1)
+	assert.Equal(t, "orders", got.Databases[0].Database)
+}
+
+func TestParseTenantStateBlockNotFound(t *testing.T) {
+	got, found, err := parseTenantStateBlock("just a normal PR comment, nothing to see here")
+	require.NoError(t, err)
+	assert.False(t, found)
+	assert.Equal(t, TenantState{}, got)
+}
+
+// A present-but-broken block must surface an error (found=true) so the leader
+// fails closed and treats the tenant as not-reported rather than trusting it.
+func TestParseTenantStateBlockMalformed(t *testing.T) {
+	comment := "<!-- " + tenantStateMarker + " v=1\n{not valid json}\n-->"
+	_, found, err := parseTenantStateBlock(comment)
+	assert.True(t, found, "the marker was present")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse tenant-state block")
+}
+
+func TestParseTenantStateBlockUnsupportedVersion(t *testing.T) {
+	comment := "<!-- " + tenantStateMarker + " v=2\n{\"tenant\":\"tenant-b\"}\n-->"
+	_, found, err := parseTenantStateBlock(comment)
+	assert.True(t, found)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported tenant-state block version")
+}
+
+// A no-changes report carries an empty databases list and still round-trips —
+// participants must publish this so the leader can distinguish "done, nothing to
+// do" from "not yet reported".
+func TestTenantStateBlockNoChanges(t *testing.T) {
+	state := TenantState{Tenant: "tenant-c", SHA: "abc1234", Rollup: "no_changes"}
+	block, err := renderTenantStateBlock(state)
+	require.NoError(t, err)
+	assert.True(t, strings.Contains(block, "no_changes"))
+
+	got, found, err := parseTenantStateBlock(block)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, state, got)
+	assert.Empty(t, got.Databases)
+}


### PR DESCRIPTION
## Why this matters
The leader that folds many deployments' state into one Check Run must read that state through a stable seam, so the *transport* (PR comments now; a dedicated issue or an authenticated RPC channel later) can change without touching the fold, the render, or the check. This adds that seam and the data model it carries. It is inert: no transport implementation and no caller yet.

## What it does
- `TenantState` — a tenant's published state for a PR head SHA: tenant id, SHA, an overall rollup, and per-database rows (`db`, `op`, `state`, `detail`).
- `TenantStateSource` — the interface the leader fold reads through: `StatesForPR(ctx, repo, pr, headSHA) ([]TenantState, error)`.
- A hidden machine-readable comment block (`render`/`parse`) that carries a `TenantState`. The parser:
  - captures the payload up to the closing marker (not the first `}`), so nested JSON in the databases array round-trips,
  - returns `found=false` when no block is present (not an error),
  - returns an error on a malformed or unsupported-version block, so a reader can fail closed and treat the tenant as not-reported rather than trust a bad block.

## Northstar
The transport seam that keeps the fold, the render, and the check independent of how tenant state travels — so the comment adapter today and a control-plane RPC adapter later are swaps behind one interface, not rewrites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
