### PR TITLE
feat(tern): verify re-planned DDL matches reviewed DDL before resume

### DIFF
--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -446,12 +446,53 @@ func (c *LocalClient) replanAndFilterTasks(ctx context.Context, apply *storage.A
 				fmt.Sprintf("Task %s already completed (re-plan shows no remaining changes)", task.TaskIdentifier))
 			completedCount++
 		} else {
+			// Fail closed if the re-plan would apply DDL this task was not
+			// reviewed with: the re-plan recomputes the delta against live
+			// schema, so on a drifted deployment it can produce unreviewed DDL
+			// that overwriting task.DDL would silently apply.
+			if err := verifyReplannedTaskDDL(task, ddl); err != nil {
+				return nil, err
+			}
 			task.DDL = ddl
 			activeTasks = append(activeTasks, task)
 		}
 	}
 
 	return &replanResult{ActiveTasks: activeTasks, CompletedCount: completedCount}, nil
+}
+
+// verifyReplannedTaskDDL fails closed when the DDL a resume re-plan would now
+// apply for a task differs from the DDL the task was reviewed with. The resume
+// re-plan recomputes each deployment's own delta against its live schema; on a
+// deployment whose schema has drifted, that recomputed delta is DDL no human
+// reviewed, and overwriting task.DDL with it would apply it silently. Comparing
+// canonical forms tolerates incidental formatting differences so only a real
+// semantic divergence trips the guard. A task with no reviewed DDL carries no
+// reference to compare against (only the legacy synthetic VSchema tasks, which
+// the engine-change builder already skips), so it is left to existing handling.
+func verifyReplannedTaskDDL(task *storage.Task, replannedDDL string) error {
+	if task.DDL == "" {
+		return nil
+	}
+	reviewedCanon, err := canonicalDDLForDrift(task.DDL)
+	if err != nil {
+		return fmt.Errorf("reviewed DDL for task %s: %w", task.TaskIdentifier, err)
+	}
+	replannedCanon, err := canonicalDDLForDrift(replannedDDL)
+	if err != nil {
+		return fmt.Errorf("re-planned DDL for task %s: %w", task.TaskIdentifier, err)
+	}
+	if reviewedCanon == replannedCanon {
+		return nil
+	}
+	loc := formatDriftLocation(driftChangeKey{
+		namespace: task.Namespace,
+		shard:     task.Shard,
+		table:     task.TableName,
+		operation: task.DDLAction,
+	})
+	return fmt.Errorf("local schema has drifted from the reviewed plan; resume would apply unreviewed DDL for %s: reviewed %q, re-planned %q",
+		loc, reviewedCanon, replannedCanon)
 }
 
 // prepareRetryableTasksForResume queues only the task work that previously

--- a/pkg/tern/local_control_resume_test.go
+++ b/pkg/tern/local_control_resume_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/block/schemabot/pkg/engine"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/spirit/pkg/statement"
 )
 
 // A sharded re-plan repeats the same table across shards (and across keyspaces),
