### PR TITLE
fix(github): stabilize the apply status comment headline and surface state on a Status line

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -1779,7 +1779,7 @@ CREATE TABLE `addresses` (
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
-Schema changes are being applied. Progress updates will be posted as new comments.
+Schema changes are being applied. This comment will be updated with progress.
 
 </details>
 
@@ -2851,7 +2851,7 @@ Cutover is already in progress. SchemaBot will keep reporting progress from the 
 
 <details><summary>Apply details (3 tables)</summary>
 
-**Apply ID**: `apply-a1b2c3d4e5f6`
+_Apply ID: `apply-a1b2c3d4e5f6`_
 
 
 **`orders`**
@@ -2994,7 +2994,7 @@ This schema change was cancelled and cannot be resumed. Open a new schema change
 
 <details><summary>Apply details (8 tables)</summary>
 
-**Apply ID**: `apply-a1b2c3d4e5f6`
+_Apply ID: `apply-a1b2c3d4e5f6`_
 
 
 **`orders`**
@@ -3054,7 +3054,7 @@ ALTER TABLE `notifications` ADD INDEX `idx_user_status`(`user_id`, `status`);
 
 <details><summary>Apply details (1 table, 1 VSchema update)</summary>
 
-**Apply ID**: `apply-a1b2c3d4e5f6`
+_Apply ID: `apply-a1b2c3d4e5f6`_
 
 Applied by namespace:
 
@@ -3093,7 +3093,7 @@ ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
 
 <details><summary>Apply details (1 VSchema update)</summary>
 
-**Apply ID**: `apply-a1b2c3d4e5f6`
+_Apply ID: `apply-a1b2c3d4e5f6`_
 
 
 ### VSchema
@@ -3242,7 +3242,7 @@ schemabot apply -e staging
 
 <details><summary>Apply details (5 tables)</summary>
 
-**Apply ID**: `apply-a1b2c3d4e5f6`
+_Apply ID: `apply-a1b2c3d4e5f6`_
 
 Applied by namespace:
 
@@ -4978,7 +4978,7 @@ schemabot unlock
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
-Schema changes are being applied. Progress updates will be posted as new comments.
+Schema changes are being applied. This comment will be updated with progress.
 
 
 </details>
@@ -5731,7 +5731,7 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 
 <details><summary>Apply details (3 tables)</summary>
 
-**Apply ID**: `apply-a1b2c3d4e5f6`
+_Apply ID: `apply-a1b2c3d4e5f6`_
 
 
 ### testapp
@@ -5767,7 +5767,7 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 
 <details><summary>Apply details (3 tables)</summary>
 
-**Apply ID**: `apply-a1b2c3d4e5f6`
+_Apply ID: `apply-a1b2c3d4e5f6`_
 
 
 ### testapp
@@ -5803,7 +5803,7 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 
 <details><summary>Apply details (3 tables)</summary>
 
-**Apply ID**: `apply-a1b2c3d4e5f6`
+_Apply ID: `apply-a1b2c3d4e5f6`_
 
 
 ### testapp
@@ -5867,7 +5867,7 @@ schemabot apply -e production
 
 <details><summary>Apply details (3 tables)</summary>
 
-**Apply ID**: `apply-a1b2c3d4e5f6`
+_Apply ID: `apply-a1b2c3d4e5f6`_
 
 
 ### testapp

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -3251,7 +3251,7 @@ Applied by namespace:
 - `analytics`: 1 table
 
 
-### ✅ commerce
+### commerce
 
 **`orders`**
 ```sql
@@ -3264,7 +3264,7 @@ ALTER TABLE `payments` ADD INDEX `idx_order_id`(`order_id`);
 ```
 
 
-### ✅ customers
+### customers
 
 **`users`**
 ```sql
@@ -3277,7 +3277,7 @@ ALTER TABLE `addresses` ADD INDEX `idx_zip`(`zip_code`);
 ```
 
 
-### ✅ analytics
+### analytics
 
 **`events`**
 ```sql
@@ -5734,7 +5734,7 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 **Apply ID**: `apply-a1b2c3d4e5f6`
 
 
-### ✅ testapp
+### testapp
 
 **`orders`**
 ```sql
@@ -5770,7 +5770,7 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 **Apply ID**: `apply-a1b2c3d4e5f6`
 
 
-### ✅ testapp
+### testapp
 
 **`orders`**
 ```sql
@@ -5806,7 +5806,7 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 **Apply ID**: `apply-a1b2c3d4e5f6`
 
 
-### ✅ testapp
+### testapp
 
 **`orders`**
 ```sql
@@ -5870,7 +5870,7 @@ schemabot apply -e production
 **Apply ID**: `apply-a1b2c3d4e5f6`
 
 
-### ✅ testapp
+### testapp
 
 **`orders`**
 ```sql

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -1773,7 +1773,7 @@ CREATE TABLE `addresses` (
 <summary><a name="apply-started"></a><strong>Apply Started</strong></summary>
 
 
-## Schema Change In Progress — Staging
+## Schema Change Status — Staging
 
 **Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
@@ -1787,11 +1787,13 @@ Schema changes are being applied. Progress updates will be posted as new comment
 <summary><a name="single-table-running"></a><strong>Single Table: Running</strong></summary>
 
 
-## Schema Change In Progress — Staging
+## Schema Change Status — Staging
 
 **Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: In Progress
 
 **`users`**: 🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 48%
 
@@ -1896,11 +1898,13 @@ schemabot start apply-a1b2c3d4e5f6 -e staging
 <summary><a name="all-pending"></a><strong>All Pending</strong></summary>
 
 
-## Schema Change In Progress — Staging
+## Schema Change Status — Staging
 
 **Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: In Progress
 
 📊 3 queued
 
@@ -1940,11 +1944,13 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="first-table-running"></a><strong>First Table Running</strong></summary>
 
 
-## Schema Change In Progress — Staging
+## Schema Change Status — Staging
 
 **Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: In Progress
 
 📊 1 running (22%) · 2 queued
 
@@ -1985,11 +1991,13 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="second-table-running"></a><strong>Second Table Running</strong></summary>
 
 
-## Schema Change In Progress — Staging
+## Schema Change Status — Staging
 
 **Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: In Progress
 
 📊 1/3 complete · 1 running (62%) · 1 queued
 
@@ -2030,11 +2038,13 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="second-table-estimate-exceeded"></a><strong>Second Table Estimate Exceeded</strong></summary>
 
 
-## Schema Change In Progress — Staging
+## Schema Change Status — Staging
 
 **Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: In Progress
 
 📊 1/3 complete · 1 running (Active) · 1 queued
 
@@ -2076,11 +2086,13 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="second-table-checksumming"></a><strong>Second Table Checksumming</strong></summary>
 
 
-## Schema Change In Progress — Staging
+## Schema Change Status — Staging
 
 **Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: In Progress
 
 📊 1/3 complete · 1 checksumming · 1 queued
 
@@ -2121,11 +2133,13 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="third-table-running"></a><strong>Third Table Running</strong></summary>
 
 
-## Schema Change In Progress — Staging
+## Schema Change Status — Staging
 
 **Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: In Progress
 
 📊 2/3 complete · 1 running (17%)
 
@@ -2166,11 +2180,13 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="sharded-shard-progress"></a><strong>Sharded: Shard Progress</strong></summary>
 
 
-## Schema Change In Progress — Staging
+## Schema Change Status — Staging
 
 **Database**: `commerce` | **Apply ID**: `apply-7aa13cf03496454b`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: In Progress
 
 **Schema `commerce`**
 
@@ -2198,11 +2214,13 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="sharded-many-shards-256"></a><strong>Sharded: Many Shards (256)</strong></summary>
 
 
-## Schema Change In Progress — Staging
+## Schema Change Status — Staging
 
 **Database**: `commerce` | **Apply ID**: `apply-7aa13cf03496454b`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: In Progress
 
 **Schema `commerce`**
 
@@ -2267,11 +2285,13 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 <summary><a name="vitess-vschema-only"></a><strong>Vitess: VSchema Only</strong></summary>
 
 
-## Schema Change In Progress — Staging
+## Schema Change Status — Staging
 
 **Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: In Progress
 
 ### VSchema
 
@@ -2297,11 +2317,13 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="vitess-ddl--vschema"></a><strong>Vitess: DDL + VSchema</strong></summary>
 
 
-## Schema Change In Progress — Staging
+## Schema Change Status — Staging
 
 **Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: In Progress
 
 Deploy request: https://app.planetscale.com/acme/myapp/deploy-requests/42
 
@@ -2336,11 +2358,13 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="vitess-multikeyspace-vschema"></a><strong>Vitess: Multi-keyspace VSchema</strong></summary>
 
 
-## Schema Change In Progress — Staging
+## Schema Change Status — Staging
 
 **Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: In Progress
 
 ### VSchema
 
@@ -2503,7 +2527,7 @@ schemabot start apply-a1b2c3d4e5f6 -e staging
 <summary><a name="resuming"></a><strong>Resuming</strong></summary>
 
 
-## Schema Change In Progress — Staging
+## Schema Change Status — Staging
 
 **Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
@@ -2569,7 +2593,7 @@ This schema change was cancelled and cannot be resumed. Open a new schema change
 <summary><a name="waiting-for-cutover"></a><strong>Waiting For Cutover</strong></summary>
 
 
-## Schema Change In Progress — Staging
+## Schema Change Status — Staging
 
 **Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
@@ -2617,7 +2641,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="cutting-over"></a><strong>Cutting Over</strong></summary>
 
 
-## Schema Change In Progress — Staging
+## Schema Change Status — Staging
 
 **Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
@@ -2662,7 +2686,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="revert-window"></a><strong>Revert Window</strong></summary>
 
 
-## Schema Change Applied (Pending Revert) — Staging
+## Schema Change Status — Staging
 
 **Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
@@ -2715,7 +2739,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="skipping-revert"></a><strong>Skipping Revert</strong></summary>
 
 
-## Skipping Revert — Finalizing — Staging
+## Schema Change Status — Staging
 
 **Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
@@ -4948,7 +4972,7 @@ schemabot unlock
 <summary><a name="apply-started"></a><strong>Apply Started</strong></summary>
 
 
-## Schema Change In Progress — Staging
+## Schema Change Status — Staging
 
 **Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
@@ -5303,7 +5327,7 @@ schemabot apply -e staging
 <summary><a name="barrier-rollout-in-progress"></a><strong>Barrier Rollout In Progress</strong></summary>
 
 
-## Schema Change In Progress — Production
+## Schema Change Status — Production
 
 **Apply ID**: `apply-a1b2c3d4e5f6`
 
@@ -5326,7 +5350,7 @@ schemabot cutover apply-a1b2c3d4e5f6 -e production
 <details open>
 <summary>🟢 eu — ready for cutover — next in order</summary>
 
-## Schema Change In Progress — Production
+## Schema Change Status — Production
 
 **Database**: `payments_eu` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
@@ -5371,11 +5395,13 @@ schemabot cutover apply-a1b2c3d4e5f6 -e production
 <details open>
 <summary>🔄 us — running table copy</summary>
 
-## Schema Change In Progress — Production
+## Schema Change Status — Production
 
 **Database**: `payments_us` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
+
+**Status**: In Progress
 
 📊 1/3 complete · 1 running (62%) · 1 queued
 
@@ -5432,7 +5458,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="halt-on-failure-one-deployment-failed"></a><strong>Halt On Failure (One Deployment Failed)</strong></summary>
 
 
-## ❌ Schema Change Failed — Production
+## Schema Change Status — Production
 
 **Apply ID**: `apply-a1b2c3d4e5f6`
 
@@ -5555,7 +5581,7 @@ _No details available yet._
 <summary><a name="all-deployments-completed"></a><strong>All Deployments Completed</strong></summary>
 
 
-## ✅ Schema Change Applied — Production
+## Schema Change Status — Production
 
 **Apply ID**: `apply-a1b2c3d4e5f6`
 
@@ -6048,7 +6074,7 @@ schemabot apply -e production
 <summary><a name="apply-in-progress"></a><strong>Apply In Progress</strong></summary>
 
 
-## Schema Change In Progress — Production
+## Schema Change Status — Production
 
 **Database**: `cdb_resolute` | **Type**: `Strata` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
@@ -6073,7 +6099,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="apply-failed-one-shard-failed"></a><strong>Apply Failed (One Shard Failed)</strong></summary>
 
 
-## ❌ Schema Change Failed — Production
+## Schema Change Status — Production
 
 **Database**: `cdb_resolute` | **Type**: `Strata` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
@@ -6105,7 +6131,7 @@ schemabot apply -e production
 <summary><a name="apply-with-divergent-shards"></a><strong>Apply With Divergent Shards</strong></summary>
 
 
-## Schema Change In Progress — Production
+## Schema Change Status — Production
 
 **Database**: `cdb_resolute` | **Type**: `Strata` | **Apply ID**: `apply-a1b2c3d4e5f6`
 

--- a/pkg/webhook/apply_comment_integration_test.go
+++ b/pkg/webhook/apply_comment_integration_test.go
@@ -439,7 +439,7 @@ func TestE2EResumeRotatesProgressComment(t *testing.T) {
 	select {
 	case created := <-capture.creates:
 		newProgressID = created.ID
-		assert.Contains(t, created.Body, "Schema Change In Progress — Staging")
+		assert.Contains(t, created.Body, "Schema Change Status — Staging")
 		assert.Contains(t, created.Body, "**Status**: Resuming")
 		assert.Contains(t, created.Body, "Resuming…")
 		assert.NotContains(t, created.Body, "Stopped")

--- a/pkg/webhook/apply_integration_test.go
+++ b/pkg/webhook/apply_integration_test.go
@@ -642,11 +642,11 @@ func TestE2EApplyConfirmExecutesApply(t *testing.T) {
 	// For a CREATE TABLE, it completes fast — the sync handler catches it and
 	// posts the summary directly without an "In Progress" comment.
 	//
-	// Wait for either "Schema Change In Progress" or "Schema Change Applied/Failed"
+	// Wait for either "Schema Change Status" or "Schema Change Applied/Failed"
 	// as the first comment.
 	select {
 	case body := <-result.comments:
-		hasProgress := strings.Contains(body, "Schema Change In Progress")
+		hasProgress := strings.Contains(body, "Schema Change Status")
 		hasApplied := strings.Contains(body, "Schema Change Applied")
 		hasFailed := strings.Contains(body, "Schema Change Failed")
 		assert.True(t, hasProgress || hasApplied || hasFailed,
@@ -1446,7 +1446,7 @@ func TestE2EApplyConfirmRejectsWhenHEADAdvanced(t *testing.T) {
 		assert.Contains(t, body, "abc123", "must show discovery SHA")
 		assert.Contains(t, body, "newsha456", "must show current SHA")
 		assert.Contains(t, body, "schemabot apply-confirm -e staging", "retry hint must show full retry command")
-		assert.NotContains(t, body, "Schema Change In Progress", "apply must not have started")
+		assert.NotContains(t, body, "Schema Change Status", "apply must not have started")
 		assert.NotContains(t, body, "Schema Change Applied", "apply must not have completed")
 	case <-time.After(30 * time.Second):
 		t.Fatal("timed out waiting for rejection comment")
@@ -1744,7 +1744,7 @@ func TestE2EApplyConfirmRejectsWhenPlanSHAStale(t *testing.T) {
 		assert.Contains(t, body, "newsha456", "must show the current PR HEAD")
 		assert.Contains(t, body, "schemabot apply -e staging",
 			"retry hint must point at `apply` (a fresh plan is needed), not `apply-confirm`")
-		assert.NotContains(t, body, "Schema Change In Progress", "apply must not have started")
+		assert.NotContains(t, body, "Schema Change Status", "apply must not have started")
 		assert.NotContains(t, body, "Schema Change Applied", "apply must not have completed")
 	case <-time.After(30 * time.Second):
 		t.Fatal("timed out waiting for rejection comment")
@@ -1806,7 +1806,7 @@ func TestE2EApplyConfirmRejectsRollbackLock(t *testing.T) {
 	case body := <-result.comments:
 		assert.Contains(t, body, "rollback plan")
 		assert.Contains(t, body, "schemabot rollback-confirm")
-		assert.NotContains(t, body, "Schema Change In Progress")
+		assert.NotContains(t, body, "Schema Change Status")
 	case <-time.After(30 * time.Second):
 		t.Fatal("timed out waiting for rollback-lock rejection comment")
 	}
@@ -2009,7 +2009,7 @@ func TestE2EApplyConfirmRejectsWhenPlainPlanSupersedesApplyPlan(t *testing.T) {
 		assert.Contains(t, body, "the plan you confirmed is stale")
 		assert.Contains(t, body, "abc123", "must name the plan SHA the user reviewed")
 		assert.Contains(t, body, "newsha456", "must name the current HEAD")
-		assert.NotContains(t, body, "Schema Change In Progress", "apply must not start")
+		assert.NotContains(t, body, "Schema Change Status", "apply must not start")
 		assert.NotContains(t, body, "Schema Change Applied", "apply must not complete")
 	case <-time.After(30 * time.Second):
 		t.Fatal("timed out waiting for apply-confirm rejection")
@@ -2088,7 +2088,7 @@ func TestE2EApplyAutoConfirmReGatesAgainstFreshHEADBeforeApply(t *testing.T) {
 	for blocked == "" {
 		select {
 		case body := <-result.comments:
-			assert.NotContains(t, body, "Schema Change In Progress", "apply must not have started")
+			assert.NotContains(t, body, "Schema Change Status", "apply must not have started")
 			assert.NotContains(t, body, "Schema Change Applied", "apply must not have completed")
 			if strings.Contains(body, "Apply Blocked") && strings.Contains(body, "ci/lint") {
 				blocked = body
@@ -2198,7 +2198,7 @@ func TestE2EApplyAutoConfirmFreshHEADBlockPreservesOtherPRLock(t *testing.T) {
 	for blocked == "" {
 		select {
 		case body := <-result.comments:
-			assert.NotContains(t, body, "Schema Change In Progress", "apply must not have started")
+			assert.NotContains(t, body, "Schema Change Status", "apply must not have started")
 			assert.NotContains(t, body, "Schema Change Applied", "apply must not have completed")
 			if strings.Contains(body, "Apply Blocked") && strings.Contains(body, "ci/lint") {
 				blocked = body

--- a/pkg/webhook/apply_test.go
+++ b/pkg/webhook/apply_test.go
@@ -43,7 +43,7 @@ func TestFormatProgressComment(t *testing.T) {
 	assert.Contains(t, body, "`users`")
 	assert.Contains(t, body, "`orders`")
 	assert.Contains(t, body, "45%")
-	assert.Contains(t, body, "In Progress")
+	assert.Contains(t, body, "Schema Change Status")
 	// Should NOT contain the old table format
 	assert.NotContains(t, body, "| Table |")
 	assert.NotContains(t, body, "|-------|")

--- a/pkg/webhook/apply_test.go
+++ b/pkg/webhook/apply_test.go
@@ -44,6 +44,8 @@ func TestFormatProgressComment(t *testing.T) {
 	assert.Contains(t, body, "`orders`")
 	assert.Contains(t, body, "45%")
 	assert.Contains(t, body, "Schema Change Status")
+	// The running state is communicated on the always-present Status line.
+	assert.Contains(t, body, "**Status**: In Progress")
 	// Should NOT contain the old table format
 	assert.NotContains(t, body, "| Table |")
 	assert.NotContains(t, body, "|-------|")

--- a/pkg/webhook/comment_observer_test.go
+++ b/pkg/webhook/comment_observer_test.go
@@ -145,7 +145,7 @@ func TestFormatStatusCommentRoutesSingleDeployment(t *testing.T) {
 
 	body := o.formatStatusComment(runningApply(), nil)
 
-	assert.Contains(t, body, "## Schema Change In Progress")
+	assert.Contains(t, body, "## Schema Change Status")
 	assert.NotContains(t, body, "**Deployments**:")
 }
 
@@ -156,7 +156,7 @@ func TestFormatStatusCommentFallsBackOnLoadError(t *testing.T) {
 
 	body := o.formatStatusComment(runningApply(), nil)
 
-	assert.Contains(t, body, "## Schema Change In Progress")
+	assert.Contains(t, body, "## Schema Change Status")
 	assert.NotContains(t, body, "**Deployments**:")
 }
 

--- a/pkg/webhook/multi_apply_test.go
+++ b/pkg/webhook/multi_apply_test.go
@@ -23,7 +23,7 @@ func runningApply() *storage.Apply {
 // the single-deployment comment unchanged — no aggregate header.
 func TestFormatApplyStatusComment_NoOperationsRendersSingle(t *testing.T) {
 	out := formatApplyStatusComment(runningApply(), nil, false, nil, nil, nil)
-	assert.Contains(t, out, "## Schema Change In Progress")
+	assert.Contains(t, out, "## Schema Change Status")
 	assert.NotContains(t, out, "**Deployments**:")
 }
 
@@ -46,7 +46,7 @@ func TestFormatApplyStatusComment_MultipleOperationsRendersMulti(t *testing.T) {
 		{ID: 2, Deployment: "us", State: state.ApplyOperation.Running, CutoverPolicy: storage.CutoverPolicyBarrier},
 	}
 	out := formatApplyStatusComment(runningApply(), ops, false, nil, nil, nil)
-	assert.Contains(t, out, "## Schema Change In Progress")
+	assert.Contains(t, out, "## Schema Change Status")
 	assert.Contains(t, out, "**Deployments**: 1 completed, 1 running")
 	assert.Contains(t, out, "- ✅ eu — completed")
 	assert.Contains(t, out, "- 🔄 us — running table copy")

--- a/pkg/webhook/sharded_apply_test.go
+++ b/pkg/webhook/sharded_apply_test.go
@@ -102,7 +102,7 @@ func TestFormatApplyStatusComment_ShardedFailedSurfacesError(t *testing.T) {
 
 	out := formatApplyStatusComment(apply, ops, false, tasks, nil, nil)
 
-	assert.Contains(t, out, "❌ Schema Change Failed", "uses the shard-unit failed headline")
+	assert.Contains(t, out, "## Schema Change Status", "uses the stable in-place status headline")
 	assert.Contains(t, out, "**Shards**:", "counts shards, not deployments")
 	assert.NotContains(t, out, "**Deployments**:", "must not use the deployment-unit layout")
 	assert.Contains(t, out, failErr, "the failed shard's error is surfaced (the bug fix)")

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -1241,6 +1241,16 @@ func writeSummaryTableListWithOptions(sb *strings.Builder, data ApplyStatusComme
 	}
 
 	collapsed := collapseNamespaceGroups && len(data.Tables) > 5
+	// Per-namespace status emojis only carry information when outcomes differ
+	// across namespaces (some failed, some succeeded). When every namespace
+	// succeeded, the repeated ✅ is noise, so the headers omit the emoji.
+	showGroupEmoji := false
+	for _, g := range groups {
+		if groupStateEmoji(g.tables) != "✅" {
+			showGroupEmoji = true
+			break
+		}
+	}
 	// Skip namespace header when there's only one group and it's "default" or
 	// matches the database name — the header is redundant with the metadata line.
 	singleGroup := len(groups) == 1
@@ -1254,13 +1264,16 @@ func writeSummaryTableListWithOptions(sb *strings.Builder, data ApplyStatusComme
 				header = data.Database
 			}
 
-			groupEmoji := groupStateEmoji(g.tables)
+			emojiPrefix := ""
+			if showGroupEmoji {
+				emojiPrefix = groupStateEmoji(g.tables) + " "
+			}
 
 			if groupCollapsed {
 				sb.WriteString("\n<details><summary>")
-				fmt.Fprintf(sb, "%s <strong>%s</strong> (%d tables)</summary>\n\n", groupEmoji, header, len(g.tables))
+				fmt.Fprintf(sb, "%s<strong>%s</strong> (%d tables)</summary>\n\n", emojiPrefix, header, len(g.tables))
 			} else {
-				fmt.Fprintf(sb, "\n### %s %s\n\n", groupEmoji, header)
+				fmt.Fprintf(sb, "\n### %s%s\n\n", emojiPrefix, header)
 			}
 		} else {
 			sb.WriteString("\n")

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -1094,7 +1094,7 @@ func writeCompletedSummaryDetails(sb *strings.Builder, data ApplyStatusCommentDa
 
 	fmt.Fprintf(sb, "\n<details><summary>%s</summary>\n\n", completedSummaryDetailsLabel(data))
 	if data.ApplyID != "" {
-		fmt.Fprintf(sb, "**Apply ID**: `%s`\n\n", data.ApplyID)
+		fmt.Fprintf(sb, "_Apply ID: `%s`_\n\n", data.ApplyID)
 	}
 	writeCompletedNamespaceSummary(sb, data)
 	if len(data.Tables) > 0 {

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -138,39 +138,23 @@ func renderApplyStatusComment(data ApplyStatusCommentData, includeLastUpdated bo
 	return sb.String()
 }
 
+// writeApplyStatusHeader writes the headline for an in-place apply status
+// comment. The title is intentionally state-independent — always "Schema Change
+// Status — <env>" — so the headline stays stable as the apply moves through its
+// states (running → revert window → applied); the current state is conveyed by
+// the Status line and the per-table progress, not the headline. The single-,
+// multi-deployment, and sharded status comments all use this so their headline
+// vocabulary is identical. Terminal summary/notification comments use
+// writeApplyHeader, which keeps a state-specific title.
 func writeApplyStatusHeader(sb *strings.Builder, data ApplyStatusCommentData) {
-	if state.IsTerminalApplyState(data.State) {
-		writeEnvironmentTitle(sb, "Schema Change Status", data.Environment)
-		return
-	}
-	writeApplyHeader(sb, data)
+	writeEnvironmentTitle(sb, "Schema Change Status", data.Environment)
 }
 
-// writeApplyHeader writes the comment header with a state-specific title.
+// writeApplyHeader writes the state-specific title for a terminal summary or
+// notification comment (the separate comment posted when an apply reaches a
+// terminal state), distinct from the stable in-place status headline.
 func writeApplyHeader(sb *strings.Builder, data ApplyStatusCommentData) {
 	switch data.State {
-	case state.Apply.Pending,
-		state.Apply.Running,
-		state.Apply.RunningDegraded,
-		state.Apply.FailedRetryable,
-		state.Apply.WaitingForDeploy,
-		state.Apply.WaitingForCutover,
-		state.Apply.Recovering,
-		state.Apply.Resuming,
-		state.Apply.CuttingOver,
-		state.Apply.PreparingBranch,
-		state.Apply.ApplyingBranchChanges,
-		state.Apply.ValidatingBranch,
-		state.Apply.CreatingDeployRequest,
-		state.Apply.ValidatingDeployRequest:
-		// running_degraded is a continue rollout still in flight past a failed
-		// sibling: the change is still in progress, and the failed deployment is
-		// surfaced in the per-deployment breakdown, not the headline.
-		writeEnvironmentTitle(sb, "Schema Change In Progress", data.Environment)
-	case state.Apply.RevertWindow:
-		writeEnvironmentTitle(sb, "Schema Change Applied (Pending Revert)", data.Environment)
-	case state.Apply.SkippingRevert:
-		writeEnvironmentTitle(sb, "Skipping Revert — Finalizing", data.Environment)
 	case state.Apply.Completed:
 		writeEnvironmentTitle(sb, "✅ Schema Change Applied", data.Environment)
 	case state.Apply.Failed:
@@ -182,11 +166,7 @@ func writeApplyHeader(sb *strings.Builder, data ApplyStatusCommentData) {
 	case state.Apply.Cancelled:
 		writeEnvironmentTitle(sb, "🚫 Schema Change Cancelled", data.Environment)
 	default:
-		if state.IsTerminalApplyState(data.State) {
-			writeEnvironmentTitle(sb, fmt.Sprintf("Schema Change: %s", humanizeState(data.State)), data.Environment)
-		} else {
-			writeEnvironmentTitle(sb, "Schema Change In Progress", data.Environment)
-		}
+		writeEnvironmentTitle(sb, fmt.Sprintf("Schema Change: %s", humanizeState(data.State)), data.Environment)
 	}
 }
 
@@ -239,6 +219,10 @@ func applyStatusDetail(applyState string) string {
 		return "Cancelled"
 	case state.Apply.Pending:
 		return "Starting"
+	case state.Apply.Running, state.Apply.RunningDegraded:
+		return "In Progress"
+	case state.Apply.FailedRetryable:
+		return "Retrying"
 	case state.Apply.WaitingForDeploy:
 		return "Waiting for Deploy"
 	case state.Apply.WaitingForCutover:
@@ -260,7 +244,7 @@ func applyStatusDetail(applyState string) string {
 	case state.Apply.ValidatingDeployRequest:
 		return "Validating Deploy Request"
 	default:
-		if applyState == "" || state.IsTerminalApplyState(applyState) || state.IsState(applyState, state.Apply.Running, state.Apply.RunningDegraded, state.Apply.FailedRetryable) {
+		if applyState == "" || state.IsTerminalApplyState(applyState) {
 			return ""
 		}
 		return humanizeState(applyState)

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -145,7 +145,7 @@ func RenderApplyStarted(data ApplyStatusCommentData) string {
 
 	writeApplyStatusHeader(&sb, data)
 	writeApplyMetadata(&sb, data, currentTimestamp())
-	sb.WriteString("\nSchema changes are being applied. Progress updates will be posted as new comments.\n")
+	sb.WriteString("\nSchema changes are being applied. This comment will be updated with progress.\n")
 
 	return sb.String()
 }

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -136,11 +136,14 @@ func RenderUnsafeChangesBlocked(data PlanCommentData) string {
 	return sb.String()
 }
 
-// RenderApplyStarted renders a comment when an apply begins.
+// RenderApplyStarted renders the initial body of the live progress comment when
+// an apply begins. It uses the same stable status title as the in-place status
+// comment the observer later edits this into, so the headline does not jump from
+// one title to another on the first progress update.
 func RenderApplyStarted(data ApplyStatusCommentData) string {
 	var sb strings.Builder
 
-	writeEnvironmentTitle(&sb, "Schema Change In Progress", data.Environment)
+	writeApplyStatusHeader(&sb, data)
 	writeApplyMetadata(&sb, data, currentTimestamp())
 	sb.WriteString("\nSchema changes are being applied. Progress updates will be posted as new comments.\n")
 

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -1408,13 +1408,33 @@ func TestRenderApplySummaryCommentCompletedCollapsedDetailsApplyIDInside(t *test
 	result := RenderApplySummaryComment(data)
 
 	assert.Contains(t, result, "<details><summary>Apply details (6 tables)</summary>")
-	assert.Contains(t, result, "### ✅ testapp_primary")
+	// All namespaces succeeded, so the per-namespace header carries no redundant ✅.
+	assert.Contains(t, result, "### testapp_primary")
 	// The Apply ID lives inside the collapsed details block, not as a trailing line.
 	assert.Contains(t, result, "**Apply ID**: `apply-a1b2c3d4e5f6`")
 	assert.NotContains(t, result, "_Apply ID:")
 	idIdx := strings.Index(result, "**Apply ID**: `apply-a1b2c3d4e5f6`")
 	closeIdx := strings.LastIndex(result, "</details>")
 	assert.True(t, idIdx >= 0 && idIdx < closeIdx, "Apply ID should appear inside the details, before the closing tag")
+}
+
+// When namespaces have mixed outcomes, the summary keeps the per-namespace status
+// emoji so the operator can see which keyspace failed and which succeeded.
+func TestRenderApplySummaryCommentMixedNamespacesKeepEmoji(t *testing.T) {
+	data := ApplyStatusCommentData{
+		ApplyID:     "apply-mixed01",
+		Database:    "boardgames",
+		Environment: "staging",
+		State:       state.Apply.Failed,
+		Tables: []TableProgressData{
+			{TableName: "orders", Namespace: "commerce", Status: state.Task.Completed},
+			{TableName: "users", Namespace: "identity", Status: state.Task.Failed},
+		},
+	}
+
+	result := RenderApplySummaryComment(data)
+	assert.Contains(t, result, "### ✅ commerce")
+	assert.Contains(t, result, "### ❌ identity")
 }
 
 func TestPreviewCommentSummaryCompletedVitessTracksVSchema(t *testing.T) {

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -43,7 +43,7 @@ func TestRenderApplyCommentsIncludeEnvironmentInTitle(t *testing.T) {
 		})
 		firstLine, _, _ := strings.Cut(rendered, "\n")
 
-		assert.Equal(t, "## Schema Change In Progress — Production", firstLine)
+		assert.Equal(t, "## Schema Change Status — Production", firstLine)
 		assert.NotContains(t, rendered, "**Elapsed**")
 	})
 
@@ -171,7 +171,7 @@ func TestRenderApplyStatusComment_Checksumming(t *testing.T) {
 
 	result := RenderApplyStatusComment(data)
 
-	assert.Contains(t, result, "## Schema Change In Progress", "apply stays in progress; checksumming is table-level")
+	assert.Contains(t, result, "## Schema Change Status", "apply stays in progress; checksumming is table-level")
 	assert.Contains(t, result, "**`orders`**")
 	assert.Contains(t, result, "🔍 Checksumming to verify data (21%)")
 	assert.Contains(t, result, "Rows verified: 321,450 / 1,466,232")
@@ -327,7 +327,8 @@ func TestRenderApplyStatusComment_Running(t *testing.T) {
 
 	result := RenderApplyStatusComment(data)
 
-	assert.Contains(t, result, "## Schema Change In Progress")
+	assert.Contains(t, result, "## Schema Change Status")
+	assert.Contains(t, result, "**Status**: In Progress", "the constant title carries no state, so a running apply shows its state in the Status line")
 	assert.Contains(t, result, "@aparajon")
 	assert.Contains(t, result, "`testapp`")
 	assert.Contains(t, result, "— Staging")
@@ -521,7 +522,7 @@ func TestRenderApplyStatusComment_ValidatingDeployRequest(t *testing.T) {
 
 	result := RenderApplyStatusComment(data)
 
-	assert.Contains(t, result, "## Schema Change In Progress")
+	assert.Contains(t, result, "## Schema Change Status")
 	assert.Contains(t, result, "**Status**: Validating Deploy Request")
 	assert.Contains(t, result, "To cancel this schema change:")
 	assert.Contains(t, result, "schemabot cancel apply-7aa13cf03496454b -e staging")
@@ -811,7 +812,7 @@ func TestRenderApplyStatusComment_FailedRetryable(t *testing.T) {
 
 	result := RenderApplyStatusComment(data)
 
-	assert.Contains(t, result, "## Schema Change In Progress")
+	assert.Contains(t, result, "## Schema Change Status")
 	assert.NotContains(t, result, "Failed_retryable")
 	assert.NotContains(t, result, "failed_retryable")
 	// The retry detail lives on the affected table, not in the headline.
@@ -935,7 +936,7 @@ func TestRenderApplyStatusComment_Resuming(t *testing.T) {
 
 	result := RenderApplyStatusComment(data)
 
-	assert.Contains(t, result, "## Schema Change In Progress")
+	assert.Contains(t, result, "## Schema Change Status")
 	assert.Contains(t, result, "🔄 Resuming…")
 	assert.NotContains(t, result, "21%", "the indeterminate resume window must not show the stale pre-stop percent")
 	assert.NotContains(t, result, "21,000 / 100,000", "the indeterminate resume window must not show stale row counts")
@@ -1061,7 +1062,7 @@ func TestRenderApplyStatusComment_NoTables(t *testing.T) {
 
 	result := RenderApplyStatusComment(data)
 
-	assert.Contains(t, result, "## Schema Change In Progress")
+	assert.Contains(t, result, "## Schema Change Status")
 }
 
 func TestRenderApplyStatusComment_NoRequestedBy(t *testing.T) {
@@ -1185,7 +1186,7 @@ func TestApplyStatusFromProgress(t *testing.T) {
 func TestPreviewCommentApplyProgress(t *testing.T) {
 	result := PreviewCommentApplyProgress()
 
-	assert.Contains(t, result, "Schema Change In Progress")
+	assert.Contains(t, result, "Schema Change Status")
 	assert.Contains(t, result, "**Schema `testapp`**")
 	assert.Contains(t, result, "**`orders`**")
 	assert.Contains(t, result, "**`users`**")
@@ -1197,7 +1198,7 @@ func TestPreviewCommentApplyProgress(t *testing.T) {
 func TestPreviewCommentApplyEstimateExceeded(t *testing.T) {
 	result := PreviewCommentApplyEstimateExceeded()
 
-	assert.Contains(t, result, "Schema Change In Progress")
+	assert.Contains(t, result, "Schema Change Status")
 	assert.Contains(t, result, "1 running (Active)")
 	assert.Contains(t, result, "Active")
 	assert.Contains(t, result, "Rows copied: 145,000,000 so far")
@@ -1234,7 +1235,7 @@ func TestPreviewCommentApplyStopped(t *testing.T) {
 func TestPreviewCommentApplyResuming(t *testing.T) {
 	result := PreviewCommentApplyResuming()
 
-	assert.Contains(t, result, "Schema Change In Progress")
+	assert.Contains(t, result, "Schema Change Status")
 	assert.Contains(t, result, "🔄 Resuming…")
 	// The indeterminate resume window hides the stale pre-stop percent.
 	assert.NotContains(t, result, "72%")
@@ -1788,7 +1789,7 @@ func TestRenderApplyStatusComment_RevertWindow(t *testing.T) {
 
 	result := RenderApplyStatusComment(data)
 
-	assert.Contains(t, result, "Pending Revert")
+	assert.Contains(t, result, "## Schema Change Status")
 	assert.Contains(t, result, "Complete (pending revert)")
 	assert.Contains(t, result, "schemabot revert apply-abc123 -e staging")
 	assert.Contains(t, result, "schemabot skip-revert apply-abc123 -e staging")
@@ -1811,7 +1812,7 @@ func TestRenderApplyStatusComment_SkippingRevert(t *testing.T) {
 
 	result := RenderApplyStatusComment(data)
 
-	assert.Contains(t, result, "Skipping Revert — Finalizing")
+	assert.Contains(t, result, "## Schema Change Status")
 	assert.Contains(t, result, "can no longer be reverted")
 	assert.NotContains(t, result, "schemabot revert apply-abc123 -e staging")
 	assert.NotContains(t, result, "schemabot skip-revert apply-abc123 -e staging")

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -815,6 +815,8 @@ func TestRenderApplyStatusComment_FailedRetryable(t *testing.T) {
 	assert.Contains(t, result, "## Schema Change Status")
 	assert.NotContains(t, result, "Failed_retryable")
 	assert.NotContains(t, result, "failed_retryable")
+	// The retryable state is communicated on the always-present Status line.
+	assert.Contains(t, result, "**Status**: Retrying")
 	// The retry detail lives on the affected table, not in the headline.
 	assert.Contains(t, result, "🔄 Interrupted — retrying automatically")
 	assert.Contains(t, result, "> ⚠️ Last error: remote deployment unavailable")
@@ -1379,7 +1381,7 @@ func TestPreviewCommentSummaryCompletedLargeCollapsesAppliedDetails(t *testing.T
 
 	assert.Contains(t, result, "Applied successfully — your schema changes are live!")
 	assert.Contains(t, result, "<details><summary>Apply details (8 tables)</summary>")
-	assert.Contains(t, result, "**Apply ID**: `apply-a1b2c3d4e5f6`")
+	assert.Contains(t, result, "_Apply ID: `apply-a1b2c3d4e5f6`_")
 	assert.Equal(t, 1, strings.Count(result, "</details>"))
 }
 
@@ -1411,9 +1413,8 @@ func TestRenderApplySummaryCommentCompletedCollapsedDetailsApplyIDInside(t *test
 	// All namespaces succeeded, so the per-namespace header carries no redundant ✅.
 	assert.Contains(t, result, "### testapp_primary")
 	// The Apply ID lives inside the collapsed details block, not as a trailing line.
-	assert.Contains(t, result, "**Apply ID**: `apply-a1b2c3d4e5f6`")
-	assert.NotContains(t, result, "_Apply ID:")
-	idIdx := strings.Index(result, "**Apply ID**: `apply-a1b2c3d4e5f6`")
+	assert.Contains(t, result, "_Apply ID: `apply-a1b2c3d4e5f6`_")
+	idIdx := strings.Index(result, "_Apply ID: `apply-a1b2c3d4e5f6`_")
 	closeIdx := strings.LastIndex(result, "</details>")
 	assert.True(t, idIdx >= 0 && idIdx < closeIdx, "Apply ID should appear inside the details, before the closing tag")
 }

--- a/pkg/webhook/templates/multi_apply.go
+++ b/pkg/webhook/templates/multi_apply.go
@@ -56,9 +56,9 @@ func RenderMultiDeploymentApplyComment(data MultiDeploymentApplyData) string {
 	var sb strings.Builder
 	renderedAt := currentTimestamp()
 
-	// Aggregate header: reuse the single-deployment title map keyed on the
-	// derived aggregate state so the headline vocabulary is identical.
-	writeApplyHeader(&sb, ApplyStatusCommentData{State: data.Model.State, Environment: data.Environment})
+	// Aggregate header: the stable in-place status title, identical to the
+	// single-deployment comment so the headline vocabulary stays shared.
+	writeApplyStatusHeader(&sb, ApplyStatusCommentData{State: data.Model.State, Environment: data.Environment})
 	writeAggregateMetadata(&sb, data, renderedAt)
 	writeDeploymentCounts(&sb, data.Model.Counts)
 	writeAggregateFirstFailure(&sb, data.Model.FirstFailure)

--- a/pkg/webhook/templates/multi_apply_test.go
+++ b/pkg/webhook/templates/multi_apply_test.go
@@ -41,7 +41,7 @@ func TestRenderMultiDeploymentApplyComment_BarrierInProgress(t *testing.T) {
 		Environment: "production",
 	})
 
-	assert.Contains(t, out, "## Schema Change In Progress")
+	assert.Contains(t, out, "## Schema Change Status")
 	assert.Contains(t, out, "— Production")
 	assert.Contains(t, out, "**Apply ID**: `apply-123`")
 	assert.Contains(t, out, "_Last updated: <relative-time datetime=\"2026-06-16T19:43:00Z\">2026-06-16 19:43:00 UTC</relative-time> (2026-06-16 19:43:00 UTC)_")
@@ -84,7 +84,7 @@ func TestRenderMultiDeploymentApplyComment_FailedHalt(t *testing.T) {
 		Environment: "production",
 	})
 
-	assert.Contains(t, out, "## ❌ Schema Change Failed")
+	assert.Contains(t, out, "## Schema Change Status")
 	assert.Contains(t, out, "**Deployments**: 1 ready for cutover, 2 halted, 1 failed")
 	// The recovery path for a failed apply is retry, matching the single-deployment
 	// footer. revert is only for a deployment in its post-cutover revert window.
@@ -178,7 +178,7 @@ func TestRenderMultiDeploymentApplyComment_FirstFailureSurfacesError(t *testing.
 	})
 
 	// The rollout is still in progress (running_degraded), not headlined as failed.
-	assert.Contains(t, out, "## Schema Change In Progress")
+	assert.Contains(t, out, "## Schema Change Status")
 	assert.NotContains(t, out, "Schema Change Failed")
 	// A later deployment is still running while siblings have failed.
 	assert.Contains(t, out, "- 🔄 au — running table copy")
@@ -365,7 +365,7 @@ func TestRenderMultiDeploymentApplyComment_NoNextActionWhenCompleted(t *testing.
 		rollingOp("us", so.Completed),
 	})
 	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{Model: model, ApplyID: "apply-123", Environment: "production"})
-	assert.Contains(t, out, "## ✅ Schema Change Applied")
+	assert.Contains(t, out, "## Schema Change Status")
 	assert.NotContains(t, out, "schemabot cutover")
 	assert.NotContains(t, out, "schemabot revert")
 	assert.NotContains(t, out, "To resume:")

--- a/pkg/webhook/templates/sharded_apply.go
+++ b/pkg/webhook/templates/sharded_apply.go
@@ -84,7 +84,7 @@ func RenderShardedApplyComment(data ShardedApplyData) string {
 	var sb strings.Builder
 	renderedAt := currentTimestamp()
 
-	writeApplyHeader(&sb, ApplyStatusCommentData{State: data.State, Environment: data.Environment})
+	writeApplyStatusHeader(&sb, ApplyStatusCommentData{State: data.State, Environment: data.Environment})
 	writeShardedMetadata(&sb, data, renderedAt)
 
 	writeShardCounts(&sb, data.Shards)

--- a/pkg/webhook/templates/sharded_apply_test.go
+++ b/pkg/webhook/templates/sharded_apply_test.go
@@ -45,7 +45,7 @@ func TestRenderShardedApplyComment_FailedSurfacesError(t *testing.T) {
 		Cells: []ShardCell{mutesCell("-40"), mutesCell("80-")},
 	})
 
-	assert.Contains(t, out, "❌ Schema Change Failed")
+	assert.Contains(t, out, "## Schema Change Status")
 	assert.Contains(t, out, "> ⚠️ **First failure:** shard <code>-40</code> — "+failErr)
 	assert.Contains(t, out, failErr, "the error also appears in the failed shard's row")
 	assert.Contains(t, out, "To retry:")


### PR DESCRIPTION
## Why this matters

The in-place apply status comment changed its headline as the apply moved through states ("In Progress", "Applied (Pending Revert)", "Skipping Revert"), while terminal states already collapsed to "Schema Change Status". The headline jumped around as the comment was edited in place. Plus a small summary-comment nit: a redundant ✅ stamped on every namespace.

## What it does

- **Stable headline** — the in-place status comment is now always `Schema Change Status — <env>`, across all in-place renderers (single-deployment, multi-deployment, sharded) and the initial "apply started" body, so the headline never jumps. The current state is carried by the `Status` line, which now renders for *every* state (including `running` → **In Progress** and `failed_retryable` → **Retrying**, which previously had none).
- **Per-namespace emoji only when it matters** — the summary comment stamped a ✅ on every namespace even when the whole apply succeeded. It now shows the per-namespace status emoji only when outcomes differ (some failed, some succeeded), where it tells the operator which keyspace failed; all-success namespaces get a plain header.

Terminal summary/notification comments keep their distinct `✅ Applied` / `❌ Failed` titles.

## How it moves toward northstar

A stable headline, an always-present `Status` line, and noise-free namespace headers make the live comment read consistently through the whole apply lifecycle.