### PR TITLE
feat(github): render participant deployments in a labeled aggregate section

### DIFF
--- a/pkg/webhook/check_aggregate.go
+++ b/pkg/webhook/check_aggregate.go
@@ -240,7 +240,6 @@ func aggregateSummary(checks []*storage.Check, conclusion string) (title, summar
 	return title, summary
 }
 
-// buildAggregateTable builds a markdown table showing the status of each per-database check.
 // isParticipantCheck reports whether a check is a participant deployment's
 // outcome folded into the leader's aggregate, rather than one of the leader's
 // own per-database checks. Participant outcomes carry the aggregate sentinel as
@@ -253,8 +252,10 @@ func isParticipantCheck(c *storage.Check) bool {
 // per-database checks in a Database table, and — when the leader gates on
 // participant deployments — each participant's rolled-up status in a separate
 // Tenant deployments table, so a reader can tell "my databases" from "the other
-// tenants I'm gating on" at a glance. Each section bounds its own size against
-// GitHub's check run output limit.
+// tenants I'm gating on" at a glance. Participant gating is the key information,
+// so the Tenant deployments section is rendered first and its size reserved: it
+// is never dropped, even when many per-database rows would otherwise fill the
+// Check Run text limit — those rows truncate instead.
 func buildAggregateTable(checks []*storage.Check) string {
 	var dbChecks, participantChecks []*storage.Check
 	for _, c := range checks {
@@ -265,38 +266,58 @@ func buildAggregateTable(checks []*storage.Check) string {
 		}
 	}
 
+	tenantSection := renderParticipantSection(participantChecks)
+	dbSection := renderDatabaseSection(dbChecks, maxCheckRunTextLength-1000-len(tenantSection))
+
 	var sb strings.Builder
-
-	if len(dbChecks) > 0 {
-		sb.WriteString("| Database | Environment | Status |\n")
-		sb.WriteString("|----------|-------------|--------|\n")
-		for i, c := range dbChecks {
-			row := fmt.Sprintf("| `%s` | %s | %s |\n", c.DatabaseName, c.Environment, checkStatusLabel(c))
-			if sb.Len()+len(row) > maxCheckRunTextLength-1000 {
-				fmt.Fprintf(&sb, "\n... and %d more check(s)\n", len(dbChecks)-i)
-				return sb.String()
-			}
-			sb.WriteString(row)
-		}
-	}
-
-	if len(participantChecks) > 0 {
+	sb.WriteString(dbSection)
+	if tenantSection != "" {
 		if sb.Len() > 0 {
 			sb.WriteString("\n")
 		}
-		sb.WriteString("**Tenant deployments**\n\n")
-		sb.WriteString("| Tenant | Status |\n")
-		sb.WriteString("|--------|--------|\n")
-		for i, c := range participantChecks {
-			row := fmt.Sprintf("| `%s` | %s |\n", c.DatabaseName, checkStatusLabel(c))
-			if sb.Len()+len(row) > maxCheckRunTextLength-1000 {
-				fmt.Fprintf(&sb, "\n... and %d more tenant(s)\n", len(participantChecks)-i)
-				return sb.String()
-			}
-			sb.WriteString(row)
-		}
+		sb.WriteString(tenantSection)
 	}
+	return sb.String()
+}
 
+// renderDatabaseSection renders the leader's own per-database checks as a
+// Database table, truncating to stay within budget bytes.
+func renderDatabaseSection(dbChecks []*storage.Check, budget int) string {
+	if len(dbChecks) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("| Database | Environment | Status |\n")
+	sb.WriteString("|----------|-------------|--------|\n")
+	for i, c := range dbChecks {
+		row := fmt.Sprintf("| `%s` | %s | %s |\n", c.DatabaseName, c.Environment, checkStatusLabel(c))
+		if sb.Len()+len(row) > budget {
+			fmt.Fprintf(&sb, "\n... and %d more check(s)\n", len(dbChecks)-i)
+			break
+		}
+		sb.WriteString(row)
+	}
+	return sb.String()
+}
+
+// renderParticipantSection renders the folded participant deployments as a
+// Tenant table keyed by tenant, truncating within the Check Run text limit.
+func renderParticipantSection(participantChecks []*storage.Check) string {
+	if len(participantChecks) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("**Tenant deployments**\n\n")
+	sb.WriteString("| Tenant | Status |\n")
+	sb.WriteString("|--------|--------|\n")
+	for i, c := range participantChecks {
+		row := fmt.Sprintf("| `%s` | %s |\n", c.DatabaseName, checkStatusLabel(c))
+		if sb.Len()+len(row) > maxCheckRunTextLength-1000 {
+			fmt.Fprintf(&sb, "\n... and %d more tenant(s)\n", len(participantChecks)-i)
+			break
+		}
+		sb.WriteString(row)
+	}
 	return sb.String()
 }
 

--- a/pkg/webhook/check_aggregate.go
+++ b/pkg/webhook/check_aggregate.go
@@ -241,19 +241,60 @@ func aggregateSummary(checks []*storage.Check, conclusion string) (title, summar
 }
 
 // buildAggregateTable builds a markdown table showing the status of each per-database check.
-// Truncates to stay within GitHub's check run output limits.
-func buildAggregateTable(checks []*storage.Check) string {
-	var sb strings.Builder
-	sb.WriteString("| Database | Environment | Status |\n")
-	sb.WriteString("|----------|-------------|--------|\n")
+// isParticipantCheck reports whether a check is a participant deployment's
+// outcome folded into the leader's aggregate, rather than one of the leader's
+// own per-database checks. Participant outcomes carry the aggregate sentinel as
+// their database type and the tenant name as their database name.
+func isParticipantCheck(c *storage.Check) bool {
+	return c.DatabaseType == aggregateSentinel && c.DatabaseName != aggregateSentinel
+}
 
-	for i, c := range checks {
-		row := fmt.Sprintf("| `%s` | %s | %s |\n", c.DatabaseName, c.Environment, checkStatusLabel(c))
-		if sb.Len()+len(row) > maxCheckRunTextLength-1000 {
-			fmt.Fprintf(&sb, "\n... and %d more check(s)\n", len(checks)-i)
-			break
+// buildAggregateTable renders the aggregate check's summary: the leader's own
+// per-database checks in a Database table, and — when the leader gates on
+// participant deployments — each participant's rolled-up status in a separate
+// Tenant deployments table, so a reader can tell "my databases" from "the other
+// tenants I'm gating on" at a glance. Each section bounds its own size against
+// GitHub's check run output limit.
+func buildAggregateTable(checks []*storage.Check) string {
+	var dbChecks, participantChecks []*storage.Check
+	for _, c := range checks {
+		if isParticipantCheck(c) {
+			participantChecks = append(participantChecks, c)
+		} else {
+			dbChecks = append(dbChecks, c)
 		}
-		sb.WriteString(row)
+	}
+
+	var sb strings.Builder
+
+	if len(dbChecks) > 0 {
+		sb.WriteString("| Database | Environment | Status |\n")
+		sb.WriteString("|----------|-------------|--------|\n")
+		for i, c := range dbChecks {
+			row := fmt.Sprintf("| `%s` | %s | %s |\n", c.DatabaseName, c.Environment, checkStatusLabel(c))
+			if sb.Len()+len(row) > maxCheckRunTextLength-1000 {
+				fmt.Fprintf(&sb, "\n... and %d more check(s)\n", len(dbChecks)-i)
+				return sb.String()
+			}
+			sb.WriteString(row)
+		}
+	}
+
+	if len(participantChecks) > 0 {
+		if sb.Len() > 0 {
+			sb.WriteString("\n")
+		}
+		sb.WriteString("**Tenant deployments**\n\n")
+		sb.WriteString("| Tenant | Status |\n")
+		sb.WriteString("|--------|--------|\n")
+		for i, c := range participantChecks {
+			row := fmt.Sprintf("| `%s` | %s |\n", c.DatabaseName, checkStatusLabel(c))
+			if sb.Len()+len(row) > maxCheckRunTextLength-1000 {
+				fmt.Fprintf(&sb, "\n... and %d more tenant(s)\n", len(participantChecks)-i)
+				return sb.String()
+			}
+			sb.WriteString(row)
+		}
 	}
 
 	return sb.String()

--- a/pkg/webhook/check_aggregate_test.go
+++ b/pkg/webhook/check_aggregate_test.go
@@ -154,6 +154,30 @@ func TestAggregateSummary(t *testing.T) {
 	assert.Contains(t, summary, "Pending")
 }
 
+// When the leader gates on participant deployments, their folded outcomes render
+// in a separate "Tenant deployments" section, keyed by tenant, distinct from the
+// leader's own per-database rows.
+func TestAggregateSummary_WithParticipants(t *testing.T) {
+	checks := []*storage.Check{
+		{DatabaseType: "mysql", DatabaseName: "orders", Environment: "production", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess, HasChanges: true},
+		{DatabaseType: aggregateSentinel, DatabaseName: "tenant-b", Environment: "production", Status: checkStatusCompleted, Conclusion: checkConclusionActionRequired},
+		{DatabaseType: aggregateSentinel, DatabaseName: "tenant-c", Environment: "production", Status: checkStatusInProgress},
+	}
+
+	_, summary := aggregateSummary(checks, checkConclusionActionRequired)
+
+	// Leader's own database in the Database section.
+	assert.Contains(t, summary, "| Database | Environment | Status |")
+	assert.Contains(t, summary, "`orders`")
+	// Participants in their own Tenant section, not the Database table.
+	assert.Contains(t, summary, "**Tenant deployments**")
+	assert.Contains(t, summary, "| Tenant | Status |")
+	assert.Contains(t, summary, "`tenant-b`")
+	assert.Contains(t, summary, "`tenant-c`")
+	// The tenant section has no Environment column, so its header is distinct.
+	assert.NotContains(t, summary, "| tenant-b | production |")
+}
+
 func TestAggregateSummary_AllSuccess(t *testing.T) {
 	checks := []*storage.Check{
 		{DatabaseName: "orders", Environment: "staging", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess, HasChanges: true},

--- a/pkg/webhook/check_aggregate_test.go
+++ b/pkg/webhook/check_aggregate_test.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -166,16 +167,43 @@ func TestAggregateSummary_WithParticipants(t *testing.T) {
 
 	_, summary := aggregateSummary(checks, checkConclusionActionRequired)
 
-	// Leader's own database in the Database section.
-	assert.Contains(t, summary, "| Database | Environment | Status |")
-	assert.Contains(t, summary, "`orders`")
-	// Participants in their own Tenant section, not the Database table.
-	assert.Contains(t, summary, "**Tenant deployments**")
-	assert.Contains(t, summary, "| Tenant | Status |")
-	assert.Contains(t, summary, "`tenant-b`")
-	assert.Contains(t, summary, "`tenant-c`")
-	// The tenant section has no Environment column, so its header is distinct.
-	assert.NotContains(t, summary, "| tenant-b | production |")
+	dbSection, tenantSection, found := strings.Cut(summary, "**Tenant deployments**")
+	require.True(t, found, "summary has a Tenant deployments section")
+
+	// The leader's own database renders in the Database section; participants do not.
+	assert.Contains(t, dbSection, "| Database | Environment | Status |")
+	assert.Contains(t, dbSection, "`orders`")
+	assert.NotContains(t, dbSection, "tenant-b", "participants must not appear in the Database section")
+	assert.NotContains(t, dbSection, "tenant-c")
+
+	// Participants render in their own tenant-keyed section.
+	assert.Contains(t, tenantSection, "| Tenant | Status |")
+	assert.Contains(t, tenantSection, "`tenant-b`")
+	assert.Contains(t, tenantSection, "`tenant-c`")
+}
+
+// Participant gating is the key information, so the Tenant deployments section
+// must survive even when the leader has so many per-database checks that the
+// Database section truncates.
+func TestAggregateSummary_TenantSectionSurvivesDatabaseTruncation(t *testing.T) {
+	var checks []*storage.Check
+	for range 6000 {
+		checks = append(checks, &storage.Check{
+			DatabaseType: "mysql", DatabaseName: "orders", Environment: "production",
+			Status: checkStatusCompleted, Conclusion: checkConclusionActionRequired,
+		})
+	}
+	checks = append(checks, &storage.Check{
+		DatabaseType: aggregateSentinel, DatabaseName: "tenant-b", Environment: "production",
+		Status: checkStatusInProgress,
+	})
+
+	_, summary := aggregateSummary(checks, checkStatusInProgress)
+
+	assert.Less(t, len(summary), maxCheckRunTextLength, "summary stays under the Check Run limit")
+	assert.Contains(t, summary, "more check(s)", "the Database section truncates")
+	assert.Contains(t, summary, "**Tenant deployments**", "the tenant section is not dropped")
+	assert.Contains(t, summary, "`tenant-b`", "the participant still appears despite database truncation")
 }
 
 func TestAggregateSummary_AllSuccess(t *testing.T) {


### PR DESCRIPTION
The aggregate leader's Details summary now separates its own per-database checks from the participant deployments it gates on:
- **Database** table — the leader's own databases (unchanged).
- **Tenant deployments** table — one row per participant tenant with its rolled-up status.

Previously the folded participant outcomes rendered as plain database rows named after the tenant, indistinguishable from real databases. Now a reader can tell "my databases" from "the other tenants I'm gating on" at a glance. Each section bounds its own size against the check-run text limit.

*Drafted by Claude Code (claude-opus-4-8).*