### PR TITLE
feat(github): render leader-folded per-tenant aggregate table

### DIFF
--- a/pkg/webhook/tenant_aggregate_table.go
+++ b/pkg/webhook/tenant_aggregate_table.go
@@ -53,14 +53,16 @@ func buildTenantAggregateTable(states []TenantState) string {
 		sb.WriteString("|----------|--------|--------|\n")
 	}
 
+	rowsByTenant := make([][]aggregateRow, len(states))
 	total := 0
-	for _, state := range states {
-		total += len(tenantAggregateRows(state))
+	for i, state := range states {
+		rowsByTenant[i] = tenantAggregateRows(state)
+		total += len(rowsByTenant[i])
 	}
 
 	rendered := 0
-	for _, state := range states {
-		for _, row := range tenantAggregateRows(state) {
+	for i, state := range states {
+		for _, row := range rowsByTenant[i] {
 			var line string
 			if multiTenant {
 				line = fmt.Sprintf("| %s | %s | %s | %s |\n", state.Tenant, formatCell(row.database), formatChange(row.change), row.status)
@@ -78,17 +80,17 @@ func buildTenantAggregateTable(states []TenantState) string {
 	return sb.String()
 }
 
-// formatCell backtick-quotes a database name, leaving the placeholder dash
-// unquoted.
+// formatCell renders a database name as an inline code span, leaving the
+// placeholder dash unquoted.
 func formatCell(value string) string {
 	if value == "" || value == "—" {
 		return "—"
 	}
-	return "`" + value + "`"
+	return codeSpan(value)
 }
 
-// formatChange backtick-quotes a DDL change, leaving free-text placeholders like
-// "no changes" (and empties) unquoted.
+// formatChange renders a DDL change as an inline code span, leaving free-text
+// placeholders like "no changes" (and empties) unquoted.
 func formatChange(value string) string {
 	switch value {
 	case "", "no changes":
@@ -97,6 +99,30 @@ func formatChange(value string) string {
 		}
 		return value
 	default:
-		return "`" + value + "`"
+		return codeSpan(value)
 	}
+}
+
+// codeSpan wraps value in a Markdown inline code span, choosing a backtick fence
+// longer than any run of backticks inside the value so quoted SQL identifiers
+// (e.g. “ `email` “) don't break the span. Per CommonMark, a value that begins
+// or ends with a backtick is padded with a single space inside the fence.
+func codeSpan(value string) string {
+	longest, run := 0, 0
+	for _, r := range value {
+		if r == '`' {
+			run++
+			if run > longest {
+				longest = run
+			}
+			continue
+		}
+		run = 0
+	}
+	fence := strings.Repeat("`", longest+1)
+	pad := ""
+	if strings.HasPrefix(value, "`") || strings.HasSuffix(value, "`") {
+		pad = " "
+	}
+	return fence + pad + value + pad + fence
 }

--- a/pkg/webhook/tenant_aggregate_table.go
+++ b/pkg/webhook/tenant_aggregate_table.go
@@ -1,0 +1,102 @@
+package webhook
+
+import (
+	"fmt"
+	"strings"
+)
+
+// aggregateRow is one rendered row of the per-tenant aggregate table.
+type aggregateRow struct {
+	database string
+	change   string
+	status   string
+}
+
+// tenantAggregateRows returns the table rows for one tenant's state. A tenant
+// that reported no databases (a "no changes" report) renders a single
+// placeholder row so it is still visible in the breakdown.
+func tenantAggregateRows(state TenantState) []aggregateRow {
+	if len(state.Databases) == 0 {
+		return []aggregateRow{{database: "—", change: "no changes", status: "—"}}
+	}
+	rows := make([]aggregateRow, 0, len(state.Databases))
+	for _, db := range state.Databases {
+		change := db.Detail
+		if change == "" {
+			change = db.Op
+		}
+		rows = append(rows, aggregateRow{
+			database: db.Database,
+			change:   change,
+			status:   db.State,
+		})
+	}
+	return rows
+}
+
+// buildTenantAggregateTable renders the leader-folded per-tenant state as the
+// markdown table for the aggregate check's Details page. With a single tenant
+// it omits the Tenant column, so a single-tenant repo looks identical to a
+// standard single-deployment check; with two or more tenants it renders the
+// full (tenant, database) grid. It bounds output to the Check Run text limit,
+// truncating with a "... and N more" note rather than producing an oversized
+// body.
+func buildTenantAggregateTable(states []TenantState) string {
+	multiTenant := len(states) > 1
+
+	var sb strings.Builder
+	if multiTenant {
+		sb.WriteString("| Tenant | Database | Change | Status |\n")
+		sb.WriteString("|--------|----------|--------|--------|\n")
+	} else {
+		sb.WriteString("| Database | Change | Status |\n")
+		sb.WriteString("|----------|--------|--------|\n")
+	}
+
+	total := 0
+	for _, state := range states {
+		total += len(tenantAggregateRows(state))
+	}
+
+	rendered := 0
+	for _, state := range states {
+		for _, row := range tenantAggregateRows(state) {
+			var line string
+			if multiTenant {
+				line = fmt.Sprintf("| %s | %s | %s | %s |\n", state.Tenant, formatCell(row.database), formatChange(row.change), row.status)
+			} else {
+				line = fmt.Sprintf("| %s | %s | %s |\n", formatCell(row.database), formatChange(row.change), row.status)
+			}
+			if sb.Len()+len(line) > maxCheckRunTextLength-1000 {
+				fmt.Fprintf(&sb, "\n... and %d more row(s)\n", total-rendered)
+				return sb.String()
+			}
+			sb.WriteString(line)
+			rendered++
+		}
+	}
+	return sb.String()
+}
+
+// formatCell backtick-quotes a database name, leaving the placeholder dash
+// unquoted.
+func formatCell(value string) string {
+	if value == "" || value == "—" {
+		return "—"
+	}
+	return "`" + value + "`"
+}
+
+// formatChange backtick-quotes a DDL change, leaving free-text placeholders like
+// "no changes" (and empties) unquoted.
+func formatChange(value string) string {
+	switch value {
+	case "", "no changes":
+		if value == "" {
+			return "—"
+		}
+		return value
+	default:
+		return "`" + value + "`"
+	}
+}

--- a/pkg/webhook/tenant_aggregate_table_test.go
+++ b/pkg/webhook/tenant_aggregate_table_test.go
@@ -69,3 +69,23 @@ func TestBuildTenantAggregateTableTruncates(t *testing.T) {
 	require.Contains(t, table, "more row(s)")
 	assert.True(t, strings.HasSuffix(strings.TrimSpace(table), "more row(s)"), "truncation note is last")
 }
+
+// A DDL summary that contains backticks (from quoted SQL identifiers) is wrapped
+// in a longer backtick fence so the Markdown code span still renders.
+func TestBuildTenantAggregateTableEscapesBacktickedDDL(t *testing.T) {
+	table := buildTenantAggregateTable([]TenantState{
+		{Tenant: "tenant-a", SHA: "abc", Rollup: "pending", Databases: []TenantDatabaseState{
+			{Database: "orders", Op: "ALTER TABLE", State: "running", Detail: "ADD COLUMN `email`"},
+		}},
+	})
+
+	assert.Contains(t, table, "`` ADD COLUMN `email` ``",
+		"a value containing backticks uses a double-backtick fence with space padding")
+}
+
+func TestCodeSpan(t *testing.T) {
+	assert.Equal(t, "`orders`", codeSpan("orders"))
+	assert.Equal(t, "`` `email` ``", codeSpan("`email`"), "leading/trailing backtick is space-padded inside a longer fence")
+	assert.Equal(t, "``a`b``", codeSpan("a`b"), "an interior backtick still forces a longer fence")
+	assert.Equal(t, "```a``b``c```", codeSpan("a``b``c"), "fence is one longer than the longest interior run")
+}

--- a/pkg/webhook/tenant_aggregate_table_test.go
+++ b/pkg/webhook/tenant_aggregate_table_test.go
@@ -1,0 +1,71 @@
+package webhook
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A single-tenant repo renders without a Tenant column — identical in shape to
+// a standard single-deployment check.
+func TestBuildTenantAggregateTableSingleTenant(t *testing.T) {
+	table := buildTenantAggregateTable([]TenantState{
+		{Tenant: "tenant-a", SHA: "abc", Rollup: "pending", Databases: []TenantDatabaseState{
+			{Database: "orders", Op: "ALTER TABLE", State: "running", Detail: "add column email"},
+			{Database: "ledger", Op: "CREATE TABLE", State: "applied"},
+		}},
+	})
+
+	assert.NotContains(t, table, "Tenant |", "single tenant omits the Tenant column")
+	assert.Contains(t, table, "| Database | Change | Status |")
+	assert.Contains(t, table, "`orders`")
+	assert.Contains(t, table, "`add column email`") // Detail wins over Op
+	assert.Contains(t, table, "running")
+	assert.Contains(t, table, "`ledger`")
+	assert.Contains(t, table, "`CREATE TABLE`") // falls back to Op when Detail is empty
+	assert.Contains(t, table, "applied")
+}
+
+// Two or more tenants render the full (tenant, database) grid, and a no-changes
+// tenant still appears as a single placeholder row.
+func TestBuildTenantAggregateTableMultiTenant(t *testing.T) {
+	table := buildTenantAggregateTable([]TenantState{
+		{Tenant: "tenant-a", SHA: "abc", Rollup: "applied", Databases: []TenantDatabaseState{
+			{Database: "coffeeshop", Op: "ADD COLUMN sku", State: "applied"},
+		}},
+		{Tenant: "tenant-b", SHA: "abc", Rollup: "pending", Databases: []TenantDatabaseState{
+			{Database: "orders", Op: "ADD COLUMN email", State: "running"},
+		}},
+		{Tenant: "tenant-c", SHA: "abc", Rollup: "no_changes"},
+	})
+
+	assert.Contains(t, table, "| Tenant | Database | Change | Status |")
+	assert.Contains(t, table, "| tenant-a | `coffeeshop` | `ADD COLUMN sku` | applied |")
+	assert.Contains(t, table, "| tenant-b | `orders` | `ADD COLUMN email` | running |")
+	assert.Contains(t, table, "| tenant-c | — | no changes | — |", "no-changes tenant gets a placeholder row")
+}
+
+// A tenant whose databases are empty (a "no changes" report) is still visible
+// even on a single-tenant repo.
+func TestBuildTenantAggregateTableNoChangesOnly(t *testing.T) {
+	table := buildTenantAggregateTable([]TenantState{
+		{Tenant: "tenant-a", SHA: "abc", Rollup: "no_changes"},
+	})
+	assert.Contains(t, table, "| — | no changes | — |")
+}
+
+// The table bounds its size to the Check Run text limit and truncates with a
+// note rather than emitting an oversized body.
+func TestBuildTenantAggregateTableTruncates(t *testing.T) {
+	var dbs []TenantDatabaseState
+	for range 5000 {
+		dbs = append(dbs, TenantDatabaseState{Database: "db", Op: "ALTER TABLE add a very descriptive column name here", State: "running"})
+	}
+	table := buildTenantAggregateTable([]TenantState{{Tenant: "tenant-a", SHA: "abc", Rollup: "pending", Databases: dbs}})
+
+	assert.Less(t, len(table), maxCheckRunTextLength, "output stays under the Check Run text limit")
+	require.Contains(t, table, "more row(s)")
+	assert.True(t, strings.HasSuffix(strings.TrimSpace(table), "more row(s)"), "truncation note is last")
+}


### PR DESCRIPTION
## Why this matters
The aggregate check's Details page is the human-facing surface — one click from the merge button. It needs to render the leader-folded per-tenant state as a clean breakdown, degrading to today's single-deployment shape when only one tenant is present.

## What it does
Adds `buildTenantAggregateTable([]TenantState) string`:
- **Single tenant** → `| Database | Change | Status |` (no Tenant column) — identical in shape to a standard single-deployment check.
- **Two or more tenants** → the full `| Tenant | Database | Change | Status |` grid.
- A tenant that reported no databases renders a single `no changes` row so it stays visible.
- Output is bounded to the Check Run text limit, truncating with a `... and N more row(s)` note rather than emitting an oversized body.

Inert: the leader fold that calls this lands in a later change.

## Northstar
The output-seam render — a pure function of the folded state, independent of transport and of where the fold runs — so the same Details UX carries forward unchanged to a control plane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
