### PR TITLE
feat(github): fan-out unscoped apply to aggregate participants

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1078,6 +1078,7 @@ var knownStatusCheckOperations = map[string]bool{
 	"schema_config_environment_validation": true,
 	"managed_dir_missing_config":           true,
 	"aggregate_participant_skip":           true,
+	"aggregate_participant_fanout":         true,
 }
 
 var knownStatusCheckStatuses = map[string]bool{

--- a/pkg/webhook/aggregate_participant_fanout_test.go
+++ b/pkg/webhook/aggregate_participant_fanout_test.go
@@ -1,0 +1,80 @@
+package webhook
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/block/schemabot/pkg/api"
+)
+
+// An aggregate participant fans out an unscoped work command: an
+// `apply -e <env>` with no -t tenant reaches every participant on a shared
+// repo, and each participant self-selects its own databases instead of
+// ignoring the command. Only per-tenant -t routing requires an explicit tenant.
+func TestFansOutUnscopedCommand(t *testing.T) {
+	const repo = "octocat/hello-world"
+
+	participantCfg := &api.ServerConfig{
+		Tenant: "tenant-b",
+		Repos: map[string]api.RepoConfig{
+			repo: {Aggregate: &api.AggregateConfig{Role: api.AggregateRoleParticipant}},
+		},
+	}
+	leaderCfg := &api.ServerConfig{
+		Tenant: "tenant-a",
+		Repos: map[string]api.RepoConfig{
+			repo: {Aggregate: &api.AggregateConfig{
+				Role: api.AggregateRoleLeader,
+				ExpectedTenants: []api.ExpectedTenant{
+					{Tenant: "tenant-b", Paths: []string{"tenant-b/schema"}},
+				},
+			}},
+		},
+	}
+	noAggregateCfg := &api.ServerConfig{
+		Tenant: "tenant-b",
+		Repos:  map[string]api.RepoConfig{repo: {}},
+	}
+
+	t.Run("participant fans out for its repo", func(t *testing.T) {
+		h := &Handler{service: api.New(nil, participantCfg, nil, testLogger())}
+		assert.True(t, h.fansOutUnscopedCommand(repo))
+	})
+
+	t.Run("tenanted non-participant does not fan out", func(t *testing.T) {
+		h := &Handler{service: api.New(nil, noAggregateCfg, nil, testLogger())}
+		assert.False(t, h.fansOutUnscopedCommand(repo))
+	})
+
+	t.Run("leader does not fan out via this path", func(t *testing.T) {
+		// A leader is untenanted in practice and never hits the guard, but the
+		// participant predicate must be false for it regardless.
+		h := &Handler{service: api.New(nil, leaderCfg, nil, testLogger())}
+		assert.False(t, h.fansOutUnscopedCommand(repo))
+	})
+
+	t.Run("unconfigured repo does not fan out", func(t *testing.T) {
+		h := &Handler{service: api.New(nil, participantCfg, nil, testLogger())}
+		assert.False(t, h.fansOutUnscopedCommand("octocat/other-repo"))
+	})
+
+	t.Run("no service does not fan out", func(t *testing.T) {
+		h := &Handler{}
+		assert.False(t, h.fansOutUnscopedCommand(repo))
+	})
+}
+
+// A tenant-targeted command (-t tenant-b) routes only to the matching isolated
+// deployment; a participant for a different tenant must not respond. This
+// per-tenant routing is unchanged by the fan-out behavior.
+func TestTenantTargetedRoutingUnchanged(t *testing.T) {
+	tenantBCfg := &api.ServerConfig{Tenant: "tenant-b"}
+
+	assert.True(t, tenantBCfg.ShouldRespondToTenant("tenant-b"),
+		"the owning deployment responds to its own tenant")
+	assert.False(t, tenantBCfg.ShouldRespondToTenant("tenant-c"),
+		"a deployment does not respond to another tenant's -t command")
+	assert.True(t, tenantBCfg.ShouldRespondToTenant(""),
+		"an unscoped command is not filtered by tenant ownership")
+}

