### PR TITLE
feat(tern): non-persisting PlanDiff RPC + per-deployment diff producer

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -570,6 +570,9 @@ type mockTernClient struct {
 	planResp                 *ternv1.PlanResponse
 	planErr                  error
 	planReq                  *ternv1.PlanRequest
+	planDiffResp             *ternv1.PlanDiffResponse
+	planDiffErr              error
+	planDiffReq              *ternv1.PlanRequest
 	pullSchemaResp           *ternv1.PullSchemaResponse
 	pullSchemaErr            error
 	pullSchemaReq            *ternv1.PullSchemaRequest
@@ -632,6 +635,13 @@ func (m *mockTernClient) Plan(ctx context.Context, req *ternv1.PlanRequest) (*te
 		return m.planResp, m.planErr
 	}
 	return nil, m.planErr
+}
+func (m *mockTernClient) PlanDiff(ctx context.Context, req *ternv1.PlanRequest) (*ternv1.PlanDiffResponse, error) {
+	m.planDiffReq = req
+	if m.planDiffResp != nil {
+		return m.planDiffResp, m.planDiffErr
+	}
+	return nil, m.planDiffErr
 }
 func (m *mockTernClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ternv1.ApplyResponse, error) {
 	m.applyReq = req

--- a/pkg/api/plan_deployment_diffs.go
+++ b/pkg/api/plan_deployment_diffs.go
@@ -1,0 +1,142 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/sync/errgroup"
+
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/routing"
+)
+
+// planDeploymentDiffConcurrency bounds how many deployments are diffed at once.
+// Each deployment diff runs one live-schema read against a (often remote)
+// deployment; a small cap rides out multi-deployment fan-out without opening an
+// unbounded number of concurrent connections across regions.
+const planDeploymentDiffConcurrency = 4
+
+// DeploymentPlanDiff is one deployment's desired-vs-live diff computed at review
+// time, or the error that prevented computing it. It is the per-deployment
+// producer output the control-plane rollup compares across a database's
+// deployments to surface drift before approval. The rollup must treat any Err —
+// or a deployment missing from the results — as blocking, never as agreement.
+type DeploymentPlanDiff struct {
+	DatabaseType string
+	Deployment   string
+	Target       string
+
+	Engine         ternv1.Engine
+	Changes        []*ternv1.SchemaChange
+	Shards         []*ternv1.ShardPlan
+	LintViolations []*ternv1.LintViolation
+
+	Err error
+}
+
+// PlanDeploymentDiffs computes every configured deployment's desired-vs-live
+// diff for a database/environment at review time. Only the primary deployment
+// plans locally today; the non-primary deployments never do, so drift on them is
+// invisible until apply. This is the producer that closes that gap: each
+// non-primary deployment is diffed with the non-persisting PlanDiff RPC, and the
+// primary reuses the already-persisted reviewed plan (primaryPlan) so the rollup
+// compares against exactly what the user reviewed rather than re-reading the
+// primary's live schema — which could differ from the reviewed plan and trip a
+// spurious primary-vs-primary mismatch.
+//
+// Per-deployment failures are captured in each result's Err so one unreachable
+// deployment neither hides the others nor aborts the rollup; only a
+// request-level failure (target resolution) returns an error. Results are
+// returned in rollout order, primary first.
+func (s *Service) PlanDeploymentDiffs(ctx context.Context, req PlanRequest, primaryPlan *ternv1.PlanResponse) ([]DeploymentPlanDiff, error) {
+	targets, err := s.config.ResolveDatabaseTargets(req.Database, req.Environment)
+	if err != nil {
+		return nil, fmt.Errorf("resolve deployment targets for %s/%s: %w", req.Database, req.Environment, err)
+	}
+
+	results := make([]DeploymentPlanDiff, len(targets))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(planDeploymentDiffConcurrency)
+
+	for i, target := range targets {
+		results[i] = DeploymentPlanDiff{
+			DatabaseType: target.DatabaseType,
+			Deployment:   target.Deployment,
+			Target:       target.Target,
+		}
+
+		// Rollout index 0 is the primary. When its reviewed plan is provided,
+		// reuse it so the rollup's primary member is exactly what was reviewed and
+		// no redundant live-schema read runs.
+		if i == 0 && primaryPlan != nil {
+			results[i].Engine = primaryPlan.Engine
+			results[i].Changes = primaryPlan.Changes
+			results[i].Shards = primaryPlan.Shards
+			results[i].LintViolations = primaryPlan.LintViolations
+			continue
+		}
+
+		i, target := i, target
+		g.Go(func() error {
+			resp, err := s.planDeploymentDiff(gctx, req, target)
+			if err != nil {
+				s.logger.Warn("plan deployment diff failed; deployment will block the review rollup",
+					"database", req.Database,
+					"environment", req.Environment,
+					"deployment", target.Deployment,
+					"target", target.Target,
+					"error", err)
+				results[i].Err = err
+				return nil
+			}
+			results[i].Engine = resp.Engine
+			results[i].Changes = resp.Changes
+			results[i].Shards = resp.Shards
+			results[i].LintViolations = resp.LintViolations
+			return nil
+		})
+	}
+
+	// Deployment failures are captured per result, so Wait only returns non-nil
+	// if the parent context was cancelled.
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf("plan deployment diffs for %s/%s: %w", req.Database, req.Environment, err)
+	}
+	return results, nil
+}
+
+// planDeploymentDiff runs the non-persisting PlanDiff RPC against a single
+// deployment, building the per-target request the same way ExecutePlan builds
+// the primary's plan request.
+func (s *Service) planDeploymentDiff(ctx context.Context, req PlanRequest, target routing.ExecutionTarget) (*ternv1.PlanDiffResponse, error) {
+	client, err := s.TernClient(target.Deployment, req.Environment)
+	if err != nil {
+		return nil, fmt.Errorf("tern client for deployment %q environment %q: %w", target.Deployment, req.Environment, err)
+	}
+
+	trustedSchemaPath := ""
+	if req.SourceTrusted {
+		trustedSchemaPath = req.SchemaPath
+	}
+	ternReq := &ternv1.PlanRequest{
+		Database:    req.Database,
+		Type:        target.DatabaseType,
+		SchemaFiles: req.SchemaFiles,
+		Repository:  req.Repository,
+		Environment: req.Environment,
+		Target:      target.Target,
+		SchemaPath:  trustedSchemaPath,
+	}
+	if req.PullRequest != nil {
+		ternReq.PullRequest = *req.PullRequest
+	}
+	if req.HeadSHA != nil {
+		ternReq.HeadSha = *req.HeadSHA
+	}
+
+	resp, err := client.PlanDiff(ctx, ternReq)
+	if err != nil {
+		return nil, fmt.Errorf("plan diff on deployment %q target %q: %w", target.Deployment, target.Target, err)
+	}
+	return resp, nil
+}

--- a/pkg/api/plan_deployment_diffs.go
+++ b/pkg/api/plan_deployment_diffs.go
@@ -73,6 +73,12 @@ func (s *Service) PlanDeploymentDiffs(ctx context.Context, req PlanRequest, prim
 			results[i].Changes = primaryPlan.Changes
 			results[i].Shards = primaryPlan.Shards
 			results[i].LintViolations = primaryPlan.LintViolations
+			// A reviewed plan that reported planning errors is not a trustworthy
+			// baseline; record the error so the rollup fails closed rather than
+			// comparing deployments against a broken primary.
+			if len(primaryPlan.Errors) > 0 {
+				results[i].Err = fmt.Errorf("reviewed primary plan reported errors: %v", primaryPlan.Errors)
+			}
 			continue
 		}
 
@@ -93,6 +99,19 @@ func (s *Service) PlanDeploymentDiffs(ctx context.Context, req PlanRequest, prim
 			results[i].Changes = resp.Changes
 			results[i].Shards = resp.Shards
 			results[i].LintViolations = resp.LintViolations
+			// A diff that succeeded at the RPC layer but reported planning errors
+			// is not a trustworthy comparison input; block on it so the rollup
+			// never mistakes an incomplete diff for agreement.
+			if len(resp.Errors) > 0 {
+				diffErr := fmt.Errorf("plan diff on deployment %q target %q reported errors: %v", target.Deployment, target.Target, resp.Errors)
+				s.logger.Warn("plan deployment diff reported errors; deployment will block the review rollup",
+					"database", req.Database,
+					"environment", req.Environment,
+					"deployment", target.Deployment,
+					"target", target.Target,
+					"error", diffErr)
+				results[i].Err = diffErr
+			}
 			return nil
 		})
 	}

