### PR TITLE
refactor(tern,spirit): drift-guard recovery hint and invariant notes; rename internal migration symbols to schema change

### DIFF
--- a/pkg/engine/spirit/README.md
+++ b/pkg/engine/spirit/README.md
@@ -6,9 +6,9 @@ Spirit copies table data row-by-row to a new shadow table with the desired schem
 
 ## Key Types
 
-**Engine** — The main type. Holds a `ddl.Differ` for schema diffing, a `lint.Linter` for safety checks, and a `runningMigration` for tracking the active schema change. Only one schema change can run at a time per Engine instance.
+**Engine** — The main type. Holds a `ddl.Differ` for schema diffing, a `lint.Linter` for safety checks, and a `runningSchemaChange` for tracking the active schema change. Only one schema change can run at a time per Engine instance.
 
-**runningMigration** — Tracks a running schema change: the Spirit runners, affected tables, DDL statements, state, and a cancel function for stopping. Created by `Apply()`, consumed by `Progress()` and control operations.
+**runningSchemaChange** — Tracks a running schema change: the Spirit runners, affected tables, DDL statements, state, and a cancel function for stopping. Created by `Apply()`, consumed by `Progress()` and control operations.
 
 **Config** — Engine configuration:
 - `TargetChunkTime` (default 500ms): How long each batch of row copies should take
@@ -79,7 +79,7 @@ Two checkpoint-related errors require user intervention:
 | File | Purpose |
 |------|---------|
 | `spirit.go` | Engine type, `Plan()`, `Apply()`, `Progress()` |
-| `execution.go` | `executeMigration()`, Spirit runner setup, error handling |
+| `execution.go` | `executeSchemaChange()`, Spirit runner setup, error handling |
 | `control.go` | `Stop()`, `Start()`, `Cutover()`, `Volume()`, `Revert()`, `SkipRevert()` |
 | `helpers.go` | Schema fetching, DSN parsing, statement classification, internal table detection |
 | `logger.go` | Custom log handler that filters Spirit debug logs and routes to apply log storage |

