### PR TITLE
feat(github): aggregate participants stay silent on non-schema PRs

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1032,6 +1032,7 @@ var knownStatusCheckOperations = map[string]bool{
 	"schema_config_source_policy":          true,
 	"schema_config_environment_validation": true,
 	"managed_dir_missing_config":           true,
+	"aggregate_participant_skip":           true,
 }
 
 var knownStatusCheckStatuses = map[string]bool{

--- a/pkg/webhook/aggregate_check_integration_test.go
+++ b/pkg/webhook/aggregate_check_integration_test.go
@@ -608,6 +608,81 @@ func TestE2EPassingAggregateOnNonSchemaPR(t *testing.T) {
 	assert.True(t, seen["SchemaBot (production)"], "expected SchemaBot (production) check")
 }
 
+// An aggregate participant does not own the required check on a repo — the
+// leader does. On a PR that touches none of its schema, a participant posts no
+// check run at all (rather than a passing "No managed schema changes" aggregate
+// that would add a per-tenant row near the merge button).
+func TestE2EParticipantSilentOnNonSchemaPR(t *testing.T) {
+	svc := setupE2EServiceWithConfig(t, &api.ServerConfig{
+		AllowedEnvironments: []string{"staging", "production"},
+		Repos: map[string]api.RepoConfig{
+			"octocat/hello-world": {Aggregate: &api.AggregateConfig{Role: api.AggregateRoleParticipant}},
+		},
+	})
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(gh.PullRequest{
+			Head: &gh.PullRequestBranch{Ref: new("feature-branch"), SHA: new("abc123")},
+			Base: &gh.PullRequestBranch{Ref: new("main"), SHA: new("def456")},
+			User: &gh.User{Login: new("testuser")},
+		})
+	})
+
+	// PR changed files — no schema files.
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]*gh.CommitFile{
+			{Filename: new("README.md"), Status: new("modified")},
+		})
+	})
+
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/abc123", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(gh.Tree{SHA: new("abc123"), Entries: []*gh.TreeEntry{}, Truncated: new(false)})
+	})
+
+	// Any check-run POST here is a failure — a participant must stay silent.
+	checkRuns := make(chan checkRunCapture, 10)
+	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		var body checkRunCapture
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		checkRuns <- body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	installClient := ghclient.NewInstallationClient(client, logger)
+	factory := &fakeClientFactory{client: installClient}
+
+	h := NewHandler(svc, factory, nil, logger)
+
+	req := buildPRWebhookRequest(t, prWebhookPayloadOpts{
+		action:  "opened",
+		headSHA: "abc123",
+		headRef: "feature-branch",
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "aggregate participant, staying silent")
+
+	// The skip is synchronous (it returns before scheduling any passing
+	// aggregate), so a brief drain confirms no check run was posted.
+	select {
+	case cr := <-checkRuns:
+		t.Fatalf("participant posted a check run on a non-schema PR: %q", cr.Name)
+	case <-time.After(2 * time.Second):
+	}
+}
+
 // TestE2ECheckRunRerequestReplansCurrentPR verifies that rerunning a SchemaBot
 // Check Run from GitHub reuses auto-plan discovery and republishes aggregate
 // check state for the current PR head.

--- a/pkg/webhook/aggregate_participant_test.go
+++ b/pkg/webhook/aggregate_participant_test.go
@@ -1,0 +1,47 @@
+package webhook
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/block/schemabot/pkg/api"
+)
+
+// A deployment configured as an aggregate participant for a repo stays silent on
+// PRs that touch none of its schema (the leader owns the required check), while
+// a leader or a sole SchemaBot with no aggregate config keeps posting its
+// passing aggregate so branch protection is never wedged.
+func TestIsAggregateParticipant(t *testing.T) {
+	cfg := &api.ServerConfig{
+		Repos: map[string]api.RepoConfig{
+			"octocat/shared-repo": {Aggregate: &api.AggregateConfig{
+				Role: api.AggregateRoleLeader,
+				ExpectedTenants: []api.ExpectedTenant{
+					{Tenant: "bb-block", Paths: []string{"kgoose/schema"}},
+				},
+			}},
+			"octocat/participant-repo": {Aggregate: &api.AggregateConfig{
+				Role: api.AggregateRoleParticipant,
+			}},
+			"octocat/plain-repo": {},
+		},
+	}
+	h := &Handler{service: api.New(nil, cfg, nil, testLogger())}
+
+	assert.True(t, h.isAggregateParticipant("octocat/participant-repo"),
+		"a participant stays silent on non-schema PRs")
+	assert.False(t, h.isAggregateParticipant("octocat/shared-repo"),
+		"the leader owns the required check and keeps posting")
+	assert.False(t, h.isAggregateParticipant("octocat/plain-repo"),
+		"a repo with no aggregate config is a sole deployment and keeps posting")
+	assert.False(t, h.isAggregateParticipant("octocat/unknown-repo"),
+		"an unconfigured repo keeps posting")
+}
+
+// The predicate tolerates a handler with no server config (returns false, so the
+// deployment keeps its existing posting behaviour rather than going silent).
+func TestIsAggregateParticipantNoConfig(t *testing.T) {
+	h := &Handler{service: api.New(nil, nil, nil, testLogger())}
+	assert.False(t, h.isAggregateParticipant("octocat/any-repo"))
+}