--- a/pkg/api/plan_deployment_diffs_test.go
+++ b/pkg/api/plan_deployment_diffs_test.go
@@ -1,0 +1,160 @@
+package api
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/tern"
+)
+
+// twoDeploymentService builds a testapp/production database that fans out to two
+// deployments (eu primary, us), each backed by its own registered mock tern
+// client, so PlanDeploymentDiffs can be exercised without live databases.
+func twoDeploymentService(t *testing.T, eu, us *mockTernClient) *Service {
+	t.Helper()
+	cfg := &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"testapp": {
+				Type: storage.DatabaseTypeMySQL,
+				Environments: map[string]EnvironmentConfig{
+					"production": {
+						Deployments: map[string]DeploymentTarget{
+							"eu": {Target: "testapp"},
+							"us": {Target: "testapp"},
+						},
+						DeploymentOrder: []string{"eu", "us"},
+					},
+				},
+			},
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	return New(&mockStorage{}, cfg, map[string]tern.Client{
+		"eu/production": eu,
+		"us/production": us,
+	}, logger)
+}
+
+func planDiffReq(t *testing.T) PlanRequest {
+	t.Helper()
+	return PlanRequest{
+		Database:    "testapp",
+		Environment: "production",
+		Type:        storage.DatabaseTypeMySQL,
+		SchemaFiles: map[string]*ternv1.SchemaFiles{
+			"testapp": {Files: map[string]string{"users.sql": "CREATE TABLE `users` (id bigint primary key)"}},
+		},
+	}
+}
+
+func alterUsersDiff(ddl string) *ternv1.PlanDiffResponse {
+	return &ternv1.PlanDiffResponse{
+		Engine: ternv1.Engine_ENGINE_SPIRIT,
+		Changes: []*ternv1.SchemaChange{{
+			Namespace: "testapp",
+			TableChanges: []*ternv1.TableChange{{
+				TableName:  "users",
+				ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER,
+				Ddl:        ddl,
+				Namespace:  "testapp",
+			}},
+		}},
+	}
+}
+
+// With the reviewed primary plan supplied, the primary member of the rollup is
+// the reviewed plan itself (no redundant live-schema read of the primary), and
+// only the non-primary deployments run PlanDiff. Results stay in rollout order.
+func TestPlanDeploymentDiffs_PrimaryReusesReviewedPlan(t *testing.T) {
+	eu := &mockTernClient{}
+	us := &mockTernClient{planDiffResp: alterUsersDiff("ALTER TABLE `users` ADD COLUMN `email` varchar(255)")}
+	svc := twoDeploymentService(t, eu, us)
+
+	primaryPlan := &ternv1.PlanResponse{
+		PlanId: "plan_eu",
+		Engine: ternv1.Engine_ENGINE_SPIRIT,
+		Changes: []*ternv1.SchemaChange{{
+			Namespace: "testapp",
+			TableChanges: []*ternv1.TableChange{{
+				TableName:  "users",
+				ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER,
+				Ddl:        "ALTER TABLE `users` ADD COLUMN `email` varchar(255)",
+				Namespace:  "testapp",
+			}},
+		}},
+	}
+
+	results, err := svc.PlanDeploymentDiffs(t.Context(), planDiffReq(t), primaryPlan)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	assert.Equal(t, "eu", results[0].Deployment)
+	assert.Nil(t, eu.planDiffReq, "primary must reuse the reviewed plan, not re-diff")
+	require.NoError(t, results[0].Err)
+	assert.Equal(t, primaryPlan.Changes, results[0].Changes)
+
+	assert.Equal(t, "us", results[1].Deployment)
+	require.NotNil(t, us.planDiffReq, "non-primary deployment must be diffed")
+	assert.Equal(t, "testapp", us.planDiffReq.Target)
+	require.NoError(t, results[1].Err)
+	require.Len(t, results[1].Changes, 1)
+	assert.Equal(t, "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", results[1].Changes[0].TableChanges[0].Ddl)
+}
+
+// Without a reviewed plan, every deployment (including the primary) is diffed
+// with PlanDiff.
+func TestPlanDeploymentDiffs_DiffsAllDeploymentsWhenNoPrimary(t *testing.T) {
+	eu := &mockTernClient{planDiffResp: alterUsersDiff("ALTER TABLE `users` ADD COLUMN `email` varchar(255)")}
+	us := &mockTernClient{planDiffResp: alterUsersDiff("ALTER TABLE `users` ADD COLUMN `email` varchar(255)")}
+	svc := twoDeploymentService(t, eu, us)
+
+	results, err := svc.PlanDeploymentDiffs(t.Context(), planDiffReq(t), nil)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	require.NotNil(t, eu.planDiffReq, "primary must be diffed when no reviewed plan is supplied")
+	require.NotNil(t, us.planDiffReq)
+	require.NoError(t, results[0].Err)
+	require.NoError(t, results[1].Err)
+}
+
+// One deployment failing to diff must not abort the rollup or hide the others:
+// its error is captured per result (so the rollup can fail closed on it) while
+// the healthy deployment still returns its changes.
+func TestPlanDeploymentDiffs_PerDeploymentErrorIsCaptured(t *testing.T) {
+	eu := &mockTernClient{planDiffResp: alterUsersDiff("ALTER TABLE `users` ADD COLUMN `email` varchar(255)")}
+	us := &mockTernClient{planDiffErr: errors.New("deployment unreachable")}
+	svc := twoDeploymentService(t, eu, us)
+
+	results, err := svc.PlanDeploymentDiffs(t.Context(), planDiffReq(t), nil)
+	require.NoError(t, err, "a single deployment failure must not abort the rollup")
+	require.Len(t, results, 2)
+
+	require.NoError(t, results[0].Err)
+	require.Len(t, results[0].Changes, 1)
+
+	require.Error(t, results[1].Err)
+	assert.Contains(t, results[1].Err.Error(), "deployment unreachable")
+	assert.Nil(t, results[1].Changes)
+}
+
+// A request-level failure (the database/environment resolves no deployments)
+// returns an error rather than a per-deployment result.
+func TestPlanDeploymentDiffs_UnresolvedTargetsError(t *testing.T) {
+	svc := twoDeploymentService(t, &mockTernClient{}, &mockTernClient{})
+
+	_, err := svc.PlanDeploymentDiffs(t.Context(), PlanRequest{
+		Database:    "testapp",
+		Environment: "staging", // not configured
+		Type:        storage.DatabaseTypeMySQL,
+	}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolve deployment targets")
+}

--- a/pkg/proto/tern.proto
+++ b/pkg/proto/tern.proto
@@ -56,6 +56,21 @@ service Tern {
     };
   }
 
+  // PlanDiff computes a deployment's desired-vs-live diff without persisting a
+  // plan. It is the read-only producer for review-time drift detection: the
+  // control plane runs it against every deployment of a database and compares
+  // the results to surface a deployment that diverges from the reviewed plan.
+  //
+  // Unlike Plan, PlanDiff does not create a stored plan record and returns no
+  // plan_id — its result is intentionally not applyable. It is idempotent and
+  // safe to retry.
+  rpc PlanDiff(PlanRequest) returns (PlanDiffResponse) {
+    option (google.api.http) = {
+      post: "/v1/plan-diff"
+      body: "*"
+    };
+  }
+
   // Apply executes a previously generated plan. Returns immediately with an
   // apply_id; execution happens asynchronously. Use Progress to track status.
   //
@@ -465,6 +480,20 @@ message PlanResponse {
   // Per-shard membership and drift, populated for sharded engines. Empty for
   // single-endpoint engines.
   repeated ShardPlan shards = 6;
+}
+
+// PlanDiffResponse contains a deployment's desired-vs-live diff. It mirrors
+// PlanResponse but omits plan_id: PlanDiff never persists a plan, so its result
+// is not applyable. Used by the control plane to compare deployments at review
+// time.
+message PlanDiffResponse {
+  Engine engine = 1;
+  repeated SchemaChange changes = 2;
+  repeated LintViolation lint_violations = 3;
+  repeated string errors = 4;
+  // Per-shard membership and drift, populated for sharded engines. Empty for
+  // single-endpoint engines.
+  repeated ShardPlan shards = 5;
 }
 
 // ApplyRequest requests execution of a previously generated plan.

--- a/pkg/proto/ternv1/tern.pb.go
+++ b/pkg/proto/ternv1/tern.pb.go
@@ -1526,6 +1526,88 @@ func (x *PlanResponse) GetShards() []*ShardPlan {
 	return nil
 }
 