--- a/pkg/engine/spirit/control.go
+++ b/pkg/engine/spirit/control.go
@@ -29,7 +29,7 @@ import (
 // We force a checkpoint before canceling to preserve progress (Spirit only checkpoints every 50s).
 func (e *Engine) Stop(ctx context.Context, req *engine.ControlRequest) (*engine.ControlResult, error) {
 	e.mu.Lock()
-	rm := e.runningMigration
+	rm := e.runningSchemaChange
 	if rm == nil {
 		e.mu.Unlock()
 		return nil, fmt.Errorf("no active schema change to stop")
@@ -93,7 +93,7 @@ func (e *Engine) Stop(ctx context.Context, req *engine.ControlRequest) (*engine.
 // resume.
 func (e *Engine) Cancel(ctx context.Context, req *engine.ControlRequest) (*engine.ControlResult, error) {
 	e.mu.Lock()
-	rm := e.runningMigration
+	rm := e.runningSchemaChange
 	if rm == nil {
 		e.mu.Unlock()
 		return nil, fmt.Errorf("no active schema change to cancel")
@@ -120,8 +120,8 @@ func (e *Engine) Cancel(ctx context.Context, req *engine.ControlRequest) (*engin
 		return nil, err
 	}
 	e.mu.Lock()
-	if e.runningMigration == rm {
-		e.runningMigration = nil
+	if e.runningSchemaChange == rm {
+		e.runningSchemaChange = nil
 	}
 	e.mu.Unlock()
 
@@ -131,7 +131,7 @@ func (e *Engine) Cancel(ctx context.Context, req *engine.ControlRequest) (*engin
 	}, nil
 }
 
-func (e *Engine) dropCancelledArtifacts(ctx context.Context, rm *runningMigration) error {
+func (e *Engine) dropCancelledArtifacts(ctx context.Context, rm *runningSchemaChange) error {
 	if rm == nil || rm.host == "" {
 		return fmt.Errorf("cancelled schema change cleanup missing connection details")
 	}
@@ -178,7 +178,7 @@ func (e *Engine) dropCancelledArtifacts(ctx context.Context, rm *runningMigratio
 // When Run() is called, Spirit checks for a checkpoint and resumes if found.
 func (e *Engine) Start(ctx context.Context, req *engine.ControlRequest) (*engine.ControlResult, error) {
 	e.mu.Lock()
-	rm := e.runningMigration
+	rm := e.runningSchemaChange
 	if rm == nil {
 		e.mu.Unlock()
 		return nil, fmt.Errorf("no schema change to resume - use Apply to start a new one")
@@ -223,11 +223,11 @@ func (e *Engine) Start(ctx context.Context, req *engine.ControlRequest) (*engine
 		bgCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 		defer cancel()
 		e.mu.Lock()
-		if e.runningMigration != nil {
-			e.runningMigration.cancelFunc = cancel
+		if e.runningSchemaChange != nil {
+			e.runningSchemaChange.cancelFunc = cancel
 		}
 		e.mu.Unlock()
-		e.resumeMigration(bgCtx, host, username, password, database, originalDDLs, combinedStatement, deferCutover)
+		e.resumeSchemaChange(bgCtx, host, username, password, database, originalDDLs, combinedStatement, deferCutover)
 	})
 
 	return &engine.ControlResult{
@@ -248,7 +248,7 @@ func (e *Engine) Cutover(ctx context.Context, req *engine.ControlRequest) (*engi
 	}
 
 	e.mu.Lock()
-	rm := e.runningMigration
+	rm := e.runningSchemaChange
 	database := req.Database
 	if rm != nil {
 		if !rm.deferCutover {
@@ -364,7 +364,7 @@ func (e *Engine) SkipRevert(ctx context.Context, req *engine.ControlRequest) (*e
 // update the settings, and restart from checkpoint.
 func (e *Engine) Volume(ctx context.Context, req *engine.VolumeRequest) (*engine.VolumeResult, error) {
 	e.mu.Lock()
-	rm := e.runningMigration
+	rm := e.runningSchemaChange
 	e.mu.Unlock()
 
 	if rm == nil {
@@ -434,7 +434,7 @@ func (e *Engine) Volume(ctx context.Context, req *engine.VolumeRequest) (*engine
 
 	// Log checkpoint state AFTER restart (should still be same - Spirit resumes from checkpoint)
 	e.mu.Lock()
-	rmAfter := e.runningMigration
+	rmAfter := e.runningSchemaChange
 	e.mu.Unlock()
 	if rmAfter != nil {
 		e.logCheckpointState(rmAfter, "after_restart", nil)
@@ -448,10 +448,10 @@ func (e *Engine) Volume(ctx context.Context, req *engine.VolumeRequest) (*engine
 	}, nil
 }
 
-func (e *Engine) setVolumeRestartInProgress(rm *runningMigration, inProgress bool) {
+func (e *Engine) setVolumeRestartInProgress(rm *runningSchemaChange, inProgress bool) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	if e.runningMigration == rm {
+	if e.runningSchemaChange == rm {
 		rm.volumeRestartInProgress = inProgress
 	}
 }
@@ -577,7 +577,7 @@ func (e *Engine) queryCPUHint(ctx context.Context, dsn string) int {
 // - binlog_name: MySQL binlog file being replayed
 // - binlog_pos: position within the binlog file
 // - statement: the DDL being executed
-func (e *Engine) logCheckpointState(rm *runningMigration, phase string, extra map[string]any) {
+func (e *Engine) logCheckpointState(rm *runningSchemaChange, phase string, extra map[string]any) {
 	if rm == nil || rm.host == "" {
 		e.logger.Debug("logCheckpointState: no running schema change or credentials")
 		return

--- a/pkg/engine/spirit/control_test.go
+++ b/pkg/engine/spirit/control_test.go
@@ -193,7 +193,7 @@ func TestVolumeToSpiritSettings_ThreadCap(t *testing.T) {
 func TestCancelMarksRunningSchemaChangeCancelled(t *testing.T) {
 	eng := New(Config{})
 	cancelCalled := false
-	eng.runningMigration = &runningMigration{
+	eng.runningSchemaChange = &runningSchemaChange{
 		database: "testdb",
 		tables:   []string{"users"},
 		state:    engine.StateRunning,
@@ -206,7 +206,7 @@ func TestCancelMarksRunningSchemaChangeCancelled(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cleanup missing connection details")
 	assert.True(t, cancelCalled)
-	assert.Equal(t, engine.StateCancelled, eng.runningMigration.state)
+	assert.Equal(t, engine.StateCancelled, eng.runningSchemaChange.state)
 }
 
 func TestCPUScaledThreads(t *testing.T) {
@@ -250,7 +250,7 @@ func TestSettingsToVolume(t *testing.T) {
 // the operator keeps polling the active schema change.
 func TestVolumeReportsRunningWhileStoredStoppedStateRestarts(t *testing.T) {
 	eng := New(Config{})
-	rm := &runningMigration{
+	rm := &runningSchemaChange{
 		database:       "testdb",
 		tableNamespace: map[string]string{},
 		state:          engine.StateRunning,
@@ -259,7 +259,7 @@ func TestVolumeReportsRunningWhileStoredStoppedStateRestarts(t *testing.T) {
 	}
 	rm.wg.Add(1)
 	eng.mu.Lock()
-	eng.runningMigration = rm
+	eng.runningSchemaChange = rm
 	eng.mu.Unlock()
 
 	errCh := make(chan error, 1)

--- a/pkg/engine/spirit/execution.go
+++ b/pkg/engine/spirit/execution.go
@@ -23,7 +23,7 @@ func (e *Engine) executeMigration(ctx context.Context, host, username, password,
 	phases, err := classifyDDLPhases(ddlStatements)
 	if err != nil {
 		e.logger.Error("failed to classify statement", "error", err)
-		e.setMigrationFailed(err)
+		e.setSchemaChangeFailed(err)
 		return
 	}
 
@@ -58,7 +58,7 @@ func (e *Engine) executeMigration(ctx context.Context, host, username, password,
 
 	// Completion is signalled only after every phase has run, so a poller never
 	// observes StateCompleted while a later DROP phase is still pending.
-	e.setMigrationCompleted()
+	e.setSchemaChangeCompleted()
 }
 
 // resumeMigration continues a stopped schema change to completion.
@@ -94,7 +94,7 @@ func (e *Engine) resumeMigration(ctx context.Context, host, username, password, 
 	phases, err := classifyDDLPhases(originalDDLs)
 	if err != nil {
 		e.logger.Error("failed to classify statements on resume", "database", database, "error", err)
-		e.setMigrationFailed(err)
+		e.setSchemaChangeFailed(err)
 		return
 	}
 
@@ -110,7 +110,7 @@ func (e *Engine) resumeMigration(ctx context.Context, host, username, password, 
 		return
 	}
 
-	e.setMigrationCompleted()
+	e.setSchemaChangeCompleted()
 }
 
 // ddlPhases groups a plan's statements into the order Spirit requires:
@@ -160,7 +160,7 @@ func (e *Engine) runStatementPhase(ctx context.Context, database, stopLabel, fai
 				return false
 			}
 			e.logger.Error(failLabel+" failed", "database", database, "error", err)
-			e.setMigrationFailed(fmt.Errorf("%s failed: %w", failLabel, err))
+			e.setSchemaChangeFailed(fmt.Errorf("%s failed: %w", failLabel, err))
 			return false
 		}
 	}
@@ -190,7 +190,7 @@ func (e *Engine) executeAlterPhase(ctx context.Context, host, username, password
 		parsed, err := statement.New(stmt)
 		if err != nil {
 			e.logger.Error("failed to parse statement for logging", "database", database, "error", err, "statement", stmt)
-			e.setMigrationFailed(fmt.Errorf("parse ALTER statement %q: %w", stmt, err))
+			e.setSchemaChangeFailed(fmt.Errorf("parse ALTER statement %q: %w", stmt, err))
 			return false
 		}
 		if len(parsed) > 0 {
@@ -296,7 +296,7 @@ func (e *Engine) executeSpiritMigration(ctx context.Context, host, username, pas
 	parsed, err := statement.New(combinedStatement)
 	if err != nil {
 		e.logger.Error("failed to parse combined statement", "error", err)
-		e.setMigrationFailed(fmt.Errorf("failed to parse combined statement: %w", err))
+		e.setSchemaChangeFailed(fmt.Errorf("failed to parse combined statement: %w", err))
 		return err
 	}
 	var tables []string
@@ -326,7 +326,7 @@ func (e *Engine) executeSpiritMigration(ctx context.Context, host, username, pas
 			"error", err,
 			"statement", combinedStatement,
 		)
-		e.setMigrationFailed(fmt.Errorf("failed to create Spirit runner: %w", err))
+		e.setSchemaChangeFailed(fmt.Errorf("failed to create Spirit runner: %w", err))
 		return err
 	}
 
@@ -371,7 +371,7 @@ func (e *Engine) executeSpiritMigration(ctx context.Context, host, username, pas
 		e.logger.Error("schema change failed",
 			"error", err,
 		)
-		e.setMigrationFailed(fmt.Errorf("schema change failed: %w", err))
+		e.setSchemaChangeFailed(fmt.Errorf("schema change failed: %w", err))
 		utils.CloseAndLog(runner)
 		return err
 	}
@@ -381,7 +381,7 @@ func (e *Engine) executeSpiritMigration(ctx context.Context, host, username, pas
 	return nil
 }
 
-func (e *Engine) setMigrationCompleted() {
+func (e *Engine) setSchemaChangeCompleted() {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if e.runningMigration != nil {
@@ -389,8 +389,8 @@ func (e *Engine) setMigrationCompleted() {
 	}
 }
 
-// setMigrationFailed sets the state to failed with an error message.
-func (e *Engine) setMigrationFailed(err error) {
+// setSchemaChangeFailed sets the state to failed with an error message.
+func (e *Engine) setSchemaChangeFailed(err error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if e.runningMigration != nil {

--- a/pkg/engine/spirit/execution.go
+++ b/pkg/engine/spirit/execution.go
@@ -15,11 +15,11 @@ import (
 	"github.com/block/schemabot/pkg/engine"
 )
 
-// executeMigration runs the Spirit schema change synchronously.
+// executeSchemaChange runs the Spirit schema change synchronously.
 // All DDL statements (CREATE, DROP, ALTER, RENAME) are passed through Spirit.
 // Spirit requires non-ALTER statements to be executed individually (not combined).
 // ALTER statements can be combined for atomic multi-table schema changes.
-func (e *Engine) executeMigration(ctx context.Context, host, username, password, database string, ddlStatements []string, deferCutover bool) {
+func (e *Engine) executeSchemaChange(ctx context.Context, host, username, password, database string, ddlStatements []string, deferCutover bool) {
 	phases, err := classifyDDLPhases(ddlStatements)
 	if err != nil {
 		e.logger.Error("failed to classify statement", "error", err)
@@ -61,7 +61,7 @@ func (e *Engine) executeMigration(ctx context.Context, host, username, password,
 	e.setSchemaChangeCompleted()
 }
 
-// resumeMigration continues a stopped schema change to completion.
+// resumeSchemaChange continues a stopped schema change to completion.
 //
 // When an ALTER was in flight, its statements are resumed from Spirit's
 // checkpoint using the stored verbatim combined statement (not the original DDL
@@ -71,9 +71,9 @@ func (e *Engine) executeMigration(ctx context.Context, host, username, password,
 // phase, so once an ALTER has started they are already applied; only the DROP
 // phase remains and must run after the resumed ALTER completes. When no ALTER was
 // in flight, the whole plan is run from the start.
-func (e *Engine) resumeMigration(ctx context.Context, host, username, password, database string, originalDDLs []string, combinedStatement string, deferCutover bool) {
+func (e *Engine) resumeSchemaChange(ctx context.Context, host, username, password, database string, originalDDLs []string, combinedStatement string, deferCutover bool) {
 	if combinedStatement == "" {
-		e.executeMigration(ctx, host, username, password, database, originalDDLs, deferCutover)
+		e.executeSchemaChange(ctx, host, username, password, database, originalDDLs, deferCutover)
 		return
 	}
 
@@ -336,12 +336,12 @@ func (e *Engine) executeSpiritMigration(ctx context.Context, host, username, pas
 
 	// Track schema change state
 	e.mu.Lock()
-	if e.runningMigration != nil {
-		e.runningMigration.tables = tables
-		e.runningMigration.ddls = ddls
-		e.runningMigration.combinedStatement = combinedStatement
-		e.runningMigration.runners = []*spiritmigration.Runner{runner}
-		e.runningMigration.progressCallback = func() string {
+	if e.runningSchemaChange != nil {
+		e.runningSchemaChange.tables = tables
+		e.runningSchemaChange.ddls = ddls
+		e.runningSchemaChange.combinedStatement = combinedStatement
+		e.runningSchemaChange.runners = []*spiritmigration.Runner{runner}
+		e.runningSchemaChange.progressCallback = func() string {
 			return runner.Progress().Summary
 		}
 	}
@@ -384,8 +384,8 @@ func (e *Engine) executeSpiritMigration(ctx context.Context, host, username, pas
 func (e *Engine) setSchemaChangeCompleted() {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	if e.runningMigration != nil {
-		e.runningMigration.state = engine.StateCompleted
+	if e.runningSchemaChange != nil {
+		e.runningSchemaChange.state = engine.StateCompleted
 	}
 }
 
@@ -393,10 +393,10 @@ func (e *Engine) setSchemaChangeCompleted() {
 func (e *Engine) setSchemaChangeFailed(err error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	if e.runningMigration != nil {
-		e.runningMigration.state = engine.StateFailed
+	if e.runningSchemaChange != nil {
+		e.runningSchemaChange.state = engine.StateFailed
 		if err != nil {
-			e.runningMigration.errorMessage = err.Error()
+			e.runningSchemaChange.errorMessage = err.Error()
 		}
 	}
 }

--- a/pkg/engine/spirit/pending_drops_integration_test.go
+++ b/pkg/engine/spirit/pending_drops_integration_test.go
@@ -55,18 +55,18 @@ func runDDLApply(t *testing.T, eng *Engine, dsn string, ddlStatements []string) 
 	require.NoError(t, err, "parseDSN")
 
 	eng.mu.Lock()
-	eng.runningMigration = &runningMigration{
+	eng.runningSchemaChange = &runningSchemaChange{
 		database: database,
 		state:    engine.StateRunning,
 		started:  time.Now(),
 	}
 	eng.mu.Unlock()
 
-	eng.executeMigration(t.Context(), host, username, password, database, ddlStatements, false)
+	eng.executeSchemaChange(t.Context(), host, username, password, database, ddlStatements, false)
 
 	eng.mu.Lock()
 	defer eng.mu.Unlock()
-	return eng.runningMigration.state
+	return eng.runningSchemaChange.state
 }
 
 // A dropped table is quarantined in the pending drops database with its data

--- a/pkg/engine/spirit/spirit.go
+++ b/pkg/engine/spirit/spirit.go
@@ -62,12 +62,12 @@ type Engine struct {
 	onLog func(level slog.Level, table, msg string)
 
 	// Running schema change state
-	mu               sync.Mutex
-	runningMigration *runningMigration
+	mu                  sync.Mutex
+	runningSchemaChange *runningSchemaChange
 }
 
-// runningMigration tracks the state of an in-progress schema change.
-type runningMigration struct {
+// runningSchemaChange tracks the state of an in-progress schema change.
+type runningSchemaChange struct {
 	database                string            // MySQL database name parsed from DSN
 	tableNamespace          map[string]string // table name → namespace (from ApplyRequest.Changes)
 	tables                  []string
@@ -189,7 +189,7 @@ func (e *Engine) DebugLogs() bool {
 // fully released before new operations begin.
 func (e *Engine) Drain() {
 	e.mu.Lock()
-	rm := e.runningMigration
+	rm := e.runningSchemaChange
 	if rm == nil {
 		e.mu.Unlock()
 		return
@@ -199,7 +199,7 @@ func (e *Engine) Drain() {
 	rm.wg.Wait()
 
 	e.mu.Lock()
-	e.runningMigration = nil
+	e.runningSchemaChange = nil
 	e.mu.Unlock()
 }
 
@@ -405,10 +405,10 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 		}
 	}
 
-	rm := &runningMigration{
+	rm := &runningSchemaChange{
 		database:       database,
 		tableNamespace: tableNamespace,
-		tables:         nil, // Tables will be populated by executeMigration
+		tables:         nil, // Tables will be populated by executeSchemaChange
 		originalDDLs:   req.FlatDDL(),
 		state:          engine.StateRunning,
 		started:        time.Now(),
@@ -417,7 +417,7 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 		username:       username,
 		password:       password,
 	}
-	e.runningMigration = rm
+	e.runningSchemaChange = rm
 	e.mu.Unlock()
 
 	// Start schema change in background with cancellable context.
@@ -428,11 +428,11 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 		bgCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 		defer cancel()
 		e.mu.Lock()
-		if e.runningMigration != nil {
-			e.runningMigration.cancelFunc = cancel
+		if e.runningSchemaChange != nil {
+			e.runningSchemaChange.cancelFunc = cancel
 		}
 		e.mu.Unlock()
-		e.executeMigration(bgCtx, host, username, password, database, req.FlatDDL(), deferCutover)
+		e.executeSchemaChange(bgCtx, host, username, password, database, req.FlatDDL(), deferCutover)
 	})
 
 	return &engine.ApplyResult{
@@ -448,14 +448,14 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	if e.runningMigration == nil {
+	if e.runningSchemaChange == nil {
 		return &engine.ProgressResult{
 			State:   engine.StatePending,
 			Message: "No active schema change",
 		}, nil
 	}
 
-	rm := e.runningMigration
+	rm := e.runningSchemaChange
 
 	// Get progress from the single runner (handles all tables together)
 	message := fmt.Sprintf("Schema change %s", rm.state)
@@ -576,7 +576,7 @@ func buildSpiritTableProgress(prog status.Progress, stateStr string, ddlByTable,
 // surfacing the sentinel wait for a deferred cutover. A stopped tracked state
 // with a volume restart in flight reports running because the schema change
 // is restarting with new settings.
-func progressState(rm *runningMigration, spiritState status.State) engine.State {
+func progressState(rm *runningSchemaChange, spiritState status.State) engine.State {
 	state := rm.state
 	if state == engine.StateStopped && rm.volumeRestartInProgress {
 		state = engine.StateRunning

--- a/pkg/engine/spirit/spirit_integration_test.go
+++ b/pkg/engine/spirit/spirit_integration_test.go
@@ -571,17 +571,17 @@ func TestNew_CustomConfig(t *testing.T) {
 	assert.Equal(t, 8, eng.threads)
 }
 
-func TestSetMigrationCompleted(t *testing.T) {
+func TestSetSchemaChangeCompleted(t *testing.T) {
 	eng := New(Config{})
 
 	// No running schema change - should not panic
-	eng.setMigrationCompleted()
+	eng.setSchemaChangeCompleted()
 
 	// With running schema change
 	eng.runningMigration = &runningMigration{
 		state: engine.StateRunning,
 	}
-	eng.setMigrationCompleted()
+	eng.setSchemaChangeCompleted()
 
 	assert.Equal(t, engine.StateCompleted, eng.runningMigration.state)
 }

--- a/pkg/engine/spirit/spirit_integration_test.go
+++ b/pkg/engine/spirit/spirit_integration_test.go
@@ -453,7 +453,7 @@ func TestEngine_Progress_NoMigration(t *testing.T) {
 
 func TestEngine_Progress_WithMigration(t *testing.T) {
 	eng := New(Config{})
-	eng.runningMigration = &runningMigration{
+	eng.runningSchemaChange = &runningSchemaChange{
 		database: "testdb",
 		tables:   []string{"users"},
 		state:    engine.StateRunning,
@@ -480,7 +480,7 @@ func TestEngine_Stop_NoMigration(t *testing.T) {
 
 func TestEngine_Stop_WithMigration(t *testing.T) {
 	eng := New(Config{})
-	eng.runningMigration = &runningMigration{
+	eng.runningSchemaChange = &runningSchemaChange{
 		database: "testdb",
 		state:    engine.StateRunning,
 	}
@@ -491,7 +491,7 @@ func TestEngine_Stop_WithMigration(t *testing.T) {
 	require.NoError(t, err, "Stop()")
 
 	assert.True(t, result.Accepted, "expected Accepted to be true")
-	assert.Equal(t, engine.StateStopped, eng.runningMigration.state)
+	assert.Equal(t, engine.StateStopped, eng.runningSchemaChange.state)
 }
 
 func TestEngine_Start_NotSupported(t *testing.T) {
@@ -578,12 +578,12 @@ func TestSetSchemaChangeCompleted(t *testing.T) {
 	eng.setSchemaChangeCompleted()
 
 	// With running schema change
-	eng.runningMigration = &runningMigration{
+	eng.runningSchemaChange = &runningSchemaChange{
 		state: engine.StateRunning,
 	}
 	eng.setSchemaChangeCompleted()
 
-	assert.Equal(t, engine.StateCompleted, eng.runningMigration.state)
+	assert.Equal(t, engine.StateCompleted, eng.runningSchemaChange.state)
 }
 
 func TestParseDSN_Valid(t *testing.T) {
@@ -706,7 +706,7 @@ func TestEngine_CancelledArtifactCleanup(t *testing.T) {
 	host, username, password, database, err := parseDSN(dsn)
 	require.NoError(t, err)
 	eng := New(Config{})
-	err = eng.dropCancelledArtifacts(t.Context(), &runningMigration{
+	err = eng.dropCancelledArtifacts(t.Context(), &runningSchemaChange{
 		database: database,
 		tables:   []string{baseTable},
 		host:     host,
@@ -809,7 +809,7 @@ func TestEngine_Apply_WithChanges(t *testing.T) {
 
 func TestEngine_Progress_WithRunners(t *testing.T) {
 	eng := New(Config{})
-	eng.runningMigration = &runningMigration{
+	eng.runningSchemaChange = &runningSchemaChange{
 		database: "testdb",
 		tables:   []string{"users", "orders"},
 		state:    engine.StateRunning,
@@ -828,7 +828,7 @@ func TestEngine_Progress_NamespaceFromApplyChanges(t *testing.T) {
 	// syncAtomicTaskProgress fails silently (task has namespace="orders",
 	// engine returns namespace=""), and row progress is never persisted.
 	eng := New(Config{})
-	eng.runningMigration = &runningMigration{
+	eng.runningSchemaChange = &runningSchemaChange{
 		database:       "orders",
 		tableNamespace: map[string]string{"orders": "orders", "users": "myapp"},
 		tables:         []string{"orders", "users"},
@@ -877,7 +877,7 @@ func TestEngine_Progress_ClosedRunnerIsNotCompletion(t *testing.T) {
 
 	t.Run("running state keeps reporting running", func(t *testing.T) {
 		eng := New(Config{})
-		eng.runningMigration = &runningMigration{
+		eng.runningSchemaChange = &runningSchemaChange{
 			database: database,
 			tables:   []string{"progress_close"},
 			state:    engine.StateRunning,
@@ -891,7 +891,7 @@ func TestEngine_Progress_ClosedRunnerIsNotCompletion(t *testing.T) {
 
 	t.Run("volume restart reports running", func(t *testing.T) {
 		eng := New(Config{})
-		eng.runningMigration = &runningMigration{
+		eng.runningSchemaChange = &runningSchemaChange{
 			database:                database,
 			tables:                  []string{"progress_close"},
 			state:                   engine.StateStopped,
@@ -906,7 +906,7 @@ func TestEngine_Progress_ClosedRunnerIsNotCompletion(t *testing.T) {
 
 	t.Run("failed state keeps reporting failed", func(t *testing.T) {
 		eng := New(Config{})
-		eng.runningMigration = &runningMigration{
+		eng.runningSchemaChange = &runningSchemaChange{
 			database:     database,
 			tables:       []string{"progress_close"},
 			state:        engine.StateFailed,
@@ -923,7 +923,7 @@ func TestEngine_Progress_ClosedRunnerIsNotCompletion(t *testing.T) {
 
 	t.Run("completed state keeps reporting completed", func(t *testing.T) {
 		eng := New(Config{})
-		eng.runningMigration = &runningMigration{
+		eng.runningSchemaChange = &runningSchemaChange{
 			database:     database,
 			tables:       []string{"progress_close"},
 			state:        engine.StateCompleted,
@@ -973,14 +973,14 @@ func TestEngine_ExecuteMigration_AddColumn(t *testing.T) {
 	host, username, password, database, err := parseDSN(dsn)
 	require.NoError(t, err, "parseDSN")
 
-	// Run the schema change directly using executeMigration
+	// Run the schema change directly using executeSchemaChange
 	ddlStatements := []string{
 		"ALTER TABLE `test_migrate` ADD COLUMN `email` varchar(255) NULL",
 	}
 
 	// Set up running schema change state
 	eng.mu.Lock()
-	eng.runningMigration = &runningMigration{
+	eng.runningSchemaChange = &runningSchemaChange{
 		database: database,
 		tables:   []string{"test_migrate"},
 		state:    engine.StateRunning,
@@ -989,11 +989,11 @@ func TestEngine_ExecuteMigration_AddColumn(t *testing.T) {
 	eng.mu.Unlock()
 
 	// Execute the schema change synchronously for testing
-	eng.executeMigration(t.Context(), host, username, password, database, ddlStatements, false)
+	eng.executeSchemaChange(t.Context(), host, username, password, database, ddlStatements, false)
 
 	// Check that schema change completed
 	eng.mu.Lock()
-	finalState := eng.runningMigration.state
+	finalState := eng.runningSchemaChange.state
 	eng.mu.Unlock()
 
 	assert.Equal(t, engine.StateCompleted, finalState)
@@ -1046,7 +1046,7 @@ func TestEngine_ExecuteMigration_ModifyColumn(t *testing.T) {
 	}
 
 	eng.mu.Lock()
-	eng.runningMigration = &runningMigration{
+	eng.runningSchemaChange = &runningSchemaChange{
 		database: database,
 		tables:   []string{"test_modify"},
 		state:    engine.StateRunning,
@@ -1054,10 +1054,10 @@ func TestEngine_ExecuteMigration_ModifyColumn(t *testing.T) {
 	}
 	eng.mu.Unlock()
 
-	eng.executeMigration(t.Context(), host, username, password, database, ddlStatements, false)
+	eng.executeSchemaChange(t.Context(), host, username, password, database, ddlStatements, false)
 
 	eng.mu.Lock()
-	finalState := eng.runningMigration.state
+	finalState := eng.runningSchemaChange.state
 	eng.mu.Unlock()
 
 	assert.Equal(t, engine.StateCompleted, finalState)
@@ -1102,7 +1102,7 @@ func TestEngine_ExecuteMigration_DropColumn(t *testing.T) {
 	}
 
 	eng.mu.Lock()
-	eng.runningMigration = &runningMigration{
+	eng.runningSchemaChange = &runningSchemaChange{
 		database: database,
 		tables:   []string{"test_drop"},
 		state:    engine.StateRunning,
@@ -1110,10 +1110,10 @@ func TestEngine_ExecuteMigration_DropColumn(t *testing.T) {
 	}
 	eng.mu.Unlock()
 
-	eng.executeMigration(t.Context(), host, username, password, database, ddlStatements, false)
+	eng.executeSchemaChange(t.Context(), host, username, password, database, ddlStatements, false)
 
 	eng.mu.Lock()
-	finalState := eng.runningMigration.state
+	finalState := eng.runningSchemaChange.state
 	eng.mu.Unlock()
 
 	assert.Equal(t, engine.StateCompleted, finalState)
@@ -1159,7 +1159,7 @@ func TestEngine_ExecuteMigration_AddIndex(t *testing.T) {
 	}
 
 	eng.mu.Lock()
-	eng.runningMigration = &runningMigration{
+	eng.runningSchemaChange = &runningSchemaChange{
 		database: database,
 		tables:   []string{"test_index"},
 		state:    engine.StateRunning,
@@ -1167,10 +1167,10 @@ func TestEngine_ExecuteMigration_AddIndex(t *testing.T) {
 	}
 	eng.mu.Unlock()
 
-	eng.executeMigration(t.Context(), host, username, password, database, ddlStatements, false)
+	eng.executeSchemaChange(t.Context(), host, username, password, database, ddlStatements, false)
 
 	eng.mu.Lock()
-	finalState := eng.runningMigration.state
+	finalState := eng.runningSchemaChange.state
 	eng.mu.Unlock()
 
 	assert.Equal(t, engine.StateCompleted, finalState)
@@ -1187,7 +1187,7 @@ func TestEngine_ExecuteMigration_AddIndex(t *testing.T) {
 	assert.NotZero(t, indexCount, "expected idx_email index to exist")
 }
 
-// TestEngine_ExecuteMigration_InvalidSQL tests that executeMigration handles
+// TestEngine_ExecuteMigration_InvalidSQL tests that executeSchemaChange handles
 // invalid SQL gracefully by setting state to Failed.
 func TestEngine_ExecuteMigration_InvalidSQL(t *testing.T) {
 	dsn, db := setupTestMySQL(t)
@@ -1208,7 +1208,7 @@ func TestEngine_ExecuteMigration_InvalidSQL(t *testing.T) {
 	}
 
 	eng.mu.Lock()
-	eng.runningMigration = &runningMigration{
+	eng.runningSchemaChange = &runningSchemaChange{
 		database: database,
 		tables:   []string{"test_invalid"},
 		state:    engine.StateRunning,
@@ -1216,10 +1216,10 @@ func TestEngine_ExecuteMigration_InvalidSQL(t *testing.T) {
 	}
 	eng.mu.Unlock()
 
-	eng.executeMigration(t.Context(), host, username, password, database, ddlStatements, false)
+	eng.executeSchemaChange(t.Context(), host, username, password, database, ddlStatements, false)
 
 	eng.mu.Lock()
-	finalState := eng.runningMigration.state
+	finalState := eng.runningSchemaChange.state
 	eng.mu.Unlock()
 
 	assert.Equal(t, engine.StateFailed, finalState, "expected StateFailed for invalid SQL")
@@ -1246,7 +1246,7 @@ func TestEngine_Progress_FailingApplyNeverReportsCompleted(t *testing.T) {
 	}
 
 	eng.mu.Lock()
-	eng.runningMigration = &runningMigration{
+	eng.runningSchemaChange = &runningSchemaChange{
 		database: database,
 		tables:   []string{"fail_progress"},
 		state:    engine.StateRunning,
@@ -1258,7 +1258,7 @@ func TestEngine_Progress_FailingApplyNeverReportsCompleted(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		eng.executeMigration(ctx, host, username, password, database, ddlStatements, false)
+		eng.executeSchemaChange(ctx, host, username, password, database, ddlStatements, false)
 	}()
 
 	deadline := time.NewTimer(30 * time.Second)
@@ -1327,7 +1327,7 @@ func TestEngine_ExecuteMigration_MultipleStatements(t *testing.T) {
 	}
 
 	eng.mu.Lock()
-	eng.runningMigration = &runningMigration{
+	eng.runningSchemaChange = &runningSchemaChange{
 		database: database,
 		tables:   []string{"test_multi_a", "test_multi_b"},
 		state:    engine.StateRunning,
@@ -1335,10 +1335,10 @@ func TestEngine_ExecuteMigration_MultipleStatements(t *testing.T) {
 	}
 	eng.mu.Unlock()
 
-	eng.executeMigration(t.Context(), host, username, password, database, ddlStatements, false)
+	eng.executeSchemaChange(t.Context(), host, username, password, database, ddlStatements, false)
 
 	eng.mu.Lock()
-	finalState := eng.runningMigration.state
+	finalState := eng.runningSchemaChange.state
 	eng.mu.Unlock()
 
 	assert.Equal(t, engine.StateCompleted, finalState)
@@ -1413,7 +1413,7 @@ func TestEngine_ExecuteMigration_SingleStatementReleasesConnections(t *testing.T
 		createDDL := fmt.Sprintf("CREATE TABLE `%s` (`id` bigint unsigned NOT NULL AUTO_INCREMENT, `name` varchar(100) NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", table)
 
 		eng.mu.Lock()
-		eng.runningMigration = &runningMigration{
+		eng.runningSchemaChange = &runningSchemaChange{
 			database: database,
 			tables:   []string{table},
 			state:    engine.StateRunning,
@@ -1421,10 +1421,10 @@ func TestEngine_ExecuteMigration_SingleStatementReleasesConnections(t *testing.T
 		}
 		eng.mu.Unlock()
 
-		eng.executeMigration(t.Context(), host, username, password, database, []string{createDDL}, false)
+		eng.executeSchemaChange(t.Context(), host, username, password, database, []string{createDDL}, false)
 
 		eng.mu.Lock()
-		createState := eng.runningMigration.state
+		createState := eng.runningSchemaChange.state
 		eng.mu.Unlock()
 		require.Equal(t, engine.StateCompleted, createState, "CREATE TABLE %s did not complete", table)
 
@@ -1438,7 +1438,7 @@ func TestEngine_ExecuteMigration_SingleStatementReleasesConnections(t *testing.T
 		dropDDL := fmt.Sprintf("DROP TABLE `%s`", table)
 
 		eng.mu.Lock()
-		eng.runningMigration = &runningMigration{
+		eng.runningSchemaChange = &runningSchemaChange{
 			database: database,
 			tables:   []string{table},
 			state:    engine.StateRunning,
@@ -1446,10 +1446,10 @@ func TestEngine_ExecuteMigration_SingleStatementReleasesConnections(t *testing.T
 		}
 		eng.mu.Unlock()
 
-		eng.executeMigration(t.Context(), host, username, password, database, []string{dropDDL}, false)
+		eng.executeSchemaChange(t.Context(), host, username, password, database, []string{dropDDL}, false)
 
 		eng.mu.Lock()
-		dropState := eng.runningMigration.state
+		dropState := eng.runningSchemaChange.state
 		eng.mu.Unlock()
 		require.Equal(t, engine.StateCompleted, dropState, "DROP TABLE %s did not complete", table)
 
@@ -1529,10 +1529,10 @@ func TestEngine_Apply_StartsGoroutine(t *testing.T) {
 
 	// Check that a schema change was started
 	eng.mu.Lock()
-	hasRunningMigration := eng.runningMigration != nil
+	hasRunningSchemaChange := eng.runningSchemaChange != nil
 	eng.mu.Unlock()
 
-	if !hasRunningMigration {
+	if !hasRunningSchemaChange {
 		t.Log("Note: schema change may have completed very quickly")
 	}
 }
@@ -1540,7 +1540,7 @@ func TestEngine_Apply_StartsGoroutine(t *testing.T) {
 // TestEngine_Progress_WithProgressCallback tests Progress with a callback set
 func TestEngine_Progress_WithNilCallback(t *testing.T) {
 	eng := New(Config{})
-	eng.runningMigration = &runningMigration{
+	eng.runningSchemaChange = &runningSchemaChange{
 		database:         "testdb",
 		tables:           []string{"users"},
 		state:            engine.StateRunning,
@@ -1557,7 +1557,7 @@ func TestEngine_Progress_WithNilCallback(t *testing.T) {
 // TestEngine_Progress_WithEmptyCallback tests Progress when callback returns empty
 func TestEngine_Progress_WithEmptyCallback(t *testing.T) {
 	eng := New(Config{})
-	eng.runningMigration = &runningMigration{
+	eng.runningSchemaChange = &runningSchemaChange{
 		database: "testdb",
 		tables:   []string{"users"},
 		state:    engine.StateRunning,
@@ -1790,7 +1790,7 @@ func TestEngine_ExecuteMigration_CancelledContextKeepsStoppedState(t *testing.T)
 	require.NoError(t, err, "parseDSN")
 
 	eng.mu.Lock()
-	eng.runningMigration = &runningMigration{
+	eng.runningSchemaChange = &runningSchemaChange{
 		database: database,
 		tables:   []string{"stop_pending_drop"},
 		state:    engine.StateStopped,
@@ -1806,10 +1806,10 @@ func TestEngine_ExecuteMigration_CancelledContextKeepsStoppedState(t *testing.T)
 		"DROP TABLE `stop_pending_drop`",
 	}
 
-	eng.executeMigration(ctx, host, username, password, database, ddlStatements, false)
+	eng.executeSchemaChange(ctx, host, username, password, database, ddlStatements, false)
 
 	eng.mu.Lock()
-	finalState := eng.runningMigration.state
+	finalState := eng.runningSchemaChange.state
 	eng.mu.Unlock()
 	assert.Equal(t, engine.StateStopped, finalState, "cancelled context must leave state Stopped, not Failed/Completed")
 

--- a/pkg/engine/spirit/spirit_test.go
+++ b/pkg/engine/spirit/spirit_test.go
@@ -18,13 +18,13 @@ import (
 func TestProgressState(t *testing.T) {
 	tests := []struct {
 		name        string
-		rm          *runningMigration
+		rm          *runningSchemaChange
 		spiritState status.State
 		want        engine.State
 	}{
 		{
 			name: "completed is never downgraded by sentinel wait",
-			rm: &runningMigration{
+			rm: &runningSchemaChange{
 				state:        engine.StateCompleted,
 				deferCutover: true,
 			},
@@ -33,7 +33,7 @@ func TestProgressState(t *testing.T) {
 		},
 		{
 			name: "completed is not re-derived from a closing runner",
-			rm: &runningMigration{
+			rm: &runningSchemaChange{
 				state: engine.StateCompleted,
 			},
 			spiritState: status.Close,
@@ -41,7 +41,7 @@ func TestProgressState(t *testing.T) {
 		},
 		{
 			name: "failed is never downgraded by sentinel wait",
-			rm: &runningMigration{
+			rm: &runningSchemaChange{
 				state:        engine.StateFailed,
 				deferCutover: true,
 			},
@@ -50,7 +50,7 @@ func TestProgressState(t *testing.T) {
 		},
 		{
 			name: "stopped stays stopped while the runner tears down",
-			rm: &runningMigration{
+			rm: &runningSchemaChange{
 				state:        engine.StateStopped,
 				deferCutover: true,
 			},
@@ -59,7 +59,7 @@ func TestProgressState(t *testing.T) {
 		},
 		{
 			name: "cancelled stays cancelled while the runner tears down",
-			rm: &runningMigration{
+			rm: &runningSchemaChange{
 				state:        engine.StateCancelled,
 				deferCutover: true,
 			},
@@ -68,7 +68,7 @@ func TestProgressState(t *testing.T) {
 		},
 		{
 			name: "closing runner does not imply completion",
-			rm: &runningMigration{
+			rm: &runningSchemaChange{
 				state: engine.StateRunning,
 			},
 			spiritState: status.Close,
@@ -76,7 +76,7 @@ func TestProgressState(t *testing.T) {
 		},
 		{
 			name: "sentinel wait surfaces deferred cutover",
-			rm: &runningMigration{
+			rm: &runningSchemaChange{
 				state:        engine.StateRunning,
 				deferCutover: true,
 			},
@@ -85,7 +85,7 @@ func TestProgressState(t *testing.T) {
 		},
 		{
 			name: "sentinel wait without deferred cutover stays running",
-			rm: &runningMigration{
+			rm: &runningSchemaChange{
 				state: engine.StateRunning,
 			},
 			spiritState: status.WaitingOnSentinelTable,
@@ -93,7 +93,7 @@ func TestProgressState(t *testing.T) {
 		},
 		{
 			name: "volume restart reports stopped state as running",
-			rm: &runningMigration{
+			rm: &runningSchemaChange{
 				state:                   engine.StateStopped,
 				volumeRestartInProgress: true,
 			},
@@ -102,7 +102,7 @@ func TestProgressState(t *testing.T) {
 		},
 		{
 			name: "volume restart still surfaces deferred cutover",
-			rm: &runningMigration{
+			rm: &runningSchemaChange{
 				state:                   engine.StateStopped,
 				volumeRestartInProgress: true,
 				deferCutover:            true,

--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -106,7 +106,7 @@ func (c *LocalClient) tryResolveStaleTask(ctx context.Context, t *storage.Task, 
 
 	// Engine says terminal — update storage and unblock.
 	// IMPORTANT: Only trust terminal states, NOT "No active schema change".
-	// "No active schema change" just means Spirit has no runningMigration,
+	// "No active schema change" just means Spirit has no runningSchemaChange,
 	// which could mean completed, never started, or crashed.
 	if result.State.IsTerminal() {
 		c.logger.Info("conflict check: engine reports terminal state",

--- a/pkg/tern/local_apply_sequential.go
+++ b/pkg/tern/local_apply_sequential.go
@@ -326,7 +326,7 @@ func (c *LocalClient) pollTaskToCompletion(ctx context.Context, apply *storage.A
 
 			// Re-fetch task state from storage to detect external changes (e.g., Stop).
 			// This also guards against a race where a new apply starts and the engine's
-			// runningMigration no longer corresponds to this task.
+			// runningSchemaChange no longer corresponds to this task.
 			freshTask, fetchErr := c.storage.Tasks().Get(ctx, task.TaskIdentifier)
 			if fetchErr == nil && freshTask != nil && state.IsTerminalTaskState(freshTask.State) {
 				// Task was already marked terminal externally — stop polling

--- a/pkg/tern/local_plan_drift.go
+++ b/pkg/tern/local_plan_drift.go
@@ -19,6 +19,18 @@ import (
 // a sharded engine emits one change set per shard and the same table repeats
 // across shards: keying without it would conflate a change on one shard with a
 // different change on another.
+//
+// The shard-aware comparison relies on the engine emitting a stable shard
+// identifier (engine.SchemaChange.Shard.Name) equal to the value the dispatch
+// fan-out keyed its per-shard operations on. Both sides of the multiset read
+// that same field — the dispatch's TargetShards is rebuilt from it and the
+// re-plan reads it directly — so a legitimate shard-scoped apply is compared
+// symmetrically rather than refused. This guard couples "what may be applied" to
+// "what re-planning live-vs-desired reproduces": a future reconciliation path
+// that applies repair DDL derived some other way (e.g. shard-to-shard
+// comparison or a stored repair a live-vs-desired re-plan would not recompute)
+// must route through a normal reviewed plan or add an explicit reconciliation
+// mode here, or it would trip the guard.
 type driftChangeKey struct {
 	namespace string
 	shard     string
@@ -30,6 +42,12 @@ type driftChangeKey struct {
 // driftChangeMultiset counts table DDL changes by key so duplicate changes are
 // compared exactly (set equality would silently tolerate a duplicated change).
 type driftChangeMultiset map[driftChangeKey]int
+
+// driftRecoveryHint gives a blocked operator the defined next step when the
+// guard fails closed: the reviewed plan no longer matches live schema, so it
+// must be regenerated against the current schema and re-reviewed before
+// re-applying. Without this an operator only learns what drifted, not what to do.
+const driftRecoveryHint = "to recover, re-plan against the current live schema to refresh the reviewed plan, then re-apply"
 
 // verifyMaterializedPlanMatchesLiveSchema fails closed unless the reviewed DDL a
 // dispatch carries exactly matches what this deployment would independently plan
@@ -74,16 +92,21 @@ func (c *LocalClient) verifyMaterializedPlanMatchesLiveSchema(ctx context.Contex
 		return fmt.Errorf("dispatched plan: %w", err)
 	}
 	if err := compareDriftMultisets(recomputed, dispatched); err != nil {
-		return fmt.Errorf("local schema has drifted from the reviewed plan (database %q, target %q): %w", c.config.Database, req.Target, err)
+		return fmt.Errorf("local schema has drifted from the reviewed plan (database %q, target %q): %w; %s", c.config.Database, req.Target, err, driftRecoveryHint)
 	}
 
 	// VSchema changes are namespace-level, not shard-scoped, and travel on the
 	// whole-deployment dispatch — a shard-scoped DDL dispatch never carries them
 	// (VSchema is applied by a separate task-less finalizer). So parity is only
 	// meaningful for a whole-deployment materialize.
+	//
+	// The two sides bridge different representations of "vschema changed": the
+	// re-plan reads the engine's Metadata["vschema_changed"], the dispatch reads
+	// the proto CHANGE_TYPE_VSCHEMA. They agree today; any divergence drops a
+	// namespace from one set, which trips parity in the fail-closed direction.
 	if !shardScoped {
 		if err := compareVSchemaParity(vschemaNamespacesFromPlanResult(c, result), vschemaNamespacesFromApplyRequest(c, req.DdlChanges)); err != nil {
-			return fmt.Errorf("local vschema has drifted from the reviewed plan (database %q, target %q): %w", c.config.Database, req.Target, err)
+			return fmt.Errorf("local vschema has drifted from the reviewed plan (database %q, target %q): %w; %s", c.config.Database, req.Target, err, driftRecoveryHint)
 		}
 	}
 	return nil

--- a/pkg/tern/local_plan_drift_guard_test.go
+++ b/pkg/tern/local_plan_drift_guard_test.go
@@ -87,6 +87,7 @@ func TestDriftGuard_MissingReviewedChangeFailsClosed(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "drifted")
+	assert.Contains(t, err.Error(), "re-plan against the current live schema", "the error must tell a blocked operator how to recover")
 	assert.Nil(t, store.created, "must not materialize a drifted plan")
 }
 


### PR DESCRIPTION
## Summary
Two related follow-ups to the materialize-time drift guard review, plus a terminology cleanup in the Spirit engine.

## Changes
- Add an operator recovery hint to the fail-closed drift and vschema-parity errors.
- Document the shard-aware comparison invariants (stable shard identity, symmetric reads) and the vschema parity coupling / forward-compat boundary.
- Rename the Spirit engine's internal `*Migration*` symbols (`runningMigration`, `executeMigration`, `resumeMigration`, and helpers) to `*SchemaChange*` per the project terminology guideline. Upstream Spirit references (`spiritmigration.*`, `executeSpiritMigration`, `ResumeState.MigrationContext`) are intentionally unchanged.

No behavior change — error message text and internal symbol names only.
