### PR TITLE
fix(ux): tidy the apply comment body — deploy-request link and table-progress namespaces

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -777,7 +777,7 @@ That command wasn't recognized. Available commands:
 
 📊 1/3 complete · 1 failed · 1 cancelled
 
-### Table Progress
+**Schema `testapp`**
 
 **`users`**: 🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
 
@@ -1793,8 +1793,6 @@ Schema changes are being applied. Progress updates will be posted as new comment
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
-### Table Progress
-
 **`users`**: 🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 48%
 
 ```sql
@@ -1826,8 +1824,6 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 **Status**: Applied
 
-### Table Progress
-
 **`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
 
 ```sql
@@ -1848,8 +1844,6 @@ ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 **Status**: Failed
-
-### Table Progress
 
 **`users`**: 🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
 
@@ -1881,8 +1875,6 @@ schemabot apply -e staging
 
 **Status**: Stopped
 
-### Table Progress
-
 **`users`**: 🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 39%
 
 ```sql
@@ -1912,7 +1904,7 @@ schemabot start apply-a1b2c3d4e5f6 -e staging
 
 📊 3 queued
 
-### Table Progress
+**Schema `testapp`**
 
 **`orders`**: ⏳ Queued
 
@@ -1956,7 +1948,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 📊 1 running (22%) · 2 queued
 
-### Table Progress
+**Schema `testapp`**
 
 **`orders`**: 🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 22%
 
@@ -2001,7 +1993,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 📊 1/3 complete · 1 running (62%) · 1 queued
 
-### Table Progress
+**Schema `testapp`**
 
 **`users`**: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜ 62%
 
@@ -2046,7 +2038,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 📊 1/3 complete · 1 running (Active) · 1 queued
 
-### Table Progress
+**Schema `testapp`**
 
 **`users`**: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Active
 
@@ -2092,7 +2084,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 📊 1/3 complete · 1 checksumming · 1 queued
 
-### Table Progress
+**Schema `testapp`**
 
 **`users`**: 🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 🔍 Checksumming to verify data (21%)
 
@@ -2137,7 +2129,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 📊 2/3 complete · 1 running (17%)
 
-### Table Progress
+**Schema `testapp`**
 
 **`products`**: 🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 17%
 
@@ -2180,7 +2172,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
-### Table Progress
+**Schema `commerce`**
 
 **`users`**: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜ 62%
 
@@ -2212,7 +2204,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
-### Table Progress
+**Schema `commerce`**
 
 **`orders`**: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜ 70%
 
@@ -2248,7 +2240,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 📊 3/3 complete
 
-### Table Progress
+**Schema `testapp`**
 
 **`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
 
@@ -2311,9 +2303,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
-🔗 **Deploy request**: https://app.planetscale.com/acme/myapp/deploy-requests/42
-
-### Table Progress
+Deploy request: https://app.planetscale.com/acme/myapp/deploy-requests/42
 
 **`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
 
@@ -2392,7 +2382,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 📊 1 failed · 2 cancelled
 
-### Table Progress
+**Schema `testapp`**
 
 **`orders`**: 🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
 
@@ -2438,7 +2428,7 @@ schemabot apply -e staging
 
 📊 1/3 complete · 1 failed · 1 cancelled
 
-### Table Progress
+**Schema `testapp`**
 
 **`users`**: 🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
 
@@ -2484,7 +2474,7 @@ schemabot apply -e staging
 
 📊 1/2 complete · 1 stopped
 
-### Table Progress
+**Schema `testapp`**
 
 **`users`**: 🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 72%
 
@@ -2521,7 +2511,7 @@ schemabot start apply-a1b2c3d4e5f6 -e staging
 
 **Status**: Resuming
 
-### Table Progress
+**Schema `testapp`**
 
 **`users`**: 🔄 Resuming…
 
@@ -2554,7 +2544,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 📊 1/2 complete · 1 cancelled
 
