### PR TITLE
feat(github): implement the revert PR-comment command

### DIFF
--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -227,29 +227,6 @@ func controlOperationCaller(caller string) string {
 	return caller
 }
 
-// logControlOperation appends an apply log entry for a control operation (cutover, stop, start, revert, etc.).
-func (s *Service) logControlOperation(r *http.Request, applyID, caller, eventType, message string) {
-	if applyID == "" {
-		s.logger.Debug("skipping control operation log — no apply ID", "event", eventType)
-		return
-	}
-	applyStore := s.storage.Applies()
-	if applyStore == nil {
-		s.logger.Error("apply store not available for control operation log", "apply_id", applyID, "event", eventType)
-		return
-	}
-	apply, err := applyStore.GetByApplyIdentifier(r.Context(), applyID)
-	if err != nil {
-		s.logger.Error("failed to look up apply for control operation log", "apply_id", applyID, "event", eventType, "error", err)
-		return
-	}
-	if apply == nil {
-		s.logger.Warn("apply not found for control operation log", "apply_id", applyID, "event", eventType)
-		return
-	}
-	s.logControlOperationForApply(r.Context(), apply, caller, eventType, message)
-}
-
 func (s *Service) logControlOperationForApply(ctx context.Context, apply *storage.Apply, caller, eventType, message string) {
 	logStore := s.storage.ApplyLogs()
 	if logStore == nil {
@@ -1961,29 +1938,47 @@ type RevertRequest struct {
 // handleRevert handles POST /api/revert requests.
 func (s *Service) handleRevert(w http.ResponseWriter, r *http.Request) {
 	var req RevertRequest
-	client, apply, applyID, ok := s.decodeControlRequest(w, r, &req, &req.ApplyID, &req.Environment)
+	client, apply, ternApplyID, ok := s.decodeControlRequest(w, r, &req, &req.ApplyID, &req.Environment)
 	if !ok {
 		return
 	}
-
-	resp, err := client.Revert(r.Context(), &ternv1.RevertRequest{
-		ApplyId:     applyID,
-		Environment: apply.Environment,
-	})
+	resp, httpStatus, err := s.executeRevertForApply(r.Context(), client, apply, ternApplyID, req.Caller)
 	if err != nil {
-		metrics.RecordControlOperation(r.Context(), "revert", apply.Database, apply.Deployment, apply.Environment, "error")
 		s.writeControlError(w, "revert", apply, err)
 		return
 	}
-	metrics.RecordControlOperation(r.Context(), "revert", apply.Database, apply.Deployment, apply.Environment, controlStatus(resp.Accepted))
-	if resp.Accepted {
-		s.logControlOperation(r, apply.ApplyIdentifier, req.Caller, storage.LogEventRevertTriggered, "Revert triggered by user")
-	}
+	s.writeJSON(w, httpStatus, resp)
+}
 
-	s.writeJSON(w, http.StatusOK, &apitypes.ControlResponse{
+// ExecuteRevert reverts a completed schema change during its revert window. It
+// resolves the apply's data-plane client and proxies the revert, so the HTTP
+// handler and the PR-comment command share one path.
+func (s *Service) ExecuteRevert(ctx context.Context, req apitypes.ControlRequest) (*apitypes.ControlResponse, error) {
+	client, apply, ternApplyID, err := s.controlTarget(ctx, "revert", req.ApplyID, req.Environment)
+	if err != nil {
+		return nil, err
+	}
+	resp, _, err := s.executeRevertForApply(ctx, client, apply, ternApplyID, req.Caller)
+	return resp, err
+}
+
+func (s *Service) executeRevertForApply(ctx context.Context, client tern.Client, apply *storage.Apply, ternApplyID, caller string) (*apitypes.ControlResponse, int, error) {
+	resp, err := client.Revert(ctx, &ternv1.RevertRequest{
+		ApplyId:     ternApplyID,
+		Environment: apply.Environment,
+	})
+	if err != nil {
+		metrics.RecordControlOperation(ctx, "revert", apply.Database, apply.Deployment, apply.Environment, "error")
+		return nil, 0, fmt.Errorf("revert apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	metrics.RecordControlOperation(ctx, "revert", apply.Database, apply.Deployment, apply.Environment, controlStatus(resp.Accepted))
+	if resp.Accepted {
+		s.logControlOperationForApply(ctx, apply, caller, storage.LogEventRevertTriggered, "Revert triggered by user")
+	}
+	return &apitypes.ControlResponse{
 		Accepted:     resp.Accepted,
 		ErrorMessage: resp.ErrorMessage,
-	})
+	}, http.StatusOK, nil
 }
 
 // SkipRevertRequest is the HTTP request body for POST /api/skip-revert.

--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -1966,6 +1966,13 @@ func (s *Service) ExecuteRevert(ctx context.Context, req apitypes.ControlRequest
 // revert. The returned HTTP status is meaningful only when err == nil; error
 // paths return a zero status and callers derive it from the error.
 func (s *Service) executeRevertForApply(ctx context.Context, client tern.Client, apply *storage.Apply, ternApplyID, caller string) (*apitypes.ControlResponse, int, error) {
+	// Revert undoes a PlanetScale deploy request in its revert window; other
+	// engines hard-error it. Gate on the engine so a non-PlanetScale apply can
+	// never accumulate a permanently-pending revert request.
+	if apply.Engine != storage.EnginePlanetScale {
+		metrics.RecordControlOperation(ctx, "revert", apply.Database, apply.Deployment, apply.Environment, "rejected")
+		return nil, 0, controlConflictf("revert is only supported for PlanetScale schema changes")
+	}
 	// Revert is only meaningful while the apply is in its revert window; gating
 	// here keeps a non-revert-window apply from accumulating a permanently-pending
 	// revert request.

--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -1962,23 +1962,75 @@ func (s *Service) ExecuteRevert(ctx context.Context, req apitypes.ControlRequest
 	return resp, err
 }
 
+// executeRevertForApply records durable revert intent and attempts an immediate
+// revert. The returned HTTP status is meaningful only when err == nil; error
+// paths return a zero status and callers derive it from the error.
 func (s *Service) executeRevertForApply(ctx context.Context, client tern.Client, apply *storage.Apply, ternApplyID, caller string) (*apitypes.ControlResponse, int, error) {
+	// Revert is only meaningful while the apply is in its revert window; gating
+	// here keeps a non-revert-window apply from accumulating a permanently-pending
+	// revert request.
+	if !state.IsState(apply.State, state.Apply.RevertWindow) {
+		metrics.RecordControlOperation(ctx, "revert", apply.Database, apply.Deployment, apply.Environment, "rejected")
+		return nil, 0, controlConflictf("schema change is not in its revert window (current state: %s)", apply.State)
+	}
+	controlStore := s.storage.ControlRequests()
+	if controlStore == nil {
+		metrics.RecordControlOperation(ctx, "revert", apply.Database, apply.Deployment, apply.Environment, "error")
+		return nil, 0, fmt.Errorf("control request store is not available")
+	}
+
+	// Record durable revert intent before the engine call, so a comment-driven
+	// revert survives the API process dying before the call lands, and so the
+	// apply owner (the data-plane operator for a remote apply, not the webhook
+	// pod) can drive it to completion.
+	_, alreadyPending, err := controlStore.RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationRevert,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: caller,
+	})
+	if err != nil {
+		metrics.RecordControlOperation(ctx, "revert", apply.Database, apply.Deployment, apply.Environment, "error")
+		return nil, 0, fmt.Errorf("record revert control request for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if alreadyPending {
+		// A prior revert request is already queued; do not re-drive the engine.
+		// The apply owner is completing the existing one.
+		metrics.RecordControlOperation(ctx, "revert", apply.Database, apply.Deployment, apply.Environment, "success")
+		s.logControlOperationForApply(ctx, apply, caller, storage.LogEventRevertTriggered, "Revert requested by user while revert request already pending")
+		s.wakeOperator(apply.ApplyIdentifier, apply.Database, apply.Environment)
+		return &apitypes.ControlResponse{Accepted: true, Status: apitypes.ControlStatusAlreadyRequested}, http.StatusAccepted, nil
+	}
+	s.logControlOperationForApply(ctx, apply, caller, storage.LogEventRevertTriggered, "Revert triggered by user")
+
+	// Attempt the revert immediately. If it fails or this process dies, the
+	// durable request remains pending for the apply owner to retry.
 	resp, err := client.Revert(ctx, &ternv1.RevertRequest{
 		ApplyId:     ternApplyID,
 		Environment: apply.Environment,
 	})
 	if err != nil {
 		metrics.RecordControlOperation(ctx, "revert", apply.Database, apply.Deployment, apply.Environment, "error")
-		return nil, 0, fmt.Errorf("revert apply %s: %w", apply.ApplyIdentifier, err)
+		s.logger.Warn("immediate revert failed; durable request remains pending for apply owner retry",
+			append(apply.LogAttrs(), "error", err)...)
+		s.wakeOperator(apply.ApplyIdentifier, apply.Database, apply.Environment)
+		return &apitypes.ControlResponse{Accepted: true}, http.StatusAccepted, nil
 	}
 	metrics.RecordControlOperation(ctx, "revert", apply.Database, apply.Deployment, apply.Environment, controlStatus(resp.Accepted))
+
 	if resp.Accepted {
-		s.logControlOperationForApply(ctx, apply, caller, storage.LogEventRevertTriggered, "Revert triggered by user")
+		// The engine accepted the revert; the durable request's work is done.
+		if err := controlStore.CompletePending(ctx, apply.ID, storage.ControlOperationRevert); err != nil {
+			s.logger.Warn("failed to complete revert control request after immediate success; operator will reconcile",
+				append(apply.LogAttrs(), "error", err)...)
+		}
+	} else if err := controlStore.FailPending(ctx, apply.ID, storage.ControlOperationRevert, resp.ErrorMessage); err != nil {
+		s.logger.Warn("failed to fail rejected revert control request",
+			append(apply.LogAttrs(), "error", err)...)
 	}
-	return &apitypes.ControlResponse{
-		Accepted:     resp.Accepted,
-		ErrorMessage: resp.ErrorMessage,
-	}, http.StatusOK, nil
+	s.wakeOperator(apply.ApplyIdentifier, apply.Database, apply.Environment)
+
+	return &apitypes.ControlResponse{Accepted: resp.Accepted, ErrorMessage: resp.ErrorMessage}, http.StatusOK, nil
 }
 
 // SkipRevertRequest is the HTTP request body for POST /api/skip-revert.

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -5058,7 +5058,12 @@ func TestRevertHandler(t *testing.T) {
 		mock := &mockTernClient{
 			revertResp: &ternv1.RevertResponse{Accepted: true},
 		}
-		svc := newControlTestService(mock, activeTestApply("apply-rev123"))
+		// Revert is only accepted while the apply is in its revert window.
+		apply := activeTestApply("apply-rev123")
+		apply.State = state.Apply.RevertWindow
+		apply.Engine = storage.EnginePlanetScale
+		apply.DatabaseType = storage.DatabaseTypeVitess
+		svc := newControlTestService(mock, apply)
 		mux := http.NewServeMux()
 		svc.ConfigureRoutes(mux)
 

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -750,6 +750,12 @@ const (
 	ControlOperationCancel ControlOperation = "cancel"
 	// ControlOperationCutover triggers deferred cutover.
 	ControlOperationCutover ControlOperation = "cutover"
+	// ControlOperationRevert undoes a completed PlanetScale schema change during
+	// its revert window. Durable so a comment-driven revert survives the API
+	// process dying before the engine call lands, and so the apply owner (which
+	// for a remote apply is the data-plane operator, not the webhook pod) drives
+	// it to completion.
+	ControlOperationRevert ControlOperation = "revert"
 	// ControlOperationSkipRevert closes the revert window, making a PlanetScale
 	// schema change permanent. Durable so a comment-driven skip-revert survives
 	// the API process dying before the engine call lands, and so the apply owner

--- a/pkg/tern/control_requests.go
+++ b/pkg/tern/control_requests.go
@@ -45,6 +45,25 @@ func completePendingControlRequests(ctx context.Context, store storage.Storage, 
 	return nil
 }
 
+// completePendingRequestsForTerminalApply completes the pending control
+// requests that a terminal apply moots: a pending stop is settled (the apply
+// can no longer be stopped), and a pending revert or skip-revert can no longer
+// act because the revert window is gone. Sweeping all three keeps a request
+// issued moments before the apply settled — or one that lost to a contradictory
+// command — from lingering pending forever.
+func completePendingRequestsForTerminalApply(ctx context.Context, store storage.Storage, apply *storage.Apply) error {
+	for _, op := range []storage.ControlOperation{
+		storage.ControlOperationStop,
+		storage.ControlOperationRevert,
+		storage.ControlOperationSkipRevert,
+	} {
+		if err := completePendingControlRequests(ctx, store, apply, op); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // failPendingControlRequests marks the pending control request of the given
 // operation terminally failed. A failed request is no longer pending, so the
 // operator-owned retry loop stops re-running the operation instead of spinning

--- a/pkg/tern/control_requests_test.go
+++ b/pkg/tern/control_requests_test.go
@@ -1,0 +1,50 @@
+package tern
+
+import (
+	"testing"
+
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A terminal apply moots every pending window/stop control request: a stop is
+// settled, and a revert or skip-revert can no longer act once the revert window
+// is gone — including a request that lost to a contradictory command (e.g. a
+// revert still pending after skip-revert finalized the apply). The sweep
+// completes all of them so no request lingers pending forever.
+func TestCompletePendingRequestsForTerminalApply(t *testing.T) {
+	apply := &storage.Apply{
+		ID:              7,
+		ApplyIdentifier: "apply-terminal-sweep",
+		Database:        "testdb",
+		Environment:     "staging",
+		State:           state.Apply.Completed,
+	}
+	sweptOps := []storage.ControlOperation{
+		storage.ControlOperationStop,
+		storage.ControlOperationRevert,
+		storage.ControlOperationSkipRevert,
+	}
+	requests := make([]*storage.ApplyControlRequest, 0, len(sweptOps))
+	for _, op := range sweptOps {
+		requests = append(requests, &storage.ApplyControlRequest{
+			ApplyID: apply.ID, Operation: op, Status: storage.ControlRequestPending,
+		})
+	}
+	controlRequests := &testControlRequestStore{requests: requests}
+	store := &mockStorage{controlRequests: controlRequests}
+
+	require.NoError(t, completePendingRequestsForTerminalApply(t.Context(), store, apply))
+
+	for _, op := range sweptOps {
+		pending, err := controlRequests.GetPending(t.Context(), apply.ID, op)
+		require.NoError(t, err)
+		assert.Nil(t, pending, "pending %s request must be completed once the apply is terminal", op)
+		swept, err := controlRequests.GetByOperation(t.Context(), apply.ID, op)
+		require.NoError(t, err)
+		require.NotNil(t, swept)
+		assert.Equal(t, storage.ControlRequestCompleted, swept.Status)
+	}
+}

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -623,6 +623,45 @@ func (c *GRPCClient) processPendingSkipRevertControlRequest(ctx context.Context,
 	return completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationSkipRevert)
 }
 
+// processPendingRevertControlRequest drives a durable revert control request for
+// a remote apply: it proxies Revert to the data plane and completes the request.
+// This is the apply owner's retry path when the API's immediate revert attempt
+// failed or its process died, leaving the request pending. A transient failure
+// returns an error so the drive exits and the operator retries (the request
+// stays pending); a rejected revert fails the request.
+func (c *GRPCClient) processPendingRevertControlRequest(ctx context.Context, apply *storage.Apply, remoteID string) error {
+	controlReq, err := pendingControlRequest(ctx, c.storage, apply, storage.ControlOperationRevert)
+	if err != nil {
+		return err
+	}
+	if controlReq == nil {
+		return nil
+	}
+	// Revert is only meaningful in the revert window. Once the apply has left it
+	// (finalized, reverted, …) the request is moot — complete it so it does not
+	// linger.
+	if !state.IsState(apply.State, state.Apply.RevertWindow) {
+		return completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationRevert)
+	}
+	resp, err := c.client.Revert(ctx, &ternv1.RevertRequest{
+		ApplyId:     remoteID,
+		Environment: apply.Environment,
+	})
+	if err != nil {
+		return fmt.Errorf("process pending revert for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if !resp.Accepted {
+		message := "revert was not accepted by the data plane"
+		if resp.ErrorMessage != "" {
+			message = fmt.Sprintf("revert was not accepted: %s", resp.ErrorMessage)
+		}
+		return failPendingControlRequests(ctx, c.storage, apply, storage.ControlOperationRevert, message)
+	}
+	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventRevertTriggered,
+		fmt.Sprintf("Revert triggered by user%s", callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
+	return completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationRevert)
+}
+
 // logOperationDriveLeavesParentStop records that a multi-operation
 // operation-only drive observed an apply-level pending stop request and is
 // leaving it pending. Such a drive owns only its operation; the parent stop
@@ -3026,6 +3065,15 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 			}
 			if err := c.processPendingSkipRevertControlRequest(ctx, apply, scope.remoteApplyID(apply)); err != nil {
 				slog.Warn("pending gRPC skip-revert request processing failed; current apply owner will exit for operator retry",
+					"apply_id", apply.ApplyIdentifier,
+					"external_id", apply.ExternalID,
+					"database", apply.Database,
+					"environment", apply.Environment,
+					"error", err)
+				return err
+			}
+			if err := c.processPendingRevertControlRequest(ctx, apply, scope.remoteApplyID(apply)); err != nil {
+				slog.Warn("pending gRPC revert request processing failed; current apply owner will exit for operator retry",
 					"apply_id", apply.ApplyIdentifier,
 					"external_id", apply.ExternalID,
 					"database", apply.Database,

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -467,6 +467,7 @@ type capturingTernServer struct {
 	startApplyID      string
 	cutoverApplyID    string
 	skipRevertApplyID string
+	revertApplyID     string
 	progressApplyID   string
 	progressReq       *ternv1.ProgressRequest
 	progressState     ternv1.State // state returned by Progress; 0 = STATE_COMPLETED
@@ -547,6 +548,13 @@ func (s *capturingTernServer) SkipRevert(_ context.Context, req *ternv1.SkipReve
 	return &ternv1.SkipRevertResponse{Accepted: true}, nil
 }
 
+func (s *capturingTernServer) Revert(_ context.Context, req *ternv1.RevertRequest) (*ternv1.RevertResponse, error) {
+	s.mu.Lock()
+	s.revertApplyID = req.ApplyId
+	s.mu.Unlock()
+	return &ternv1.RevertResponse{Accepted: true}, nil
+}
+
 func (s *capturingTernServer) Progress(_ context.Context, req *ternv1.ProgressRequest) (*ternv1.ProgressResponse, error) {
 	s.mu.Lock()
 	s.progressReq = &ternv1.ProgressRequest{
@@ -596,6 +604,12 @@ func (s *capturingTernServer) getSkipRevertApplyID() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.skipRevertApplyID
+}
+
+func (s *capturingTernServer) getRevertApplyID() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.revertApplyID
 }
 
 func (s *capturingTernServer) getCutoverApplyID() string {
@@ -4534,6 +4548,58 @@ func TestGRPCClient_ProcessPendingSkipRevert(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, server.getSkipRevertApplyID(), "no engine call once the revert window is gone")
 		pending, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationSkipRevert)
+		require.NoError(t, err)
+		assert.Nil(t, pending, "moot request completed")
+	})
+}
+
+func TestGRPCClient_ProcessPendingRevert(t *testing.T) {
+	newApply := func(s string) *storage.Apply {
+		return &storage.Apply{
+			ID: 1, ApplyIdentifier: "apply-revert-grpc",
+			Database: "testdb", DatabaseType: storage.DatabaseTypeVitess,
+			Environment: "staging", Engine: storage.EnginePlanetScale,
+			ExternalID: "remote-revert-grpc", State: s,
+		}
+	}
+	newStore := func(apply *storage.Apply) (*mockStorage, *testControlRequestStore) {
+		controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{{
+			ApplyID: apply.ID, Operation: storage.ControlOperationRevert,
+			Status: storage.ControlRequestPending, RequestedBy: "cli:alice",
+		}}}
+		stored := *apply
+		applies := &mockApplyStore{apply: &stored}
+		return &mockStorage{applies: applies, tasks: &mockTaskStore{}, logs: &mockApplyLogStore{}, controlRequests: controlRequests}, controlRequests
+	}
+
+	t.Run("revert window: proxies revert and completes the request", func(t *testing.T) {
+		server := &capturingTernServer{}
+		client, cleanup := testCapturingGRPCClient(t, server)
+		defer cleanup()
+		apply := newApply(state.Apply.RevertWindow)
+		store, controlRequests := newStore(apply)
+		client.storage = store
+
+		err := client.processPendingRevertControlRequest(t.Context(), apply, apply.ExternalID)
+		require.NoError(t, err)
+		assert.Equal(t, "remote-revert-grpc", server.getRevertApplyID(), "revert proxied to the data plane")
+		pending, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationRevert)
+		require.NoError(t, err)
+		assert.Nil(t, pending, "request completed after a successful revert")
+	})
+
+	t.Run("apply already left the revert window: completes without an engine call", func(t *testing.T) {
+		server := &capturingTernServer{}
+		client, cleanup := testCapturingGRPCClient(t, server)
+		defer cleanup()
+		apply := newApply(state.Apply.Completed)
+		store, controlRequests := newStore(apply)
+		client.storage = store
+
+		err := client.processPendingRevertControlRequest(t.Context(), apply, apply.ExternalID)
+		require.NoError(t, err)
+		assert.Empty(t, server.getRevertApplyID(), "no engine call once the revert window is gone")
+		pending, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationRevert)
 		require.NoError(t, err)
 		assert.Nil(t, pending, "moot request completed")
 	})

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -828,9 +828,34 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		}
 	}
 
+	// A durable revert control request (the interactive "revert" command) was
+	// queued; honor it. This is the apply owner's retry path: the API's immediate
+	// revert attempt may have failed or its process may have died, leaving the
+	// request pending for the drive.
+	revertedByControlRequest := false
+	if result.State == engine.StateRevertWindow && !ps.revertSkipped {
+		if pending, err := pendingControlRequest(ctx, c.storage, apply, storage.ControlOperationRevert); err != nil {
+			c.logger.Warn("could not load pending revert control request", "apply_id", apply.ApplyIdentifier, "error", err)
+		} else if pending != nil {
+			c.logger.Info("revert requested by user; reverting schema change", "apply_id", apply.ApplyIdentifier, "requested_by", controlRequestCaller(pending))
+			if _, err := eng.Revert(ctx, controlReq); err != nil {
+				// Leave the request pending so the next drive tick retries.
+				c.logger.Error("revert (control request) failed; will retry", "error", err, "apply_id", apply.ApplyIdentifier)
+			} else {
+				revertedByControlRequest = true
+				if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationRevert); err != nil {
+					c.logger.Warn("failed to complete revert control request", "apply_id", apply.ApplyIdentifier, "error", err)
+				}
+				c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventRevertTriggered, storage.LogSourceSchemaBot,
+					fmt.Sprintf("Revert triggered by user%s", callerApplyLogSuffix(controlRequestCaller(pending))), state.Apply.RevertWindow, state.Apply.Reverted)
+			}
+		}
+	}
+
 	// Revert window enabled (default): auto-skip based on deployed_at + configured duration.
-	// Falls back to stateEnteredAt if deployed_at is unavailable.
-	if result.State == engine.StateRevertWindow && !opts.SkipRevert && !ps.revertSkipped {
+	// Falls back to stateEnteredAt if deployed_at is unavailable. A user revert
+	// this tick takes precedence — do not also auto-skip the window shut.
+	if result.State == engine.StateRevertWindow && !opts.SkipRevert && !ps.revertSkipped && !revertedByControlRequest {
 		revertDeadline := c.revertWindowDeadline(result.ResumeState, ps.stateEnteredAt)
 		if !revertDeadline.IsZero() && now.After(revertDeadline) {
 			c.logger.Info("revert window expired, skipping", "apply_id", apply.ApplyIdentifier, "deadline", revertDeadline)

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -847,7 +847,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 					c.logger.Warn("failed to complete revert control request", "apply_id", apply.ApplyIdentifier, "error", err)
 				}
 				c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventRevertTriggered, storage.LogSourceSchemaBot,
-					fmt.Sprintf("Revert triggered by user%s", callerApplyLogSuffix(controlRequestCaller(pending))), state.Apply.RevertWindow, state.Apply.Reverted)
+					fmt.Sprintf("Revert triggered by user%s", callerApplyLogSuffix(controlRequestCaller(pending))), state.Apply.RevertWindow, state.Apply.Reverting)
 			}
 		}
 	}

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -938,8 +938,8 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 			"stored_state", freshApply.State,
 			"progress_state", apply.State)
 		*apply = *freshApply
