### PR TITLE
feat(github): aggregate leader gates on participant check runs

### DIFF
--- a/pkg/api/aggregate_config.go
+++ b/pkg/api/aggregate_config.go
@@ -45,6 +45,14 @@ type AggregateConfig struct {
 type ExpectedTenant struct {
 	Tenant string   `yaml:"tenant"`
 	Paths  []string `yaml:"paths"`
+
+	// CheckName is the participant's aggregate check-name base (e.g.
+	// "SchemaBot BB Block"). The leader env-scopes it with
+	// aggregateCheckNameForEnv to find the participant's per-environment Check
+	// Run and fold it into the aggregate. It is required on a leader's expected
+	// tenants: the leader cannot gate on a participant whose Check Run name it
+	// cannot resolve, so a missing name is a fail-closed configuration error.
+	CheckName string `yaml:"check_name"`
 }
 
 func (a *AggregateConfig) isLeader() bool {
@@ -77,6 +85,25 @@ func (c *ServerConfig) IsAggregateLeaderForRepo(repo string) bool {
 // terminal-success before the check can pass. Returns nil when this deployment
 // is not the leader for repo, since only the leader holds the expected set.
 func (c *ServerConfig) ExpectedTenantsForPR(repo string, changedFiles []string) []string {
+	expected := c.ExpectedParticipantChecksForPR(repo, changedFiles)
+	if expected == nil {
+		return nil
+	}
+	names := make([]string, 0, len(expected))
+	for _, tenant := range expected {
+		names = append(names, tenant.Tenant)
+	}
+	return names
+}
+
+// ExpectedParticipantChecksForPR returns the full expected-tenant entries
+// (tenant, paths, and participant check-name base) that the leader must gate on
+// for a PR touching changedFiles: the subset of the repo's expected-tenant set
+// whose managed path prefixes cover at least one changed file. The leader
+// env-scopes each returned CheckName to find the participant's per-environment
+// Check Run and fold it into the aggregate. Returns nil when this deployment is
+// not the leader for repo, since only the leader holds the expected set.
+func (c *ServerConfig) ExpectedParticipantChecksForPR(repo string, changedFiles []string) []ExpectedTenant {
 	if c == nil {
 		return nil
 	}
@@ -84,10 +111,10 @@ func (c *ServerConfig) ExpectedTenantsForPR(repo string, changedFiles []string) 
 	if !ok || !repoConfig.Aggregate.isLeader() {
 		return nil
 	}
-	var expected []string
+	var expected []ExpectedTenant
 	for _, tenant := range repoConfig.Aggregate.ExpectedTenants {
 		if anyPathCovered(tenant.Paths, changedFiles) {
-			expected = append(expected, tenant.Tenant)
+			expected = append(expected, tenant)
 		}
 	}
 	return expected
@@ -141,6 +168,9 @@ func validateAggregateConfig(repo string, agg *AggregateConfig) error {
 			return fmt.Errorf("repos.%s.aggregate.expected_tenants contains duplicate tenant %q", repo, name)
 		}
 		seen[name] = struct{}{}
+		if strings.TrimSpace(tenant.CheckName) == "" {
+			return fmt.Errorf("repos.%s.aggregate.expected_tenants[%q].check_name is required for role %q", repo, name, AggregateRoleLeader)
+		}
 		if len(tenant.Paths) == 0 {
 			return fmt.Errorf("repos.%s.aggregate.expected_tenants[%q].paths is empty", repo, name)
 		}

--- a/pkg/api/aggregate_config_test.go
+++ b/pkg/api/aggregate_config_test.go
@@ -14,9 +14,9 @@ func leaderConfig() *ServerConfig {
 				Aggregate: &AggregateConfig{
 					Role: AggregateRoleLeader,
 					ExpectedTenants: []ExpectedTenant{
-						{Tenant: "tenant-a", Paths: []string{"services/a"}},
-						{Tenant: "tenant-b", Paths: []string{"services/b"}},
-						{Tenant: "tenant-c", Paths: []string{"services/c"}},
+						{Tenant: "tenant-a", Paths: []string{"services/a"}, CheckName: "SchemaBot Tenant A"},
+						{Tenant: "tenant-b", Paths: []string{"services/b"}, CheckName: "SchemaBot Tenant B"},
+						{Tenant: "tenant-c", Paths: []string{"services/c"}, CheckName: "SchemaBot Tenant C"},
 					},
 				},
 			},
@@ -27,7 +27,7 @@ func leaderConfig() *ServerConfig {
 func TestAggregateRoleAccessors(t *testing.T) {
 	c := &ServerConfig{
 		Repos: map[string]RepoConfig{
-			"octocat/shared-repo": {Aggregate: &AggregateConfig{Role: AggregateRoleLeader, ExpectedTenants: []ExpectedTenant{{Tenant: "tenant-b", Paths: []string{"services/b"}}}}},
+			"octocat/shared-repo": {Aggregate: &AggregateConfig{Role: AggregateRoleLeader, ExpectedTenants: []ExpectedTenant{{Tenant: "tenant-b", Paths: []string{"services/b"}, CheckName: "SchemaBot Tenant B"}}}},
 			"octocat/other-repo":  {Aggregate: &AggregateConfig{Role: AggregateRoleParticipant}},
 			"octocat/plain":       {},
 		},
@@ -80,6 +80,36 @@ func TestExpectedTenantsForPR(t *testing.T) {
 	})
 }
 
+// The leader resolves each expected participant's Check Run name from the
+// expected-tenant entry, so ExpectedParticipantChecksForPR must carry the
+// check-name base through alongside the tenant and its paths.
+func TestExpectedParticipantChecksForPR(t *testing.T) {
+	c := leaderConfig()
+
+	t.Run("returns full entries with check name", func(t *testing.T) {
+		got := c.ExpectedParticipantChecksForPR("octocat/shared-repo", []string{
+			"services/a/schema/users.sql",
+			"services/b/schema/orders.sql",
+		})
+		assert.ElementsMatch(t, []ExpectedTenant{
+			{Tenant: "tenant-a", Paths: []string{"services/a"}, CheckName: "SchemaBot Tenant A"},
+			{Tenant: "tenant-b", Paths: []string{"services/b"}, CheckName: "SchemaBot Tenant B"},
+		}, got)
+	})
+
+	t.Run("no tenant paths touched", func(t *testing.T) {
+		got := c.ExpectedParticipantChecksForPR("octocat/shared-repo", []string{"docs/README.md"})
+		assert.Empty(t, got)
+	})
+
+	t.Run("not the leader returns nil", func(t *testing.T) {
+		participant := &ServerConfig{Repos: map[string]RepoConfig{
+			"octocat/shared-repo": {Aggregate: &AggregateConfig{Role: AggregateRoleParticipant}},
+		}}
+		assert.Nil(t, participant.ExpectedParticipantChecksForPR("octocat/shared-repo", []string{"services/b/x.sql"}))
+	})
+}
+
 func TestValidateAggregateConfig(t *testing.T) {
 	t.Run("nil is allowed", func(t *testing.T) {
 		require.NoError(t, validateAggregateConfig("octocat/r", nil))
@@ -88,7 +118,7 @@ func TestValidateAggregateConfig(t *testing.T) {
 	t.Run("valid leader", func(t *testing.T) {
 		require.NoError(t, validateAggregateConfig("octocat/r", &AggregateConfig{
 			Role:            AggregateRoleLeader,
-			ExpectedTenants: []ExpectedTenant{{Tenant: "tenant-b", Paths: []string{"services/b"}}},
+			ExpectedTenants: []ExpectedTenant{{Tenant: "tenant-b", Paths: []string{"services/b"}, CheckName: "SchemaBot Tenant B"}},
 		}))
 	})
 
@@ -111,30 +141,35 @@ func TestValidateAggregateConfig(t *testing.T) {
 		{"leader without expected_tenants", &AggregateConfig{Role: AggregateRoleLeader}, "expected_tenants is required"},
 		{
 			"leader with empty tenant",
-			&AggregateConfig{Role: AggregateRoleLeader, ExpectedTenants: []ExpectedTenant{{Tenant: "  ", Paths: []string{"a"}}}},
+			&AggregateConfig{Role: AggregateRoleLeader, ExpectedTenants: []ExpectedTenant{{Tenant: "  ", Paths: []string{"a"}, CheckName: "X"}}},
 			"empty tenant",
 		},
 		{
 			"leader with duplicate tenant",
 			&AggregateConfig{Role: AggregateRoleLeader, ExpectedTenants: []ExpectedTenant{
-				{Tenant: "tenant-b", Paths: []string{"a"}},
-				{Tenant: "tenant-b", Paths: []string{"b"}},
+				{Tenant: "tenant-b", Paths: []string{"a"}, CheckName: "X"},
+				{Tenant: "tenant-b", Paths: []string{"b"}, CheckName: "Y"},
 			}},
 			"duplicate tenant",
 		},
 		{
+			"leader with empty check_name",
+			&AggregateConfig{Role: AggregateRoleLeader, ExpectedTenants: []ExpectedTenant{{Tenant: "tenant-b", Paths: []string{"a"}, CheckName: "   "}}},
+			"check_name is required",
+		},
+		{
 			"leader with empty paths",
-			&AggregateConfig{Role: AggregateRoleLeader, ExpectedTenants: []ExpectedTenant{{Tenant: "tenant-b"}}},
+			&AggregateConfig{Role: AggregateRoleLeader, ExpectedTenants: []ExpectedTenant{{Tenant: "tenant-b", CheckName: "X"}}},
 			"paths is empty",
 		},
 		{
 			"leader with absolute path",
-			&AggregateConfig{Role: AggregateRoleLeader, ExpectedTenants: []ExpectedTenant{{Tenant: "tenant-b", Paths: []string{"/etc"}}}},
+			&AggregateConfig{Role: AggregateRoleLeader, ExpectedTenants: []ExpectedTenant{{Tenant: "tenant-b", Paths: []string{"/etc"}, CheckName: "X"}}},
 			"invalid value",
 		},
 		{
 			"leader with escaping path",
-			&AggregateConfig{Role: AggregateRoleLeader, ExpectedTenants: []ExpectedTenant{{Tenant: "tenant-b", Paths: []string{"../secrets"}}}},
+			&AggregateConfig{Role: AggregateRoleLeader, ExpectedTenants: []ExpectedTenant{{Tenant: "tenant-b", Paths: []string{"../secrets"}, CheckName: "X"}}},
 			"invalid value",
 		},
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -403,6 +403,10 @@ const (
 	CheckTrustGatePassingChecks = "passing_checks"
 	// CheckTrustGatePromotion is the prior-environment promotion gate.
 	CheckTrustGatePromotion = "promotion"
+	// CheckTrustGateLeaderFold is the cross-tenant aggregate-leader fold gate,
+	// where the leader reads a participant deployment's aggregate Check Run and
+	// folds it into the shared aggregate.
+	CheckTrustGateLeaderFold = "leader_fold"
 )
 
 // RecordUntrustedAggregateNamedCheck counts PR checks that carry a SchemaBot
@@ -423,6 +427,47 @@ func RecordUntrustedAggregateNamedCheck(ctx context.Context, repository, environ
 		EnvironmentAttribute(environment),
 		attribute.String("app_slug", appSlug),
 		attribute.String("gate", gate),
+	)
+}
+
+// Outcomes for RecordLeaderParticipantGate. Each names why the
+// aggregate leader resolved a participant's Check Run to the given state when
+// folding it into the shared aggregate.
+const (
+	// LeaderParticipantGateSuccess: the participant's Check Run was trusted,
+	// completed, and successful — it does not block the aggregate.
+	LeaderParticipantGateSuccess = "success"
+	// LeaderParticipantGateFailure: the participant's Check Run completed with a
+	// non-success conclusion — the aggregate fails.
+	LeaderParticipantGateFailure = "failure"
+	// LeaderParticipantGateInProgress: the participant's Check Run is not yet
+	// terminal — the aggregate stays in progress.
+	LeaderParticipantGateInProgress = "in_progress"
+	// LeaderParticipantGateMissing: no trusted participant Check Run exists on the
+	// commit — the aggregate blocks until the participant reports.
+	LeaderParticipantGateMissing = "missing"
+	// LeaderParticipantGateUntrusted: a same-named Check Run exists but only from
+	// untrusted GitHub Apps — the aggregate blocks.
+	LeaderParticipantGateUntrusted = "untrusted"
+	// LeaderParticipantGateError: the GitHub Checks API lookup failed or the
+	// participant's check name could not be resolved — the aggregate blocks.
+	LeaderParticipantGateError = "error"
+)
+
+// RecordLeaderParticipantGate counts, per outcome, how the aggregate leader
+// resolved each expected participant's Check Run when folding it into the shared
+// aggregate. Every outcome other than "success" blocks the aggregate. A spike in
+// "missing", "untrusted", or "error" points an operator at a participant
+// deployment that is not reporting, a trusted-check-app-slugs gap or check-name
+// spoof, or a GitHub API problem, respectively — the matching warn/error logs
+// carry the repo, PR, environment, head SHA, and check name.
+func RecordLeaderParticipantGate(ctx context.Context, repository, environment, tenant, outcome string) {
+	addCounter(ctx, "schemabot.leader_participant_gate_total",
+		"Total participant Check Run resolutions folded into the aggregate leader's check, by outcome", "{gate}",
+		attribute.String("repository", repository),
+		EnvironmentAttribute(environment),
+		attribute.String("tenant", tenant),
+		attribute.String("outcome", outcome),
 	)
 }
 

--- a/pkg/webhook/check_publisher.go
+++ b/pkg/webhook/check_publisher.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"context"
 
+	"github.com/block/schemabot/pkg/api"
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/metrics"
 	"github.com/block/schemabot/pkg/storage"
@@ -106,19 +107,46 @@ func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.Ins
 		}
 	}
 
+	config := h.service.Config()
+
+	// The aggregate-check leader gates its per-environment aggregate on the
+	// Check Runs published by participant deployments, so it must fold those in
+	// even when it has no per-database checks of its own. Non-leaders (and repos
+	// with no aggregate config) never fetch files or fold — their behavior is
+	// unchanged.
+	var expectedParticipants []api.ExpectedTenant
+	if config.IsAggregateLeaderForRepo(repo) {
+		files, err := client.FetchPRFiles(ctx, repo, pr)
+		if err != nil {
+			// The leader cannot determine which participants a PR requires without
+			// the changed files. Fail closed: do not publish an aggregate at all,
+			// which leaves any existing (still-blocking) aggregate in place rather
+			// than downgrading it to a passing success we cannot justify.
+			metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+				Operation:  "aggregate_check_sync",
+				Repository: repo,
+				Status:     "error",
+			})
+			h.logger.Error("aggregate leader cannot fetch PR files, not publishing aggregate",
+				"repo", repo, "pr", pr, "head_sha", headSHA, "error", err)
+			return
+		}
+		expectedParticipants = config.ExpectedParticipantChecksForPR(repo, prFilePaths(files))
+	}
+
 	// No per-database checks means the PR doesn't touch schema files (or all check
-	// records were already deleted by PR close cleanup). No aggregate to create.
-	if len(dbChecks) == 0 {
+	// records were already deleted by PR close cleanup). With no expected
+	// participants to fold either, there is no aggregate to create.
+	if len(dbChecks) == 0 && len(expectedParticipants) == 0 {
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
 			Operation:  "aggregate_check_sync",
 			Repository: repo,
 			Status:     "noop",
 		})
-		h.logger.Debug("no per-database checks for aggregate", "repo", repo, "pr", pr)
+		h.logger.Debug("no per-database checks or expected participants for aggregate", "repo", repo, "pr", pr)
 		return
 	}
 
-	config := h.service.Config()
 	checkNameBase := h.aggregateCheckNameForRepo(repo)
 
 	if len(config.AllowedEnvironments) > 0 {
@@ -127,7 +155,11 @@ func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.Ins
 		// between environments (e.g., staging vs production aggregates).
 		for _, env := range config.AllowedEnvironments {
 			envChecks := filterChecksByEnvironment(dbChecks, env)
+			participantChecks := h.participantCheckOutcomes(ctx, client, repo, pr, env, headSHA, expectedParticipants)
+			envChecks = append(envChecks, participantChecks...)
 			if len(envChecks) == 0 {
+				h.logger.Debug("no checks or expected participants for aggregate environment",
+					"repo", repo, "pr", pr, "environment", env)
 				continue
 			}
 			checkName := aggregateCheckNameForEnv(checkNameBase, env)
@@ -136,8 +168,22 @@ func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.Ins
 	} else {
 		// Single aggregate. Uses aggregateSentinel for the environment field
 		// since there is no per-environment scoping.
-		h.upsertAggregateCheckRun(ctx, client, repo, pr, headSHA, dbChecks, checkNameBase, aggregateSentinel)
+		participantChecks := h.participantCheckOutcomes(ctx, client, repo, pr, aggregateSentinel, headSHA, expectedParticipants)
+		aggChecks := make([]*storage.Check, 0, len(dbChecks)+len(participantChecks))
+		aggChecks = append(aggChecks, dbChecks...)
+		aggChecks = append(aggChecks, participantChecks...)
+		h.upsertAggregateCheckRun(ctx, client, repo, pr, headSHA, aggChecks, checkNameBase, aggregateSentinel)
 	}
+}
+
+// prFilePaths extracts the changed-file paths from a PR file listing for
+// expected-participant matching.
+func prFilePaths(files []ghclient.PRFile) []string {
+	paths := make([]string, 0, len(files))
+	for _, f := range files {
+		paths = append(paths, f.Filename)
+	}
+	return paths
 }
 
 // upsertAggregateCheckRun computes the aggregate conclusion from the given checks

--- a/pkg/webhook/check_run.go
+++ b/pkg/webhook/check_run.go
@@ -11,6 +11,8 @@ type checkRunPayload struct {
 	CheckRun struct {
 		ID           int64  `json:"id"`
 		Name         string `json:"name"`
+		Status       string `json:"status"`
+		Conclusion   string `json:"conclusion"`
 		HeadSHA      string `json:"head_sha"`
 		PullRequests []struct {
 			Number int `json:"number"`
@@ -31,16 +33,95 @@ func (h *Handler) handleCheckRun(ctx context.Context, w http.ResponseWriter, bod
 		return
 	}
 
-	if payload.Action != "rerequested" {
+	switch payload.Action {
+	case "rerequested":
+		h.handleCheckRunRerequest(ctx, w, payload)
+	case "completed":
+		h.handleParticipantCheckCompleted(ctx, w, payload)
+	default:
 		h.logger.Debug("check_run action ignored",
 			"action", payload.Action,
 			"repo", payload.Repository.FullName,
 			"check_run_id", payload.CheckRun.ID,
 			"check_name", payload.CheckRun.Name)
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "check_run action ignored"})
+	}
+}
+
+// handleParticipantCheckCompleted re-folds the aggregate leader's check when a
+// participant deployment's Check Run completes on a repo this deployment leads.
+// The completed payload only triggers the re-fold; updateAggregateCheck re-reads
+// every participant's state via the trusted FindCheckRunByName path, so reacting
+// to any completed check on a led repo is safe. The leader's own aggregate check
+// is skipped so its own writes do not trigger a self-loop.
+func (h *Handler) handleParticipantCheckCompleted(ctx context.Context, w http.ResponseWriter, payload checkRunPayload) {
+	repo := payload.Repository.FullName
+
+	if h.service == nil || !h.service.Config().IsAggregateLeaderForRepo(repo) {
+		h.logger.Debug("check_run completion ignored because deployment is not the aggregate leader",
+			"repo", repo, "check_run_id", payload.CheckRun.ID, "check_name", payload.CheckRun.Name)
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "check_run completion ignored for non-leader repo"})
 		return
 	}
 
+	if h.isSchemaBotAggregateCheckName(repo, payload.CheckRun.Name) {
+		h.logger.Debug("check_run completion ignored because it is the leader's own aggregate check",
+			"repo", repo, "check_run_id", payload.CheckRun.ID, "check_name", payload.CheckRun.Name)
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "check_run completion ignored for own aggregate check"})
+		return
+	}
+
+	if !h.service.Config().IsRepoAllowed(repo) {
+		h.logger.Warn("webhook from unregistered repository",
+			"event", "check_run", "action", payload.Action, "repo", repo,
+			"check_run_id", payload.CheckRun.ID, "check_name", payload.CheckRun.Name)
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "repository not registered"})
+		return
+	}
+
+	installationID := h.effectiveInstallationID(ctx, payload.Installation.ID)
+	if installationID == 0 {
+		h.writeError(w, http.StatusBadRequest, "missing installation ID in webhook payload")
+		return
+	}
+
+	pr, ok := checkRunPullRequestNumber(payload)
+	if !ok {
+		h.logger.Info("participant check completion ignored without pull request",
+			"repo", repo, "check_run_id", payload.CheckRun.ID,
+			"check_name", payload.CheckRun.Name, "head_sha", payload.CheckRun.HeadSHA)
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "check_run completion ignored without pull request"})
+		return
+	}
+
+	if payload.CheckRun.HeadSHA == "" {
+		h.writeError(w, http.StatusBadRequest, "missing check_run head SHA")
+		return
+	}
+
+	ctx, cancel, client, err := h.autoPlanBootstrap(repo, installationID)
+	if err != nil {
+		h.logger.Error("failed to bootstrap participant check completion re-fold",
+			"repo", repo, "pr", pr, "head_sha", payload.CheckRun.HeadSHA,
+			"installation_id", installationID, "check_run_id", payload.CheckRun.ID,
+			"check_name", payload.CheckRun.Name, "error", err)
+		h.writeError(w, http.StatusInternalServerError, "failed to initialize GitHub client")
+		return
+	}
+	defer cancel()
+
+	h.logger.Info("participant check completion triggered aggregate re-fold",
+		"repo", repo, "pr", pr, "head_sha", payload.CheckRun.HeadSHA,
+		"installation_id", installationID, "check_run_id", payload.CheckRun.ID,
+		"check_name", payload.CheckRun.Name,
+		"check_status", payload.CheckRun.Status, "check_conclusion", payload.CheckRun.Conclusion)
+
+	h.updateAggregateCheck(ctx, client, repo, pr, payload.CheckRun.HeadSHA)
+
+	h.writeJSON(w, http.StatusOK, map[string]string{"message": "aggregate re-folded on participant check completion"})
+}
+
+func (h *Handler) handleCheckRunRerequest(ctx context.Context, w http.ResponseWriter, payload checkRunPayload) {
 	installationID := h.effectiveInstallationID(ctx, payload.Installation.ID)
 	if installationID == 0 {
 		h.writeError(w, http.StatusBadRequest, "missing installation ID in webhook payload")

--- a/pkg/webhook/leader_participant_gate.go
+++ b/pkg/webhook/leader_participant_gate.go
@@ -1,0 +1,181 @@
+package webhook
+
+import (
+	"context"
+
+	"github.com/block/schemabot/pkg/api"
+	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/metrics"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// checkRunFinder is the narrow slice of the GitHub client the aggregate leader
+// needs to fold participant deployments' Check Runs into its own aggregate. It
+// returns the newest trusted-app Check Run by name, the slugs of any same-named
+// but untrusted apps seen, and an error when ownership cannot be verified.
+// *ghclient.InstallationClient satisfies it; tests use a fake.
+type checkRunFinder interface {
+	FindCheckRunByName(ctx context.Context, repo, headSHA, checkName string) (*ghclient.CheckRunResult, []string, error)
+}
+
+// participantCheckOutcome is the resolved state of one participant's Check Run
+// for a single environment, ready to fold into the aggregate.
+type participantCheckOutcome struct {
+	tenant     string
+	checkName  string
+	status     string // checkStatus*
+	conclusion string // checkConclusion* (empty when in_progress)
+}
+
+// synthesizeParticipantCheck maps a resolved participant outcome to a stored
+// Check shape so computeAggregate folds it exactly like a per-database check.
+// DatabaseType is the aggregate sentinel and DatabaseName is the tenant so the
+// synthesized row is distinguishable in the aggregate table while still
+// contributing its status/conclusion to the fold.
+func synthesizeParticipantCheck(outcome participantCheckOutcome, repo string, pr int, headSHA, env string) *storage.Check {
+	return &storage.Check{
+		Repository:   repo,
+		PullRequest:  pr,
+		HeadSHA:      headSHA,
+		Environment:  env,
+		DatabaseType: aggregateSentinel,
+		DatabaseName: outcome.tenant,
+		HasChanges:   outcome.conclusion != checkConclusionSuccess,
+		Status:       outcome.status,
+		Conclusion:   outcome.conclusion,
+	}
+}
+
+// blockedParticipantOutcome builds a fail-closed outcome that folds to
+// action_required so any resolution uncertainty blocks the aggregate.
+func blockedParticipantOutcome(tenant, checkName string) participantCheckOutcome {
+	return participantCheckOutcome{
+		tenant:     tenant,
+		checkName:  checkName,
+		status:     checkStatusCompleted,
+		conclusion: checkConclusionActionRequired,
+	}
+}
+
+// participantCheckName resolves the Check Run name a participant publishes for
+// env. It mirrors how the aggregate publisher names its own check: when the
+// leader has no allowed environments (env is the aggregate sentinel) the
+// participant's Check Run uses the unscoped base name; otherwise it is
+// env-scoped, exactly as aggregateCheckNameForEnv builds it.
+func participantCheckName(base, env string) string {
+	if env == aggregateSentinel {
+		return base
+	}
+	return aggregateCheckNameForEnv(base, env)
+}
+
+// participantCheckOutcomes resolves every expected participant's per-environment
+// Check Run for headSHA and returns synthesized stored Check rows to fold into
+// the aggregate leader's check for env. It fails closed: anything other than a
+// trusted, completed, success participant check yields a blocking row.
+//
+// resolveParticipantOutcome is the fail-closed truth table:
+//   - unresolvable check name        → action_required (blocks)
+//   - Checks API error               → action_required (blocks)
+//   - only untrusted same-named runs → action_required (blocks)
+//   - no trusted run on the commit   → action_required (blocks)
+//   - trusted run, non-terminal      → in_progress    (blocks)
+//   - trusted run, completed+success → success        (passes)
+//   - trusted run, completed+other   → failure        (blocks)
+func (h *Handler) participantCheckOutcomes(
+	ctx context.Context, client checkRunFinder,
+	repo string, pr int, env, headSHA string,
+	expected []api.ExpectedTenant,
+) []*storage.Check {
+	checks := make([]*storage.Check, 0, len(expected))
+	for _, tenant := range expected {
+		outcome := h.resolveParticipantOutcome(ctx, client, repo, pr, env, headSHA, tenant)
+		checks = append(checks, synthesizeParticipantCheck(outcome, repo, pr, headSHA, env))
+	}
+	return checks
+}
+
+func (h *Handler) resolveParticipantOutcome(
+	ctx context.Context, client checkRunFinder,
+	repo string, pr int, env, headSHA string,
+	tenant api.ExpectedTenant,
+) participantCheckOutcome {
+	if tenant.CheckName == "" {
+		// Config validation requires a check name on every leader-expected tenant.
+		// Fail closed anyway: without a name the leader cannot resolve the
+		// participant's Check Run, so the aggregate must block.
+		h.logger.Warn("aggregate leader cannot resolve participant check name, blocking aggregate",
+			"repo", repo, "pr", pr, "environment", env, "head_sha", headSHA, "tenant", tenant.Tenant)
+		metrics.RecordLeaderParticipantGate(ctx, repo, env, tenant.Tenant, metrics.LeaderParticipantGateError)
+		return blockedParticipantOutcome(tenant.Tenant, "")
+	}
+
+	checkName := participantCheckName(tenant.CheckName, env)
+
+	result, untrusted, err := client.FindCheckRunByName(ctx, repo, headSHA, checkName)
+	if err != nil {
+		h.logger.Error("failed to query participant check for aggregate leader, blocking aggregate",
+			"repo", repo, "pr", pr, "environment", env, "head_sha", headSHA,
+			"tenant", tenant.Tenant, "check_name", checkName, "error", err)
+		metrics.RecordLeaderParticipantGate(ctx, repo, env, tenant.Tenant, metrics.LeaderParticipantGateError)
+		return blockedParticipantOutcome(tenant.Tenant, checkName)
+	}
+
+	if result == nil && len(untrusted) > 0 {
+		// A same-named Check Run exists on this commit but only from untrusted
+		// Apps — re-running the participant cannot fix this; only trusting the
+		// participant's App (or removing a spoofed check) can.
+		h.logger.Warn("participant check exists only from untrusted GitHub Apps, blocking aggregate",
+			"repo", repo, "pr", pr, "environment", env, "head_sha", headSHA,
+			"tenant", tenant.Tenant, "check_name", checkName, "untrusted_app_slugs", untrusted)
+		for _, appSlug := range untrusted {
+			metrics.RecordUntrustedAggregateNamedCheck(ctx, repo, env, appSlug, metrics.CheckTrustGateLeaderFold)
+		}
+		metrics.RecordLeaderParticipantGate(ctx, repo, env, tenant.Tenant, metrics.LeaderParticipantGateUntrusted)
+		return blockedParticipantOutcome(tenant.Tenant, checkName)
+	}
+
+	if result == nil {
+		h.logger.Warn("expected participant has not reported its check, blocking aggregate",
+			"repo", repo, "pr", pr, "environment", env, "head_sha", headSHA,
+			"tenant", tenant.Tenant, "check_name", checkName)
+		metrics.RecordLeaderParticipantGate(ctx, repo, env, tenant.Tenant, metrics.LeaderParticipantGateMissing)
+		return blockedParticipantOutcome(tenant.Tenant, checkName)
+	}
+
+	if result.Status != checkStatusCompleted {
+		h.logger.Debug("participant check is not yet terminal, aggregate stays in progress",
+			"repo", repo, "pr", pr, "environment", env, "head_sha", headSHA,
+			"tenant", tenant.Tenant, "check_name", checkName, "check_status", result.Status)
+		metrics.RecordLeaderParticipantGate(ctx, repo, env, tenant.Tenant, metrics.LeaderParticipantGateInProgress)
+		return participantCheckOutcome{
+			tenant:    tenant.Tenant,
+			checkName: checkName,
+			status:    checkStatusInProgress,
+		}
+	}
+
+	if result.Conclusion == checkConclusionSuccess {
+		h.logger.Debug("participant check succeeded, does not block aggregate",
+			"repo", repo, "pr", pr, "environment", env, "head_sha", headSHA,
+			"tenant", tenant.Tenant, "check_name", checkName)
+		metrics.RecordLeaderParticipantGate(ctx, repo, env, tenant.Tenant, metrics.LeaderParticipantGateSuccess)
+		return participantCheckOutcome{
+			tenant:     tenant.Tenant,
+			checkName:  checkName,
+			status:     checkStatusCompleted,
+			conclusion: checkConclusionSuccess,
+		}
+	}
+
+	h.logger.Warn("participant check completed without success, blocking aggregate",
+		"repo", repo, "pr", pr, "environment", env, "head_sha", headSHA,
+		"tenant", tenant.Tenant, "check_name", checkName, "check_conclusion", result.Conclusion)
+	metrics.RecordLeaderParticipantGate(ctx, repo, env, tenant.Tenant, metrics.LeaderParticipantGateFailure)
+	return participantCheckOutcome{
+		tenant:     tenant.Tenant,
+		checkName:  checkName,
+		status:     checkStatusCompleted,
+		conclusion: checkConclusionFailure,
+	}
+}

--- a/pkg/webhook/leader_participant_gate_test.go
+++ b/pkg/webhook/leader_participant_gate_test.go
@@ -1,0 +1,158 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/api"
+	ghclient "github.com/block/schemabot/pkg/github"
+)
+
+// fakeCheckRunFinder returns canned results per check name so the aggregate
+// leader's participant fold can be exercised without GitHub.
+type fakeCheckRunFinder struct {
+	results   map[string]*ghclient.CheckRunResult
+	untrusted map[string][]string
+	errs      map[string]error
+}
+
+func (f *fakeCheckRunFinder) FindCheckRunByName(_ context.Context, _, _, checkName string) (*ghclient.CheckRunResult, []string, error) {
+	if err, ok := f.errs[checkName]; ok {
+		return nil, nil, err
+	}
+	return f.results[checkName], f.untrusted[checkName], nil
+}
+
+// The aggregate leader folds each expected participant's Check Run into its own
+// aggregate, failing closed on anything that is not a trusted, completed,
+// successful participant check.
+func TestParticipantCheckOutcomesFold(t *testing.T) {
+	const (
+		repo    = "octocat/shared-repo"
+		pr      = 7
+		env     = "staging"
+		headSHA = "abc123"
+	)
+	expected := []api.ExpectedTenant{{Tenant: "tenant-a", Paths: []string{"services/a"}, CheckName: "SchemaBot Tenant A"}}
+	checkName := aggregateCheckNameForEnv("SchemaBot Tenant A", env)
+
+	cases := []struct {
+		name           string
+		finder         *fakeCheckRunFinder
+		wantConclusion string
+		wantStatus     string
+	}{
+		{
+			name: "trusted completed success passes",
+			finder: &fakeCheckRunFinder{results: map[string]*ghclient.CheckRunResult{
+				checkName: {Status: checkStatusCompleted, Conclusion: checkConclusionSuccess},
+			}},
+			wantConclusion: checkConclusionSuccess,
+			wantStatus:     checkStatusCompleted,
+		},
+		{
+			name: "in progress blocks",
+			finder: &fakeCheckRunFinder{results: map[string]*ghclient.CheckRunResult{
+				checkName: {Status: checkStatusInProgress},
+			}},
+			wantConclusion: "",
+			wantStatus:     checkStatusInProgress,
+		},
+		{
+			name: "queued blocks as in progress",
+			finder: &fakeCheckRunFinder{results: map[string]*ghclient.CheckRunResult{
+				checkName: {Status: checkStatusQueued},
+			}},
+			wantConclusion: "",
+			wantStatus:     checkStatusInProgress,
+		},
+		{
+			name: "completed failure blocks",
+			finder: &fakeCheckRunFinder{results: map[string]*ghclient.CheckRunResult{
+				checkName: {Status: checkStatusCompleted, Conclusion: checkConclusionFailure},
+			}},
+			wantConclusion: checkConclusionFailure,
+			wantStatus:     checkStatusCompleted,
+		},
+		{
+			name: "completed action_required blocks as failure",
+			finder: &fakeCheckRunFinder{results: map[string]*ghclient.CheckRunResult{
+				checkName: {Status: checkStatusCompleted, Conclusion: checkConclusionActionRequired},
+			}},
+			wantConclusion: checkConclusionFailure,
+			wantStatus:     checkStatusCompleted,
+		},
+		{
+			name:           "missing check blocks",
+			finder:         &fakeCheckRunFinder{},
+			wantConclusion: checkConclusionActionRequired,
+			wantStatus:     checkStatusCompleted,
+		},
+		{
+			name: "untrusted-only check blocks",
+			finder: &fakeCheckRunFinder{untrusted: map[string][]string{
+				checkName: {"some-other-app"},
+			}},
+			wantConclusion: checkConclusionActionRequired,
+			wantStatus:     checkStatusCompleted,
+		},
+		{
+			name: "lookup error blocks",
+			finder: &fakeCheckRunFinder{errs: map[string]error{
+				checkName: fmt.Errorf("boom"),
+			}},
+			wantConclusion: checkConclusionActionRequired,
+			wantStatus:     checkStatusCompleted,
+		},
+	}
+
+	h := &Handler{logger: testLogger()}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			checks := h.participantCheckOutcomes(t.Context(), tc.finder, repo, pr, env, headSHA, expected)
+			require.Len(t, checks, 1)
+
+			c := checks[0]
+			assert.Equal(t, aggregateSentinel, c.DatabaseType, "synthesized row must use the aggregate sentinel type")
+			assert.Equal(t, "tenant-a", c.DatabaseName, "synthesized row must be labeled by tenant")
+			assert.Equal(t, env, c.Environment)
+			assert.Equal(t, headSHA, c.HeadSHA)
+
+			conclusion, status := computeAggregate(checks)
+			assert.Equal(t, tc.wantConclusion, conclusion)
+			assert.Equal(t, tc.wantStatus, status)
+		})
+	}
+}
+
+// An empty expected set folds to nothing, so a non-leader or a PR touching no
+// participant paths never contributes participant rows to the aggregate.
+func TestParticipantCheckOutcomesEmptyExpected(t *testing.T) {
+	h := &Handler{logger: testLogger()}
+	checks := h.participantCheckOutcomes(t.Context(), &fakeCheckRunFinder{}, "octocat/shared-repo", 1, "staging", "sha", nil)
+	assert.Empty(t, checks)
+}
+
+// A missing participant check name is a fail-closed configuration error: the
+// leader cannot resolve the Check Run, so the aggregate blocks.
+func TestParticipantCheckOutcomesEmptyCheckNameBlocks(t *testing.T) {
+	h := &Handler{logger: testLogger()}
+	expected := []api.ExpectedTenant{{Tenant: "tenant-a", Paths: []string{"services/a"}}}
+	checks := h.participantCheckOutcomes(t.Context(), &fakeCheckRunFinder{}, "octocat/shared-repo", 1, "staging", "sha", expected)
+	require.Len(t, checks, 1)
+
+	conclusion, status := computeAggregate(checks)
+	assert.Equal(t, checkConclusionActionRequired, conclusion)
+	assert.Equal(t, checkStatusCompleted, status)
+}
+
+// When the leader has no allowed environments the participant Check Run uses the
+// unscoped base name, mirroring how the aggregate publisher names its own check.
+func TestParticipantCheckNameSingleAggregate(t *testing.T) {
+	assert.Equal(t, "SchemaBot Tenant A", participantCheckName("SchemaBot Tenant A", aggregateSentinel))
+	assert.Equal(t, "SchemaBot Tenant A (production)", participantCheckName("SchemaBot Tenant A", "production"))
+}