-### Table Progress
+**Schema `testapp`**
 
 **`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
 
@@ -2591,7 +2581,7 @@ This schema change was cancelled and cannot be resumed. Open a new schema change
 
 📊 3 waiting for cutover
 
-### Table Progress
+**Schema `testapp`**
 
 **`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Waiting for cutover
 
@@ -2639,7 +2629,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 📊 3 cutting over
 
-### Table Progress
+**Schema `testapp`**
 
 **`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 🔄 Cutting over...
 
@@ -2680,11 +2670,11 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 **Status**: Revert window
 
-🔗 **Deploy request**: https://app.planetscale.com/acme/myapp/deploy-requests/42
+Deploy request: https://app.planetscale.com/acme/myapp/deploy-requests/42
 
 ⏳ **Revert window closes in**: 28m 30s
 
-### Table Progress
+**Keyspace `testapp`**
 
 **`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✓ Complete (pending revert)
 
@@ -2733,9 +2723,9 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 **Status**: Skipping revert
 
-🔗 **Deploy request**: https://app.planetscale.com/acme/myapp/deploy-requests/42
+Deploy request: https://app.planetscale.com/acme/myapp/deploy-requests/42
 
-### Table Progress
+**Keyspace `testapp`**
 
 **`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✓ Complete (pending revert)
 
@@ -5348,7 +5338,7 @@ schemabot cutover apply-a1b2c3d4e5f6 -e production
 
 📊 3 waiting for cutover
 
-### Table Progress
+**Schema `testapp`**
 
 **`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Waiting for cutover
 
@@ -5389,7 +5379,7 @@ schemabot cutover apply-a1b2c3d4e5f6 -e production
 
 📊 1/3 complete · 1 running (62%) · 1 queued
 
-### Table Progress
+**Schema `testapp`**
 
 **`users`**: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜ 62%
 
@@ -5477,7 +5467,7 @@ schemabot apply -e production
 
 📊 3/3 complete
 
-### Table Progress
+**Schema `testapp`**
 
 **`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
 
@@ -5513,7 +5503,7 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 
 📊 1/3 complete · 1 failed · 1 cancelled
 
-### Table Progress
+**Schema `testapp`**
 
 **`users`**: 🟥🟥🟥🟥🟥🟥⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ❌ Failed
 
@@ -5590,7 +5580,7 @@ _No details available yet._
 
 📊 3/3 complete
 
-### Table Progress
+**Schema `testapp`**
 
 **`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
 
@@ -5626,7 +5616,7 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 
 📊 3/3 complete
 
-### Table Progress
+**Schema `testapp`**
 
 **`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
 
@@ -5662,7 +5652,7 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 
 📊 3/3 complete
 
-### Table Progress
+**Schema `testapp`**
 
 **`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
 

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -527,18 +527,25 @@ type namespaceTableGroup struct {
 }
 
 // groupTablesByNamespace groups tables by namespace, preserving the order in