-		if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStop); err != nil {
-			c.logger.Warn("failed to complete pending stop request for terminal apply; current apply owner will exit for operator retry",
+		if err := completePendingRequestsForTerminalApply(ctx, c.storage, apply); err != nil {
+			c.logger.Warn("failed to complete pending control requests for terminal apply; current apply owner will exit for operator retry",
 				"apply_id", apply.ApplyIdentifier, "error", err)
 			return true
 		}
@@ -985,8 +985,8 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 				"apply_id", apply.ApplyIdentifier, "expected_state", expectedState, "derived_state", apply.State)
 			return true
 		}
-		if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStop); err != nil {
-			c.logger.Warn("failed to complete pending stop request after terminal progress reconciliation; current apply owner will exit for operator retry",
+		if err := completePendingRequestsForTerminalApply(ctx, c.storage, apply); err != nil {
+			c.logger.Warn("failed to complete pending control requests after terminal progress reconciliation; current apply owner will exit for operator retry",
 				"apply_id", apply.ApplyIdentifier, "error", err)
 			return true
 		}

--- a/pkg/tern/local_apply_sequential.go
+++ b/pkg/tern/local_apply_sequential.go
@@ -468,8 +468,8 @@ func (c *LocalClient) finalizeSequentialApply(ctx context.Context, apply *storag
 			"apply_id", apply.ApplyIdentifier,
 			"stored_state", freshApply.State)
 		*apply = *freshApply
-		if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStop); err != nil {
-			c.logger.Warn("failed to complete pending stop request for terminal sequential apply",
+		if err := completePendingRequestsForTerminalApply(ctx, c.storage, apply); err != nil {
+			c.logger.Warn("failed to complete pending control requests for terminal sequential apply",
 				"apply_id", apply.ApplyIdentifier, "error", err)
 		}
 		return
@@ -499,8 +499,8 @@ func (c *LocalClient) finalizeSequentialApply(ctx context.Context, apply *storag
 		c.logger.Error("failed to update apply state", append(apply.LogAttrs(), "error", err)...)
 	}
 	if state.IsTerminalApplyState(apply.State) {
-		if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStop); err != nil {
-			c.logger.Warn("failed to complete pending stop request after sequential finalization",
+		if err := completePendingRequestsForTerminalApply(ctx, c.storage, apply); err != nil {
+			c.logger.Warn("failed to complete pending control requests after sequential finalization",
 				append(apply.LogAttrs(), "error", err)...)
 			return
 		}

--- a/pkg/webhook/control.go
+++ b/pkg/webhook/control.go
@@ -375,3 +375,28 @@ func (h *Handler) handleSkipRevertCommand(repo string, pr int, installationID in
 		RequestedBy: requestedBy,
 	}))
 }
+
+func (h *Handler) handleRevertCommand(repo string, pr int, installationID int64, requestedBy string, result CommandResult) {
+	ctx, cancel := h.commandContext(commandTimeout)
+	defer cancel()
+
+	resp := runControlCommand(h, ctx, repo, pr, installationID, requestedBy, result, action.Revert,
+		h.service.ExecuteRevert,
+		func(r *apitypes.ControlResponse) bool { return r.Accepted },
+		func(r *apitypes.ControlResponse) string { return r.ErrorMessage })
+	if resp == nil {
+		return
+	}
+
+	h.logger.Info("revert PR command accepted",
+		"repo", repo,
+		"pr", pr,
+		"apply_id", result.ApplyID,
+		"environment", result.Environment,
+		"requested_by", requestedBy)
+	h.postComment(repo, pr, installationID, templates.RenderRevertCommandAccepted(templates.RevertCommandAcceptedData{
+		ApplyID:     result.ApplyID,
+		Environment: result.Environment,
+		RequestedBy: requestedBy,
+	}))
+}

--- a/pkg/webhook/control_integration_test.go
+++ b/pkg/webhook/control_integration_test.go
@@ -678,6 +678,14 @@ func TestE2ERevertCommandRevertsApply(t *testing.T) {
 	ternClient.mu.Unlock()
 	assert.Equal(t, 1, revertCalls, "the data-plane revert should be invoked exactly once")
 
+	// Revert is a durable control request, like the other control operations, so
+	// it survives an API restart and can be driven by the apply owner. The
+	// immediate attempt succeeded here, so the request lands completed.
+	controlReq, err := store.ControlRequests().GetByOperation(ctx, applyID, storage.ControlOperationRevert)
+	require.NoError(t, err)
+	require.NotNil(t, controlReq, "revert should record a durable control request")
+	assert.Equal(t, storage.ControlRequestCompleted, controlReq.Status)
+
 	assertReactionEventually(t, reactions)
 }
 

--- a/pkg/webhook/control_integration_test.go
+++ b/pkg/webhook/control_integration_test.go
@@ -605,6 +605,82 @@ func TestE2ESkipRevertCommandAcceptsApplyID(t *testing.T) {
 	assertReactionEventually(t, reactions)
 }
 
+// TestE2ERevertCommandRevertsApply verifies that a `schemabot revert <apply-id>
+// -e staging` PR comment reverts a schema change during its revert window: the
+// apply ID is parsed, the data-plane revert is invoked, and the PR shows the
+// acknowledgement. Revert runs synchronously, unlike the durable stop/cutover/
+// skip-revert intents.
+func TestE2ERevertCommandRevertsApply(t *testing.T) {
+	ctx := t.Context()
+	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
+	require.NoError(t, err)
+	require.NoError(t, schemabotDB.PingContext(ctx))
+
+	store := mysqlstore.New(schemabotDB)
+	applyIdentifier := "apply_abcd1234"
+	database := "revert_pr_comments_db"
+	cleanupStopCommandTestRows(t, schemabotDB, applyIdentifier, database)
+	t.Cleanup(func() {
+		cleanupStopCommandTestRows(t, schemabotDB, applyIdentifier, database)
+		utils.CloseAndLog(schemabotDB)
+	})
+
+	applyID := createStopCommandApply(t, store, applyIdentifier, database)
+	storedApply, err := store.Applies().GetByApplyIdentifier(ctx, applyIdentifier)
+	require.NoError(t, err)
+	require.NotNil(t, storedApply)
+	storedApply.State = state.Apply.RevertWindow
+	require.NoError(t, store.Applies().Update(ctx, storedApply))
+
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 10)
+	reactions := make(chan string, 10)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Body string `json:"body"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		comments <- body.Body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+	})
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/comments/42/reactions", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Content string `json:"content"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		reactions <- body.Content
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+
+	service := apiServiceForStopCommandTest(t, store, database)
+	ternClient := &stopCommandTernClient{remote: true}
+	service.RegisterTernClient(database, "staging", ternClient)
+	h := &Handler{
+		service:   service,
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())}),
+		logger:    testLogger(),
+	}
+
+	postRevertCommand(t, h, applyIdentifier, "alice")
+	comment := readComment(t, comments)
+	assert.Contains(t, comment, "Revert Request Accepted")
+	assert.Contains(t, comment, "`"+applyIdentifier+"`")
+	assert.Contains(t, comment, "@alice")
+
+	logs, err := store.ApplyLogs().List(ctx, storage.ApplyLogFilter{ApplyID: applyID, Limit: 20})
+	require.NoError(t, err)
+	assert.True(t, applyLogContains(logs, "Revert triggered by user"))
+
+	ternClient.mu.Lock()
+	revertCalls := ternClient.revertCalls
+	ternClient.mu.Unlock()
+	assert.Equal(t, 1, revertCalls, "the data-plane revert should be invoked exactly once")
+
+	assertReactionEventually(t, reactions)
+}
+
 // TestE2ECutoverCommandRejectsPendingStop verifies that a PR comment cutover
 // command honors an outstanding stop request for the same apply, preserving the
 // operator's stop intent and surfacing the rejection back to the PR.
