### PR TITLE
feat(auth): add forward-auth authorizer for trusted-proxy identity

### DIFF
--- a/pkg/auth/forward_auth.go
+++ b/pkg/auth/forward_auth.go
@@ -27,7 +27,10 @@ type ForwardAuthConfig struct {
 
 	// TrustedProxySPIFFE lists the SPIFFE IDs allowed to act as the proxy. The
 	// caller's SPIFFE ID is read from the Envoy X-Forwarded-Client-Cert (XFCC)
-	// header. A request is trusted if its XFCC carries one of these IDs.
+	// header. Because XFCC is a spoofable HTTP header, it is only honored behind
+	// a transport anchor: TrustedProxyCIDRs must also be set, and a request is
+	// trusted only when its source is in a trusted CIDR AND its XFCC carries one
+	// of these IDs.
 	TrustedProxySPIFFE []string
 
 	// TrustedProxyCIDRs lists source networks allowed to act as the proxy. A
@@ -45,14 +48,17 @@ type ForwardAuthConfig struct {
 
 // ForwardAuthAuthorizer authenticates requests from an authenticating reverse
 // proxy that has already verified the user, then enforces a per-endpoint access
-// tier. It first proves the request came from the trusted proxy — by the proxy's
-// SPIFFE identity (from the Envoy XFCC header) or its source network — and only
-// then trusts the forwarded identity headers. This mirrors the Kubernetes API
-// server's authenticating-proxy model, Grafana's auth proxy, and oauth2-proxy.
+// tier. It first proves the request came from the trusted proxy — its source is
+// in a trusted CIDR and, when SPIFFE is configured, its Envoy XFCC header
+// carries a trusted SPIFFE ID — and only then trusts the forwarded identity
+// headers. This mirrors the Kubernetes API server's authenticating-proxy model,
+// Grafana's auth proxy, and oauth2-proxy.
 //
 // The trust anchor is mandatory: without a configured SPIFFE ID or CIDR the
 // authorizer refuses to construct, so it can never trust spoofed headers by
-// default. Read (visibility) endpoints require only an authenticated caller
+// default. Because the XFCC header is itself spoofable, SPIFFE trust is gated
+// behind the source-CIDR check (the constructor requires a CIDR whenever SPIFFE
+// is set). Read (visibility) endpoints require only an authenticated caller
 // (optionally narrowed to ReadGroups); write endpoints — which include planning,
 // since a plan stages a change against a database — require membership in a
 // configured write group. The direct-API/CLI write path is for a small
@@ -111,6 +117,12 @@ func NewForwardAuthAuthorizer(cfg ForwardAuthConfig, logger *slog.Logger) (*Forw
 
 	if len(nets) == 0 && len(spiffe) == 0 {
 		return nil, fmt.Errorf("forward_auth requires at least one trust anchor (trusted_proxy_spiffe or trusted_proxy_cidrs)")
+	}
+	// XFCC is an HTTP header a direct client could spoof, so SPIFFE trust is only
+	// meaningful once the connection itself is trusted. Require a transport anchor
+	// (CIDR) whenever SPIFFE is configured, so XFCC is honored only behind it.
+	if len(spiffe) > 0 && len(nets) == 0 {
+		return nil, fmt.Errorf("forward_auth trusted_proxy_spiffe requires trusted_proxy_cidrs (XFCC is only trustworthy behind a trusted transport)")
 	}
 
 	return &ForwardAuthAuthorizer{
@@ -210,32 +222,43 @@ func (a *ForwardAuthAuthorizer) extractGroups(r *http.Request) []string {
 }
 
 // isTrustedProxy reports whether the request provably came from the configured
-// proxy, and a short identifier of the matched anchor for logging. A request is
-// trusted if it satisfies any configured anchor: its source IP is in a trusted
-// CIDR, or its XFCC header carries a trusted SPIFFE ID.
+// proxy, and a short identifier of the matched anchor for logging.
+//
+// The source-CIDR check is a transport property the caller cannot forge, so it
+// gates everything: when CIDRs are configured, a request from outside them is
+// never trusted. The SPIFFE check reads the Envoy XFCC header, which is only
+// trustworthy once the connection itself is trusted — a direct client could
+// otherwise spoof the header. So XFCC is honored only after the CIDR gate
+// passes (the constructor requires a CIDR whenever SPIFFE is configured):
+//   - SPIFFE configured: trusted iff the source is in a trusted CIDR AND the
+//     XFCC carries a trusted SPIFFE ID.
+//   - CIDR only: trusted iff the source is in a trusted CIDR.
 func (a *ForwardAuthAuthorizer) isTrustedProxy(r *http.Request) (bool, string) {
-	if len(a.trustedNets) > 0 {
-		host, _, err := net.SplitHostPort(r.RemoteAddr)
-		if err != nil {
-			host = r.RemoteAddr
-		}
-		if ip := net.ParseIP(strings.TrimSpace(host)); ip != nil {
-			for _, network := range a.trustedNets {
-				if network.Contains(ip) {
-					return true, "cidr:" + ip.String()
-				}
-			}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+	ip := net.ParseIP(strings.TrimSpace(host))
+	inTrustedNet := false
+	for _, network := range a.trustedNets {
+		if ip != nil && network.Contains(ip) {
+			inTrustedNet = true
+			break
 		}
 	}
-
-	if len(a.trustedSPIFFE) > 0 {
-		for _, uri := range parseXFCCURIs(r.Header.Get("X-Forwarded-Client-Cert")) {
-			if slices.Contains(a.trustedSPIFFE, uri) {
-				return true, "spiffe:" + uri
-			}
-		}
+	if !inTrustedNet {
+		return false, ""
 	}
 
+	if len(a.trustedSPIFFE) == 0 {
+		return true, "cidr:" + ip.String()
+	}
+
+	for _, uri := range parseXFCCURIs(r.Header.Get("X-Forwarded-Client-Cert")) {
+		if slices.Contains(a.trustedSPIFFE, uri) {
+			return true, "spiffe:" + uri
+		}
+	}
 	return false, ""
 }
 

--- a/pkg/auth/forward_auth.go
+++ b/pkg/auth/forward_auth.go
@@ -27,10 +27,10 @@ type ForwardAuthConfig struct {
 
 	// TrustedProxySPIFFE lists the SPIFFE IDs allowed to act as the proxy. The
 	// caller's SPIFFE ID is read from the Envoy X-Forwarded-Client-Cert (XFCC)
-	// header. Because XFCC is a spoofable HTTP header, it is only honored behind
-	// a transport anchor: TrustedProxyCIDRs must also be set, and a request is
-	// trusted only when its source is in a trusted CIDR AND its XFCC carries one
-	// of these IDs.
+	// header. XFCC is a spoofable HTTP header, so SPIFFE-only trust (no
+	// TrustedProxyCIDRs) is safe only when the proxy sanitizes inbound XFCC and
+	// the server is not directly reachable — a service mesh. Pair it with
+	// TrustedProxyCIDRs for defense in depth outside that setting.
 	TrustedProxySPIFFE []string
 
 	// TrustedProxyCIDRs lists source networks allowed to act as the proxy. A
@@ -49,16 +49,17 @@ type ForwardAuthConfig struct {
 // ForwardAuthAuthorizer authenticates requests from an authenticating reverse
 // proxy that has already verified the user, then enforces a per-endpoint access
 // tier. It first proves the request came from the trusted proxy — its source is
-// in a trusted CIDR and, when SPIFFE is configured, its Envoy XFCC header
-// carries a trusted SPIFFE ID — and only then trusts the forwarded identity
-// headers. This mirrors the Kubernetes API server's authenticating-proxy model,
-// Grafana's auth proxy, and oauth2-proxy.
+// in a trusted CIDR, and/or its Envoy XFCC header carries a trusted SPIFFE ID —
+// and only then trusts the forwarded identity headers. This mirrors the
+// Kubernetes API server's authenticating-proxy model, Grafana's auth proxy, and
+// oauth2-proxy.
 //
 // The trust anchor is mandatory: without a configured SPIFFE ID or CIDR the
 // authorizer refuses to construct, so it can never trust spoofed headers by
-// default. Because the XFCC header is itself spoofable, SPIFFE trust is gated
-// behind the source-CIDR check (the constructor requires a CIDR whenever SPIFFE
-// is set). Read (visibility) endpoints require only an authenticated caller
+// default. XFCC is itself a spoofable header, so SPIFFE-only trust (no CIDR) is
+// safe only behind a proxy that sanitizes inbound XFCC on a server that isn't
+// directly reachable — a service mesh; the constructor warns when it's used
+// alone. Read (visibility) endpoints require only an authenticated caller
 // (optionally narrowed to ReadGroups); write endpoints — which include planning,
 // since a plan stages a change against a database — require membership in a
 // configured write group. The direct-API/CLI write path is for a small
@@ -118,11 +119,13 @@ func NewForwardAuthAuthorizer(cfg ForwardAuthConfig, logger *slog.Logger) (*Forw
 	if len(nets) == 0 && len(spiffe) == 0 {
 		return nil, fmt.Errorf("forward_auth requires at least one trust anchor (trusted_proxy_spiffe or trusted_proxy_cidrs)")
 	}
-	// XFCC is an HTTP header a direct client could spoof, so SPIFFE trust is only
-	// meaningful once the connection itself is trusted. Require a transport anchor
-	// (CIDR) whenever SPIFFE is configured, so XFCC is honored only behind it.
+	// SPIFFE-only mode reads the caller's SPIFFE ID from XFCC, an HTTP header. It
+	// is safe only when the proxy sanitizes inbound XFCC and the server is not
+	// directly reachable (e.g. a service mesh where the sidecar sets XFCC and the
+	// app accepts traffic only from it). Without a CIDR anchor the authorizer
+	// can't verify that at runtime, so warn rather than silently trust.
 	if len(spiffe) > 0 && len(nets) == 0 {
-		return nil, fmt.Errorf("forward_auth trusted_proxy_spiffe requires trusted_proxy_cidrs (XFCC is only trustworthy behind a trusted transport)")
+		logger.Warn("forward-auth trusting XFCC with no source-CIDR anchor: ensure the proxy sanitizes inbound X-Forwarded-Client-Cert and the server is not directly reachable")
 	}
 
 	return &ForwardAuthAuthorizer{
@@ -222,38 +225,41 @@ func (a *ForwardAuthAuthorizer) extractGroups(r *http.Request) []string {
 }
 
 // isTrustedProxy reports whether the request provably came from the configured
-// proxy, and a short identifier of the matched anchor for logging.
-//
-// The source-CIDR check is a transport property the caller cannot forge, so it
-// gates everything: when CIDRs are configured, a request from outside them is
-// never trusted. The SPIFFE check reads the Envoy XFCC header, which is only
-// trustworthy once the connection itself is trusted — a direct client could
-// otherwise spoof the header. So XFCC is honored only after the CIDR gate
-// passes (the constructor requires a CIDR whenever SPIFFE is configured):
-//   - SPIFFE configured: trusted iff the source is in a trusted CIDR AND the
-//     XFCC carries a trusted SPIFFE ID.
+// proxy, and a short identifier of the matched anchor for logging. The
+// source-CIDR check is a transport property the caller cannot forge; the SPIFFE
+// check reads the proxy's identity from the Envoy XFCC header. The three modes:
+//   - CIDR + SPIFFE: trusted iff the source is in a trusted CIDR AND the XFCC
+//     carries a trusted SPIFFE ID (defense in depth).
 //   - CIDR only: trusted iff the source is in a trusted CIDR.
+//   - SPIFFE only: trusted iff the XFCC carries a trusted SPIFFE ID. Safe only
+//     when the proxy sanitizes inbound XFCC and the server isn't directly
+//     reachable (a service mesh); the constructor warns when this mode is used.
 func (a *ForwardAuthAuthorizer) isTrustedProxy(r *http.Request) (bool, string) {
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		host = r.RemoteAddr
-	}
-	ip := net.ParseIP(strings.TrimSpace(host))
-	inTrustedNet := false
-	for _, network := range a.trustedNets {
-		if ip != nil && network.Contains(ip) {
-			inTrustedNet = true
-			break
+	// When CIDRs are configured they gate everything: a request from outside
+	// them is never trusted, regardless of XFCC.
+	if len(a.trustedNets) > 0 {
+		host, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			host = r.RemoteAddr
+		}
+		ip := net.ParseIP(strings.TrimSpace(host))
+		inTrustedNet := false
+		for _, network := range a.trustedNets {
+			if ip != nil && network.Contains(ip) {
+				inTrustedNet = true
+				break
+			}
+		}
+		if !inTrustedNet {
+			return false, ""
+		}
+		if len(a.trustedSPIFFE) == 0 {
+			return true, "cidr:" + ip.String()
 		}
 	}
-	if !inTrustedNet {
-		return false, ""
-	}
 
-	if len(a.trustedSPIFFE) == 0 {
-		return true, "cidr:" + ip.String()
-	}
-
+	// SPIFFE check: either SPIFFE-only mode, or the CIDR gate above has passed
+	// and a matching SPIFFE ID is additionally required.
 	for _, uri := range parseXFCCURIs(r.Header.Get("X-Forwarded-Client-Cert")) {
 		if slices.Contains(a.trustedSPIFFE, uri) {
 			return true, "spiffe:" + uri

--- a/pkg/auth/forward_auth.go
+++ b/pkg/auth/forward_auth.go
@@ -1,0 +1,292 @@
+package auth
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"slices"
+	"strings"
+)
+
+// ForwardAuthConfig configures the forward-auth authorizer, which trusts
+// identity headers set by an authenticating reverse proxy in front of the API.
+type ForwardAuthConfig struct {
+	// UserHeader carries the authenticated user identity. Defaults to
+	// "X-Forwarded-User" (the oauth2-proxy convention).
+	UserHeader string
+
+	// GroupsHeader carries the caller's group memberships. Defaults to
+	// "X-Forwarded-Groups". Values are split on GroupsDelimiter and the header
+	// may also be repeated; all values are collected.
+	GroupsHeader string
+
+	// GroupsDelimiter splits a single GroupsHeader value into groups. Defaults
+	// to ",".
+	GroupsDelimiter string
+
+	// TrustedProxySPIFFE lists the SPIFFE IDs allowed to act as the proxy. The
+	// caller's SPIFFE ID is read from the Envoy X-Forwarded-Client-Cert (XFCC)
+	// header. A request is trusted if its XFCC carries one of these IDs.
+	TrustedProxySPIFFE []string
+
+	// TrustedProxyCIDRs lists source networks allowed to act as the proxy. A
+	// request is trusted if its source IP falls within one of these ranges.
+	TrustedProxyCIDRs []string
+
+	// ReadGroups are the groups granted the read tier. When empty, any
+	// authenticated caller from the trusted proxy may use read-tier endpoints.
+	ReadGroups []string
+
+	// WriteGroups are the groups granted the write tier. When empty, no caller
+	// can perform write-tier operations (read still works).
+	WriteGroups []string
+}
+
+// ForwardAuthAuthorizer authenticates requests from an authenticating reverse
+// proxy that has already verified the user, then enforces a per-endpoint access
+// tier. It first proves the request came from the trusted proxy — by the proxy's
+// SPIFFE identity (from the Envoy XFCC header) or its source network — and only
+// then trusts the forwarded identity headers. This mirrors the Kubernetes API
+// server's authenticating-proxy model, Grafana's auth proxy, and oauth2-proxy.
+//
+// The trust anchor is mandatory: without a configured SPIFFE ID or CIDR the
+// authorizer refuses to construct, so it can never trust spoofed headers by
+// default. Read (visibility) endpoints require only an authenticated caller
+// (optionally narrowed to ReadGroups); write endpoints — which include planning,
+// since a plan stages a change against a database — require membership in a
+// configured write group. The direct-API/CLI write path is for a small
+// privileged set; general users go through the PR-comment workflow instead.
+type ForwardAuthAuthorizer struct {
+	userHeader    string
+	groupsHeader  string
+	groupsDelim   string
+	trustedSPIFFE []string
+	trustedNets   []*net.IPNet
+	readGroups    []string
+	writeGroups   []string
+	logger        *slog.Logger
+}
+
+// NewForwardAuthAuthorizer builds a forward-auth authorizer. It requires at
+// least one trust anchor (a SPIFFE ID or a CIDR); without one it returns an
+// error rather than trusting forwarded headers from any source.
+func NewForwardAuthAuthorizer(cfg ForwardAuthConfig, logger *slog.Logger) (*ForwardAuthAuthorizer, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	userHeader := cfg.UserHeader
+	if userHeader == "" {
+		userHeader = "X-Forwarded-User"
+	}
+	groupsHeader := cfg.GroupsHeader
+	if groupsHeader == "" {
+		groupsHeader = "X-Forwarded-Groups"
+	}
+	delim := cfg.GroupsDelimiter
+	if delim == "" {
+		delim = ","
+	}
+
+	var nets []*net.IPNet
+	for _, c := range cfg.TrustedProxyCIDRs {
+		c = strings.TrimSpace(c)
+		if c == "" {
+			continue
+		}
+		_, network, err := net.ParseCIDR(c)
+		if err != nil {
+			return nil, fmt.Errorf("parse trusted_proxy_cidr %q: %w", c, err)
+		}
+		nets = append(nets, network)
+	}
+
+	var spiffe []string
+	for _, s := range cfg.TrustedProxySPIFFE {
+		if s = strings.TrimSpace(s); s != "" {
+			spiffe = append(spiffe, s)
+		}
+	}
+
+	if len(nets) == 0 && len(spiffe) == 0 {
+		return nil, fmt.Errorf("forward_auth requires at least one trust anchor (trusted_proxy_spiffe or trusted_proxy_cidrs)")
+	}
+
+	return &ForwardAuthAuthorizer{
+		userHeader:    userHeader,
+		groupsHeader:  groupsHeader,
+		groupsDelim:   delim,
+		trustedSPIFFE: spiffe,
+		trustedNets:   nets,
+		readGroups:    cfg.ReadGroups,
+		writeGroups:   cfg.WriteGroups,
+		logger:        logger,
+	}, nil
+}
+
+// Middleware verifies the request came from the trusted proxy, reads the
+// forwarded identity, enforces the endpoint's access tier, and records the
+// authenticated user in the request context. A request that did not arrive
+// through the trusted proxy is rejected before any forwarded header is trusted.
+func (a *ForwardAuthAuthorizer) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if skipAuth(r.URL.Path) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		tier := tierForRequest(r.Method, r.URL.Path)
+
+		trusted, proxyID := a.isTrustedProxy(r)
+		if !trusted {
+			a.logger.Warn("forward-auth request did not arrive through the trusted proxy; refusing to honor identity headers",
+				"path", r.URL.Path, "remote_addr", r.RemoteAddr)
+			authDecision(r, tier, "deny", "untrusted_proxy")
+			writeAuthError(w, http.StatusUnauthorized, "request did not arrive through the trusted authenticating proxy")
+			return
+		}
+
+		// Read the canonical header only. Go's net/http does not fold an
+		// underscore variant (X_Forwarded_User) into the dashed form, so a
+		// smuggled underscore header cannot be read here.
+		user := strings.TrimSpace(r.Header.Get(a.userHeader))
+		if user == "" {
+			a.logger.Warn("forward-auth trusted proxy supplied no user identity",
+				"path", r.URL.Path, "proxy", proxyID, "user_header", a.userHeader)
+			authDecision(r, tier, "deny", "no_identity")
+			writeAuthError(w, http.StatusUnauthorized, "no authenticated user in forwarded headers")
+			return
+		}
+		groups := a.extractGroups(r)
+
+		switch tier {
+		case TierWrite:
+			if !matchesAnyGroup(groups, a.writeGroups) {
+				a.logger.Warn("forward-auth authorization denied for write operation",
+					"path", r.URL.Path, "subject", user)
+				authDecision(r, tier, "deny", "not_admin")
+				writeAuthError(w, http.StatusForbidden, "this operation requires membership in a write-access group")
+				return
+			}
+		default: // TierRead
+			if !a.canRead(groups) {
+				a.logger.Warn("forward-auth authorization denied for read operation",
+					"path", r.URL.Path, "subject", user)
+				authDecision(r, tier, "deny", "not_authorized")
+				writeAuthError(w, http.StatusForbidden, "this operation requires membership in a read-access group")
+				return
+			}
+		}
+
+		authDecision(r, tier, "allow", "")
+		ctx := WithUser(r.Context(), &User{Subject: user, Groups: groups})
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// canRead reports whether the caller may use read-tier endpoints. With no
+// configured read groups, reads are open to any authenticated caller; otherwise
+// the caller must be in a read group (write-group members can always read).
+func (a *ForwardAuthAuthorizer) canRead(groups []string) bool {
+	if len(a.readGroups) == 0 {
+		return true
+	}
+	return matchesAnyGroup(groups, a.readGroups) || matchesAnyGroup(groups, a.writeGroups)
+}
+
+// extractGroups collects the caller's groups from the groups header, supporting
+// both a delimited single value and a repeated header.
+func (a *ForwardAuthAuthorizer) extractGroups(r *http.Request) []string {
+	var groups []string
+	for _, value := range r.Header.Values(a.groupsHeader) {
+		for g := range strings.SplitSeq(value, a.groupsDelim) {
+			if g = strings.TrimSpace(g); g != "" {
+				groups = append(groups, g)
+			}
+		}
+	}
+	return groups
+}
+
+// isTrustedProxy reports whether the request provably came from the configured
+// proxy, and a short identifier of the matched anchor for logging. A request is
+// trusted if it satisfies any configured anchor: its source IP is in a trusted
+// CIDR, or its XFCC header carries a trusted SPIFFE ID.
+func (a *ForwardAuthAuthorizer) isTrustedProxy(r *http.Request) (bool, string) {
+	if len(a.trustedNets) > 0 {
+		host, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			host = r.RemoteAddr
+		}
+		if ip := net.ParseIP(strings.TrimSpace(host)); ip != nil {
+			for _, network := range a.trustedNets {
+				if network.Contains(ip) {
+					return true, "cidr:" + ip.String()
+				}
+			}
+		}
+	}
+
+	if len(a.trustedSPIFFE) > 0 {
+		for _, uri := range parseXFCCURIs(r.Header.Get("X-Forwarded-Client-Cert")) {
+			if slices.Contains(a.trustedSPIFFE, uri) {
+				return true, "spiffe:" + uri
+			}
+		}
+	}
+
+	return false, ""
+}
+
+// parseXFCCURIs extracts the URI (SPIFFE SVID) values from an Envoy
+// X-Forwarded-Client-Cert header. The header is a list of elements separated by
+// commas (one per cert in the chain); each element is a list of key=value pairs
+// separated by semicolons; values may be double-quoted, and a quoted value may
+// contain commas and semicolons. Only URI keys are returned.
+func parseXFCCURIs(header string) []string {
+	if header == "" {
+		return nil
+	}
+	var uris []string
+	for _, pair := range splitXFCC(header) {
+		before, after, ok := strings.Cut(pair, "=")
+		if !ok {
+			continue
+		}
+		key := strings.TrimSpace(before)
+		val := strings.Trim(strings.TrimSpace(after), `"`)
+		if val != "" && strings.EqualFold(key, "URI") {
+			uris = append(uris, val)
+		}
+	}
+	return uris
+}
+
+// splitXFCC splits an XFCC header into key=value tokens, treating both the
+// element separator (comma) and the pair separator (semicolon) as boundaries
+// while respecting double-quoted values.
+func splitXFCC(header string) []string {
+	var (
+		tokens  []string
+		current strings.Builder
+		inQuote bool
+	)
+	for i := 0; i < len(header); i++ {
+		c := header[i]
+		switch {
+		case c == '"':
+			inQuote = !inQuote
+			current.WriteByte(c)
+		case (c == ',' || c == ';') && !inQuote:
+			tokens = append(tokens, current.String())
+			current.Reset()
+		default:
+			current.WriteByte(c)
+		}
+	}
+	if current.Len() > 0 {
+		tokens = append(tokens, current.String())
+	}
+	return tokens
+}

--- a/pkg/auth/forward_auth_test.go
+++ b/pkg/auth/forward_auth_test.go
@@ -125,16 +125,30 @@ func TestForwardAuth_WriteRequiresWriteGroup(t *testing.T) {
 	})
 }
 
+func TestNewForwardAuthAuthorizer_SPIFFERequiresCIDR(t *testing.T) {
+	// SPIFFE trust reads a spoofable header, so it must be gated behind a
+	// transport anchor. Configuring SPIFFE without a CIDR fails closed.
+	_, err := auth.NewForwardAuthAuthorizer(auth.ForwardAuthConfig{
+		TrustedProxySPIFFE: []string{ingressSVID},
+		WriteGroups:        []string{"ops"},
+	}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "trusted_proxy_cidrs")
+}
+
 func TestForwardAuth_TrustedViaSPIFFE(t *testing.T) {
+	// SPIFFE is gated behind the transport CIDR: the request must both come from
+	// a trusted source and carry a trusted SVID in XFCC.
 	cfg := auth.ForwardAuthConfig{
+		TrustedProxyCIDRs:  []string{trustedCIDR},
 		TrustedProxySPIFFE: []string{ingressSVID},
 		WriteGroups:        []string{"ops"},
 	}
 
-	t.Run("matching SVID in XFCC is trusted", func(t *testing.T) {
+	t.Run("trusted source with matching SVID is trusted", func(t *testing.T) {
 		handler, captured := newForwardAuth(t, cfg)
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
-		req.RemoteAddr = untrustedAddr // only SPIFFE can grant trust here
+		req.RemoteAddr = trustedIPAddr
 		req.Header.Set("X-Forwarded-Client-Cert", `By=spiffe://example.org/ns/api/sa/schemabot;Hash=abc123;URI=`+ingressSVID)
 		req.Header.Set("X-Forwarded-User", "alice")
 		rec := httptest.NewRecorder()
@@ -145,11 +159,26 @@ func TestForwardAuth_TrustedViaSPIFFE(t *testing.T) {
 		assert.Equal(t, "alice", captured.user.Subject)
 	})
 
-	t.Run("wrong SVID is not trusted", func(t *testing.T) {
+	t.Run("trusted source with wrong SVID is not trusted", func(t *testing.T) {
+		handler, captured := newForwardAuth(t, cfg)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
+		req.RemoteAddr = trustedIPAddr
+		req.Header.Set("X-Forwarded-Client-Cert", `URI=spiffe://example.org/ns/other/sa/attacker`)
+		req.Header.Set("X-Forwarded-User", "alice")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.Nil(t, captured.user)
+	})
+
+	t.Run("spoofed SVID from an untrusted source is not trusted", func(t *testing.T) {
+		// A direct client outside the trusted CIDR cannot gain trust by forging
+		// the XFCC header, because the transport gate fails first.
 		handler, captured := newForwardAuth(t, cfg)
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
 		req.RemoteAddr = untrustedAddr
-		req.Header.Set("X-Forwarded-Client-Cert", `URI=spiffe://example.org/ns/other/sa/attacker`)
+		req.Header.Set("X-Forwarded-Client-Cert", `URI=`+ingressSVID)
 		req.Header.Set("X-Forwarded-User", "alice")
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)

--- a/pkg/auth/forward_auth_test.go
+++ b/pkg/auth/forward_auth_test.go
@@ -1,0 +1,288 @@
+package auth_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/auth"
+)
+
+const (
+	trustedCIDR   = "192.0.2.0/24"
+	trustedIPAddr = "192.0.2.10:443"
+	untrustedAddr = "203.0.113.5:443"
+	ingressSVID   = "spiffe://example.org/ns/ingress/sa/proxy"
+)
+
+// newForwardAuth builds a forward-auth authorizer around a handler that records
+// the authenticated user, and returns both so tests can assert the response and
+// the resolved identity.
+func newForwardAuth(t *testing.T, cfg auth.ForwardAuthConfig) (http.Handler, *capturedUser) {
+	t.Helper()
+	authz, err := auth.NewForwardAuthAuthorizer(cfg, nil)
+	require.NoError(t, err)
+	captured := &capturedUser{}
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.user = auth.UserFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+	return authz.Middleware(inner), captured
+}
+
+type capturedUser struct {
+	user *auth.User
+}
+
+func TestNewForwardAuthAuthorizer_RequiresTrustAnchor(t *testing.T) {
+	_, err := auth.NewForwardAuthAuthorizer(auth.ForwardAuthConfig{
+		WriteGroups: []string{"ops"},
+	}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "trust anchor")
+}
+
+func TestNewForwardAuthAuthorizer_RejectsBadCIDR(t *testing.T) {
+	_, err := auth.NewForwardAuthAuthorizer(auth.ForwardAuthConfig{
+		TrustedProxyCIDRs: []string{"not-a-cidr"},
+	}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "trusted_proxy_cidr")
+}
+
+func TestForwardAuth_UntrustedSourceDenied(t *testing.T) {
+	handler, captured := newForwardAuth(t, auth.ForwardAuthConfig{
+		TrustedProxyCIDRs: []string{trustedCIDR},
+		WriteGroups:       []string{"ops"},
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
+	req.RemoteAddr = untrustedAddr
+	req.Header.Set("X-Forwarded-User", "alice")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	// A request that did not come through the trusted proxy is rejected before
+	// any forwarded identity header is honored.
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Nil(t, captured.user)
+}
+
+func TestForwardAuth_TrustedCIDRReadAllowedForAnyUser(t *testing.T) {
+	// With no read_groups configured, reads are open to any authenticated caller
+	// arriving through the trusted proxy.
+	handler, captured := newForwardAuth(t, auth.ForwardAuthConfig{
+		TrustedProxyCIDRs: []string{trustedCIDR},
+		WriteGroups:       []string{"ops"},
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
+	req.RemoteAddr = trustedIPAddr
+	req.Header.Set("X-Forwarded-User", "alice")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, captured.user)
+	assert.Equal(t, "alice", captured.user.Subject)
+}
+
+func TestForwardAuth_WriteRequiresWriteGroup(t *testing.T) {
+	cfg := auth.ForwardAuthConfig{
+		TrustedProxyCIDRs: []string{trustedCIDR},
+		WriteGroups:       []string{"ops", "owners"},
+	}
+
+	t.Run("denied without write group", func(t *testing.T) {
+		handler, captured := newForwardAuth(t, cfg)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/plan", nil)
+		req.RemoteAddr = trustedIPAddr
+		req.Header.Set("X-Forwarded-User", "alice")
+		req.Header.Set("X-Forwarded-Groups", "readers,viewers")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+		assert.Nil(t, captured.user)
+	})
+
+	t.Run("allowed with write group", func(t *testing.T) {
+		handler, captured := newForwardAuth(t, cfg)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/plan", nil)
+		req.RemoteAddr = trustedIPAddr
+		req.Header.Set("X-Forwarded-User", "bob")
+		req.Header.Set("X-Forwarded-Groups", "viewers,owners")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NotNil(t, captured.user)
+		assert.Equal(t, "bob", captured.user.Subject)
+		assert.Equal(t, []string{"viewers", "owners"}, captured.user.Groups)
+	})
+}
+
+func TestForwardAuth_TrustedViaSPIFFE(t *testing.T) {
+	cfg := auth.ForwardAuthConfig{
+		TrustedProxySPIFFE: []string{ingressSVID},
+		WriteGroups:        []string{"ops"},
+	}
+
+	t.Run("matching SVID in XFCC is trusted", func(t *testing.T) {
+		handler, captured := newForwardAuth(t, cfg)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
+		req.RemoteAddr = untrustedAddr // only SPIFFE can grant trust here
+		req.Header.Set("X-Forwarded-Client-Cert", `By=spiffe://example.org/ns/api/sa/schemabot;Hash=abc123;URI=`+ingressSVID)
+		req.Header.Set("X-Forwarded-User", "alice")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NotNil(t, captured.user)
+		assert.Equal(t, "alice", captured.user.Subject)
+	})
+
+	t.Run("wrong SVID is not trusted", func(t *testing.T) {
+		handler, captured := newForwardAuth(t, cfg)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
+		req.RemoteAddr = untrustedAddr
+		req.Header.Set("X-Forwarded-Client-Cert", `URI=spiffe://example.org/ns/other/sa/attacker`)
+		req.Header.Set("X-Forwarded-User", "alice")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.Nil(t, captured.user)
+	})
+}
+
+func TestForwardAuth_TrustedProxyWithoutUserDenied(t *testing.T) {
+	handler, captured := newForwardAuth(t, auth.ForwardAuthConfig{
+		TrustedProxyCIDRs: []string{trustedCIDR},
+		WriteGroups:       []string{"ops"},
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
+	req.RemoteAddr = trustedIPAddr // trusted, but no user identity forwarded
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Nil(t, captured.user)
+}
+
+func TestForwardAuth_UnderscoreHeaderNotHonored(t *testing.T) {
+	// A smuggled underscore variant (X_Forwarded_User) must not be read as the
+	// identity: net/http does not fold it into the canonical dashed header.
+	handler, captured := newForwardAuth(t, auth.ForwardAuthConfig{
+		TrustedProxyCIDRs: []string{trustedCIDR},
+		WriteGroups:       []string{"ops"},
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
+	req.RemoteAddr = trustedIPAddr
+	req.Header.Set("X_Forwarded_User", "attacker")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Nil(t, captured.user)
+}
+
+func TestForwardAuth_ReadGroupsRestrictReads(t *testing.T) {
+	cfg := auth.ForwardAuthConfig{
+		TrustedProxyCIDRs: []string{trustedCIDR},
+		ReadGroups:        []string{"users"},
+		WriteGroups:       []string{"owners"},
+	}
+
+	t.Run("caller outside read and write groups is denied", func(t *testing.T) {
+		handler, _ := newForwardAuth(t, cfg)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
+		req.RemoteAddr = trustedIPAddr
+		req.Header.Set("X-Forwarded-User", "alice")
+		req.Header.Set("X-Forwarded-Groups", "strangers")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
+
+	t.Run("read-group member is allowed", func(t *testing.T) {
+		handler, _ := newForwardAuth(t, cfg)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
+		req.RemoteAddr = trustedIPAddr
+		req.Header.Set("X-Forwarded-User", "alice")
+		req.Header.Set("X-Forwarded-Groups", "users")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("write-group member can always read", func(t *testing.T) {
+		handler, _ := newForwardAuth(t, cfg)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
+		req.RemoteAddr = trustedIPAddr
+		req.Header.Set("X-Forwarded-User", "bob")
+		req.Header.Set("X-Forwarded-Groups", "owners")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+}
+
+func TestForwardAuth_WriteDeniedWhenNoWriteGroupsConfigured(t *testing.T) {
+	// An empty write_groups means no caller can write, even a trusted one.
+	handler, _ := newForwardAuth(t, auth.ForwardAuthConfig{
+		TrustedProxyCIDRs: []string{trustedCIDR},
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/plan", nil)
+	req.RemoteAddr = trustedIPAddr
+	req.Header.Set("X-Forwarded-User", "alice")
+	req.Header.Set("X-Forwarded-Groups", "owners")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestForwardAuth_GroupsFromRepeatedAndDelimitedHeaders(t *testing.T) {
+	handler, captured := newForwardAuth(t, auth.ForwardAuthConfig{
+		TrustedProxyCIDRs: []string{trustedCIDR},
+		WriteGroups:       []string{"owners"},
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/plan", nil)
+	req.RemoteAddr = trustedIPAddr
+	req.Header.Set("X-Forwarded-User", "bob")
+	req.Header.Add("X-Forwarded-Groups", "viewers, readers")
+	req.Header.Add("X-Forwarded-Groups", "owners")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, captured.user)
+	assert.Equal(t, []string{"viewers", "readers", "owners"}, captured.user.Groups)
+}
+
+func TestForwardAuth_SkipsInfraPaths(t *testing.T) {
+	// Health/metrics/webhook paths bypass the authorizer entirely.
+	handler, _ := newForwardAuth(t, auth.ForwardAuthConfig{
+		TrustedProxyCIDRs: []string{trustedCIDR},
+		WriteGroups:       []string{"owners"},
+	})
+
+	for _, path := range []string{"/health", "/metrics", "/webhook"} {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, path, nil)
+		req.RemoteAddr = untrustedAddr // untrusted, but these paths skip auth
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		assert.Equalf(t, http.StatusOK, rec.Code, "path %s should bypass auth", path)
+	}
+}

--- a/pkg/auth/forward_auth_test.go
+++ b/pkg/auth/forward_auth_test.go
@@ -125,19 +125,48 @@ func TestForwardAuth_WriteRequiresWriteGroup(t *testing.T) {
 	})
 }
 
-func TestNewForwardAuthAuthorizer_SPIFFERequiresCIDR(t *testing.T) {
-	// SPIFFE trust reads a spoofable header, so it must be gated behind a
-	// transport anchor. Configuring SPIFFE without a CIDR fails closed.
-	_, err := auth.NewForwardAuthAuthorizer(auth.ForwardAuthConfig{
+func TestForwardAuth_SPIFFEOnlyMode(t *testing.T) {
+	// SPIFFE-only (no CIDR) trusts a request purely by the SVID its XFCC carries —
+	// the mesh sidecar mode. The source IP is irrelevant; only the SVID matters.
+	cfg := auth.ForwardAuthConfig{
 		TrustedProxySPIFFE: []string{ingressSVID},
 		WriteGroups:        []string{"ops"},
-	}, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "trusted_proxy_cidrs")
+	}
+
+	t.Run("matching SVID is trusted regardless of source", func(t *testing.T) {
+		handler, captured := newForwardAuth(t, cfg)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
+		req.RemoteAddr = untrustedAddr
+		req.Header.Set("X-Forwarded-Client-Cert", `URI=`+ingressSVID)
+		req.Header.Set("X-Forwarded-User", "alice")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NotNil(t, captured.user)
+		assert.Equal(t, "alice", captured.user.Subject)
+	})
+
+	t.Run("missing or wrong SVID is not trusted", func(t *testing.T) {
+		for _, xfcc := range []string{"", `URI=spiffe://example.org/ns/other/sa/attacker`} {
+			handler, captured := newForwardAuth(t, cfg)
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
+			req.RemoteAddr = trustedIPAddr
+			if xfcc != "" {
+				req.Header.Set("X-Forwarded-Client-Cert", xfcc)
+			}
+			req.Header.Set("X-Forwarded-User", "alice")
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusUnauthorized, rec.Code)
+			assert.Nil(t, captured.user)
+		}
+	})
 }
 
 func TestForwardAuth_TrustedViaSPIFFE(t *testing.T) {
-	// SPIFFE is gated behind the transport CIDR: the request must both come from
+	// CIDR + SPIFFE together is defense in depth: the request must both come from
 	// a trusted source and carry a trusted SVID in XFCC.
 	cfg := auth.ForwardAuthConfig{
 		TrustedProxyCIDRs:  []string{trustedCIDR},


### PR DESCRIPTION
Adds `ForwardAuthAuthorizer`, a third `auth.Authorizer` alongside `none`/`oidc`, for deployments that sit behind an authenticating reverse proxy (the standard forward-auth pattern used by the Kubernetes API server's authenticating proxy, Grafana's auth proxy, and oauth2-proxy).

**How it works**
1. Prove the request came from the trusted proxy — by the proxy's SPIFFE identity (parsed from the Envoy `X-Forwarded-Client-Cert` header) or its source CIDR.
2. Only then read the forwarded identity (`X-Forwarded-User` / `X-Forwarded-Groups` by default; header names configurable).
3. Enforce the existing read/write access tiers: reads are open to any authenticated caller (optionally narrowed to `read_groups`); writes require membership in a `write_groups` group.

**Fail-closed by design**
- The trust anchor is mandatory — with no SPIFFE ID or CIDR configured, the constructor errors rather than trusting headers from any source.
- Requests that don't arrive through the trusted proxy are rejected before any forwarded header is honored.
- Only the canonical header is read, so a smuggled underscore variant (`X_Forwarded_User`) is ignored.

Scoped to the `pkg/auth` package with unit tests (spoofing, smuggling, fail-closed, tier enforcement, XFCC/CIDR trust, group parsing). Not yet wired into the server config — a follow-up registers the `forward_auth` auth type in `buildAuthorizer` and the config schema.

*PR authored by Claude Code (Opus 4.8).*