-// which each namespace first appears. Tables with no namespace are grouped under
-// the empty namespace, which renders without a header.
+// which each namespace first appears. The empty namespace and the "default"
+// placeholder both mean "no specific namespace": they are folded together and
+// render without a header, so a comment never shows a meaningless
+// "Schema `default`" / "Keyspace `default`" header or splits the same logical
+// no-namespace tables into separate groups.
 func groupTablesByNamespace(tables []TableProgressData) []namespaceTableGroup {
 	var groups []namespaceTableGroup
 	index := make(map[string]int)
 	for _, t := range tables {
-		if i, ok := index[t.Namespace]; ok {
+		ns := t.Namespace
+		if ns == "default" {
+			ns = ""
+		}
+		if i, ok := index[ns]; ok {
 			groups[i].tables = append(groups[i].tables, t)
 			continue
 		}
-		index[t.Namespace] = len(groups)
-		groups = append(groups, namespaceTableGroup{namespace: t.Namespace, tables: []TableProgressData{t}})
+		index[ns] = len(groups)
+		groups = append(groups, namespaceTableGroup{namespace: ns, tables: []TableProgressData{t}})
 	}
 	return groups
 }

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -275,7 +275,7 @@ func writeDeployRequestLink(sb *strings.Builder, data ApplyStatusCommentData) {
 	if data.DeployRequestURL == "" {
 		return
 	}
-	fmt.Fprintf(sb, "\n🔗 **Deploy request**: %s\n", data.DeployRequestURL)
+	fmt.Fprintf(sb, "\nDeploy request: %s\n", data.DeployRequestURL)
 }
 
 func stopOrCancelCommand(data ApplyStatusCommentData) string {

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -478,8 +478,10 @@ func writeVSchemaStatus(sb *strings.Builder, data ApplyStatusCommentData) {
 	}
 }
 
-// writeTableProgressSection writes the per-table progress breakdown.
-// Tables are sorted: active/running first, then pending, then completed/terminal last.
+// writeTableProgressSection writes the per-table progress breakdown, grouped by
+// namespace so the operator can see which schema (MySQL) or keyspace
+// (Vitess/PlanetScale, Strata) each table belongs to. Within a namespace, tables
+// are sorted active/running first, then pending, then completed/terminal last.
 func writeTableProgressSection(sb *strings.Builder, data ApplyStatusCommentData) {
 	// During the resume window the per-table percents are indeterminate (the data
 	// plane has not reported continuation vs fresh copy yet), so the aggregate
@@ -488,25 +490,67 @@ func writeTableProgressSection(sb *strings.Builder, data ApplyStatusCommentData)
 	if data.State != state.Apply.Resuming {
 		writeProgressSummary(sb, data.Tables)
 	}
-	sb.WriteString("\n### Table Progress\n\n")
+	sb.WriteString("\n")
 
-	sorted := make([]TableProgressData, len(data.Tables))
-	copy(sorted, data.Tables)
-	sort.SliceStable(sorted, func(i, j int) bool {
-		return tableStatePriority(sorted[i].Status) < tableStatePriority(sorted[j].Status)
-	})
+	for _, group := range groupTablesByNamespace(data.Tables) {
+		// Label the group by namespace when one is set. The bold metadata-style
+		// header and the row block below it stand in for a generic section header.
+		if group.namespace != "" {
+			fmt.Fprintf(sb, "**%s `%s`**\n\n", namespaceLabel(data.Engine), group.namespace)
+		}
 
-	for _, table := range sorted {
-		// While the apply is resuming, the data plane has not yet reported whether
-		// the schema change continues from its checkpoint or restarts from scratch,
-		// so the row-copy percent is indeterminate. Render state-only until the
-		// apply transitions to running and real progress is known.
-		if data.State == state.Apply.Resuming && !state.IsTerminalTaskState(state.NormalizeTaskStatus(table.Status)) {
-			renderResumingTable(sb, table)
+		sorted := make([]TableProgressData, len(group.tables))
+		copy(sorted, group.tables)
+		sort.SliceStable(sorted, func(i, j int) bool {
+			return tableStatePriority(sorted[i].Status) < tableStatePriority(sorted[j].Status)
+		})
+
+		for _, table := range sorted {
+			// While the apply is resuming, the data plane has not yet reported whether
+			// the schema change continues from its checkpoint or restarts from scratch,
+			// so the row-copy percent is indeterminate. Render state-only until the
+			// apply transitions to running and real progress is known.
+			if data.State == state.Apply.Resuming && !state.IsTerminalTaskState(state.NormalizeTaskStatus(table.Status)) {
+				renderResumingTable(sb, table)
+				continue
+			}
+			renderTableProgress(sb, table)
+		}
+	}
+}
+
+// namespaceTableGroup is a set of tables that share a namespace, in the order the
+// namespace first appears among the tables.
+type namespaceTableGroup struct {
+	namespace string
+	tables    []TableProgressData
+}
+
+// groupTablesByNamespace groups tables by namespace, preserving the order in
+// which each namespace first appears. Tables with no namespace are grouped under
+// the empty namespace, which renders without a header.
+func groupTablesByNamespace(tables []TableProgressData) []namespaceTableGroup {
+	var groups []namespaceTableGroup
+	index := make(map[string]int)
+	for _, t := range tables {
+		if i, ok := index[t.Namespace]; ok {
+			groups[i].tables = append(groups[i].tables, t)
 			continue
 		}
-		renderTableProgress(sb, table)
+		index[t.Namespace] = len(groups)
+		groups = append(groups, namespaceTableGroup{namespace: t.Namespace, tables: []TableProgressData{t}})
 	}
+	return groups
+}
+
+// namespaceLabel returns the operator-facing word for a table namespace: a
+// keyspace for the Vitess-family engines (PlanetScale, Strata), a schema for
+// MySQL (Spirit).
+func namespaceLabel(engine string) string {
+	if strings.EqualFold(engine, storage.EnginePlanetScale) || strings.EqualFold(engine, storage.EngineStrata) {
+		return "Keyspace"
+	}
+	return "Schema"
 }
 
 // renderResumingTable renders a table while the apply is resuming, before the

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -548,10 +548,10 @@ func TestRenderApplyStatusComment_DeployRequestLink(t *testing.T) {
 	withURL := base
 	withURL.DeployRequestURL = "https://app.planetscale.com/block-staging/boardgames/deploy-requests/103"
 	result := RenderApplyStatusComment(withURL)
-	assert.Contains(t, result, "🔗 **Deploy request**: https://app.planetscale.com/block-staging/boardgames/deploy-requests/103")
+	assert.Contains(t, result, "Deploy request: https://app.planetscale.com/block-staging/boardgames/deploy-requests/103")
 
 	// No deploy request yet — no link line.
-	assert.NotContains(t, RenderApplyStatusComment(base), "Deploy request**:")
+	assert.NotContains(t, RenderApplyStatusComment(base), "Deploy request:")
 }
 
 func TestRenderApplyStatusComment_RowCopyDisplaysOnePercentAfterCopyStarts(t *testing.T) {

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -355,6 +355,36 @@ func TestRenderApplyStatusComment_Running(t *testing.T) {
 	assert.Contains(t, result, "Queued")
 }
 
+// A Vitess/PlanetScale apply labels its namespace group "Keyspace" (not "Schema"),
+// so the engine-aware label selection is exercised distinctly from the MySQL case.
+func TestRenderApplyStatusComment_VitessUsesKeyspaceLabel(t *testing.T) {
+	result := RenderApplyStatusComment(ApplyStatusCommentData{
+		Database:    "boardgames",
+		Environment: "staging",
+		Engine:      "PlanetScale",
+		ApplyID:     "apply-abc",
+		State:       state.Apply.Running,
+		Tables: []TableProgressData{
+			{TableName: "customers", Namespace: "boardgames_sharded", Status: state.Task.Running},
+		},
+	})
+	assert.Contains(t, result, "**Keyspace `boardgames_sharded`**")
+}
+
+// The "default" namespace placeholder and the empty namespace both mean "no
+// specific namespace": they fold into a single group with no namespace string,
+// so the comment renders no meaningless "default" header and never splits the
+// same logical no-namespace tables apart.
+func TestGroupTablesByNamespaceFoldsDefaultPlaceholder(t *testing.T) {
+	groups := groupTablesByNamespace([]TableProgressData{
+		{TableName: "a", Namespace: ""},
+		{TableName: "b", Namespace: "default"},
+	})
+	require.Len(t, groups, 1)
+	assert.Equal(t, "", groups[0].namespace)
+	assert.Len(t, groups[0].tables, 2)
+}
+
 // A Vitess apply surfaces each keyspace's VSchema application status (and diff)
 // from engine display metadata as a dedicated section, so the PR comment shows
 // VSchema progress the same way the CLI does — including a multi-keyspace apply

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -338,7 +338,7 @@ func TestRenderApplyStatusComment_Running(t *testing.T) {
 	assert.Contains(t, result, "📊 1/3 complete")
 	assert.Contains(t, result, "1 running (45%)")
 	assert.Contains(t, result, "1 queued")
-	assert.Contains(t, result, "### Table Progress")
+	assert.Contains(t, result, "**`users`**")
 
 	// Per-table checks
 	assert.Contains(t, result, "**`orders`**")
@@ -662,7 +662,7 @@ func TestRenderApplyStatusComment_Completed(t *testing.T) {
 
 	assert.Contains(t, result, "## Schema Change Status — Staging")
 	assert.Contains(t, result, "**Status**: Applied")
-	assert.Contains(t, result, "### Table Progress")
+	assert.Contains(t, result, "**`orders`**")
 	// Progress summary line
 	assert.Contains(t, result, "📊 2/2 complete")
 	// Each table has "✓ Complete" = 2 total
@@ -695,7 +695,7 @@ func TestRenderApplyStatusComment_SQLFencesAreTopLevel(t *testing.T) {
 
 	result := RenderApplyStatusComment(data)
 
-	assert.Contains(t, result, "### Table Progress")
+	assert.Contains(t, result, "**`example_cursor`**")
 	assert.NotContains(t, result, "\n- **`")
 	assert.NotContains(t, result, "\n  ```sql")
 	assert.NotContains(t, result, "\n  CREATE TABLE")
@@ -1032,7 +1032,6 @@ func TestRenderApplyStatusComment_NoTables(t *testing.T) {
 	result := RenderApplyStatusComment(data)
 
 	assert.Contains(t, result, "## Schema Change In Progress")
-	assert.NotContains(t, result, "### Table Progress")
 }
 
 func TestRenderApplyStatusComment_NoRequestedBy(t *testing.T) {
@@ -1157,7 +1156,7 @@ func TestPreviewCommentApplyProgress(t *testing.T) {
 	result := PreviewCommentApplyProgress()
 
 	assert.Contains(t, result, "Schema Change In Progress")
-	assert.Contains(t, result, "### Table Progress")
+	assert.Contains(t, result, "**Schema `testapp`**")
 	assert.Contains(t, result, "**`orders`**")
 	assert.Contains(t, result, "**`users`**")
 	assert.Contains(t, result, "**`products`**")
@@ -1181,7 +1180,7 @@ func TestPreviewCommentApplyCompleted(t *testing.T) {
 
 	assert.Contains(t, result, "Schema Change Status")
 	assert.Contains(t, result, "**Status**: Applied")
-	assert.Contains(t, result, "### Table Progress")
+	assert.Contains(t, result, "**Schema `testapp`**")
 }
 
 func TestPreviewCommentApplyFailed(t *testing.T) {


### PR DESCRIPTION
## Why this matters

Two small readability fixes to the apply status comment, surfaced from a recent PlanetScale schema change.

## What it does

- **Deploy-request link**: drops the noisy 🔗 emoji and the bold `**Deploy request**` label, which clashed with the bold `**Database**` / `**Apply ID**` metadata headers it sits under. The line now reads as a plain labeled link.
- **Table progress namespaces**: groups the per-table rows by namespace under a `**Keyspace `x`**` (Vitess/PlanetScale, Strata) or `**Schema `x`**` (MySQL) header whenever a namespace is set — mirroring the CLI's namespaced output — so it's clear which keyspace/schema each table belongs to. Also drops the redundant `### Table Progress` section header (the namespace header or the progress summary line introduces the rows).

## How it moves toward northstar

Makes the multi-keyspace apply comment legible during a real apply — you can see which keyspace each table is in, without the headline noise.

Title-stability is a separate change (follow-on PR).