### PR TITLE
fix(observability): mirror per-shard progress from the remote data plane

### DIFF
--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -2871,9 +2871,22 @@ func (c *GRPCClient) syncShardProgressFromRemote(ctx context.Context, storedAppl
 			append(storedApply.LogAttrs(), "table", storedTask.TableName)...)
 		return
 	}
+	// A shard-scoped drive task (per-shard work operation) is itself the
+	// per-shard row for its shard. Fanning a table-level shard breakdown out
+	// under its operation would overwrite the drive task's own row and attach
+	// rows for shards the operation does not own. Only table-level tasks
+	// (shard == "") mirror a per-shard breakdown.
+	if storedTask.Shard != "" {
+		slog.Warn("skipping remote per-shard progress encode: stored task is scoped to a single shard and owns no breakdown",
+			append(storedApply.LogAttrs(), "table", storedTask.TableName, "task_shard", storedTask.Shard)...)
+		return
+	}
 	for _, sh := range shards {
-		// An empty shard would collide with the unsharded single-shard sentinel.
+		// An empty shard would collide with the unsharded single-shard sentinel,
+		// so the entry cannot be stored as a per-shard row.
 		if sh.Shard == "" {
+			slog.Warn("skipping remote per-shard progress entry with an empty shard name",
+				append(storedApply.LogAttrs(), "table", storedTask.TableName)...)
 			continue
 		}
 		shardState := state.NormalizeShardStatus(sh.Status)

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -2817,6 +2817,13 @@ func (c *GRPCClient) syncStoredTasksFromRemoteTasks(
 		if oldTaskState != storedTask.State {
 			c.logTaskStateTransition(ctx, storedApply.ID, storedTask, fmt.Sprintf("Remote task %s changed state: %s -> %s", storedTask.TableName, oldTaskState, storedTask.State), oldTaskState)
 		}
+
+		// Mirror the per-shard progress the data plane reported into control-plane
+		// storage so the PR comment / CLI can render the per-shard breakdown and the
+		// control plane can see shard drift. The control plane is a reader: it never
+		// polls the engine, so the only per-shard source is the remote Progress
+		// response, which the in-process drive's write-through never reaches.
+		c.syncShardProgressFromRemote(ctx, storedApply, storedTask, remoteTask.Shards, now)
 	}
 	if missingProgressTasks > 0 {
 		slog.Warn("remote gRPC progress omitted stored tasks",
@@ -2834,6 +2841,89 @@ func remoteTaskOmittedRowTotals(storedTask *storage.Task, remoteTask *ternv1.Tab
 		return false
 	}
 	return storedTask.RowsTotal > 0 && remoteTask.RowsTotal <= 0
+}
+
+// syncShardProgressFromRemote mirrors the per-shard progress carried in a remote
+// Tern Progress response into control-plane storage as per-(table, shard) task
+// rows (`shard != ""`), so the PR comment / CLI render the per-shard breakdown and
+// the control plane can see shard drift. Like the in-process drive's write-through
+// (LocalClient.writeShardProgress) it is lease-gated and best-effort: it writes
+// only inside the operator's lease-held reconcile (read-path callers carry no
+// lease and skip), and a failed shard write is logged rather than failing the
+// table-level sync — the next reconcile re-applies it.
+func (c *GRPCClient) syncShardProgressFromRemote(ctx context.Context, storedApply *storage.Apply, storedTask *storage.Task, shards []*ternv1.ShardProgress, now time.Time) {
+	if len(shards) == 0 {
+		return
+	}
+	_, hasOpLease := storage.OperationLeaseFromContext(ctx)
+	_, hasApplyLease := storage.ApplyLeaseFromContext(ctx)
+	if !hasOpLease && !hasApplyLease {
+		slog.Debug("skipping remote per-shard progress encode: no lease on reconcile context",
+			"apply_id", storedApply.ApplyIdentifier, "table", storedTask.TableName)
+		return
+	}
+	// Per-shard rows hang off the table's apply_operation; without one there is no
+	// key to write or read them under.
+	if storedTask.ApplyOperationID == nil {
+		slog.Debug("skipping remote per-shard progress encode: stored task has no apply_operation_id",
+			"apply_id", storedApply.ApplyIdentifier, "table", storedTask.TableName)
+		return
+	}
+	for _, sh := range shards {
+		// An empty shard would collide with the unsharded single-shard sentinel.
+		if sh.Shard == "" {
+			continue
+		}
+		shardState := state.NormalizeShardStatus(sh.Status)
+		// The proto carries row totals, not a percent; derive it the way the read
+		// model does and clamp (row counts can momentarily exceed the total).
+		pct := 0
+		if sh.RowsTotal > 0 {
+			pct = min(int(sh.RowsCopied*100/sh.RowsTotal), 100)
+		}
+		if state.IsState(shardState, state.Task.Completed) {
+			pct = 100
+		}
+		shardTask := &storage.Task{
+			TaskIdentifier:   newTaskIdentifier(),
+			ApplyID:          storedTask.ApplyID,
+			ApplyOperationID: storedTask.ApplyOperationID,
+			PlanID:           storedTask.PlanID,
+			Database:         storedTask.Database,
+			DatabaseType:     storedTask.DatabaseType,
+			Engine:           storedTask.Engine,
+			Repository:       storedTask.Repository,
+			PullRequest:      storedTask.PullRequest,
+			Environment:      storedTask.Environment,
+			Namespace:        storedTask.Namespace,
+			TableName:        storedTask.TableName,
+			Shard:            sh.Shard,
+			DDL:              storedTask.DDL,
+			DDLAction:        storedTask.DDLAction,
+			State:            shardState,
+			RowsCopied:       sh.RowsCopied,
+			RowsTotal:        sh.RowsTotal,
+			ProgressPercent:  pct,
+			ETASeconds:       int(sh.EtaSeconds),
+			CutoverAttempts:  int(sh.CutoverAttempts),
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}
+		if err := c.storage.Tasks().UpsertShardProgress(ctx, shardTask); err != nil {
+			if errors.Is(err, storage.ErrApplyLeaseLost) {
+				// A peer claimed the operation; this driver is displaced. Stop —
+				// every further shard would fail the same way.
+				slog.Debug("stopping remote per-shard progress encode: operation lease lost",
+					"apply_id", storedApply.ApplyIdentifier, "table", storedTask.TableName, "shard", sh.Shard)
+				return
+			}
+			slog.Error("failed to encode remote per-shard progress into control-plane storage",
+				"apply_id", storedApply.ApplyIdentifier, "external_id", storedApply.ExternalID,
+				"apply_operation_id", *storedTask.ApplyOperationID,
+				"namespace", storedTask.Namespace, "table", storedTask.TableName, "shard", sh.Shard,
+				"error", err)
+		}
+	}
 }
 
 // reconcileStoredTasksForTerminalRemoteApply force-resolves any stored task the

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -2911,9 +2911,11 @@ func (c *GRPCClient) syncShardProgressFromRemote(ctx context.Context, storedAppl
 		}
 		if err := c.storage.Tasks().UpsertShardProgress(ctx, shardTask); err != nil {
 			if errors.Is(err, storage.ErrApplyLeaseLost) {
-				// A peer claimed the operation; this driver is displaced. Stop —
-				// every further shard would fail the same way.
-				slog.Debug("stopping remote per-shard progress encode: operation lease lost",
+				// A peer claimed the work; this driver is displaced. Stop — every
+				// further shard would fail the same way. The lost lease may be the
+				// operation lease (fan-out drive) or the apply lease (single-operation
+				// drive), since UpsertShardProgress accepts either.
+				slog.Debug("stopping remote per-shard progress encode: drive lease lost",
 					"apply_id", storedApply.ApplyIdentifier, "table", storedTask.TableName, "shard", sh.Shard)
 				return
 			}

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -2846,11 +2846,11 @@ func remoteTaskOmittedRowTotals(storedTask *storage.Task, remoteTask *ternv1.Tab
 // syncShardProgressFromRemote mirrors the per-shard progress carried in a remote
 // Tern Progress response into control-plane storage as per-(table, shard) task
 // rows (`shard != ""`), so the PR comment / CLI render the per-shard breakdown and
-// the control plane can see shard drift. Like the in-process drive's write-through
-// (LocalClient.writeShardProgress) it is lease-gated and best-effort: it writes
-// only inside the operator's lease-held reconcile (read-path callers carry no
-// lease and skip), and a failed shard write is logged rather than failing the
-// table-level sync — the next reconcile re-applies it.
+// the control plane can see shard drift. It runs only inside the operator's
+// lease-held reconcile (the gRPC read path renders from storage and never reaches
+// here), so a missing lease or apply_operation is unexpected and warned rather
+// than silently dropping per-shard progress. A failed shard write is logged rather
+// than failing the table-level sync — the next reconcile re-applies it.
 func (c *GRPCClient) syncShardProgressFromRemote(ctx context.Context, storedApply *storage.Apply, storedTask *storage.Task, shards []*ternv1.ShardProgress, now time.Time) {
 	if len(shards) == 0 {
 		return
@@ -2858,15 +2858,17 @@ func (c *GRPCClient) syncShardProgressFromRemote(ctx context.Context, storedAppl
 	_, hasOpLease := storage.OperationLeaseFromContext(ctx)
 	_, hasApplyLease := storage.ApplyLeaseFromContext(ctx)
 	if !hasOpLease && !hasApplyLease {
-		slog.Debug("skipping remote per-shard progress encode: no lease on reconcile context",
-			"apply_id", storedApply.ApplyIdentifier, "table", storedTask.TableName)
+		// This path is reached only from the lease-held drive, so no lease means
+		// per-shard progress will silently not persist — surface it for triage.
+		slog.Warn("skipping remote per-shard progress encode: no lease on reconcile context",
+			append(storedApply.LogAttrs(), "table", storedTask.TableName)...)
 		return
 	}
-	// Per-shard rows hang off the table's apply_operation; without one there is no
-	// key to write or read them under.
+	// Per-shard rows hang off the table's apply_operation; a sharded task without
+	// one is unexpected and leaves the per-shard view empty.
 	if storedTask.ApplyOperationID == nil {
-		slog.Debug("skipping remote per-shard progress encode: stored task has no apply_operation_id",
-			"apply_id", storedApply.ApplyIdentifier, "table", storedTask.TableName)
+		slog.Warn("skipping remote per-shard progress encode: stored task has no apply_operation_id",
+			append(storedApply.LogAttrs(), "table", storedTask.TableName)...)
 		return
 	}
 	for _, sh := range shards {
@@ -2916,14 +2918,14 @@ func (c *GRPCClient) syncShardProgressFromRemote(ctx context.Context, storedAppl
 				// operation lease (fan-out drive) or the apply lease (single-operation
 				// drive), since UpsertShardProgress accepts either.
 				slog.Debug("stopping remote per-shard progress encode: drive lease lost",
-					"apply_id", storedApply.ApplyIdentifier, "table", storedTask.TableName, "shard", sh.Shard)
+					append(storedApply.LogAttrs(), "table", storedTask.TableName, "shard", sh.Shard)...)
 				return
 			}
 			slog.Error("failed to encode remote per-shard progress into control-plane storage",
-				"apply_id", storedApply.ApplyIdentifier, "external_id", storedApply.ExternalID,
-				"apply_operation_id", *storedTask.ApplyOperationID,
-				"namespace", storedTask.Namespace, "table", storedTask.TableName, "shard", sh.Shard,
-				"error", err)
+				append(storedApply.LogAttrs(),
+					"apply_operation_id", *storedTask.ApplyOperationID,
+					"namespace", storedTask.Namespace, "table", storedTask.TableName, "shard", sh.Shard,
+					"error", err)...)
 		}
 	}
 }

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -677,6 +677,8 @@ type mockTaskStore struct {
 	getByOperationIDErr error
 	updateErr           error
 	lastOperationID     int64
+	upsertedShards      []*storage.Task
+	upsertShardErr      error
 }
 
 func (m *mockTaskStore) GetByApplyID(context.Context, int64) ([]*storage.Task, error) {
@@ -694,6 +696,15 @@ func (m *mockTaskStore) GetByApplyOperationID(_ context.Context, applyOperationI
 	return m.tasks, nil
 }
 func (m *mockTaskStore) Update(context.Context, *storage.Task) error { return m.updateErr }
+
+func (m *mockTaskStore) UpsertShardProgress(_ context.Context, task *storage.Task) error {
+	if m.upsertShardErr != nil {
+		return m.upsertShardErr
+	}
+	stored := *task
+	m.upsertedShards = append(m.upsertedShards, &stored)
+	return nil
+}
 
 type mockApplyLogStore struct {
 	storage.ApplyLogStore
@@ -3225,6 +3236,73 @@ func TestGRPCClient_SyncStoredTasksFromRemoteTasksUsesRemoteTaskState(t *testing
 			assert.True(t, hasLogMessageContaining(logs.logs, "Remote task users changed state: running -> "+tc.wantStoredTaskState))
 		})
 	}
+}
+
+func TestGRPCClient_SyncShardProgressFromRemote(t *testing.T) {
+	// A remote Tern Progress response carries per-shard ShardProgress. The control
+	// plane is a reader/mirror, so it must encode those into per-(table, shard) task
+	// rows in its own storage — otherwise the PR comment / CLI can never show the
+	// per-shard breakdown or shard drift for a remote apply. Writing is lease-gated:
+	// the operator's drive holds the lease, read-path callers do not.
+	now := time.Now()
+	opID := int64(7)
+	apply := &storage.Apply{ID: 40, ApplyIdentifier: "apply-shard-sync", State: state.Apply.Running}
+	newStoredTask := func() *storage.Task {
+		return &storage.Task{
+			ID: 41, TaskIdentifier: "task-shard-sync", ApplyID: apply.ID,
+			ApplyOperationID: &opID, Namespace: "commerce_sharded", TableName: "customers",
+			State: state.Task.Running,
+		}
+	}
+	remoteTables := func() []*ternv1.TableProgress {
+		return []*ternv1.TableProgress{{
+			Namespace:  "commerce_sharded",
+			TableName:  "customers",
+			Status:     state.Task.Running,
+			RowsCopied: 150,
+			RowsTotal:  300,
+			Shards: []*ternv1.ShardProgress{
+				{Shard: "-80", Status: state.Task.Running, RowsCopied: 100, RowsTotal: 100},
+				{Shard: "80-", Status: state.Task.Running, RowsCopied: 50, RowsTotal: 200},
+			},
+		}}
+	}
+
+	t.Run("encodes per-shard rows under a lease", func(t *testing.T) {
+		storedTask := newStoredTask()
+		tasks := &mockTaskStore{tasks: []*storage.Task{storedTask}}
+		client := &GRPCClient{storage: &mockStorage{tasks: tasks, logs: &mockApplyLogStore{}}}
+		ctx := storage.WithApplyLease(t.Context(), storage.ApplyLease{ApplyID: apply.ID, Token: "lease-tok"})
+
+		require.NoError(t, client.syncStoredTasksFromRemoteTasks(ctx, apply, []*storage.Task{storedTask}, remoteTables(), now))
+
+		require.Len(t, tasks.upsertedShards, 2)
+		byShard := map[string]*storage.Task{}
+		for _, s := range tasks.upsertedShards {
+			byShard[s.Shard] = s
+		}
+		require.Contains(t, byShard, "-80")
+		require.Contains(t, byShard, "80-")
+		// Identity carried from the table task; rows/percent from the shard.
+		assert.Equal(t, apply.ID, byShard["-80"].ApplyID)
+		require.NotNil(t, byShard["-80"].ApplyOperationID)
+		assert.Equal(t, opID, *byShard["-80"].ApplyOperationID)
+		assert.Equal(t, "commerce_sharded", byShard["-80"].Namespace)
+		assert.Equal(t, "customers", byShard["-80"].TableName)
+		assert.Equal(t, int64(100), byShard["-80"].RowsCopied)
+		assert.Equal(t, 100, byShard["-80"].ProgressPercent) // 100/100
+		assert.Equal(t, 25, byShard["80-"].ProgressPercent)  // 50/200
+	})
+
+	t.Run("skips when no lease is on the context", func(t *testing.T) {
+		storedTask := newStoredTask()
+		tasks := &mockTaskStore{tasks: []*storage.Task{storedTask}}
+		client := &GRPCClient{storage: &mockStorage{tasks: tasks, logs: &mockApplyLogStore{}}}
+
+		require.NoError(t, client.syncStoredTasksFromRemoteTasks(t.Context(), apply, []*storage.Task{storedTask}, remoteTables(), now))
+
+		assert.Empty(t, tasks.upsertedShards, "no per-shard rows should be written without a lease")
+	})
 }
 
 func TestGRPCClient_SyncRemoteProgressByNamespace(t *testing.T) {

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -3303,6 +3303,40 @@ func TestGRPCClient_SyncShardProgressFromRemote(t *testing.T) {
 
 		assert.Empty(t, tasks.upsertedShards, "no per-shard rows should be written without a lease")
 	})
+
+	t.Run("skips a shard-scoped drive task", func(t *testing.T) {
+		// A per-shard work operation's drive task is itself the per-shard row for
+		// its shard. Mirroring a table-level breakdown under that operation would
+		// overwrite the drive task's row and attach rows for shards the operation
+		// does not own, so a shard-scoped task never fans out.
+		storedTask := newStoredTask()
+		storedTask.Shard = "-80"
+		tasks := &mockTaskStore{tasks: []*storage.Task{storedTask}}
+		client := &GRPCClient{storage: &mockStorage{tasks: tasks, logs: &mockApplyLogStore{}}}
+		ctx := storage.WithApplyLease(t.Context(), storage.ApplyLease{ApplyID: apply.ID, Token: "lease-tok"})
+
+		require.NoError(t, client.syncStoredTasksFromRemoteTasks(ctx, apply, []*storage.Task{storedTask}, remoteTables(), now))
+
+		assert.Empty(t, tasks.upsertedShards, "a shard-scoped drive task must not mirror a per-shard breakdown")
+	})
+
+	t.Run("skips a shard entry with an empty shard name", func(t *testing.T) {
+		// An empty shard name would collide with the unsharded single-shard
+		// sentinel, so the entry is dropped while the named shards still mirror.
+		storedTask := newStoredTask()
+		tasks := &mockTaskStore{tasks: []*storage.Task{storedTask}}
+		client := &GRPCClient{storage: &mockStorage{tasks: tasks, logs: &mockApplyLogStore{}}}
+		ctx := storage.WithApplyLease(t.Context(), storage.ApplyLease{ApplyID: apply.ID, Token: "lease-tok"})
+		tables := remoteTables()
+		tables[0].Shards = append(tables[0].Shards, &ternv1.ShardProgress{Status: state.Task.Running, RowsCopied: 10, RowsTotal: 10})
+
+		require.NoError(t, client.syncStoredTasksFromRemoteTasks(ctx, apply, []*storage.Task{storedTask}, tables, now))
+
+		require.Len(t, tasks.upsertedShards, 2)
+		for _, s := range tasks.upsertedShards {
+			assert.NotEmpty(t, s.Shard, "no per-shard row may be stored without a shard name")
+		}
+	})
 }
 
 func TestGRPCClient_SyncRemoteProgressByNamespace(t *testing.T) {

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
-
 	"github.com/block/schemabot/pkg/engine"
 	"github.com/block/schemabot/pkg/metrics"
 	"github.com/block/schemabot/pkg/state"
@@ -1200,7 +1198,7 @@ func (c *LocalClient) writeShardProgress(ctx context.Context, table *storage.Tas
 	}
 	for _, sh := range tp.Shards {
 		shardTask := &storage.Task{
-			TaskIdentifier:   "task-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16],
+			TaskIdentifier:   newTaskIdentifier(),
 			ApplyID:          table.ApplyID,
 			ApplyOperationID: table.ApplyOperationID,
 			PlanID:           table.PlanID,

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -1673,6 +1673,11 @@ func (c *LocalClient) existingIdempotentApply(ctx context.Context, req *ternv1.A
 	return existing, nil
 }
 
+// newTaskIdentifier returns a fresh opaque task identifier (`task-<16 hex>`).
+func newTaskIdentifier() string {
+	return "task-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16]
+}
+
 // Apply executes a previously generated plan.
 // In local mode, Apply has additional conflict checking and polls for completion.
 //
@@ -1852,7 +1857,7 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 
 	tasks := make([]*storage.Task, len(ddlChanges))
 	for i, ddlChange := range ddlChanges {
-		taskIdentifier := "task-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16]
+		taskIdentifier := newTaskIdentifier()
 		tasks[i] = &storage.Task{
 			TaskIdentifier: taskIdentifier,
 			PlanID:         plan.ID,


### PR DESCRIPTION
## In plain terms
When a schema change runs on a remote data plane, the control plane doesn't run anything itself — it polls the remote for progress over gRPC, stores what it hears, and renders the PR comment / CLI from that storage. For sharded databases the remote reports two levels of detail: the table total and a per-shard breakdown. The control plane stored only the table total and dropped the shard lines, so operators could see "customers: 50%" but never that one shard was finished while another lagged. This PR stores the shard lines too.

```
                     gRPC Progress response
 ┌──────────────┐   ─────────────────────►   ┌───────────────────┐
 │  Data plane  │   customers: 150/300       │   Control plane   │
 │ (runs the    │   ├─ shard -80: 100/100    │ (stores, renders  │
 │  apply)      │   └─ shard 80-:  50/200    │  PR comment/CLI)  │
 └──────────────┘                            └───────────────────┘

 BEFORE: stored only "customers: 150/300" — shard lines dropped
         PR comment: customers ▓▓▓▓▓░░░░░ 50%

 AFTER:  stores the shard rows too
         PR comment: customers ▓▓▓▓▓░░░░░ 50%
                     ├─ -80    ▓▓▓▓▓▓▓▓▓▓ 100% completed
                     └─ 80-    ▓▓▓░░░░░░░  25% running
```

## Why this matters
When SchemaBot drives an apply against a **remote (gRPC) data plane**, the control plane is a reader/mirror: it never polls the engine itself — it reads the data plane's progress over gRPC and encodes it into its own storage. The PR comment and CLI render per-shard progress from those stored per-`(table, shard)` rows. But the gRPC progress reconcile only copied **table-level** fields — the per-shard `ShardProgress` carried in the Progress response was silently dropped (no `UpsertShardProgress` on the gRPC path; the per-shard write-through existed only in the in-process `LocalClient` drive). So for any remote sharded apply, the per-shard breakdown never reached the storage the comment/CLI read, and **per-shard drift was invisible** to operators.

## What it does
`syncStoredTasksFromRemoteTasks` now encodes each table's per-shard `ShardProgress` into per-`(table, shard)` task rows under the table's `apply_operation`, mirroring the in-process drive's write-through:
- **Lease-gated** — writes only inside the operator's lease-held reconcile; read-path callers (no lease) skip.
- **Best-effort** — a shard write error is logged, not propagated, so it never fails the table-level sync; the next reconcile re-applies it.
- **Fails closed on rows it cannot own** — a shard-scoped drive task (per-shard work operation) is itself the per-shard row, so it never fans a breakdown out under its operation, and a shard entry with an empty shard name is logged and skipped rather than colliding with the unsharded sentinel.
- Extracts `newTaskIdentifier()` now that three sites build the same identifier.

Adds `TestGRPCClient_SyncShardProgressFromRemote` (encodes under a lease; skips without one, for shard-scoped tasks, and for unnamed shard entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