+// PlanDiffResponse contains a deployment's desired-vs-live diff. It mirrors
+// PlanResponse but omits plan_id: PlanDiff never persists a plan, so its result
+// is not applyable. Used by the control plane to compare deployments at review
+// time.
+type PlanDiffResponse struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Engine         Engine                 `protobuf:"varint,1,opt,name=engine,proto3,enum=tern.v1.Engine" json:"engine,omitempty"`
+	Changes        []*SchemaChange        `protobuf:"bytes,2,rep,name=changes,proto3" json:"changes,omitempty"`
+	LintViolations []*LintViolation       `protobuf:"bytes,3,rep,name=lint_violations,json=lintViolations,proto3" json:"lint_violations,omitempty"`
+	Errors         []string               `protobuf:"bytes,4,rep,name=errors,proto3" json:"errors,omitempty"`
+	// Per-shard membership and drift, populated for sharded engines. Empty for
+	// single-endpoint engines.
+	Shards        []*ShardPlan `protobuf:"bytes,5,rep,name=shards,proto3" json:"shards,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PlanDiffResponse) Reset() {
+	*x = PlanDiffResponse{}
+	mi := &file_tern_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PlanDiffResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PlanDiffResponse) ProtoMessage() {}
+
+func (x *PlanDiffResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_tern_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PlanDiffResponse.ProtoReflect.Descriptor instead.
+func (*PlanDiffResponse) Descriptor() ([]byte, []int) {
+	return file_tern_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *PlanDiffResponse) GetEngine() Engine {
+	if x != nil {
+		return x.Engine
+	}
+	return Engine_ENGINE_SPIRIT
+}
+
+func (x *PlanDiffResponse) GetChanges() []*SchemaChange {
+	if x != nil {
+		return x.Changes
+	}
+	return nil
+}
+
+func (x *PlanDiffResponse) GetLintViolations() []*LintViolation {
+	if x != nil {
+		return x.LintViolations
+	}
+	return nil
+}
+
+func (x *PlanDiffResponse) GetErrors() []string {
+	if x != nil {
+		return x.Errors
+	}
+	return nil
+}
+
+func (x *PlanDiffResponse) GetShards() []*ShardPlan {
+	if x != nil {
+		return x.Shards
+	}
+	return nil
+}
+
 // ApplyRequest requests execution of a previously generated plan.
 // DDL changes are passed by the caller since clients are stateless.
 type ApplyRequest struct {
@@ -1560,7 +1642,7 @@ type ApplyRequest struct {
 
 func (x *ApplyRequest) Reset() {
 	*x = ApplyRequest{}
-	mi := &file_tern_proto_msgTypes[15]
+	mi := &file_tern_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1572,7 +1654,7 @@ func (x *ApplyRequest) String() string {
 func (*ApplyRequest) ProtoMessage() {}
 
 func (x *ApplyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[15]
+	mi := &file_tern_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1585,7 +1667,7 @@ func (x *ApplyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApplyRequest.ProtoReflect.Descriptor instead.
 func (*ApplyRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{15}
+	return file_tern_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *ApplyRequest) GetPlanId() string {
@@ -1680,7 +1762,7 @@ type ApplyResponse struct {
 
 func (x *ApplyResponse) Reset() {
 	*x = ApplyResponse{}
-	mi := &file_tern_proto_msgTypes[16]
+	mi := &file_tern_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1692,7 +1774,7 @@ func (x *ApplyResponse) String() string {
 func (*ApplyResponse) ProtoMessage() {}
 
 func (x *ApplyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[16]
+	mi := &file_tern_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1705,7 +1787,7 @@ func (x *ApplyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApplyResponse.ProtoReflect.Descriptor instead.
 func (*ApplyResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{16}
+	return file_tern_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ApplyResponse) GetAccepted() bool {
@@ -1749,7 +1831,7 @@ type ProgressRequest struct {
 
 func (x *ProgressRequest) Reset() {
 	*x = ProgressRequest{}
-	mi := &file_tern_proto_msgTypes[17]
+	mi := &file_tern_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1761,7 +1843,7 @@ func (x *ProgressRequest) String() string {
 func (*ProgressRequest) ProtoMessage() {}
 
 func (x *ProgressRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[17]
+	mi := &file_tern_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1774,7 +1856,7 @@ func (x *ProgressRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProgressRequest.ProtoReflect.Descriptor instead.
 func (*ProgressRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{17}
+	return file_tern_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ProgressRequest) GetApplyId() string {
@@ -1808,7 +1890,7 @@ type ShardProgress struct {
 
 func (x *ShardProgress) Reset() {
 	*x = ShardProgress{}
-	mi := &file_tern_proto_msgTypes[18]
+	mi := &file_tern_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1820,7 +1902,7 @@ func (x *ShardProgress) String() string {
 func (*ShardProgress) ProtoMessage() {}
 
 func (x *ShardProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[18]
+	mi := &file_tern_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1833,7 +1915,7 @@ func (x *ShardProgress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShardProgress.ProtoReflect.Descriptor instead.
 func (*ShardProgress) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{18}
+	return file_tern_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ShardProgress) GetShard() string {
@@ -1918,7 +2000,7 @@ type TableProgress struct {
 
 func (x *TableProgress) Reset() {
 	*x = TableProgress{}
-	mi := &file_tern_proto_msgTypes[19]
+	mi := &file_tern_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1930,7 +2012,7 @@ func (x *TableProgress) String() string {
 func (*TableProgress) ProtoMessage() {}
 
 func (x *TableProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[19]
+	mi := &file_tern_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1943,7 +2025,7 @@ func (x *TableProgress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TableProgress.ProtoReflect.Descriptor instead.
 func (*TableProgress) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{19}
+	return file_tern_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *TableProgress) GetTaskId() string {
@@ -2070,7 +2152,7 @@ type ProgressResponse struct {
 
 func (x *ProgressResponse) Reset() {
 	*x = ProgressResponse{}
-	mi := &file_tern_proto_msgTypes[20]
+	mi := &file_tern_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2082,7 +2164,7 @@ func (x *ProgressResponse) String() string {
 func (*ProgressResponse) ProtoMessage() {}
 
 func (x *ProgressResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[20]
+	mi := &file_tern_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2095,7 +2177,7 @@ func (x *ProgressResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProgressResponse.ProtoReflect.Descriptor instead.
 func (*ProgressResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{20}
+	return file_tern_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ProgressResponse) GetApplyId() string {
@@ -2181,7 +2263,7 @@ type CutoverRequest struct {
 
 func (x *CutoverRequest) Reset() {
 	*x = CutoverRequest{}
-	mi := &file_tern_proto_msgTypes[21]
+	mi := &file_tern_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2193,7 +2275,7 @@ func (x *CutoverRequest) String() string {
 func (*CutoverRequest) ProtoMessage() {}
 
 func (x *CutoverRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[21]
+	mi := &file_tern_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2206,7 +2288,7 @@ func (x *CutoverRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CutoverRequest.ProtoReflect.Descriptor instead.
 func (*CutoverRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{21}
+	return file_tern_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *CutoverRequest) GetApplyId() string {
@@ -2234,7 +2316,7 @@ type CutoverResponse struct {
 
 func (x *CutoverResponse) Reset() {
 	*x = CutoverResponse{}
-	mi := &file_tern_proto_msgTypes[22]
+	mi := &file_tern_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2246,7 +2328,7 @@ func (x *CutoverResponse) String() string {
 func (*CutoverResponse) ProtoMessage() {}
 
 func (x *CutoverResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[22]
+	mi := &file_tern_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2259,7 +2341,7 @@ func (x *CutoverResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CutoverResponse.ProtoReflect.Descriptor instead.
 func (*CutoverResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{22}
+	return file_tern_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *CutoverResponse) GetAccepted() bool {
@@ -2289,7 +2371,7 @@ type RevertRequest struct {
 
 func (x *RevertRequest) Reset() {
 	*x = RevertRequest{}
-	mi := &file_tern_proto_msgTypes[23]
+	mi := &file_tern_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2301,7 +2383,7 @@ func (x *RevertRequest) String() string {
 func (*RevertRequest) ProtoMessage() {}
 
 func (x *RevertRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[23]
+	mi := &file_tern_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2314,7 +2396,7 @@ func (x *RevertRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevertRequest.ProtoReflect.Descriptor instead.
 func (*RevertRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{23}
+	return file_tern_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *RevertRequest) GetApplyId() string {
@@ -2342,7 +2424,7 @@ type RevertResponse struct {
 
 func (x *RevertResponse) Reset() {
 	*x = RevertResponse{}
-	mi := &file_tern_proto_msgTypes[24]
+	mi := &file_tern_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2354,7 +2436,7 @@ func (x *RevertResponse) String() string {
 func (*RevertResponse) ProtoMessage() {}
 
 func (x *RevertResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[24]
+	mi := &file_tern_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2367,7 +2449,7 @@ func (x *RevertResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevertResponse.ProtoReflect.Descriptor instead.
 func (*RevertResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{24}
+	return file_tern_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *RevertResponse) GetAccepted() bool {
@@ -2397,7 +2479,7 @@ type SkipRevertRequest struct {
 
 func (x *SkipRevertRequest) Reset() {
 	*x = SkipRevertRequest{}
-	mi := &file_tern_proto_msgTypes[25]
+	mi := &file_tern_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2409,7 +2491,7 @@ func (x *SkipRevertRequest) String() string {
 func (*SkipRevertRequest) ProtoMessage() {}
 
 func (x *SkipRevertRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[25]
+	mi := &file_tern_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2422,7 +2504,7 @@ func (x *SkipRevertRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SkipRevertRequest.ProtoReflect.Descriptor instead.
 func (*SkipRevertRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{25}
+	return file_tern_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *SkipRevertRequest) GetApplyId() string {
@@ -2450,7 +2532,7 @@ type SkipRevertResponse struct {
 
 func (x *SkipRevertResponse) Reset() {
 	*x = SkipRevertResponse{}
-	mi := &file_tern_proto_msgTypes[26]
+	mi := &file_tern_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2462,7 +2544,7 @@ func (x *SkipRevertResponse) String() string {
 func (*SkipRevertResponse) ProtoMessage() {}
 
 func (x *SkipRevertResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[26]
+	mi := &file_tern_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2475,7 +2557,7 @@ func (x *SkipRevertResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SkipRevertResponse.ProtoReflect.Descriptor instead.
 func (*SkipRevertResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{26}
+	return file_tern_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *SkipRevertResponse) GetAccepted() bool {
@@ -2501,7 +2583,7 @@ type HealthRequest struct {
 
 func (x *HealthRequest) Reset() {
 	*x = HealthRequest{}
-	mi := &file_tern_proto_msgTypes[27]
+	mi := &file_tern_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2513,7 +2595,7 @@ func (x *HealthRequest) String() string {
 func (*HealthRequest) ProtoMessage() {}
 
 func (x *HealthRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[27]
+	mi := &file_tern_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2526,7 +2608,7 @@ func (x *HealthRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthRequest.ProtoReflect.Descriptor instead.
 func (*HealthRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{27}
+	return file_tern_proto_rawDescGZIP(), []int{28}
 }
 
 // HealthResponse is the health check response.
@@ -2539,7 +2621,7 @@ type HealthResponse struct {
 
 func (x *HealthResponse) Reset() {
 	*x = HealthResponse{}
-	mi := &file_tern_proto_msgTypes[28]
+	mi := &file_tern_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2551,7 +2633,7 @@ func (x *HealthResponse) String() string {
 func (*HealthResponse) ProtoMessage() {}
 
 func (x *HealthResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[28]
+	mi := &file_tern_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2564,7 +2646,7 @@ func (x *HealthResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthResponse.ProtoReflect.Descriptor instead.
 func (*HealthResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{28}
+	return file_tern_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *HealthResponse) GetStatus() string {
@@ -2587,7 +2669,7 @@ type StopRequest struct {
 
 func (x *StopRequest) Reset() {
 	*x = StopRequest{}
-	mi := &file_tern_proto_msgTypes[29]
+	mi := &file_tern_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2599,7 +2681,7 @@ func (x *StopRequest) String() string {
 func (*StopRequest) ProtoMessage() {}
 
 func (x *StopRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[29]
+	mi := &file_tern_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2612,7 +2694,7 @@ func (x *StopRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopRequest.ProtoReflect.Descriptor instead.
 func (*StopRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{29}
+	return file_tern_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *StopRequest) GetApplyId() string {
@@ -2646,7 +2728,7 @@ type StopResponse struct {
 
 func (x *StopResponse) Reset() {
 	*x = StopResponse{}
-	mi := &file_tern_proto_msgTypes[30]
+	mi := &file_tern_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2658,7 +2740,7 @@ func (x *StopResponse) String() string {
 func (*StopResponse) ProtoMessage() {}
 
 func (x *StopResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[30]
+	mi := &file_tern_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2671,7 +2753,7 @@ func (x *StopResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopResponse.ProtoReflect.Descriptor instead.
 func (*StopResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{30}
+	return file_tern_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *StopResponse) GetAccepted() bool {
@@ -2722,7 +2804,7 @@ type CancelRequest struct {
 
 func (x *CancelRequest) Reset() {
 	*x = CancelRequest{}
-	mi := &file_tern_proto_msgTypes[31]
+	mi := &file_tern_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2734,7 +2816,7 @@ func (x *CancelRequest) String() string {
 func (*CancelRequest) ProtoMessage() {}
 
 func (x *CancelRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[31]
+	mi := &file_tern_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2747,7 +2829,7 @@ func (x *CancelRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelRequest.ProtoReflect.Descriptor instead.
 func (*CancelRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{31}
+	return file_tern_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *CancelRequest) GetApplyId() string {
@@ -2779,7 +2861,7 @@ type CancelResponse struct {
 
 func (x *CancelResponse) Reset() {
 	*x = CancelResponse{}
-	mi := &file_tern_proto_msgTypes[32]
+	mi := &file_tern_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2791,7 +2873,7 @@ func (x *CancelResponse) String() string {
 func (*CancelResponse) ProtoMessage() {}
 
 func (x *CancelResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[32]
+	mi := &file_tern_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2804,7 +2886,7 @@ func (x *CancelResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelResponse.ProtoReflect.Descriptor instead.
 func (*CancelResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{32}
+	return file_tern_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *CancelResponse) GetAccepted() bool {
@@ -2848,7 +2930,7 @@ type StartRequest struct {
 
 func (x *StartRequest) Reset() {
 	*x = StartRequest{}
-	mi := &file_tern_proto_msgTypes[33]
+	mi := &file_tern_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2860,7 +2942,7 @@ func (x *StartRequest) String() string {
 func (*StartRequest) ProtoMessage() {}
 
 func (x *StartRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[33]
+	mi := &file_tern_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2873,7 +2955,7 @@ func (x *StartRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartRequest.ProtoReflect.Descriptor instead.
 func (*StartRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{33}
+	return file_tern_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *StartRequest) GetApplyId() string {
@@ -2905,7 +2987,7 @@ type StartResponse struct {
 
 func (x *StartResponse) Reset() {
 	*x = StartResponse{}
-	mi := &file_tern_proto_msgTypes[34]
+	mi := &file_tern_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2917,7 +2999,7 @@ func (x *StartResponse) String() string {
 func (*StartResponse) ProtoMessage() {}
 
 func (x *StartResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[34]
+	mi := &file_tern_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2930,7 +3012,7 @@ func (x *StartResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartResponse.ProtoReflect.Descriptor instead.
 func (*StartResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{34}
+	return file_tern_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *StartResponse) GetAccepted() bool {
@@ -2976,7 +3058,7 @@ type VolumeRequest struct {
 
 func (x *VolumeRequest) Reset() {
 	*x = VolumeRequest{}
-	mi := &file_tern_proto_msgTypes[35]
+	mi := &file_tern_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2988,7 +3070,7 @@ func (x *VolumeRequest) String() string {
 func (*VolumeRequest) ProtoMessage() {}
 
 func (x *VolumeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[35]
+	mi := &file_tern_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3001,7 +3083,7 @@ func (x *VolumeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VolumeRequest.ProtoReflect.Descriptor instead.
 func (*VolumeRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{35}
+	return file_tern_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *VolumeRequest) GetApplyId() string {
@@ -3040,7 +3122,7 @@ type VolumeResponse struct {
 
 func (x *VolumeResponse) Reset() {
 	*x = VolumeResponse{}
-	mi := &file_tern_proto_msgTypes[36]
+	mi := &file_tern_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3052,7 +3134,7 @@ func (x *VolumeResponse) String() string {
 func (*VolumeResponse) ProtoMessage() {}
 
 func (x *VolumeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[36]
+	mi := &file_tern_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3065,7 +3147,7 @@ func (x *VolumeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VolumeResponse.ProtoReflect.Descriptor instead.
 func (*VolumeResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{36}
+	return file_tern_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *VolumeResponse) GetAccepted() bool {
@@ -3230,7 +3312,13 @@ const file_tern_proto_rawDesc = "" +
 	"\achanges\x18\x03 \x03(\v2\x15.tern.v1.SchemaChangeR\achanges\x12?\n" +
 	"\x0flint_violations\x18\x04 \x03(\v2\x16.tern.v1.LintViolationR\x0elintViolations\x12\x16\n" +
 	"\x06errors\x18\x05 \x03(\tR\x06errors\x12*\n" +
-	"\x06shards\x18\x06 \x03(\v2\x12.tern.v1.ShardPlanR\x06shards\"\xc9\x04\n" +
+	"\x06shards\x18\x06 \x03(\v2\x12.tern.v1.ShardPlanR\x06shards\"\xf1\x01\n" +
+	"\x10PlanDiffResponse\x12'\n" +
+	"\x06engine\x18\x01 \x01(\x0e2\x0f.tern.v1.EngineR\x06engine\x12/\n" +
+	"\achanges\x18\x02 \x03(\v2\x15.tern.v1.SchemaChangeR\achanges\x12?\n" +
+	"\x0flint_violations\x18\x03 \x03(\v2\x16.tern.v1.LintViolationR\x0elintViolations\x12\x16\n" +
+	"\x06errors\x18\x04 \x03(\tR\x06errors\x12*\n" +
+	"\x06shards\x18\x05 \x03(\v2\x12.tern.v1.ShardPlanR\x06shards\"\xc9\x04\n" +
 	"\fApplyRequest\x12\x17\n" +
 	"\aplan_id\x18\x01 \x01(\tR\x06planId\x12<\n" +
 	"\aoptions\x18\x02 \x03(\v2\".tern.v1.ApplyRequest.OptionsEntryR\aoptions\x12I\n" +
@@ -3399,11 +3487,12 @@ const file_tern_proto_rawDesc = "" +
 	"\x13CHANGE_TYPE_VSCHEMA\x10\x04*T\n" +
 	"\x11PullCatalogDetail\x12\x1d\n" +
 	"\x19PULL_CATALOG_DETAIL_BASIC\x10\x00\x12 \n" +
-	"\x1cPULL_CATALOG_DETAIL_DETAILED\x10\x012\xf1\a\n" +
+	"\x1cPULL_CATALOG_DETAIL_DETAILED\x10\x012\xc8\b\n" +
 	"\x04Tern\x12a\n" +
 	"\n" +
 	"PullSchema\x12\x1a.tern.v1.PullSchemaRequest\x1a\x1b.tern.v1.PullSchemaResponse\"\x1a\x82\xd3\xe4\x93\x02\x14:\x01*\"\x0f/v1/pull-schema\x12H\n" +
-	"\x04Plan\x12\x14.tern.v1.PlanRequest\x1a\x15.tern.v1.PlanResponse\"\x13\x82\xd3\xe4\x93\x02\r:\x01*\"\b/v1/plan\x12L\n" +
+	"\x04Plan\x12\x14.tern.v1.PlanRequest\x1a\x15.tern.v1.PlanResponse\"\x13\x82\xd3\xe4\x93\x02\r:\x01*\"\b/v1/plan\x12U\n" +
+	"\bPlanDiff\x12\x14.tern.v1.PlanRequest\x1a\x19.tern.v1.PlanDiffResponse\"\x18\x82\xd3\xe4\x93\x02\x12:\x01*\"\r/v1/plan-diff\x12L\n" +
 	"\x05Apply\x12\x15.tern.v1.ApplyRequest\x1a\x16.tern.v1.ApplyResponse\"\x14\x82\xd3\xe4\x93\x02\x0e:\x01*\"\t/v1/apply\x12X\n" +
 	"\bProgress\x12\x18.tern.v1.ProgressRequest\x1a\x19.tern.v1.ProgressResponse\"\x17\x82\xd3\xe4\x93\x02\x11:\x01*\"\f/v1/progress\x12T\n" +
 	"\aCutover\x12\x17.tern.v1.CutoverRequest\x1a\x18.tern.v1.CutoverResponse\"\x16\x82\xd3\xe4\x93\x02\x10:\x01*\"\v/v1/cutover\x12P\n" +
@@ -3433,7 +3522,7 @@ func file_tern_proto_rawDescGZIP() []byte {
 }
 
 var file_tern_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_tern_proto_msgTypes = make([]protoimpl.MessageInfo, 48)
+var file_tern_proto_msgTypes = make([]protoimpl.MessageInfo, 49)
 var file_tern_proto_goTypes = []any{
 	(Engine)(0),                // 0: tern.v1.Engine
 	(State)(0),                 // 1: tern.v1.State
@@ -3454,103 +3543,110 @@ var file_tern_proto_goTypes = []any{
 	(*LintViolation)(nil),      // 16: tern.v1.LintViolation
 	(*ShardPlan)(nil),          // 17: tern.v1.ShardPlan
 	(*PlanResponse)(nil),       // 18: tern.v1.PlanResponse
-	(*ApplyRequest)(nil),       // 19: tern.v1.ApplyRequest
-	(*ApplyResponse)(nil),      // 20: tern.v1.ApplyResponse
-	(*ProgressRequest)(nil),    // 21: tern.v1.ProgressRequest
-	(*ShardProgress)(nil),      // 22: tern.v1.ShardProgress
-	(*TableProgress)(nil),      // 23: tern.v1.TableProgress
-	(*ProgressResponse)(nil),   // 24: tern.v1.ProgressResponse
-	(*CutoverRequest)(nil),     // 25: tern.v1.CutoverRequest
-	(*CutoverResponse)(nil),    // 26: tern.v1.CutoverResponse
-	(*RevertRequest)(nil),      // 27: tern.v1.RevertRequest
-	(*RevertResponse)(nil),     // 28: tern.v1.RevertResponse
-	(*SkipRevertRequest)(nil),  // 29: tern.v1.SkipRevertRequest
-	(*SkipRevertResponse)(nil), // 30: tern.v1.SkipRevertResponse
-	(*HealthRequest)(nil),      // 31: tern.v1.HealthRequest
-	(*HealthResponse)(nil),     // 32: tern.v1.HealthResponse
-	(*StopRequest)(nil),        // 33: tern.v1.StopRequest
-	(*StopResponse)(nil),       // 34: tern.v1.StopResponse
-	(*CancelRequest)(nil),      // 35: tern.v1.CancelRequest
-	(*CancelResponse)(nil),     // 36: tern.v1.CancelResponse
-	(*StartRequest)(nil),       // 37: tern.v1.StartRequest
-	(*StartResponse)(nil),      // 38: tern.v1.StartResponse
-	(*VolumeRequest)(nil),      // 39: tern.v1.VolumeRequest
-	(*VolumeResponse)(nil),     // 40: tern.v1.VolumeResponse
-	nil,                        // 41: tern.v1.SchemaFiles.FilesEntry
-	nil,                        // 42: tern.v1.PulledNamespace.TablesEntry
-	nil,                        // 43: tern.v1.PulledNamespace.ArtifactsEntry
-	nil,                        // 44: tern.v1.PulledNamespace.TableCatalogEntry
-	nil,                        // 45: tern.v1.PullSchemaResponse.NamespacesEntry
-	nil,                        // 46: tern.v1.PlanRequest.SchemaFilesEntry
-	nil,                        // 47: tern.v1.SchemaChange.MetadataEntry
-	nil,                        // 48: tern.v1.SchemaChange.OriginalFilesEntry
-	nil,                        // 49: tern.v1.ApplyRequest.OptionsEntry
-	nil,                        // 50: tern.v1.ApplyRequest.SchemaFilesEntry
-	nil,                        // 51: tern.v1.ProgressResponse.MetadataEntry
+	(*PlanDiffResponse)(nil),   // 19: tern.v1.PlanDiffResponse
+	(*ApplyRequest)(nil),       // 20: tern.v1.ApplyRequest
+	(*ApplyResponse)(nil),      // 21: tern.v1.ApplyResponse
+	(*ProgressRequest)(nil),    // 22: tern.v1.ProgressRequest
+	(*ShardProgress)(nil),      // 23: tern.v1.ShardProgress
+	(*TableProgress)(nil),      // 24: tern.v1.TableProgress
+	(*ProgressResponse)(nil),   // 25: tern.v1.ProgressResponse
+	(*CutoverRequest)(nil),     // 26: tern.v1.CutoverRequest
+	(*CutoverResponse)(nil),    // 27: tern.v1.CutoverResponse
+	(*RevertRequest)(nil),      // 28: tern.v1.RevertRequest
+	(*RevertResponse)(nil),     // 29: tern.v1.RevertResponse
+	(*SkipRevertRequest)(nil),  // 30: tern.v1.SkipRevertRequest
+	(*SkipRevertResponse)(nil), // 31: tern.v1.SkipRevertResponse
+	(*HealthRequest)(nil),      // 32: tern.v1.HealthRequest
+	(*HealthResponse)(nil),     // 33: tern.v1.HealthResponse
+	(*StopRequest)(nil),        // 34: tern.v1.StopRequest
+	(*StopResponse)(nil),       // 35: tern.v1.StopResponse
+	(*CancelRequest)(nil),      // 36: tern.v1.CancelRequest
+	(*CancelResponse)(nil),     // 37: tern.v1.CancelResponse
+	(*StartRequest)(nil),       // 38: tern.v1.StartRequest
+	(*StartResponse)(nil),      // 39: tern.v1.StartResponse
+	(*VolumeRequest)(nil),      // 40: tern.v1.VolumeRequest
+	(*VolumeResponse)(nil),     // 41: tern.v1.VolumeResponse
+	nil,                        // 42: tern.v1.SchemaFiles.FilesEntry
+	nil,                        // 43: tern.v1.PulledNamespace.TablesEntry
+	nil,                        // 44: tern.v1.PulledNamespace.ArtifactsEntry
+	nil,                        // 45: tern.v1.PulledNamespace.TableCatalogEntry
+	nil,                        // 46: tern.v1.PullSchemaResponse.NamespacesEntry
+	nil,                        // 47: tern.v1.PlanRequest.SchemaFilesEntry
+	nil,                        // 48: tern.v1.SchemaChange.MetadataEntry
+	nil,                        // 49: tern.v1.SchemaChange.OriginalFilesEntry
+	nil,                        // 50: tern.v1.ApplyRequest.OptionsEntry
+	nil,                        // 51: tern.v1.ApplyRequest.SchemaFilesEntry
+	nil,                        // 52: tern.v1.ProgressResponse.MetadataEntry
 }
 var file_tern_proto_depIdxs = []int32{
-	41, // 0: tern.v1.SchemaFiles.files:type_name -> tern.v1.SchemaFiles.FilesEntry
+	42, // 0: tern.v1.SchemaFiles.files:type_name -> tern.v1.SchemaFiles.FilesEntry
 	3,  // 1: tern.v1.PullSchemaRequest.catalog_detail:type_name -> tern.v1.PullCatalogDetail
-	42, // 2: tern.v1.PulledNamespace.tables:type_name -> tern.v1.PulledNamespace.TablesEntry
-	43, // 3: tern.v1.PulledNamespace.artifacts:type_name -> tern.v1.PulledNamespace.ArtifactsEntry
+	43, // 2: tern.v1.PulledNamespace.tables:type_name -> tern.v1.PulledNamespace.TablesEntry
+	44, // 3: tern.v1.PulledNamespace.artifacts:type_name -> tern.v1.PulledNamespace.ArtifactsEntry
 	7,  // 4: tern.v1.PulledNamespace.namespace_catalog:type_name -> tern.v1.NamespaceCatalog
-	44, // 5: tern.v1.PulledNamespace.table_catalog:type_name -> tern.v1.PulledNamespace.TableCatalogEntry
+	45, // 5: tern.v1.PulledNamespace.table_catalog:type_name -> tern.v1.PulledNamespace.TableCatalogEntry
 	9,  // 6: tern.v1.TableCatalog.columns:type_name -> tern.v1.ColumnCatalog
 	10, // 7: tern.v1.TableCatalog.indexes:type_name -> tern.v1.IndexCatalog
 	11, // 8: tern.v1.TableCatalog.foreign_keys:type_name -> tern.v1.ForeignKeyCatalog
-	45, // 9: tern.v1.PullSchemaResponse.namespaces:type_name -> tern.v1.PullSchemaResponse.NamespacesEntry
-	46, // 10: tern.v1.PlanRequest.schema_files:type_name -> tern.v1.PlanRequest.SchemaFilesEntry
+	46, // 9: tern.v1.PullSchemaResponse.namespaces:type_name -> tern.v1.PullSchemaResponse.NamespacesEntry
+	47, // 10: tern.v1.PlanRequest.schema_files:type_name -> tern.v1.PlanRequest.SchemaFilesEntry
 	2,  // 11: tern.v1.TableChange.change_type:type_name -> tern.v1.ChangeType
 	14, // 12: tern.v1.SchemaChange.table_changes:type_name -> tern.v1.TableChange
-	47, // 13: tern.v1.SchemaChange.metadata:type_name -> tern.v1.SchemaChange.MetadataEntry
-	48, // 14: tern.v1.SchemaChange.original_files:type_name -> tern.v1.SchemaChange.OriginalFilesEntry
+	48, // 13: tern.v1.SchemaChange.metadata:type_name -> tern.v1.SchemaChange.MetadataEntry
+	49, // 14: tern.v1.SchemaChange.original_files:type_name -> tern.v1.SchemaChange.OriginalFilesEntry
 	14, // 15: tern.v1.ShardPlan.changes:type_name -> tern.v1.TableChange
 	0,  // 16: tern.v1.PlanResponse.engine:type_name -> tern.v1.Engine
 	15, // 17: tern.v1.PlanResponse.changes:type_name -> tern.v1.SchemaChange
 	16, // 18: tern.v1.PlanResponse.lint_violations:type_name -> tern.v1.LintViolation
 	17, // 19: tern.v1.PlanResponse.shards:type_name -> tern.v1.ShardPlan
-	49, // 20: tern.v1.ApplyRequest.options:type_name -> tern.v1.ApplyRequest.OptionsEntry
-	50, // 21: tern.v1.ApplyRequest.schema_files:type_name -> tern.v1.ApplyRequest.SchemaFilesEntry
-	14, // 22: tern.v1.ApplyRequest.ddl_changes:type_name -> tern.v1.TableChange
-	22, // 23: tern.v1.TableProgress.shards:type_name -> tern.v1.ShardProgress
-	2,  // 24: tern.v1.TableProgress.change_type:type_name -> tern.v1.ChangeType
-	1,  // 25: tern.v1.ProgressResponse.state:type_name -> tern.v1.State
-	0,  // 26: tern.v1.ProgressResponse.engine:type_name -> tern.v1.Engine
-	23, // 27: tern.v1.ProgressResponse.tables:type_name -> tern.v1.TableProgress
-	51, // 28: tern.v1.ProgressResponse.metadata:type_name -> tern.v1.ProgressResponse.MetadataEntry
-	8,  // 29: tern.v1.PulledNamespace.TableCatalogEntry.value:type_name -> tern.v1.TableCatalog
-	6,  // 30: tern.v1.PullSchemaResponse.NamespacesEntry.value:type_name -> tern.v1.PulledNamespace
-	4,  // 31: tern.v1.PlanRequest.SchemaFilesEntry.value:type_name -> tern.v1.SchemaFiles
-	4,  // 32: tern.v1.ApplyRequest.SchemaFilesEntry.value:type_name -> tern.v1.SchemaFiles
-	5,  // 33: tern.v1.Tern.PullSchema:input_type -> tern.v1.PullSchemaRequest
-	13, // 34: tern.v1.Tern.Plan:input_type -> tern.v1.PlanRequest
-	19, // 35: tern.v1.Tern.Apply:input_type -> tern.v1.ApplyRequest
-	21, // 36: tern.v1.Tern.Progress:input_type -> tern.v1.ProgressRequest
-	25, // 37: tern.v1.Tern.Cutover:input_type -> tern.v1.CutoverRequest
-	27, // 38: tern.v1.Tern.Revert:input_type -> tern.v1.RevertRequest
-	29, // 39: tern.v1.Tern.SkipRevert:input_type -> tern.v1.SkipRevertRequest
-	31, // 40: tern.v1.Tern.Health:input_type -> tern.v1.HealthRequest
-	33, // 41: tern.v1.Tern.Stop:input_type -> tern.v1.StopRequest
-	35, // 42: tern.v1.Tern.Cancel:input_type -> tern.v1.CancelRequest
-	37, // 43: tern.v1.Tern.Start:input_type -> tern.v1.StartRequest
-	39, // 44: tern.v1.Tern.Volume:input_type -> tern.v1.VolumeRequest
-	12, // 45: tern.v1.Tern.PullSchema:output_type -> tern.v1.PullSchemaResponse
-	18, // 46: tern.v1.Tern.Plan:output_type -> tern.v1.PlanResponse
-	20, // 47: tern.v1.Tern.Apply:output_type -> tern.v1.ApplyResponse
-	24, // 48: tern.v1.Tern.Progress:output_type -> tern.v1.ProgressResponse
-	26, // 49: tern.v1.Tern.Cutover:output_type -> tern.v1.CutoverResponse
-	28, // 50: tern.v1.Tern.Revert:output_type -> tern.v1.RevertResponse
-	30, // 51: tern.v1.Tern.SkipRevert:output_type -> tern.v1.SkipRevertResponse
-	32, // 52: tern.v1.Tern.Health:output_type -> tern.v1.HealthResponse
-	34, // 53: tern.v1.Tern.Stop:output_type -> tern.v1.StopResponse
-	36, // 54: tern.v1.Tern.Cancel:output_type -> tern.v1.CancelResponse
-	38, // 55: tern.v1.Tern.Start:output_type -> tern.v1.StartResponse
-	40, // 56: tern.v1.Tern.Volume:output_type -> tern.v1.VolumeResponse
-	45, // [45:57] is the sub-list for method output_type
-	33, // [33:45] is the sub-list for method input_type
-	33, // [33:33] is the sub-list for extension type_name
-	33, // [33:33] is the sub-list for extension extendee
-	0,  // [0:33] is the sub-list for field type_name
+	0,  // 20: tern.v1.PlanDiffResponse.engine:type_name -> tern.v1.Engine
+	15, // 21: tern.v1.PlanDiffResponse.changes:type_name -> tern.v1.SchemaChange
+	16, // 22: tern.v1.PlanDiffResponse.lint_violations:type_name -> tern.v1.LintViolation
+	17, // 23: tern.v1.PlanDiffResponse.shards:type_name -> tern.v1.ShardPlan
+	50, // 24: tern.v1.ApplyRequest.options:type_name -> tern.v1.ApplyRequest.OptionsEntry
+	51, // 25: tern.v1.ApplyRequest.schema_files:type_name -> tern.v1.ApplyRequest.SchemaFilesEntry
+	14, // 26: tern.v1.ApplyRequest.ddl_changes:type_name -> tern.v1.TableChange
+	23, // 27: tern.v1.TableProgress.shards:type_name -> tern.v1.ShardProgress
+	2,  // 28: tern.v1.TableProgress.change_type:type_name -> tern.v1.ChangeType
+	1,  // 29: tern.v1.ProgressResponse.state:type_name -> tern.v1.State
+	0,  // 30: tern.v1.ProgressResponse.engine:type_name -> tern.v1.Engine
+	24, // 31: tern.v1.ProgressResponse.tables:type_name -> tern.v1.TableProgress
+	52, // 32: tern.v1.ProgressResponse.metadata:type_name -> tern.v1.ProgressResponse.MetadataEntry
+	8,  // 33: tern.v1.PulledNamespace.TableCatalogEntry.value:type_name -> tern.v1.TableCatalog
+	6,  // 34: tern.v1.PullSchemaResponse.NamespacesEntry.value:type_name -> tern.v1.PulledNamespace
+	4,  // 35: tern.v1.PlanRequest.SchemaFilesEntry.value:type_name -> tern.v1.SchemaFiles
+	4,  // 36: tern.v1.ApplyRequest.SchemaFilesEntry.value:type_name -> tern.v1.SchemaFiles
+	5,  // 37: tern.v1.Tern.PullSchema:input_type -> tern.v1.PullSchemaRequest
+	13, // 38: tern.v1.Tern.Plan:input_type -> tern.v1.PlanRequest
+	13, // 39: tern.v1.Tern.PlanDiff:input_type -> tern.v1.PlanRequest
+	20, // 40: tern.v1.Tern.Apply:input_type -> tern.v1.ApplyRequest
+	22, // 41: tern.v1.Tern.Progress:input_type -> tern.v1.ProgressRequest
+	26, // 42: tern.v1.Tern.Cutover:input_type -> tern.v1.CutoverRequest
+	28, // 43: tern.v1.Tern.Revert:input_type -> tern.v1.RevertRequest
+	30, // 44: tern.v1.Tern.SkipRevert:input_type -> tern.v1.SkipRevertRequest
+	32, // 45: tern.v1.Tern.Health:input_type -> tern.v1.HealthRequest
+	34, // 46: tern.v1.Tern.Stop:input_type -> tern.v1.StopRequest
+	36, // 47: tern.v1.Tern.Cancel:input_type -> tern.v1.CancelRequest
+	38, // 48: tern.v1.Tern.Start:input_type -> tern.v1.StartRequest
+	40, // 49: tern.v1.Tern.Volume:input_type -> tern.v1.VolumeRequest
+	12, // 50: tern.v1.Tern.PullSchema:output_type -> tern.v1.PullSchemaResponse
+	18, // 51: tern.v1.Tern.Plan:output_type -> tern.v1.PlanResponse
+	19, // 52: tern.v1.Tern.PlanDiff:output_type -> tern.v1.PlanDiffResponse
+	21, // 53: tern.v1.Tern.Apply:output_type -> tern.v1.ApplyResponse
+	25, // 54: tern.v1.Tern.Progress:output_type -> tern.v1.ProgressResponse
+	27, // 55: tern.v1.Tern.Cutover:output_type -> tern.v1.CutoverResponse
+	29, // 56: tern.v1.Tern.Revert:output_type -> tern.v1.RevertResponse
+	31, // 57: tern.v1.Tern.SkipRevert:output_type -> tern.v1.SkipRevertResponse
+	33, // 58: tern.v1.Tern.Health:output_type -> tern.v1.HealthResponse
+	35, // 59: tern.v1.Tern.Stop:output_type -> tern.v1.StopResponse
+	37, // 60: tern.v1.Tern.Cancel:output_type -> tern.v1.CancelResponse
+	39, // 61: tern.v1.Tern.Start:output_type -> tern.v1.StartResponse
+	41, // 62: tern.v1.Tern.Volume:output_type -> tern.v1.VolumeResponse
+	50, // [50:63] is the sub-list for method output_type
+	37, // [37:50] is the sub-list for method input_type
+	37, // [37:37] is the sub-list for extension type_name
+	37, // [37:37] is the sub-list for extension extendee
+	0,  // [0:37] is the sub-list for field type_name
 }
 
 func init() { file_tern_proto_init() }
@@ -3564,7 +3660,7 @@ func file_tern_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_tern_proto_rawDesc), len(file_tern_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   48,
+			NumMessages:   49,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/proto/ternv1/tern.pb.gw.go
+++ b/pkg/proto/ternv1/tern.pb.gw.go
@@ -89,6 +89,33 @@ func local_request_Tern_Plan_0(ctx context.Context, marshaler runtime.Marshaler,
 	return msg, metadata, err
 }
 
+func request_Tern_PlanDiff_0(ctx context.Context, marshaler runtime.Marshaler, client TernClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq PlanRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.PlanDiff(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_Tern_PlanDiff_0(ctx context.Context, marshaler runtime.Marshaler, server TernServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq PlanRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.PlanDiff(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_Tern_Apply_0(ctx context.Context, marshaler runtime.Marshaler, client TernClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq ApplyRequest
@@ -399,6 +426,26 @@ func RegisterTernHandlerServer(ctx context.Context, mux *runtime.ServeMux, serve
 		}
 		forward_Tern_Plan_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_Tern_PlanDiff_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/tern.v1.Tern/PlanDiff", runtime.WithHTTPPathPattern("/v1/plan-diff"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Tern_PlanDiff_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_Tern_PlanDiff_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_Tern_Apply_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -673,6 +720,23 @@ func RegisterTernHandlerClient(ctx context.Context, mux *runtime.ServeMux, clien
 		}
 		forward_Tern_Plan_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_Tern_PlanDiff_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/tern.v1.Tern/PlanDiff", runtime.WithHTTPPathPattern("/v1/plan-diff"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Tern_PlanDiff_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_Tern_PlanDiff_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_Tern_Apply_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -849,6 +913,7 @@ func RegisterTernHandlerClient(ctx context.Context, mux *runtime.ServeMux, clien
 var (
 	pattern_Tern_PullSchema_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "pull-schema"}, ""))
 	pattern_Tern_Plan_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "plan"}, ""))
+	pattern_Tern_PlanDiff_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "plan-diff"}, ""))
 	pattern_Tern_Apply_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "apply"}, ""))
 	pattern_Tern_Progress_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "progress"}, ""))
 	pattern_Tern_Cutover_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "cutover"}, ""))
@@ -864,6 +929,7 @@ var (
 var (
 	forward_Tern_PullSchema_0 = runtime.ForwardResponseMessage
 	forward_Tern_Plan_0       = runtime.ForwardResponseMessage
+	forward_Tern_PlanDiff_0   = runtime.ForwardResponseMessage
 	forward_Tern_Apply_0      = runtime.ForwardResponseMessage
 	forward_Tern_Progress_0   = runtime.ForwardResponseMessage
 	forward_Tern_Cutover_0    = runtime.ForwardResponseMessage

--- a/pkg/proto/ternv1/tern_grpc.pb.go
+++ b/pkg/proto/ternv1/tern_grpc.pb.go
@@ -21,6 +21,7 @@ const _ = grpc.SupportPackageIsVersion9
 const (
 	Tern_PullSchema_FullMethodName = "/tern.v1.Tern/PullSchema"
 	Tern_Plan_FullMethodName       = "/tern.v1.Tern/Plan"
+	Tern_PlanDiff_FullMethodName   = "/tern.v1.Tern/PlanDiff"
 	Tern_Apply_FullMethodName      = "/tern.v1.Tern/Apply"
 	Tern_Progress_FullMethodName   = "/tern.v1.Tern/Progress"
 	Tern_Cutover_FullMethodName    = "/tern.v1.Tern/Cutover"
@@ -76,6 +77,15 @@ type TernClient interface {
 	// Errors are returned in the response body (not as RPC errors) so the caller
 	// can display them to the user.
 	Plan(ctx context.Context, in *PlanRequest, opts ...grpc.CallOption) (*PlanResponse, error)
+	// PlanDiff computes a deployment's desired-vs-live diff without persisting a
+	// plan. It is the read-only producer for review-time drift detection: the
+	// control plane runs it against every deployment of a database and compares
+	// the results to surface a deployment that diverges from the reviewed plan.
+	//
+	// Unlike Plan, PlanDiff does not create a stored plan record and returns no
+	// plan_id — its result is intentionally not applyable. It is idempotent and
+	// safe to retry.
+	PlanDiff(ctx context.Context, in *PlanRequest, opts ...grpc.CallOption) (*PlanDiffResponse, error)
 	// Apply executes a previously generated plan. Returns immediately with an
 	// apply_id; execution happens asynchronously. Use Progress to track status.
 	//
@@ -198,6 +208,16 @@ func (c *ternClient) Plan(ctx context.Context, in *PlanRequest, opts ...grpc.Cal
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(PlanResponse)
 	err := c.cc.Invoke(ctx, Tern_Plan_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *ternClient) PlanDiff(ctx context.Context, in *PlanRequest, opts ...grpc.CallOption) (*PlanDiffResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(PlanDiffResponse)
+	err := c.cc.Invoke(ctx, Tern_PlanDiff_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -347,6 +367,15 @@ type TernServer interface {
 	// Errors are returned in the response body (not as RPC errors) so the caller
 	// can display them to the user.
 	Plan(context.Context, *PlanRequest) (*PlanResponse, error)
+	// PlanDiff computes a deployment's desired-vs-live diff without persisting a
+	// plan. It is the read-only producer for review-time drift detection: the
+	// control plane runs it against every deployment of a database and compares
+	// the results to surface a deployment that diverges from the reviewed plan.
+	//
+	// Unlike Plan, PlanDiff does not create a stored plan record and returns no
+	// plan_id — its result is intentionally not applyable. It is idempotent and
+	// safe to retry.
+	PlanDiff(context.Context, *PlanRequest) (*PlanDiffResponse, error)
 	// Apply executes a previously generated plan. Returns immediately with an
 	// apply_id; execution happens asynchronously. Use Progress to track status.
 	//
@@ -460,6 +489,9 @@ func (UnimplementedTernServer) PullSchema(context.Context, *PullSchemaRequest) (
 func (UnimplementedTernServer) Plan(context.Context, *PlanRequest) (*PlanResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Plan not implemented")
 }
+func (UnimplementedTernServer) PlanDiff(context.Context, *PlanRequest) (*PlanDiffResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method PlanDiff not implemented")
+}
 func (UnimplementedTernServer) Apply(context.Context, *ApplyRequest) (*ApplyResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Apply not implemented")
 }
@@ -542,6 +574,24 @@ func _Tern_Plan_Handler(srv interface{}, ctx context.Context, dec func(interface
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(TernServer).Plan(ctx, req.(*PlanRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Tern_PlanDiff_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PlanRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TernServer).PlanDiff(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Tern_PlanDiff_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TernServer).PlanDiff(ctx, req.(*PlanRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -740,6 +790,10 @@ var Tern_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Plan",
 			Handler:    _Tern_Plan_Handler,
+		},
+		{
+			MethodName: "PlanDiff",
+			Handler:    _Tern_PlanDiff_Handler,
 		},
 		{
 			MethodName: "Apply",

--- a/pkg/tern/client.go
+++ b/pkg/tern/client.go
@@ -43,6 +43,11 @@ type Client interface {
 	// Returns a plan_id that can be used with Apply.
 	Plan(ctx context.Context, req *ternv1.PlanRequest) (*ternv1.PlanResponse, error)
 
+	// PlanDiff computes a deployment's desired-vs-live diff without persisting a
+	// plan. Its result is not applyable (no plan_id); it is the read-only
+	// producer the control plane runs per deployment to detect review-time drift.
+	PlanDiff(ctx context.Context, req *ternv1.PlanRequest) (*ternv1.PlanDiffResponse, error)
+
 	// Apply executes a previously generated plan.
 	// Validates that the schema hasn't changed since Plan was called.
 	Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ternv1.ApplyResponse, error)

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -171,6 +171,7 @@ type Config struct {
 //   - PullSchema: read-only live schema fetch.
 //   - Plan: each attempt produces an independent plan record and only the
 //     returned plan ID is used, so a duplicate attempt is harmless.
+//   - PlanDiff: read-only desired-vs-live diff; persists nothing.
 //   - Progress and Health: read-only.
 //
 // State-changing RPCs (Apply, Cutover, Stop, Start, Volume, Revert,
@@ -182,6 +183,7 @@ const retryServiceConfig = `{
 		"name": [
 			{"service": "tern.v1.Tern", "method": "PullSchema"},
 			{"service": "tern.v1.Tern", "method": "Plan"},
+			{"service": "tern.v1.Tern", "method": "PlanDiff"},
 			{"service": "tern.v1.Tern", "method": "Progress"},
 			{"service": "tern.v1.Tern", "method": "Health"}
 		],
@@ -268,6 +270,10 @@ func (c *GRPCClient) Close() error {
 
 func (c *GRPCClient) Plan(ctx context.Context, req *ternv1.PlanRequest) (*ternv1.PlanResponse, error) {
 	return c.client.Plan(ctx, req)
+}
+
+func (c *GRPCClient) PlanDiff(ctx context.Context, req *ternv1.PlanRequest) (*ternv1.PlanDiffResponse, error) {
+	return c.client.PlanDiff(ctx, req)
 }
 
 func (c *GRPCClient) PullSchema(ctx context.Context, req *ternv1.PullSchemaRequest) (*ternv1.PullSchemaResponse, error) {

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -1269,6 +1269,9 @@ func (c *LocalClient) Plan(ctx context.Context, req *ternv1.PlanRequest) (*ternv
 // read-only producer the control plane runs per deployment to detect review-time
 // drift.
 func (c *LocalClient) PlanDiff(ctx context.Context, req *ternv1.PlanRequest) (*ternv1.PlanDiffResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("plan diff request is required")
+	}
 	if c.getEngine() == nil {
 		return nil, fmt.Errorf("no engine available for database type %q", c.config.Type)
 	}

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -1253,11 +1253,60 @@ func (c *LocalClient) Plan(ctx context.Context, req *ternv1.PlanRequest) (*ternv
 	}
 	plan.ID = planID
 
-	// Convert engine SchemaChanges to proto SchemaChanges. A sharded engine emits
-	// one SchemaChange per (namespace, shard); collapse them back to one proto
-	// SchemaChange per namespace (deduping repeated tables). Per-shard membership
-	// travels separately on PlanResponse.Shards below.
-	var changes []*ternv1.SchemaChange
+	changes, violations, protoShards := c.planResultToProtoChanges(result)
+	return &ternv1.PlanResponse{
+		PlanId:         result.PlanID,
+		Engine:         c.protoEngine(),
+		Changes:        changes,
+		LintViolations: violations,
+		Shards:         protoShards,
+	}, nil
+}
+
+// PlanDiff computes this deployment's desired-vs-live diff without persisting a
+// plan. It shares the engine planning and proto conversion with Plan but stops
+// before storage, so its result is not applyable (no plan_id). It is the
+// read-only producer the control plane runs per deployment to detect review-time
+// drift.
+func (c *LocalClient) PlanDiff(ctx context.Context, req *ternv1.PlanRequest) (*ternv1.PlanDiffResponse, error) {
+	if c.getEngine() == nil {
+		return nil, fmt.Errorf("no engine available for database type %q", c.config.Type)
+	}
+
+	schemaFiles, err := c.normalizeSchemaFiles(protoToSchemaFiles(req.SchemaFiles))
+	if err != nil {
+		return nil, err
+	}
+
+	planLogAttrs := []any{"database", c.config.Database}
+	planLogAttrs = append(planLogAttrs, dsnLogAttrs(c.config.TargetDSN)...)
+	planLogAttrs = append(planLogAttrs, "schema_file_count", len(schemaFiles))
+	c.logger.Info("LocalClient.PlanDiff: calling engine", planLogAttrs...)
+
+	result, err := c.planWithEngine(ctx, req, c.config.Database, schemaFiles)
+	if err != nil {
+		c.logger.Error("plan diff failed", "error", err, "database", c.config.Database)
+		return nil, err // Error already has clear prefix (SQL syntax/usage error)
+	}
+
+	changes, violations, protoShards := c.planResultToProtoChanges(result)
+	return &ternv1.PlanDiffResponse{
+		Engine:         c.protoEngine(),
+		Changes:        changes,
+		LintViolations: violations,
+		Shards:         protoShards,
+	}, nil
+}
+
+// planResultToProtoChanges converts an engine plan result into the proto pieces
+// Plan and PlanDiff both return: namespace-collapsed schema changes, lint
+// violations, and per-shard membership. It has no storage side effects, so both
+// the persisting Plan path and the non-persisting PlanDiff path produce
+// identical change sets for the same engine result. A sharded engine emits one
+// SchemaChange per (namespace, shard); the namespace view collapses them
+// (deduping repeated tables) while per-shard membership travels separately on
+// the response's Shards.
+func (c *LocalClient) planResultToProtoChanges(result *engine.PlanResult) (changes []*ternv1.SchemaChange, violations []*ternv1.LintViolation, shards []*ternv1.ShardPlan) {
 	protoByNS := make(map[string]*ternv1.SchemaChange)
 	protoTableSeen := make(map[string]map[string]bool)
 	for _, sc := range result.Changes {
@@ -1288,10 +1337,25 @@ func (c *LocalClient) Plan(ctx context.Context, req *ternv1.PlanRequest) (*ternv
 				Namespace:    ns,
 			})
 		}
+		// A SchemaChange with an empty shard targets the whole namespace
+		// (non-sharded engines) and contributes no shard rows.
+		if shardName := strings.TrimSpace(sc.Shard.Name); shardName != "" {
+			protoSP := &ternv1.ShardPlan{Shard: shardName, Namespace: ns}
+			for _, t := range sc.TableChanges {
+				protoSP.Changes = append(protoSP.Changes, &ternv1.TableChange{
+					Namespace:    ns,
+					TableName:    t.Table,
+					Ddl:          t.DDL,
+					ChangeType:   changeTypeToProto(t.Operation),
+					IsUnsafe:     t.IsUnsafe,
+					UnsafeReason: t.UnsafeReason,
+				})
+			}
+			shards = append(shards, protoSP)
+		}
 	}
 
-	// Convert lint violations to proto
-	violations := make([]*ternv1.LintViolation, len(result.LintViolations))
+	violations = make([]*ternv1.LintViolation, len(result.LintViolations))
 	for i, w := range result.LintViolations {
 		violations[i] = &ternv1.LintViolation{
 			Table:    w.Table,
@@ -1302,36 +1366,7 @@ func (c *LocalClient) Plan(ctx context.Context, req *ternv1.PlanRequest) (*ternv
 		}
 	}
 
-	// Surface per-shard plan metadata on the response too, for parity with the
-	// gRPC path: callers of Plan can display per-shard drift/membership, and the
-	// control plane rebuilds per-shard operation groups from each shard's own
-	// changes.
-	var protoShards []*ternv1.ShardPlan
-	for _, sp := range allShardPlans {
-		protoSP := &ternv1.ShardPlan{
-			Shard:     sp.Shard,
-			Namespace: sp.Namespace,
-		}
-		for _, ch := range sp.Changes {
-			protoSP.Changes = append(protoSP.Changes, &ternv1.TableChange{
-				Namespace:    ch.Namespace,
-				TableName:    ch.Table,
-				Ddl:          ch.DDL,
-				ChangeType:   ddlActionToProtoChangeType(ch.Operation),
-				IsUnsafe:     ch.IsUnsafe,
-				UnsafeReason: ch.UnsafeReason,
-			})
-		}
-		protoShards = append(protoShards, protoSP)
-	}
-
-	return &ternv1.PlanResponse{
-		PlanId:         result.PlanID,
-		Engine:         c.protoEngine(),
-		Changes:        changes,
-		LintViolations: violations,
-		Shards:         protoShards,
-	}, nil
+	return changes, violations, shards
 }
 
 func (c *LocalClient) planWithEngine(ctx context.Context, req *ternv1.PlanRequest, database string, schemaFiles schema.SchemaFiles) (*engine.PlanResult, error) {

--- a/pkg/tern/local_plan_diff_test.go
+++ b/pkg/tern/local_plan_diff_test.go
@@ -1,0 +1,120 @@
+package tern
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/block/schemabot/pkg/engine"
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/spirit/pkg/statement"
+)
+
+// PlanDiff is the read-only producer for review-time drift detection: it must
+// return the deployment's desired-vs-live changes without persisting a plan and
+// without a plan_id, so its result can never be mistaken for an applyable plan.
+func TestPlanDiff_ReturnsChangesWithoutPersisting(t *testing.T) {
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }}
+	c := newPlanMaterializeClientWithPlan(store, alterUsersEmailPlan())
+
+	resp, err := c.PlanDiff(t.Context(), &ternv1.PlanRequest{Database: "testapp"})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	assert.Nil(t, store.created, "PlanDiff must not persist a plan")
+	require.Len(t, resp.Changes, 1)
+	assert.Equal(t, "testapp", resp.Changes[0].Namespace)
+	require.Len(t, resp.Changes[0].TableChanges, 1)
+	tc := resp.Changes[0].TableChanges[0]
+	assert.Equal(t, "users", tc.TableName)
+	assert.Equal(t, ternv1.ChangeType_CHANGE_TYPE_ALTER, tc.ChangeType)
+	assert.Equal(t, "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", tc.Ddl)
+}
+
+// A sharded engine emits one change per shard; PlanDiff must surface per-shard
+// membership so the rollup can compare shard-scoped drift.
+func TestPlanDiff_SurfacesPerShardMembership(t *testing.T) {
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }}
+	c := newPlanMaterializeClientWithPlan(store, shardedAlterPlan())
+
+	resp, err := c.PlanDiff(t.Context(), &ternv1.PlanRequest{Database: "testapp"})
+	require.NoError(t, err)
+
+	assert.Nil(t, store.created)
+	require.Len(t, resp.Shards, 2)
+	byShard := map[string]*ternv1.ShardPlan{}
+	for _, sp := range resp.Shards {
+		byShard[sp.Shard] = sp
+	}
+	require.Contains(t, byShard, "-80")
+	require.Contains(t, byShard, "80-")
+	require.Len(t, byShard["-80"].Changes, 1)
+	assert.Equal(t, "ALTER TABLE `users` ADD INDEX (`created_at`)", byShard["-80"].Changes[0].Ddl)
+	assert.Equal(t, "ALTER TABLE `users` ADD INDEX (`updated_at`)", byShard["80-"].Changes[0].Ddl)
+}
+
+// The rollup's primary member comes from Plan and its non-primary members from
+// PlanDiff, so both must convert an identical engine result into identical
+// change sets — otherwise a deployment that matches the reviewed plan could read
+// as drifted purely from a conversion difference.
+func TestPlanDiff_MatchesPlanConversion(t *testing.T) {
+	for name, result := range map[string]*engine.PlanResult{
+		"non-sharded": alterUsersEmailPlan(),
+		"sharded":     shardedAlterPlan(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			store := &fakePlanStore{
+				getFn:    func(string) (*storage.Plan, error) { return nil, nil },
+				createID: 1,
+			}
+			c := newPlanMaterializeClientWithPlan(store, result)
+
+			planResp, err := c.Plan(t.Context(), &ternv1.PlanRequest{Database: "testapp"})
+			require.NoError(t, err)
+			diffResp, err := c.PlanDiff(t.Context(), &ternv1.PlanRequest{Database: "testapp"})
+			require.NoError(t, err)
+
+			assert.Equal(t, planResp.Engine, diffResp.Engine)
+			require.Len(t, diffResp.Changes, len(planResp.Changes))
+			for i := range planResp.Changes {
+				assert.True(t, proto.Equal(planResp.Changes[i], diffResp.Changes[i]),
+					"change %d differs between Plan and PlanDiff", i)
+			}
+			require.Len(t, diffResp.Shards, len(planResp.Shards))
+			for i := range planResp.Shards {
+				assert.True(t, proto.Equal(planResp.Shards[i], diffResp.Shards[i]),
+					"shard %d differs between Plan and PlanDiff", i)
+			}
+		})
+	}
+}
+
+// shardedAlterPlan is a two-shard re-plan where each shard carries its own DDL,
+// exercising per-shard membership conversion.
+func shardedAlterPlan() *engine.PlanResult {
+	return &engine.PlanResult{
+		Changes: []engine.SchemaChange{
+			{
+				Namespace: "testapp",
+				Shard:     engine.Shard{Name: "-80"},
+				TableChanges: []engine.TableChange{{
+					Table:     "users",
+					Operation: statement.StatementAlterTable,
+					DDL:       "ALTER TABLE `users` ADD INDEX (`created_at`)",
+				}},
+			},
+			{
+				Namespace: "testapp",
+				Shard:     engine.Shard{Name: "80-"},
+				TableChanges: []engine.TableChange{{
+					Table:     "users",
+					Operation: statement.StatementAlterTable,
+					DDL:       "ALTER TABLE `users` ADD INDEX (`updated_at`)",
+				}},
+			},
+		},
+	}
+}

