### PR TITLE
fix(tern): re-verify reviewed DDL before each sequential resume apply

### DIFF
--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -402,12 +402,12 @@ func replanShardTableDDL(result *engine.PlanResult) map[shardTableKey]string {
 	return out
 }
 
-// tableStillNeedsChange does a quick re-plan to check if a task's table on its
-// own shard still needs schema changes. Returns false if it already has the
-// desired schema (e.g., Spirit's cutover completed during the stop sequence).
-// When the table still needs changes, it also returns the DDL the re-plan would
-// now apply so the caller can confirm it still matches the reviewed DDL before
-// applying it.
+// tableStillNeedsChange re-plans the full schema set and then looks up whether
+// this task's table still needs a change on its (namespace, shard). Returns
+// false if it already has the desired schema (e.g., Spirit's cutover completed
+// during the stop sequence). When the table still needs changes, it also returns
+// the DDL the re-plan would now apply so the caller can confirm it still matches
+// the reviewed DDL before applying it.
 func (c *LocalClient) tableStillNeedsChange(ctx context.Context, apply *storage.Apply, plan *storage.Plan, task *storage.Task) (string, bool, error) {
 	result, err := c.planWithEngine(ctx, &ternv1.PlanRequest{}, apply.Database, plan.SchemaFiles)
 	if err != nil {

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -324,7 +324,7 @@ func (c *LocalClient) resumeApplySequential(ctx context.Context, apply *storage.
 		// between re-plan (which reads schema) and Spirit's cutover (which renames
 		// the shadow table). If Spirit completed the cutover after the re-plan read
 		// the schema, the table already has the desired changes.
-		needsChange, err := c.tableStillNeedsChange(ctx, apply, plan, task)
+		replannedDDL, needsChange, err := c.tableStillNeedsChange(ctx, apply, plan, task)
 		if err != nil {
 			c.logger.Warn("could not verify table schema state, proceeding with apply",
 				"task_id", task.TaskIdentifier, "table", task.TableName, "error", err)
@@ -337,6 +337,15 @@ func (c *LocalClient) resumeApplySequential(ctx context.Context, apply *storage.
 			c.transitionTaskState(ctx, task, apply.ID, state.Task.Completed,
 				fmt.Sprintf("Task %s already completed (cutover raced with re-plan)", task.TaskIdentifier))
 			continue
+		} else if err := verifyReplannedTaskDDL(task, replannedDDL); err != nil {
+			// Live schema drifted since resume began: the DDL this shard now
+			// needs no longer matches what was reviewed. Fail closed rather than
+			// apply unreviewed DDL.
+			c.logger.Error("resume aborting task: live schema drifted from the reviewed plan",
+				append(task.LogAttrs(), "error", err)...)
+			c.markTaskFailed(ctx, task, err.Error())
+			failedTask = task
+			break
 		}
 
 		action = c.runEngineTask(ctx, apply, task, options, creds)
@@ -396,13 +405,16 @@ func replanShardTableDDL(result *engine.PlanResult) map[shardTableKey]string {
 // tableStillNeedsChange does a quick re-plan to check if a task's table on its
 // own shard still needs schema changes. Returns false if it already has the
 // desired schema (e.g., Spirit's cutover completed during the stop sequence).
-func (c *LocalClient) tableStillNeedsChange(ctx context.Context, apply *storage.Apply, plan *storage.Plan, task *storage.Task) (bool, error) {
+// When the table still needs changes, it also returns the DDL the re-plan would
+// now apply so the caller can confirm it still matches the reviewed DDL before
+// applying it.
+func (c *LocalClient) tableStillNeedsChange(ctx context.Context, apply *storage.Apply, plan *storage.Plan, task *storage.Task) (string, bool, error) {
 	result, err := c.planWithEngine(ctx, &ternv1.PlanRequest{}, apply.Database, plan.SchemaFiles)
 	if err != nil {
-		return false, fmt.Errorf("re-plan check failed: %w", err)
+		return "", false, fmt.Errorf("re-plan check failed: %w", err)
 	}
-	_, stillNeeded := replanShardTableDDL(result)[shardTableKey{namespace: task.Namespace, shard: task.Shard, table: task.TableName}]
-	return stillNeeded, nil
+	ddl, stillNeeded := replanShardTableDDL(result)[shardTableKey{namespace: task.Namespace, shard: task.Shard, table: task.TableName}]
+	return ddl, stillNeeded, nil
 }
 
 // replanResult holds the result of replanAndFilterTasks.
@@ -439,11 +451,14 @@ func (c *LocalClient) replanAndFilterTasks(ctx context.Context, apply *storage.A
 		}
 		ddl, stillNeeded := replanDDL[shardTableKey{namespace: task.Namespace, shard: task.Shard, table: task.TableName}]
 		if !stillNeeded {
-			// This shard's table is no longer in the diff — it already completed.
+			// The re-plan diffs the reviewed target (plan.SchemaFiles) against
+			// this shard's live schema. A table dropping out of that diff means
+			// live already matches the reviewed target, so there is no remaining
+			// resume work for it — treat it as completed rather than drifted.
 			task.ProgressPercent = 100
 			task.CompletedAt = &now
 			c.transitionTaskState(ctx, task, apply.ID, state.Task.Completed,
-				fmt.Sprintf("Task %s already completed (re-plan shows no remaining changes)", task.TaskIdentifier))
+				fmt.Sprintf("Task %s already completed (live schema matches the reviewed target)", task.TaskIdentifier))
 			completedCount++
 		} else {
 			// Fail closed if the re-plan would apply DDL this task was not

--- a/pkg/tern/local_control_resume_test.go
+++ b/pkg/tern/local_control_resume_test.go
@@ -143,6 +143,103 @@ func TestReplanAndFilterTasks_FailsClosedOnDrift(t *testing.T) {
 	assert.Contains(t, err.Error(), "testapp.users/alter")
 }
 
+// The sequential resume loop re-plans each table right before applying it to
+// catch a cutover that raced the resume. tableStillNeedsChange must return the
+// DDL that re-plan would now apply so the loop can confirm it still matches the
+// reviewed DDL before applying — closing the window between the resume-entry
+// re-plan and this later per-task apply.
+func TestTableStillNeedsChange_ReturnsReplannedDDL(t *testing.T) {
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }}
+	c := newPlanMaterializeClientWithPlan(store, alterUsersEmailPlan())
+
+	apply := &storage.Apply{Database: "testapp"}
+	plan := &storage.Plan{}
+	task := &storage.Task{
+		TaskIdentifier: "task_1",
+		Namespace:      "testapp",
+		TableName:      "users",
+		DDLAction:      "alter",
+		DDL:            "ALTER TABLE `users` ADD COLUMN `email` varchar(255)",
+	}
+
+	ddl, needsChange, err := c.tableStillNeedsChange(t.Context(), apply, plan, task)
+	require.NoError(t, err)
+	assert.True(t, needsChange)
+	assert.Equal(t, "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", ddl)
+	require.NoError(t, verifyReplannedTaskDDL(task, ddl), "matching re-plan is not drift")
+}
+
+// When the table has dropped out of the re-plan diff (its cutover completed) the
+// sequential loop treats it as already applied, so tableStillNeedsChange must
+// report that no change remains.
+func TestTableStillNeedsChange_TableAbsentReportsDone(t *testing.T) {
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }}
+	// Re-plan for a different table only: the task's table is no longer in the diff.
+	otherTablePlan := &engine.PlanResult{
+		Changes: []engine.SchemaChange{{
+			Namespace: "testapp",
+			TableChanges: []engine.TableChange{{
+				Table:     "orders",
+				Operation: statement.StatementAlterTable,
+				DDL:       "ALTER TABLE `orders` ADD COLUMN `total` int",
+			}},
+		}},
+	}
+	c := newPlanMaterializeClientWithPlan(store, otherTablePlan)
+
+	apply := &storage.Apply{Database: "testapp"}
+	plan := &storage.Plan{}
+	task := &storage.Task{
+		TaskIdentifier: "task_1",
+		Namespace:      "testapp",
+		TableName:      "users",
+		DDLAction:      "alter",
+		DDL:            "ALTER TABLE `users` ADD COLUMN `email` varchar(255)",
+	}
+
+	ddl, needsChange, err := c.tableStillNeedsChange(t.Context(), apply, plan, task)
+	require.NoError(t, err)
+	assert.False(t, needsChange)
+	assert.Empty(t, ddl)
+}
+
+// If live drifts between resume entry and a later per-task apply, the re-plan the
+// sequential loop performs returns DDL that no longer matches the reviewed DDL.
+// tableStillNeedsChange surfaces that DDL and verifyReplannedTaskDDL fails closed
+// so the loop refuses to apply unreviewed DDL.
+func TestTableStillNeedsChange_DriftFailsClosed(t *testing.T) {
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }}
+	drifted := &engine.PlanResult{
+		Changes: []engine.SchemaChange{{
+			Namespace: "testapp",
+			TableChanges: []engine.TableChange{{
+				Table:     "users",
+				Operation: statement.StatementAlterTable,
+				DDL:       "ALTER TABLE `users` ADD COLUMN `email` varchar(100)",
+			}},
+		}},
+	}
+	c := newPlanMaterializeClientWithPlan(store, drifted)
+
+	apply := &storage.Apply{Database: "testapp"}
+	plan := &storage.Plan{}
+	task := &storage.Task{
+		TaskIdentifier: "task_1",
+		Namespace:      "testapp",
+		TableName:      "users",
+		DDLAction:      "alter",
+		DDL:            "ALTER TABLE `users` ADD COLUMN `email` varchar(255)",
+	}
+
+	ddl, needsChange, err := c.tableStillNeedsChange(t.Context(), apply, plan, task)
+	require.NoError(t, err)
+	require.True(t, needsChange)
+	err = verifyReplannedTaskDDL(task, ddl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "drifted from the reviewed plan")
+	assert.Contains(t, err.Error(), "testapp.users/alter")
+}
+
 // When the re-plan matches the reviewed DDL the deployment has not drifted, so
 // the task stays active and its DDL is refreshed from the re-plan.
 func TestReplanAndFilterTasks_MatchKeepsTaskActive(t *testing.T) {


### PR DESCRIPTION
## Summary
The sequential resume path re-verified re-planned DDL against the reviewed DDL only once, at resume entry. Tables applied later in the loop could drift in the meantime and get applied without re-verification. This closes that TOCTOU window on the sequential (MySQL) resume path.

## What
- `tableStillNeedsChange` now returns the DDL the per-task re-plan would apply.
- `resumeApplySequential` runs `verifyReplannedTaskDDL` on that DDL immediately before each per-task engine apply, failing closed on drift.
- Clarified the "already completed" classification comment/message in `replanAndFilterTasks`: a table dropping out of the re-plan diff means live already matches the reviewed target.
- Unit tests for the re-plan DDL return value, the table-absent (done) case, and the drift-fails-closed case.

## Why
Resume re-plans each deployment's delta against its live schema. If live drifts after resume begins, a later table's re-plan can produce DDL no human reviewed. Verifying only at resume entry left every subsequent per-task apply exposed. The grouped path already verifies immediately before apply, so only the sequential path needed this.

```diagram
resume entry ─ verify all ── task[0] apply ── … ── task[N] apply
                                          ▲ live can drift here ▲
   Before: no re-check → applies stale reviewed DDL against drifted live
   After:  re-plan + verify before each apply → fail closed on drift
```