@@ -48,4 +50,118 @@ func TestReplanShardTableDDLNonShardedDegradesToTable(t *testing.T) {
 
 	require.Len(t, got, 1)
 	assert.Equal(t, ddl, got[shardTableKey{namespace: "commerce", table: "mutes"}])
+}
+
+// On resume, replanAndFilterTasks recomputes each deployment's delta against its
+// live schema and overwrites task.DDL with it. verifyReplannedTaskDDL is the
+// gate that keeps a drifted deployment from silently applying that recomputed
+// DDL: it must pass only when the re-plan matches what the task was reviewed
+// with, tolerating incidental formatting, and fail closed otherwise.
+func TestVerifyReplannedTaskDDL(t *testing.T) {
+	task := func(reviewed string) *storage.Task {
+		return &storage.Task{
+			TaskIdentifier: "task_abc123",
+			Namespace:      "commerce",
+			Shard:          "-80",
+			TableName:      "users",
+			DDLAction:      "alter",
+			DDL:            reviewed,
+		}
+	}
+
+	t.Run("matching re-plan passes", func(t *testing.T) {
+		tk := task("ALTER TABLE `users` ADD COLUMN `email` varchar(255)")
+		err := verifyReplannedTaskDDL(tk, "ALTER TABLE `users` ADD COLUMN `email` varchar(255)")
+		require.NoError(t, err)
+	})
+
+	t.Run("incidental formatting differences pass", func(t *testing.T) {
+		// Unquoted identifiers and extra whitespace canonicalize to the same form
+		// as the reviewed DDL, so they are not drift.
+		tk := task("ALTER TABLE `users` ADD COLUMN `email` varchar(255)")
+		err := verifyReplannedTaskDDL(tk, "ALTER TABLE   users   ADD COLUMN email varchar(255)")
+		require.NoError(t, err)
+	})
+
+	t.Run("divergent re-plan fails closed", func(t *testing.T) {
+		// The deployment drifted: the re-plan would apply a different column type
+		// than the one reviewed. This unreviewed DDL must be refused.
+		tk := task("ALTER TABLE `users` ADD COLUMN `email` varchar(255)")
+		err := verifyReplannedTaskDDL(tk, "ALTER TABLE `users` ADD COLUMN `email` varchar(100)")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "drifted from the reviewed plan")
+		assert.Contains(t, err.Error(), "commerce[-80].users/alter")
+	})
+
+	t.Run("empty reviewed DDL is left to the caller", func(t *testing.T) {
+		// Only legacy synthetic VSchema tasks carry no reviewed DDL; they have no
+		// reference to compare against and are handled downstream, not here.
+		tk := task("")
+		err := verifyReplannedTaskDDL(tk, "ALTER TABLE `users` ADD COLUMN `email` varchar(255)")
+		require.NoError(t, err)
+	})
+
+	t.Run("unparseable re-planned DDL fails closed", func(t *testing.T) {
+		tk := task("ALTER TABLE `users` ADD COLUMN `email` varchar(255)")
+		err := verifyReplannedTaskDDL(tk, "this is not valid sql")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "re-planned DDL for task task_abc123")
+	})
+}
+
+// replanAndFilterTasks recomputes the delta against live schema and overwrites
+// each still-needed task's DDL with it. When the deployment has drifted, that
+// recomputed DDL diverges from what was reviewed; the resume must fail closed
+// rather than silently apply the unreviewed DDL.
+func TestReplanAndFilterTasks_FailsClosedOnDrift(t *testing.T) {
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }}
+	drifted := &engine.PlanResult{
+		Changes: []engine.SchemaChange{{
+			Namespace: "testapp",
+			TableChanges: []engine.TableChange{{
+				Table:     "users",
+				Operation: statement.StatementAlterTable,
+				DDL:       "ALTER TABLE `users` ADD COLUMN `email` varchar(100)",
+			}},
+		}},
+	}
+	c := newPlanMaterializeClientWithPlan(store, drifted)
+
+	apply := &storage.Apply{Database: "testapp"}
+	plan := &storage.Plan{}
+	tasks := []*storage.Task{{
+		TaskIdentifier: "task_1",
+		Namespace:      "testapp",
+		TableName:      "users",
+		DDLAction:      "alter",
+		DDL:            "ALTER TABLE `users` ADD COLUMN `email` varchar(255)",
+	}}
+
+	_, err := c.replanAndFilterTasks(t.Context(), apply, tasks, plan)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "drifted from the reviewed plan")
+	assert.Contains(t, err.Error(), "testapp.users/alter")
+}
+
+// When the re-plan matches the reviewed DDL the deployment has not drifted, so
+// the task stays active and its DDL is refreshed from the re-plan.
+func TestReplanAndFilterTasks_MatchKeepsTaskActive(t *testing.T) {
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }}
+	c := newPlanMaterializeClientWithPlan(store, alterUsersEmailPlan())
+
+	apply := &storage.Apply{Database: "testapp"}
+	plan := &storage.Plan{}
+	tasks := []*storage.Task{{
+		TaskIdentifier: "task_1",
+		Namespace:      "testapp",
+		TableName:      "users",
+		DDLAction:      "alter",
+		DDL:            "ALTER TABLE `users` ADD COLUMN `email` varchar(255)",
+	}}
+
+	rp, err := c.replanAndFilterTasks(t.Context(), apply, tasks, plan)
+	require.NoError(t, err)
+	require.Len(t, rp.ActiveTasks, 1)
+	assert.Equal(t, "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", rp.ActiveTasks[0].DDL)
+	assert.Zero(t, rp.CompletedCount)
 }