--- a/pkg/webhook/aggregate_participant_test.go
+++ b/pkg/webhook/aggregate_participant_test.go
@@ -18,7 +18,7 @@ func TestIsAggregateParticipant(t *testing.T) {
 			"octocat/shared-repo": {Aggregate: &api.AggregateConfig{
 				Role: api.AggregateRoleLeader,
 				ExpectedTenants: []api.ExpectedTenant{
-					{Tenant: "bb-block", Paths: []string{"kgoose/schema"}},
+					{Tenant: "tenant-b", Paths: []string{"tenant-b/schema"}},
 				},
 			}},
 			"octocat/participant-repo": {Aggregate: &api.AggregateConfig{

--- a/pkg/webhook/check_aggregate.go
+++ b/pkg/webhook/check_aggregate.go
@@ -30,6 +30,21 @@ func (h *Handler) serverConfig() (*api.ServerConfig, bool) {
 	return config, true
 }
 
+// isAggregateParticipant reports whether this deployment is configured as an
+// aggregate participant for repo — a repo where the aggregate leader owns the
+// single required check and this deployment's own check is informational. A
+// participant has nothing to publish on a PR that touches none of its schema,
+// so it stays silent there rather than adding a passing per-tenant row near the
+// merge button. A deployment that is the sole SchemaBot on a repo has no
+// aggregate config (role ""), so this returns false and it keeps posting.
+func (h *Handler) isAggregateParticipant(repo string) bool {
+	config, ok := h.serverConfig()
+	if !ok {
+		return false
+	}
+	return config.AggregateRoleForRepo(repo) == api.AggregateRoleParticipant
+}
+
 func (h *Handler) aggregateCheckNameForRepo(repo string) string {
 	config, ok := h.serverConfig()
 	if !ok {

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -187,6 +187,23 @@ func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.Install
 
 	if len(configs) == 0 {
 		h.logger.Info("no schema files in PR, skipping auto-plan", "repo", repo, "pr", pr, "head_sha", headSHA, "source", source)
+		// An aggregate participant does not own the required check for the repo —
+		// the leader does — so on a PR that touches none of this deployment's
+		// schema it has nothing to report and stays silent, rather than posting a
+		// passing check that only adds a per-tenant row near the merge button. The
+		// leader publishes the required check and gates on participants' own
+		// checks when they exist, so a silent participant cannot wedge branch
+		// protection (its check is non-required by the aggregate contract).
+		if h.isAggregateParticipant(repo) {
+			h.logger.Info("aggregate participant staying silent on PR with no managed schema changes",
+				"repo", repo, "pr", pr, "head_sha", headSHA, "source", source)
+			metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+				Operation:  "aggregate_participant_skip",
+				Repository: repo,
+				Status:     "skipped",
+			})
+			return "no schema files in PR (aggregate participant, staying silent)"
+		}
 		// Post passing aggregates on the current HEAD SHA so branch protection
 		// isn't blocked on PRs that don't touch schema files. Always post —
 		// on synchronize events the HEAD SHA changes, so the aggregate must be

--- a/pkg/webhook/webhook_integration_test.go
+++ b/pkg/webhook/webhook_integration_test.go
@@ -723,6 +723,14 @@ func e2eContainerName(base string) string {
 // posting without needing to plan).
 func setupE2EServiceWithAllowedEnvs(t *testing.T, allowedEnvs []string) *api.Service {
 	t.Helper()
+	return setupE2EServiceWithConfig(t, &api.ServerConfig{AllowedEnvironments: allowedEnvs})
+}
+
+// setupE2EServiceWithConfig builds an E2E service against the shared schemabot
+// test database using the given server config, so tests can exercise
+// repo-scoped behavior (e.g. aggregate roles) beyond just allowed environments.
+func setupE2EServiceWithConfig(t *testing.T, serverConfig *api.ServerConfig) *api.Service {
+	t.Helper()
 
 	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
 	require.NoError(t, err)
@@ -735,10 +743,6 @@ func setupE2EServiceWithAllowedEnvs(t *testing.T, allowedEnvs []string) *api.Ser
 		"DELETE FROM checks WHERE repository = 'octocat/hello-world' AND pull_request = 1")
 	_, _ = schemabotDB.ExecContext(t.Context(),
 		"DELETE FROM locks WHERE repository = 'octocat/hello-world' AND pull_request = 1")
-
-	serverConfig := &api.ServerConfig{
-		AllowedEnvironments: allowedEnvs,
-	}
 
 	svc := api.New(st, serverConfig, nil, slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})))
 	t.Cleanup(func() { _ = svc.Close() })


### PR DESCRIPTION
## Why

On a shared repo, several SchemaBot deployments can be installed at once. Today each posts a passing "No managed schema changes" check on every PR so branch protection isn't wedged — which means a PR touching no schema still shows a check row per deployment. That's noise.

## What

When this deployment is configured as an aggregate **participant** for a repo (`aggregate.role: participant`), the aggregate **leader** owns the single required check. So on a PR that touches none of this deployment's schema, the participant now stays silent instead of posting a passing aggregate. A skip metric (`aggregate_participant_skip`) records it.

A sole SchemaBot on a repo has no aggregate config (role `""`), so it keeps posting the passing aggregate — single-deployment repos are unaffected. The leader publishes the required check and gates on participants' own checks when they exist, so a silent participant cannot wedge branch protection.

Inert until a repo is configured with a participant aggregate role.

*Drafted by Claude Code (claude-opus-4-8).*