@@ -835,6 +911,19 @@ func postSkipRevertCommand(t *testing.T, h *Handler, applyIdentifier, user strin
 	assert.Contains(t, rr.Body.String(), "skip-revert started")
 }
 
+func postRevertCommand(t *testing.T, h *Handler, applyIdentifier, user string) {
+	t.Helper()
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment:   "schemabot revert " + applyIdentifier + " -e staging",
+		userLogin: user,
+		isPR:      true,
+	}, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "revert started")
+}
+
 func readComment(t *testing.T, comments chan string) string {
 	t.Helper()
 	select {
@@ -871,6 +960,7 @@ type stopCommandTernClient struct {
 	remote      bool
 	stopCalls   int
 	cancelCalls int
+	revertCalls int
 	onStop      func(context.Context, *ternv1.StopRequest) (*ternv1.StopResponse, error)
 }
 
@@ -916,7 +1006,10 @@ func (c *stopCommandTernClient) Volume(context.Context, *ternv1.VolumeRequest) (
 }
 
 func (c *stopCommandTernClient) Revert(context.Context, *ternv1.RevertRequest) (*ternv1.RevertResponse, error) {
-	return nil, nil
+	c.mu.Lock()
+	c.revertCalls++
+	c.mu.Unlock()
+	return &ternv1.RevertResponse{Accepted: true}, nil
 }
 
 func (c *stopCommandTernClient) SkipRevert(context.Context, *ternv1.SkipRevertRequest) (*ternv1.SkipRevertResponse, error) {

--- a/pkg/webhook/control_integration_test.go
+++ b/pkg/webhook/control_integration_test.go
@@ -607,9 +607,10 @@ func TestE2ESkipRevertCommandAcceptsApplyID(t *testing.T) {
 
 // TestE2ERevertCommandRevertsApply verifies that a `schemabot revert <apply-id>
 // -e staging` PR comment reverts a schema change during its revert window: the
-// apply ID is parsed, the data-plane revert is invoked, and the PR shows the
-// acknowledgement. Revert runs synchronously, unlike the durable stop/cutover/
-// skip-revert intents.
+// apply ID is parsed, a durable revert control request is recorded, the
+// data-plane revert is invoked immediately, and the PR shows the
+// acknowledgement. The durable request is the apply owner's retry path if the
+// immediate attempt cannot land.
 func TestE2ERevertCommandRevertsApply(t *testing.T) {
 	ctx := t.Context()
 	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
@@ -625,7 +626,9 @@ func TestE2ERevertCommandRevertsApply(t *testing.T) {
 		utils.CloseAndLog(schemabotDB)
 	})
 
-	applyID := createStopCommandApply(t, store, applyIdentifier, database)
+	// Revert is only valid for a PlanetScale apply in its revert window, so seed
+	// the engine at creation and move the apply into the revert window.
+	applyID := createStopCommandApplyWithEngine(t, store, applyIdentifier, database, storage.EnginePlanetScale)
 	storedApply, err := store.Applies().GetByApplyIdentifier(ctx, applyIdentifier)
 	require.NoError(t, err)
 	require.NotNil(t, storedApply)

--- a/pkg/webhook/handler_test.go
+++ b/pkg/webhook/handler_test.go
@@ -604,41 +604,6 @@ func TestWebhookEyesReaction(t *testing.T) {
 	}
 }
 
-func TestWebhookPhase2CommandNotYetAvailable(t *testing.T) {
-	h, comments, _ := newTestHandler(t)
-
-	// revert is the only remaining Phase 2 command not yet available via PR
-	// comments (apply, apply-confirm, unlock, stop, start, cutover, and skip-revert
-	// are now implemented).
-	cmds := []struct {
-		comment string
-		action  string
-	}{
-		{"schemabot revert -e staging", "revert"},
-	}
-
-	for _, cmd := range cmds {
-		req := buildWebhookRequest(t, webhookPayloadOpts{
-			comment: cmd.comment,
-			isPR:    true,
-		}, nil)
-
-		rr := httptest.NewRecorder()
-		h.ServeHTTP(rr, req)
-
-		require.Equal(t, http.StatusOK, rr.Code)
-		assert.Contains(t, rr.Body.String(), "not yet implemented")
-
-		select {
-		case body := <-comments:
-			assert.Contains(t, body, "not yet available via PR comments")
-			assert.Contains(t, body, cmd.action)
-		case <-time.After(2 * time.Second):
-			t.Fatalf("timed out waiting for comment for %q", cmd.comment)
-		}
-	}
-}
-
 func TestWebhookSignatureValidation(t *testing.T) {
 	h, comments, _ := newTestHandler(t)
 	secret := []byte("webhook-secret")

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -3,7 +3,6 @@ package webhook
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -332,13 +331,11 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 			h.handleSkipRevertCommand(repo, pr, installationID, requestedBy, result)
 		})
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "skip-revert started"})
-	// Phase 2 commands — acknowledge but not yet implemented
 	case action.Revert:
-		h.postComment(repo, pr, installationID,
-			templates.RenderCommandNotYetAvailable(result.Action, result.Environment))
-		h.writeJSON(w, http.StatusOK, map[string]string{
-			"message": fmt.Sprintf("%s command not yet implemented", result.Action),
+		h.goSafe(repo, pr, installationID, func() {
+			h.handleRevertCommand(repo, pr, installationID, requestedBy, result)
 		})
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "revert started"})
 	default:
 		h.postComment(repo, pr, installationID, templates.RenderInvalidCommand())
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "invalid command"})

--- a/pkg/webhook/templates/issue_comment.go
+++ b/pkg/webhook/templates/issue_comment.go
@@ -190,6 +190,26 @@ func RenderSkipRevertCommandAccepted(data SkipRevertCommandAcceptedData) string 
 	return body
 }
 
+// RevertCommandAcceptedData contains data for a PR comment revert acknowledgement.
+type RevertCommandAcceptedData struct {
+	ApplyID     string
+	Environment string
+	RequestedBy string
+}
+
+// RenderRevertCommandAccepted renders the acknowledgement posted when a PR
+// comment revert command is accepted.
+func RenderRevertCommandAccepted(data RevertCommandAcceptedData) string {
+	body := "## Revert Request Accepted\n\n" +
+		fmt.Sprintf("**Apply**: `%s`\n", data.ApplyID) +
+		fmt.Sprintf("**Environment**: `%s`\n", data.Environment)
+	if data.RequestedBy != "" {
+		body += fmt.Sprintf("**Requested by**: @%s\n", data.RequestedBy)
+	}
+	body += "\nRevert requested. SchemaBot will undo this schema change; status remains available from the PR progress comment or CLI.\n"
+	return body
+}
+
 // PreviewCommentStartCommandAccepted renders a sample start command
 // acknowledgement comment.
 func PreviewCommentStartCommandAccepted() string {
@@ -251,13 +271,4 @@ func PreviewCommentCutoverCommandAlreadyInProgress() string {
 		RequestedBy: "alice",
 		Status:      apitypes.ControlStatusAlreadyInProgress,
 	})