--- a/pkg/webhook/aggregate_participant_fanout_test.go
+++ b/pkg/webhook/aggregate_participant_fanout_test.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,6 +9,38 @@ import (
 	"github.com/block/schemabot/pkg/api"
 	"github.com/block/schemabot/pkg/webhook/action"
 )
+
+// On an aggregate repo, an unscoped fan-out command that resolves to schema this
+// deployment doesn't own is a silent no-op — the deployment that does own it
+// handles the command, so no "config not authorized" comment is posted. This is
+// the leader's behavior on a PR that touches only a participant's database
+// (e.g. kgoose): it gates on the participant's check but applies nothing itself.
+// A -t-scoped command, a non-aggregate repo, or a real error still surfaces.
+func TestSkipUnownedUnscopedCommand(t *testing.T) {
+	cfg := &api.ServerConfig{Repos: map[string]api.RepoConfig{
+		"octocat/participant-repo": {Aggregate: &api.AggregateConfig{Role: api.AggregateRoleParticipant}},
+		"octocat/leader-repo": {Aggregate: &api.AggregateConfig{
+			Role:            api.AggregateRoleLeader,
+			ExpectedTenants: []api.ExpectedTenant{{Tenant: "tenant-b", Paths: []string{"tenant-b/schema"}, CheckName: "SchemaBot Tenant B"}},
+		}},
+		"octocat/plain-repo": {},
+	}}
+	h := &Handler{service: api.New(nil, cfg, nil, testLogger())}
+	notOwned := &schemaConfigOutsideAllowedDirsError{Database: "kgoose", SchemaPath: "kgoose/schema"}
+
+	assert.True(t, h.skipUnownedUnscopedCommand("octocat/participant-repo", "", notOwned),
+		"a participant silently skips an unowned unscoped command")
+	assert.True(t, h.skipUnownedUnscopedCommand("octocat/leader-repo", "", notOwned),
+		"a leader silently skips schema it doesn't own (gates on the participant instead)")
+	assert.False(t, h.skipUnownedUnscopedCommand("octocat/participant-repo", "tenant-b", notOwned),
+		"a -t-scoped command named a deployment, so the error still surfaces")
+	assert.False(t, h.skipUnownedUnscopedCommand("octocat/plain-repo", "", notOwned),
+		"a non-aggregate repo is a single deployment — the error is useful, keep it")
+	assert.False(t, h.skipUnownedUnscopedCommand("octocat/unknown-repo", "", notOwned),
+		"an unconfigured repo has no aggregate role — keep the error")
+	assert.False(t, h.skipUnownedUnscopedCommand("octocat/participant-repo", "", errors.New("github unavailable")),
+		"a real error is not the not-owned case and must still surface")
+}
 
 // Fan-out applies only to actionable unscoped commands. A complete command
 // (Found) fans out; a plan without -e fans out as a multi-env plan; but a

--- a/pkg/webhook/aggregate_participant_fanout_test.go
+++ b/pkg/webhook/aggregate_participant_fanout_test.go
@@ -6,7 +6,26 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/block/schemabot/pkg/api"
+	"github.com/block/schemabot/pkg/webhook/action"
 )
+
+// Fan-out applies only to actionable unscoped commands. A complete command
+// (Found) fans out; a plan without -e fans out as a multi-env plan; but a
+// missing-env error for apply/rollback does NOT fan out — otherwise every
+// participant on a shared repo would post its own duplicate "missing
+// environment" comment (the leader posts that error once).
+func TestUnscopedCommandFansOut(t *testing.T) {
+	assert.True(t, unscopedCommandFansOut(CommandResult{Found: true, Action: action.Apply}),
+		"a complete command fans out")
+	assert.True(t, unscopedCommandFansOut(CommandResult{MissingEnv: true, Action: action.Plan}),
+		"plan without -e fans out as a multi-env plan")
+	assert.False(t, unscopedCommandFansOut(CommandResult{MissingEnv: true, Action: action.Apply}),
+		"apply without -e is an error and must not fan out (no duplicate missing-env comments)")
+	assert.False(t, unscopedCommandFansOut(CommandResult{MissingEnv: true, Action: action.Rollback}),
+		"rollback without -e is an error and must not fan out")
+	assert.False(t, unscopedCommandFansOut(CommandResult{}),
+		"an unrecognized command does not fan out")
+}
 
 // An aggregate participant fans out an unscoped work command: an
 // `apply -e <env>` with no -t tenant reaches every participant on a shared

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -37,6 +37,11 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	// Discover config and fetch schema files from PR
 	schemaResult, err := h.createManagedSchemaRequestFromPR(ctx, client, repo, pr, environment, databaseName, action.Apply)
 	if err != nil {
+		if h.skipUnownedUnscopedCommand(repo, result.Tenant, err) {
+			h.logger.Debug("unscoped fan-out apply touches no schema this deployment owns; staying silent",
+				"repo", repo, "pr", pr, "environment", environment)
+			return
+		}
 		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.Apply, err)
 		return
 	}