### PR DESCRIPTION
## Why

On a shared repo, several SchemaBot deployments publish their own check. To collapse to one required check (the leader's), the leader must actually gate on the others — otherwise the leader could pass while a participant's schema change is still pending, a fail-open hole. This is the multi-environment promotion pattern (`checkPriorEnvViaGitHub`) applied cross-tenant: the leader reads participants' check runs and folds them in.

## What

For each **expected participant** (from `aggregate.expected_tenants` matched against the PR's changed files), the leader reads that participant's check run on the PR head SHA via the trusted `FindCheckRunByName` path and folds its conclusion into the leader's per-environment aggregate. **Fail-closed** — anything other than a trusted, completed, successful participant check blocks:

| Participant check state | Folds to |
|---|---|
| trusted, completed, success | success |
| not yet terminal | in_progress (blocks) |
| completed, non-success | failure (blocks) |
| no trusted run on the commit | action_required (blocks) |
| only untrusted same-named runs | action_required (blocks) |
| Checks API error / unresolvable name | action_required (blocks) |

- `ExpectedTenant` gains a `check_name` base (required on a leader's expected tenants) so the leader can resolve each participant's check-run name; env-scoped via the existing helper.
- The leader publishes and gates even when it has **no per-database checks of its own** but does have expected participants. Non-leaders and repos with no aggregate config are unchanged.
- A participant check run completing re-folds the leader's aggregate.
- Per-outcome metric `schemabot.leader_participant_gate_total` (success/failure/in_progress/missing/untrusted/error) for triage.

Inert until a repo is configured with a leader aggregate role + expected tenants.

## Known follow-up

The completion trigger currently re-folds on any completed check on a led repo (except the leader's own aggregate). It's safe (the fold re-reads every participant via the trusted path), but on a high-volume repo that's extra GitHub reads — a fast-follow can filter the trigger to checks whose name matches a configured expected participant before enabling in production.

*Drafted by Claude Code (claude-opus-4-8).*