-}
-
-// RenderCommandNotYetAvailable renders the acknowledgement posted when a
-// recognised but not-yet-implemented PR comment command is invoked. It points
-// the user at the CLI fallback for the same action.
-func RenderCommandNotYetAvailable(action, environment string) string {
-	return fmt.Sprintf("The `%s` command is not yet available via PR comments. "+
-		"Use the CLI instead:\n```\nschemabot %s -e %s\n```",
-		action, action, environment)
 }

--- a/pkg/webhook/templates/issue_comment_test.go
+++ b/pkg/webhook/templates/issue_comment_test.go
@@ -161,9 +161,15 @@ func TestRenderCutoverCommandAcceptedAlreadyInProgress(t *testing.T) {
 	assert.Contains(t, rendered, "Cutover is already in progress")
 }
 
-func TestRenderCommandNotYetAvailable(t *testing.T) {
-	rendered := RenderCommandNotYetAvailable("stop", "staging")
-	assert.Contains(t, rendered, "`stop` command is not yet available")
-	assert.Contains(t, rendered, "Use the CLI instead")
-	assert.Contains(t, rendered, "schemabot stop -e staging")
+func TestRenderRevertCommandAccepted(t *testing.T) {
+	rendered := RenderRevertCommandAccepted(RevertCommandAcceptedData{
+		ApplyID:     "apply-957642f96d634694",
+		Environment: "staging",
+		RequestedBy: "alice",
+	})
+	assert.Contains(t, rendered, "Revert Request Accepted")
+	assert.Contains(t, rendered, "`apply-957642f96d634694`")
+	assert.Contains(t, rendered, "`staging`")
+	assert.Contains(t, rendered, "@alice")
+	assert.Contains(t, rendered, "SchemaBot will undo this schema change")
 }


### PR DESCRIPTION
## Why this matters

`revert` was the last control command stubbed as "not yet available" via PR comment, even though the CLI `revert`, `POST /api/revert`, and the data-plane revert all work. So an operator who copies the `schemabot revert <id>` command from the revert-window comment into a PR comment got a dead-end.

## What it does

Wires the comment path through the existing revert logic, mirroring skip-revert:
- Extracts `ExecuteRevert` / `executeRevertForApply` from the inline `handleRevert` so the HTTP handler and the comment command share one path.
- Adds the webhook `handleRevertCommand`, dispatches `revert` to it (replacing the not-yet-available stub), and posts a `Revert Request Accepted` acknowledgement.
- Removes the now-dead `RenderCommandNotYetAvailable` (no command is stubbed any longer).

Revert runs synchronously (proxied to the data plane), unlike the durable stop/cutover/skip-revert intents.

## How it moves toward northstar

Closes the revert-window operability gap: every action the comment advertises now works from the PR comment.

Covered by a template unit test and an integration test that drives a revert-window apply through the PR comment to a data-plane revert.