@@ -310,6 +315,11 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 	// Discover database config from PR's schemabot.yaml
 	schemaResult, err := h.createManagedSchemaRequestFromPR(ctx, client, repo, pr, environment, databaseName, action.ApplyConfirm)
 	if err != nil {
+		if h.skipUnownedUnscopedCommand(repo, result.Tenant, err) {
+			h.logger.Debug("unscoped fan-out apply-confirm touches no schema this deployment owns; staying silent",
+				"repo", repo, "pr", pr, "environment", environment)
+			return
+		}
 		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.ApplyConfirm, err)
 		return
 	}

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -130,12 +130,22 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 		return
 	}
 	if result.Tenant == "" && commandRequiresTenantTarget(result) && h.service != nil && h.service.Config().Tenant != "" {
-		h.logger.Info("ignoring work command without tenant target",
-			"repo", repo, "pr", pr, "tenant", h.service.Config().Tenant, "action", result.Action)
-		h.writeJSON(w, http.StatusOK, map[string]string{
-			"message": "tenant target required",
-		})
-		return
+		if h.fansOutUnscopedCommand(repo) {
+			h.logger.Info("aggregate participant fanning out unscoped work command; applying its own databases",
+				"repo", repo, "pr", pr, "tenant", h.service.Config().Tenant, "action", result.Action)
+			metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+				Operation:  "aggregate_participant_fanout",
+				Repository: repo,
+				Status:     "success",
+			})
+		} else {
+			h.logger.Info("ignoring work command without tenant target",
+				"repo", repo, "pr", pr, "tenant", h.service.Config().Tenant, "action", result.Action)
+			h.writeJSON(w, http.StatusOK, map[string]string{
+				"message": "tenant target required",
+			})
+			return
+		}
 	}
 
 	// Handle help command