--- a/pkg/tern/local_plan_drift.go
+++ b/pkg/tern/local_plan_drift.go
@@ -197,11 +197,19 @@ func compareDriftMultisets(recomputed, dispatched driftChangeMultiset) error {
 // and hide what actually drifted. The shard is shown only when set so
 // non-sharded messages stay uncluttered.
 func formatDriftKey(k driftChangeKey) string {
+	return fmt.Sprintf("%s (%s)", formatDriftLocation(k), k.ddl)
+}
+
+// formatDriftLocation renders the namespace/shard/table/operation of a drift key
+// without its DDL, for messages that present the reviewed and re-planned DDL
+// separately. The shard is shown only when set so non-sharded messages stay
+// uncluttered.
+func formatDriftLocation(k driftChangeKey) string {
 	loc := fmt.Sprintf("%s.%s", k.namespace, k.table)
 	if k.shard != "" {
 		loc = fmt.Sprintf("%s[%s].%s", k.namespace, k.shard, k.table)
 	}
-	return fmt.Sprintf("%s/%s (%s)", loc, k.operation, k.ddl)
+	return fmt.Sprintf("%s/%s", loc, k.operation)
 }
 
 // vschemaNamespacesFromPlanResult returns the namespaces the recomputed plan

--- a/pkg/tern/local_plan_drift.go
+++ b/pkg/tern/local_plan_drift.go
@@ -147,12 +147,15 @@ func (c *LocalClient) driftMultisetFromApplyRequest(changes []*ternv1.TableChang
 }
 
 // canonicalDDLForDrift normalizes a single DDL statement for comparison and
-// fails closed if it cannot be parsed or carries more than one statement.
-// ddl.Canonicalize returns the input unchanged on a parse failure, so an
-// unparseable statement would otherwise compare by raw text and could mask
-// drift. It also canonicalizes only the first statement, so a multi-statement
-// payload ("ALTER ...; ALTER ...") would silently drop the trailing statements
-// and mask drift on them — reject anything that is not exactly one statement.
+// fails closed if it cannot be parsed, carries more than one statement, or is
+// not actually DDL. ddl.Canonicalize returns the input unchanged on a parse
+// failure, so an unparseable statement would otherwise compare by raw text and
+// could mask drift. It also canonicalizes only the first statement, so a
+// multi-statement payload ("ALTER ...; ALTER ...") would silently drop the
+// trailing statements and mask drift on them — reject anything that is not
+// exactly one statement. statement.Classify also accepts non-DDL (e.g. SELECT,
+// INSERT), which has no place in a schema-change drift comparison, so reject
+// anything that is not a DDL statement.
 func canonicalDDLForDrift(raw string) (string, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -164,6 +167,9 @@ func canonicalDDLForDrift(raw string) (string, error) {
 	}
 	if len(results) != 1 {
 		return "", fmt.Errorf("expected exactly one DDL statement, got %d", len(results))
+	}
+	if !results[0].Type.IsDDL() {
+		return "", fmt.Errorf("expected a DDL statement, got %s", results[0].Type)
 	}
 	return ddl.Canonicalize(raw), nil
 }

--- a/pkg/tern/local_plan_drift_guard_test.go
+++ b/pkg/tern/local_plan_drift_guard_test.go
@@ -271,6 +271,15 @@ func TestCanonicalDDLForDrift_FailsClosed(t *testing.T) {
 		assert.Contains(t, err.Error(), "exactly one DDL statement")
 	})
 
+	t.Run("non-DDL statement is rejected", func(t *testing.T) {
+		// statement.Classify accepts non-DDL such as SELECT, which has no place
+		// in a schema-change drift comparison. It must fail closed instead of
+		// canonicalizing it as if it were DDL.
+		_, err := canonicalDDLForDrift("SELECT 1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected a DDL statement")
+	})
+
 	t.Run("parseable DDL is canonicalized", func(t *testing.T) {
 		// Whitespace and unquoted identifiers normalize to the same canonical form
 		// regardless of incidental formatting, so equivalent DDL compares equal.


### PR DESCRIPTION
## Summary
On resume/recovery, `replanAndFilterTasks` recomputes each deployment's own delta against its live schema and overwrites each still-needed task's DDL with that recomputed delta before applying it. On a deployment whose schema has drifted, that recomputed delta is DDL no human reviewed — and it was being applied silently. This makes the path fail closed: the resume now refuses to apply DDL that does not match what the task was reviewed with.

## What
- Add `verifyReplannedTaskDDL`: canonically compare the recomputed DDL against the task's reviewed `task.DDL`; return a drift error on mismatch. Canonicalization absorbs incidental formatting so only real divergence trips it. A task with no reviewed DDL (legacy synthetic VSchema tasks, already skipped downstream) is left to existing handling.
- Call it in `replanAndFilterTasks` before overwriting `task.DDL`. Both `Start()` and `ResumeApply()` callers already propagate the error, so the resume halts for operator reconciliation.
- Extract `formatDriftLocation` from `formatDriftKey` for the operator-facing message.

## Why
A drifted non-primary deployment could silently apply a locally recomputed, unreviewed delta on resume. This restores the fail-closed review boundary on the apply/resume path, reusing the shard-aware comparator.

```diagram
resume re-plan recomputes delta vs live schema
   table still in diff ─▶ canonical(reviewed) == canonical(recomputed)?
                              yes ─▶ apply (unchanged)
                              no  ─▶ drift error → resume STOPS (was: silent apply)
   table not in diff   ─▶ mark completed (unchanged; addressed in follow-up)
```

Scope: closes the "applies unreviewed DDL" failure mode. The "table dropped out of the diff is silently completed" mode (needs a reviewed-target reference) and shrinking the verify→apply TOCTOU window are tracked as a follow-up.