--- a/pkg/tern/local_plan_materialize_test.go
+++ b/pkg/tern/local_plan_materialize_test.go
@@ -62,6 +62,8 @@ func (e fakePlanEngine) Plan(ctx context.Context, req *engine.PlanRequest) (*eng
 	return e.planFn(ctx, req)
 }
 
+func (e fakePlanEngine) Name() string { return "spirit" }
+
 // newPlanMaterializeClientWithPlan returns a materialize client whose drift
 // guard recomputes the given plan result against "live" schema. The DB-bearing
 // TargetDSN keeps planWithEngine on the single-namespace path.

--- a/pkg/tern/routing_client.go
+++ b/pkg/tern/routing_client.go
@@ -128,6 +128,26 @@ func (c *RoutingClient) Plan(ctx context.Context, req *ternv1.PlanRequest) (*ter
 	return client.Plan(ctx, routedReq)
 }
 
+// PlanDiff routes a non-persisting desired-vs-live diff to the request's single
+// execution target, mirroring Plan's routing.
+func (c *RoutingClient) PlanDiff(ctx context.Context, req *ternv1.PlanRequest) (*ternv1.PlanDiffResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("plan diff request is required")
+	}
+	target, err := c.resolveSingleExecutionTarget(ctx, req.Database, req.Environment)
+	if err != nil {
+		return nil, err
+	}
+	client, err := c.clientForDeployment(ctx, target.Deployment, req.Environment)
+	if err != nil {
+		return nil, fmt.Errorf("get client for deployment %q environment %q: %w", target.Deployment, req.Environment, err)
+	}
+	routedReq := proto.Clone(req).(*ternv1.PlanRequest)
+	routedReq.Type = target.DatabaseType
+	routedReq.Target = target.Target
+	return client.PlanDiff(ctx, routedReq)
+}
+
 // Apply executes a stored plan on its plan-time execution target.
 func (c *RoutingClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ternv1.ApplyResponse, error) {
 	if req == nil {

--- a/pkg/tern/routing_client_test.go
+++ b/pkg/tern/routing_client_test.go
@@ -53,6 +53,7 @@ type routingRecordingClient struct {
 
 	pullSchemaReq            *ternv1.PullSchemaRequest
 	planReq                  *ternv1.PlanRequest
+	planDiffReq              *ternv1.PlanRequest
 	applyReq                 *ternv1.ApplyRequest
 	applyErr                 error
 	progressReq              *ternv1.ProgressRequest
@@ -73,6 +74,11 @@ func (c *routingRecordingClient) PullSchema(_ context.Context, req *ternv1.PullS
 func (c *routingRecordingClient) Plan(_ context.Context, req *ternv1.PlanRequest) (*ternv1.PlanResponse, error) {
 	c.planReq = req
 	return &ternv1.PlanResponse{PlanId: "plan-routed"}, nil
+}
+
+func (c *routingRecordingClient) PlanDiff(_ context.Context, req *ternv1.PlanRequest) (*ternv1.PlanDiffResponse, error) {
+	c.planDiffReq = req
+	return &ternv1.PlanDiffResponse{Engine: ternv1.Engine_ENGINE_SPIRIT}, nil
 }
 
 func (c *routingRecordingClient) Apply(_ context.Context, req *ternv1.ApplyRequest) (*ternv1.ApplyResponse, error) {
@@ -235,6 +241,40 @@ func TestRoutingClientPlanResolvesSingleExecutionTarget(t *testing.T) {
 	assert.Equal(t, "staging", clients["east/staging"].planReq.Environment)
 	assert.Equal(t, storage.DatabaseTypeMySQL, clients["east/staging"].planReq.Type)
 	assert.Equal(t, "target-123", clients["east/staging"].planReq.Target)
+}
+
+func TestRoutingClientPlanDiffResolvesSingleExecutionTarget(t *testing.T) {
+	clients := map[string]*routingRecordingClient{
+		"east/staging": {},
+	}
+	routingClient := newTestRoutingClient(t, RoutingClientConfig{
+		Resolver: routingResolverFunc(func(_ context.Context, req routing.Request) ([]routing.ExecutionTarget, error) {
+			assert.Equal(t, routing.Request{Database: "logical-db", Environment: "staging"}, req)
+			return []routing.ExecutionTarget{{
+				DatabaseType: storage.DatabaseTypeMySQL,
+				Deployment:   "east",
+				Target:       "target-123",
+			}}, nil
+		}),
+		PlanLookup:          routingPlanLookup{},
+		ApplyLookup:         routingApplyLookup{},
+		ClientForDeployment: testDeploymentClientFunc(clients),
+	})
+
+	resp, err := routingClient.PlanDiff(t.Context(), &ternv1.PlanRequest{
+		Database:    "logical-db",
+		Environment: "staging",
+		Type:        storage.DatabaseTypeVitess,
+		Target:      "caller-supplied-target",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, ternv1.Engine_ENGINE_SPIRIT, resp.Engine)
+	require.NotNil(t, clients["east/staging"].planDiffReq)
+	assert.Equal(t, "logical-db", clients["east/staging"].planDiffReq.Database)
+	assert.Equal(t, "staging", clients["east/staging"].planDiffReq.Environment)
+	assert.Equal(t, storage.DatabaseTypeMySQL, clients["east/staging"].planDiffReq.Type)
+	assert.Equal(t, "target-123", clients["east/staging"].planDiffReq.Target)
 }
 
 func TestRoutingClientPlanRejectsMultiTargetRoute(t *testing.T) {

--- a/pkg/tern/server.go
+++ b/pkg/tern/server.go
@@ -67,6 +67,14 @@ func (s *Server) Plan(ctx context.Context, req *ternv1.PlanRequest) (*ternv1.Pla
 	return resp, nil
 }
 
+func (s *Server) PlanDiff(ctx context.Context, req *ternv1.PlanRequest) (*ternv1.PlanDiffResponse, error) {
+	resp, err := s.client.PlanDiff(ctx, req)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	return resp, nil
+}
+
 func (s *Server) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ternv1.ApplyResponse, error) {
 	resp, err := s.client.Apply(ctx, req)
 	if err != nil {

--- a/pkg/tern/target_router.go
+++ b/pkg/tern/target_router.go
@@ -117,6 +117,23 @@ func (r *TargetRouter) Plan(ctx context.Context, req *ternv1.PlanRequest) (*tern
 	return client.Plan(ctx, routedReq)
 }
 
+// PlanDiff routes a non-persisting desired-vs-live diff to the resolved target,
+// mirroring Plan's routing.
+func (r *TargetRouter) PlanDiff(ctx context.Context, req *ternv1.PlanRequest) (*ternv1.PlanDiffResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("plan diff request is required")
+	}
+	client, resolved, err := r.clientForTarget(ctx, targetOrDatabase(req.Target, req.Database), req.Type, req.Environment, req.Database)
+	if err != nil {
+		return nil, err
+	}
+	routedReq := proto.Clone(req).(*ternv1.PlanRequest)
+	routedReq.Database = req.Database
+	routedReq.Type = resolved.DatabaseType
+	routedReq.Target = resolved.Target
+	return client.PlanDiff(ctx, routedReq)
+}
+
 // Apply starts a stored plan on the resolved target.
 func (r *TargetRouter) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ternv1.ApplyResponse, error) {
 	if req == nil {

--- a/pkg/tern/target_router_test.go
+++ b/pkg/tern/target_router_test.go
@@ -214,6 +214,29 @@ func TestTargetRouterRoutesPlanThroughStaticTarget(t *testing.T) {
 	assert.Len(t, created, 1, "the router should cache LocalClients by resolved target route and namespace")
 }
 
+func TestTargetRouterRoutesPlanDiffThroughStaticTarget(t *testing.T) {
+	resolver := newStaticResolver(t)
+	created := make(map[string]*targetRouterRecordingClient)
+	router := newTargetRouterForTest(t, resolver, nil, nil, created)
+
+	resp, err := router.PlanDiff(t.Context(), &ternv1.PlanRequest{
+		Database:    "orders-logical",
+		Type:        storage.DatabaseTypeMySQL,
+		Environment: "production",
+		Target:      "dsid-orders-prod",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, ternv1.Engine_ENGINE_PLANETSCALE, resp.Engine)
+	client := created["orders-logical"]
+	require.NotNil(t, client)
+	require.NotNil(t, client.planDiffReq)
+	assert.Equal(t, "orders-logical", client.planDiffReq.Database)
+	assert.Equal(t, storage.DatabaseTypeMySQL, client.planDiffReq.Type)
+	assert.Equal(t, "dsid-orders-prod", client.planDiffReq.Target)
+	assert.Equal(t, "root@tcp(localhost:3306)/", client.targetDSN)
+}
+
 func TestTargetRouterApplyUsesTargetScopedPendingObserver(t *testing.T) {
 	resolver := newStaticResolver(t)
 	created := make(map[string]*targetRouterRecordingClient)

--- a/pkg/tern/target_router_test.go
+++ b/pkg/tern/target_router_test.go
@@ -77,6 +77,7 @@ func (s targetRouterApplyStore) GetByApplyIdentifier(_ context.Context, applyIde
 type targetRouterRecordingClient struct {
 	pullReq            *ternv1.PullSchemaRequest
 	planReq            *ternv1.PlanRequest
+	planDiffReq        *ternv1.PlanRequest
 	applyReq           *ternv1.ApplyRequest
 	progressReq        *ternv1.ProgressRequest
 	resumeApply        *storage.Apply
@@ -95,6 +96,11 @@ func (c *targetRouterRecordingClient) PullSchema(_ context.Context, req *ternv1.
 func (c *targetRouterRecordingClient) Plan(_ context.Context, req *ternv1.PlanRequest) (*ternv1.PlanResponse, error) {
 	c.planReq = req
 	return &ternv1.PlanResponse{PlanId: "plan-routed"}, nil
+}
+
+func (c *targetRouterRecordingClient) PlanDiff(_ context.Context, req *ternv1.PlanRequest) (*ternv1.PlanDiffResponse, error) {
+	c.planDiffReq = req
+	return &ternv1.PlanDiffResponse{Engine: ternv1.Engine_ENGINE_PLANETSCALE}, nil
 }
 
 func (c *targetRouterRecordingClient) Apply(_ context.Context, req *ternv1.ApplyRequest) (*ternv1.ApplyResponse, error) {


### PR DESCRIPTION
## Summary
At review time only the primary deployment plans desired-vs-live, so drift on non-primary deployments stays invisible until apply. This adds the read-only producer that will let the control plane detect per-deployment drift at review time.

## What
- New `PlanDiff` RPC: computes a deployment's desired-vs-live diff and returns its change set, but persists no plan and returns no `plan_id` (result is intentionally not applyable). Read-only and idempotent, so it is retried like `Plan`/`PullSchema`.
- `LocalClient.PlanDiff` shares the engine planning and proto conversion with `Plan` (extracted `planResultToProtoChanges`) but stops before storage, so both produce identical change sets for the same result.
- Wired through the `Client` interface, gRPC client/server, and routers.
- `Service.PlanDeploymentDiffs`: runs one diff per configured deployment. The primary reuses the already-persisted reviewed plan (so the rollup compares against exactly what was reviewed); non-primaries run `PlanDiff` with bounded concurrency. Per-deployment failures are captured per result so one unreachable deployment neither hides the others nor aborts the rollup.

## Why
Moving drift detection to review time needs each deployment's own diff. Reusing `Plan` would persist N plans and hand out applyable `plan_id`s for diffs that must never be applied, so a distinct non-persisting RPC keeps the contract safe. The producer collects per-deployment errors rather than failing fast so a later rollup can fail closed on any error or missing deployment.

```diagram
review time
  Service.PlanDeploymentDiffs(req, reviewedPrimaryPlan)
    ├─ primary  ─► reuse reviewed plan (no re-read)
    ├─ us       ─► PlanDiff RPC ─► diff, no plan_id  ┐ bounded
    └─ au       ─► PlanDiff RPC ─► diff, no plan_id  ┘ concurrency
  one deployment error ⇒ captured in .Err (blocking later), never aborts
```

This is the producer only; the rollup, PR-preview rendering, and fail-closed check gate are follow-ups.
