### PR TITLE
fix(observability): make the per-shard write-through branches observable

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -263,6 +263,23 @@ func RecordTransientPlanRetry(ctx context.Context, database, environment, outcom
 	)
 }
 
+// RecordShardProgressWriteThrough records the outcome of the operator drive's
+// per-shard progress write-through. outcome is one of: "written" (>=1 shard row
+// persisted this poll), "skipped_no_shards_with_rows" (a copying table on a
+// sharded engine reported no per-shard breakdown — surprising), "skipped_no_lease"
+// (no lease on the context — a read-path caller), "lease_lost", or "error". The
+// ordinary unsharded/instant case is intentionally not recorded so a spike on any
+// outcome is actionable.
+func RecordShardProgressWriteThrough(ctx context.Context, database, databaseType, environment, outcome string) {
+	addCounter(ctx, "schemabot.operator.shard_progress_writethrough.total",
+		"operator per-shard progress write-through outcomes", "{write}",
+		attribute.String("database", database),
+		attribute.String("database_type", databaseType),
+		EnvironmentAttribute(environment),
+		attribute.String("outcome", outcome),
+	)
+}
+
 var knownSourcePolicyOperations = map[string]bool{
 	"plan":  true,
 	"apply": true,

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -1187,17 +1187,34 @@ func (c *LocalClient) syncAtomicTaskProgress(ctx context.Context, tasks []*stora
 // reconcile re-applies it.
 func (c *LocalClient) writeShardProgress(ctx context.Context, table *storage.Task, tp *engine.TableProgress, now time.Time) {
 	if len(tp.Shards) == 0 {
+		// A copying table on a sharded engine that reports no per-shard breakdown is
+		// surprising and means the per-shard view will be empty — surface it. Stay
+		// quiet for the ordinary cases (MySQL row copy, or an instant/no-row table),
+		// where no shards is expected.
+		shardedEngine := table.DatabaseType == storage.DatabaseTypeVitess || table.DatabaseType == storage.DatabaseTypeStrata
+		if shardedEngine && (tp.RowsCopied > 0 || tp.RowsTotal > 0) {
+			c.logger.Warn("operator: per-shard progress skipped, engine reported a copying table with no shards",
+				append(table.LogAttrs(), "rows_copied", tp.RowsCopied, "rows_total", tp.RowsTotal)...)
+			metrics.RecordShardProgressWriteThrough(ctx, table.Database, table.DatabaseType, table.Environment, "skipped_no_shards_with_rows")
+		}
 		return
 	}
 	_, hasOpLease := storage.OperationLeaseFromContext(ctx)
 	_, hasApplyLease := storage.ApplyLeaseFromContext(ctx)
 	if !hasOpLease && !hasApplyLease {
+		// Read-path callers carry no lease and skip; expected and frequent, so the
+		// drive should be the only writer. Record it so an unexpectedly leaseless
+		// drive is visible.
+		c.logger.Debug("operator: per-shard progress skipped, no lease on context",
+			append(table.LogAttrs(), "shard_count", len(tp.Shards))...)
+		metrics.RecordShardProgressWriteThrough(ctx, table.Database, table.DatabaseType, table.Environment, "skipped_no_lease")
 		return
 	}
 	var operationID int64
 	if table.ApplyOperationID != nil {
 		operationID = *table.ApplyOperationID
 	}
+	wroteShard := false
 	for _, sh := range tp.Shards {
 		shardTask := &storage.Task{
 			TaskIdentifier:   "task-" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16],
@@ -1226,6 +1243,7 @@ func (c *LocalClient) writeShardProgress(ctx context.Context, table *storage.Tas
 		}
 		err := c.storage.Tasks().UpsertShardProgress(ctx, shardTask)
 		if err == nil {
+			wroteShard = true
 			continue
 		}
 		if errors.Is(err, storage.ErrApplyLeaseLost) {
@@ -1236,6 +1254,7 @@ func (c *LocalClient) writeShardProgress(ctx context.Context, table *storage.Tas
 				"apply_id", table.ApplyID, "apply_operation_id", operationID,
 				"database", table.Database, "environment", table.Environment,
 				"namespace", table.Namespace, "table", table.TableName, "shard", sh.Shard)
+			metrics.RecordShardProgressWriteThrough(ctx, table.Database, table.DatabaseType, table.Environment, "lease_lost")
 			return
 		}
 		c.logger.Error("operator: failed to persist shard progress",
@@ -1243,5 +1262,9 @@ func (c *LocalClient) writeShardProgress(ctx context.Context, table *storage.Tas
 			"database", table.Database, "database_type", table.DatabaseType, "environment", table.Environment,
 			"namespace", table.Namespace, "table", table.TableName, "shard", sh.Shard,
 			"error", err)
+		metrics.RecordShardProgressWriteThrough(ctx, table.Database, table.DatabaseType, table.Environment, "error")
+	}
+	if wroteShard {
+		metrics.RecordShardProgressWriteThrough(ctx, table.Database, table.DatabaseType, table.Environment, "written")
 	}
 }


### PR DESCRIPTION
## Why this matters
`writeShardProgress` (the operator drive's per-shard write-through) has two silent early-returns — the engine reported no shards, and no lease on the context. Both are `return` with no signal, and the related engine lines are `Debug` (off in deployed environments). So when per-shard rows fail to reach storage, there is **nothing to triage from** — exactly the wall hit while investigating a sharded apply that produced no per-shard rows with no errors.

## What it does
Adds a `schemabot.operator.shard_progress_writethrough.total` counter with an `outcome` label and instruments each branch:
- `written` — at least one shard row persisted this poll
- `skipped_no_shards_with_rows` — a **sharded engine** reported a copying table (rows > 0) with no per-shard breakdown (the surprising case; also logged `Warn`)
- `skipped_no_lease` — no lease on the context (read-path caller; logged `Debug`)
- `lease_lost` / `error` — the upsert failed

The surprising no-shards case is recorded only for sharded engines (Vitess/Strata), so MySQL row-copy — rows but no shards, which is expected — stays quiet and a spike on any outcome is actionable. Satisfies the no-silent-branches rule.

## How it moves toward the north star
This is the instrument for the open data-plane question: when a sharded apply yields no per-shard rows, the metric now says *which* branch fired (engine returned no shards vs. no lease vs. write error), turning an indeterminate investigation into a single query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)