### PR TITLE
feat(github): read per-tenant state from PR comments (CommentStateSource)

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -501,6 +501,41 @@ func (ic *InstallationClient) EditIssueComment(ctx context.Context, repo string,
 	return nil
 }
 
+// IssueComment is a PR/issue comment as read by SchemaBot. AuthorLogin is the
+// GitHub-stamped author of the comment; later trust checks use it to confirm a
+// tenant-state comment was authored by SchemaBot's own App.
+type IssueComment struct {
+	ID          int64
+	Body        string
+	AuthorLogin string
+}
+
+// ListIssueComments returns every comment on a PR/issue, paginating through the
+// full set.
+func (ic *InstallationClient) ListIssueComments(ctx context.Context, repo string, pr int) ([]IssueComment, error) {
+	owner, repoName := splitRepo(repo)
+	opts := &gh.IssueListCommentsOptions{ListOptions: gh.ListOptions{PerPage: 100}}
+	var out []IssueComment
+	for {
+		comments, resp, err := ic.client.Issues.ListComments(ctx, owner, repoName, pr, opts)
+		if err != nil {
+			return nil, fmt.Errorf("list issue comments for %s#%d: %w", repo, pr, err)
+		}
+		for _, c := range comments {
+			out = append(out, IssueComment{
+				ID:          c.GetID(),
+				Body:        c.GetBody(),
+				AuthorLogin: c.GetUser().GetLogin(),
+			})
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return out, nil
+}
+
 // AddReactionToComment adds a reaction emoji to a comment.
 func (ic *InstallationClient) AddReactionToComment(ctx context.Context, repo string, commentID int64, reaction string) error {
 	owner, repoName := splitRepo(repo)

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -502,8 +502,8 @@ func (ic *InstallationClient) EditIssueComment(ctx context.Context, repo string,
 }
 
 // IssueComment is a PR/issue comment as read by SchemaBot. AuthorLogin is the
-// GitHub-stamped author of the comment; later trust checks use it to confirm a
-// tenant-state comment was authored by SchemaBot's own App.
+// GitHub-stamped author of the comment; it is captured so a trust check can
+// confirm a tenant-state comment was authored by SchemaBot's own App.
 type IssueComment struct {
 	ID          int64
 	Body        string

--- a/pkg/webhook/comment_state_source.go
+++ b/pkg/webhook/comment_state_source.go
@@ -27,6 +27,9 @@ type CommentStateSource struct {
 
 // NewCommentStateSource returns a TenantStateSource backed by a PR's comments.
 func NewCommentStateSource(client commentLister, logger *slog.Logger) *CommentStateSource {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	return &CommentStateSource{client: client, logger: logger}
 }
 

--- a/pkg/webhook/comment_state_source.go
+++ b/pkg/webhook/comment_state_source.go
@@ -1,0 +1,79 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/block/schemabot/pkg/github"
+)
+
+// commentLister lists a PR's comments. *github.InstallationClient satisfies it;
+// the narrow interface keeps CommentStateSource testable without a GitHub
+// client.
+type commentLister interface {
+	ListIssueComments(ctx context.Context, repo string, pr int) ([]github.IssueComment, error)
+}
+
+// CommentStateSource reads per-tenant state from a pull request's comments,
+// implementing TenantStateSource over the PR-comment transport. It is the
+// read side of the comment adapter: it lists the PR's comments, parses the
+// tenant-state block out of each, and returns the states reported for the
+// current head SHA.
+type CommentStateSource struct {
+	client commentLister
+	logger *slog.Logger
+}
+
+// NewCommentStateSource returns a TenantStateSource backed by a PR's comments.
+func NewCommentStateSource(client commentLister, logger *slog.Logger) *CommentStateSource {
+	return &CommentStateSource{client: client, logger: logger}
+}
+
+var _ TenantStateSource = (*CommentStateSource)(nil)
+
+// StatesForPR returns the tenant states reported on the PR for headSHA. It fails
+// closed per comment: an unparseable block is skipped (the tenant is treated as
+// not-reported) rather than trusted, and a block stamped with a different SHA is
+// ignored as stale. A list error is returned so the caller can fail closed
+// overall rather than fold a partial view.
+func (s *CommentStateSource) StatesForPR(ctx context.Context, repo string, pr int, headSHA string) ([]TenantState, error) {
+	comments, err := s.client.ListIssueComments(ctx, repo, pr)
+	if err != nil {
+		return nil, fmt.Errorf("read tenant-state comments for %s#%d: %w", repo, pr, err)
+	}
+
+	// State is keyed by (tenant, environment): a tenant publishes one block per
+	// environment it participates in, so two blocks from the same tenant for
+	// different environments are both kept.
+	type tenantEnv struct{ tenant, environment string }
+	var states []TenantState
+	seen := make(map[tenantEnv]struct{})
+	for _, comment := range comments {
+		state, found, parseErr := parseTenantStateBlock(comment.Body)
+		if !found {
+			// Not a tenant-state comment (ordinary PR chatter); skip silently.
+			continue
+		}
+		if parseErr != nil {
+			s.logger.Warn("skipping unparseable tenant-state comment; tenant treated as not reported",
+				"repo", repo, "pr", pr, "comment_id", comment.ID, "error", parseErr)
+			continue
+		}
+		if state.SHA != headSHA {
+			s.logger.Debug("skipping stale-SHA tenant-state comment",
+				"repo", repo, "pr", pr, "tenant", state.Tenant, "environment", state.Environment,
+				"comment_sha", state.SHA, "head_sha", headSHA)
+			continue
+		}
+		key := tenantEnv{tenant: state.Tenant, environment: state.Environment}
+		if _, dup := seen[key]; dup {
+			s.logger.Warn("duplicate tenant-state comment for (tenant, environment) at head SHA; keeping the first",
+				"repo", repo, "pr", pr, "tenant", state.Tenant, "environment", state.Environment, "comment_id", comment.ID)
+			continue
+		}
+		seen[key] = struct{}{}
+		states = append(states, state)
+	}
+	return states, nil
+}

--- a/pkg/webhook/comment_state_source_test.go
+++ b/pkg/webhook/comment_state_source_test.go
@@ -93,6 +93,21 @@ func TestCommentStateSourceKeepsDistinctEnvironments(t *testing.T) {
 	assert.ElementsMatch(t, []string{"staging-1", "staging-2"}, []string{states[0].Environment, states[1].Environment})
 }
 
+// A nil logger is tolerated: the source defaults to slog.Default() so a code
+// path that logs (here, a malformed block) does not panic.
+func TestCommentStateSourceNilLogger(t *testing.T) {
+	lister := &fakeCommentLister{comments: []github.IssueComment{
+		{ID: 1, Body: "<!-- " + tenantStateMarker + " v=1\n{bad json}\n-->"},
+		tenantStateComment(t, 2, TenantState{Tenant: "tenant-a", Environment: "production", SHA: "abc", Rollup: "applied"}),
+	}}
+	src := NewCommentStateSource(lister, nil)
+
+	states, err := src.StatesForPR(t.Context(), "octocat/shared-repo", 1, "abc")
+	require.NoError(t, err)
+	require.Len(t, states, 1)
+	assert.Equal(t, "tenant-a", states[0].Tenant)
+}
+
 // A list failure is surfaced so the caller can fail closed rather than fold a
 // partial view of tenant state.
 func TestCommentStateSourceListError(t *testing.T) {

--- a/pkg/webhook/comment_state_source_test.go
+++ b/pkg/webhook/comment_state_source_test.go
@@ -1,0 +1,105 @@
+package webhook
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/github"
+)
+
+type fakeCommentLister struct {
+	comments []github.IssueComment
+	err      error
+}
+
+func (f *fakeCommentLister) ListIssueComments(_ context.Context, _ string, _ int) ([]github.IssueComment, error) {
+	return f.comments, f.err
+}
+
+func tenantStateComment(t *testing.T, id int64, ts TenantState) github.IssueComment {
+	t.Helper()
+	block, err := renderTenantStateBlock(ts)
+	require.NoError(t, err)
+	return github.IssueComment{
+		ID:          id,
+		Body:        "<details><summary>SchemaBot · " + ts.Tenant + "</summary>\n\n" + block + "\n</details>",
+		AuthorLogin: "schemabot-block[bot]",
+	}
+}
+
+// The reader returns one TenantState per participating tenant at the head SHA,
+// ignoring ordinary comments and blocks stamped with a different SHA.
+func TestCommentStateSourceStatesForPR(t *testing.T) {
+	lister := &fakeCommentLister{comments: []github.IssueComment{
+		{ID: 1, Body: "just a normal human comment, no block here"},
+		tenantStateComment(t, 2, TenantState{Tenant: "tenant-a", Environment: "production", SHA: "abc", Rollup: "applied", Databases: []TenantDatabaseState{{Database: "orders", State: "applied"}}}),
+		tenantStateComment(t, 3, TenantState{Tenant: "tenant-b", Environment: "production", SHA: "abc", Rollup: "pending", Databases: []TenantDatabaseState{{Database: "ledger", State: "running"}}}),
+		tenantStateComment(t, 4, TenantState{Tenant: "tenant-c", Environment: "production", SHA: "stale0", Rollup: "applied"}),
+	}}
+	src := NewCommentStateSource(lister, testLogger())
+
+	states, err := src.StatesForPR(t.Context(), "octocat/shared-repo", 1, "abc")
+	require.NoError(t, err)
+	require.Len(t, states, 2, "the stale-SHA and non-block comments are excluded")
+	assert.ElementsMatch(t, []string{"tenant-a", "tenant-b"}, []string{states[0].Tenant, states[1].Tenant})
+}
+
+// A malformed block is skipped (its tenant treated as not reported) and does not
+// abort the read of the other tenants — fail-closed per comment.
+func TestCommentStateSourceSkipsMalformed(t *testing.T) {
+	lister := &fakeCommentLister{comments: []github.IssueComment{
+		{ID: 1, Body: "<!-- " + tenantStateMarker + " v=1\n{bad json}\n-->"},
+		tenantStateComment(t, 2, TenantState{Tenant: "tenant-a", Environment: "production", SHA: "abc", Rollup: "applied"}),
+	}}
+	src := NewCommentStateSource(lister, testLogger())
+
+	states, err := src.StatesForPR(t.Context(), "octocat/shared-repo", 1, "abc")
+	require.NoError(t, err)
+	require.Len(t, states, 1)
+	assert.Equal(t, "tenant-a", states[0].Tenant)
+}
+
+// Two state comments for the same (tenant, environment) at the same SHA keep
+// the first.
+func TestCommentStateSourceDedupesTenant(t *testing.T) {
+	lister := &fakeCommentLister{comments: []github.IssueComment{
+		tenantStateComment(t, 1, TenantState{Tenant: "tenant-a", Environment: "production", SHA: "abc", Rollup: "pending", Databases: []TenantDatabaseState{{Database: "orders", State: "running"}}}),
+		tenantStateComment(t, 2, TenantState{Tenant: "tenant-a", Environment: "production", SHA: "abc", Rollup: "applied", Databases: []TenantDatabaseState{{Database: "orders", State: "applied"}}}),
+	}}
+	src := NewCommentStateSource(lister, testLogger())
+
+	states, err := src.StatesForPR(t.Context(), "octocat/shared-repo", 1, "abc")
+	require.NoError(t, err)
+	require.Len(t, states, 1)
+	assert.Equal(t, "pending", states[0].Rollup, "keeps the first comment for a (tenant, environment)")
+}
+
+// The same tenant reporting for two different environments yields two states —
+// (tenant, environment) is the key, so distinct environments are not collapsed.
+func TestCommentStateSourceKeepsDistinctEnvironments(t *testing.T) {
+	lister := &fakeCommentLister{comments: []github.IssueComment{
+		tenantStateComment(t, 1, TenantState{Tenant: "tenant-a", Environment: "staging-1", SHA: "abc", Rollup: "applied", Databases: []TenantDatabaseState{{Database: "orders", State: "applied"}}}),
+		tenantStateComment(t, 2, TenantState{Tenant: "tenant-a", Environment: "staging-2", SHA: "abc", Rollup: "pending", Databases: []TenantDatabaseState{{Database: "orders", State: "running"}}}),
+	}}
+	src := NewCommentStateSource(lister, testLogger())
+
+	states, err := src.StatesForPR(t.Context(), "octocat/shared-repo", 1, "abc")
+	require.NoError(t, err)
+	require.Len(t, states, 2)
+	assert.ElementsMatch(t, []string{"staging-1", "staging-2"}, []string{states[0].Environment, states[1].Environment})
+}
+
+// A list failure is surfaced so the caller can fail closed rather than fold a
+// partial view of tenant state.
+func TestCommentStateSourceListError(t *testing.T) {
+	lister := &fakeCommentLister{err: errors.New("github unavailable")}
+	src := NewCommentStateSource(lister, testLogger())
+
+	_, err := src.StatesForPR(t.Context(), "octocat/shared-repo", 1, "abc")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read tenant-state comments")
+}


### PR DESCRIPTION
Stacked on #604 (the `TenantState` model + block parser it consumes). Retarget to `main` once #604 merges.

## Why this matters
The leader fold needs to read every participating tenant's reported state for a PR. This is the read side of the comment transport — the first concrete `TenantStateSource` implementation behind the seam from #604.

## What it does
- Adds `ListIssueComments` to the installation client: returns a PR's comments (paginated), with each comment's id, body, and GitHub-stamped author.
- Adds `CommentStateSource`, implementing `TenantStateSource`: lists the PR's comments, parses the tenant-state block out of each, and returns the states reported for the head SHA.
- Fails closed per comment:
  - an unparseable block is skipped (the tenant is treated as not-reported) rather than trusted,
  - a block stamped with a different SHA is ignored as stale,
  - a duplicate tenant at the head SHA keeps the first,
  - a list error is surfaced so the caller folds no partial view.

Inert: the leader fold that constructs and reads this source lands in a later change.

## Northstar
The comment adapter that lets the leader learn tenant state through GitHub — swappable behind `TenantStateSource` for a future RPC adapter without touching the fold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