@@ -337,6 +347,20 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 
 func commandRequiresTenantTarget(result CommandResult) bool {
 	return !result.IsHelp && (result.Found || result.MissingEnv)
+}
+
+// fansOutUnscopedCommand reports whether this deployment should self-serve an
+// unscoped work command (no -t tenant) for repo by applying its own databases,
+// rather than ignoring it. An aggregate participant fans out: an unscoped
+// `apply -e <env>` on a shared repo reaches every participant, and each applies
+// only its own databases (its own registry filtered by repo/env/allowed_dirs).
+// A tenanted deployment that is not a participant for repo keeps ignoring
+// unscoped work commands, since per-tenant routing requires an explicit -t.
+func (h *Handler) fansOutUnscopedCommand(repo string) bool {
+	if h.service == nil {
+		return false
+	}
+	return h.service.Config().AggregateRoleForRepo(repo) == api.AggregateRoleParticipant
 }
 
 // postComment posts a comment on a PR.

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -130,7 +130,7 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 		return
 	}
 	if result.Tenant == "" && commandRequiresTenantTarget(result) && h.service != nil && h.service.Config().Tenant != "" {
-		if h.fansOutUnscopedCommand(repo) {
+		if h.fansOutUnscopedCommand(repo) && unscopedCommandFansOut(result) {
 			h.logger.Info("aggregate participant fanning out unscoped work command; applying its own databases",
 				"repo", repo, "pr", pr, "tenant", h.service.Config().Tenant, "action", result.Action)
 			metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
@@ -361,6 +361,20 @@ func (h *Handler) fansOutUnscopedCommand(repo string) bool {
 		return false
 	}
 	return h.service.Config().AggregateRoleForRepo(repo) == api.AggregateRoleParticipant
+}
+
+// unscopedCommandFansOut reports whether an unscoped (no -t) command is one a
+// participant should actually act on when fanning out, as opposed to an error
+// case it should stay silent on. A complete command (Found) fans out, and a
+// plan without -e fans out as a multi-env plan. A missing-env error for
+// apply/rollback does NOT fan out: otherwise every participant on a shared repo
+// would post its own duplicate "missing environment" comment. The leader (which
+// never hits the tenant gate) posts that error once.
+func unscopedCommandFansOut(result CommandResult) bool {
+	if result.Found {
+		return true
+	}
+	return result.MissingEnv && result.Action == action.Plan
 }
 
 // postComment posts a comment on a PR.

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -46,6 +46,12 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 	// Discover config and fetch schema files from PR
 	schemaResult, err := h.createManagedSchemaRequestFromPR(ctx, client, repo, pr, environment, databaseName, action.Plan)
 	if err != nil {
+		if h.skipUnownedUnscopedCommand(repo, tenant, err) {
+			h.logger.Debug("unscoped fan-out plan touches no schema this deployment owns; staying silent",
+				"repo", repo, "pr", pr, "environment", environment)
+			h.writeJSON(w, http.StatusOK, map[string]string{"message": "unowned unscoped command skipped"})
+			return
+		}
 		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.Plan, err)
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "schema request error handled"})
 		return

--- a/pkg/webhook/schema_source_policy.go
+++ b/pkg/webhook/schema_source_policy.go
@@ -2,12 +2,34 @@ package webhook
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/metrics"
 )
+
+// skipUnownedUnscopedCommand reports whether a "schema not owned by this
+// deployment" error should be silently ignored instead of reported on the PR.
+// On an aggregate repo (leader or participant), an unscoped command (no -t) is a
+// fan-out broadcast every installed deployment receives; a deployment that owns
+// none of the changed schema is expected to do nothing while the deployment that
+// does own it handles the command. Posting "config not authorized" from every
+// non-owning deployment would be exactly the noise fan-out removes. Scoped to
+// the not-owned error only — real failures still surface. A -t-scoped command
+// (tenant != "") always reports, since it named a specific deployment.
+func (h *Handler) skipUnownedUnscopedCommand(repo, tenant string, err error) bool {
+	if tenant != "" {
+		return false
+	}
+	config, ok := h.serverConfig()
+	if !ok || config.AggregateRoleForRepo(repo) == "" {
+		return false
+	}
+	var notOwned *schemaConfigOutsideAllowedDirsError
+	return errors.As(err, &notOwned)
+}
 
 type schemaConfigOutsideAllowedDirsError struct {
 	Database     string


### PR DESCRIPTION
## Why

On a shared repo, `schemabot apply -e <env>` (no `--tenant`) should mean "apply everyone's schema changes for this env" — one command, all deployments. The standard leader already applies its own databases on an unscoped apply, but a tenanted participant used to ignore it and require an explicit `-t <tenant>`. That made the multi-tenant apply UX N commands instead of one.

## What

When a deployment is configured as an aggregate **participant** for the repo, an unscoped work command now fans out: the participant proceeds and applies **its own** databases instead of ignoring the command. So an unscoped `apply -e production` reaches every participant on the repo, each applying only its own databases; the leader applies its own. Per-tenant `-t` routing is unchanged, and a tenanted deployment that is *not* a participant for the repo still requires `-t`.

Safety: the tenant flag is routing-only and is never forwarded to database selection — `shouldProcessSchemaConfig` fails closed on any database not in this deployment's own config, so a fanning-out participant can only act on its own databases. Opt-in (gated on the participant aggregate role); zero impact on non-aggregate deployments. Metric: `aggregate_participant_fanout`.

*Drafted by Claude Code (claude-opus-4-8).*