### PR TITLE
feat(auth): register the forward_auth authenticator in server config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,9 @@
 - [Repository Allowlist](#repository-allowlist)
 - [PR Checks Gate](#pr-checks-gate)
 - [Review Gate](#review-gate)
+- [Authentication](#authentication)
+  - [OIDC (Bearer tokens)](#oidc-bearer-tokens)
+  - [Forward-auth (authenticating proxy)](#forward-auth-authenticating-proxy)
 - [Multi-Environment Deployment](#multi-environment-deployment)
   - [Staging Instance](#staging-instance)
   - [Production Instance](#production-instance)
@@ -442,6 +445,54 @@ CODEOWNERS support is opt-in because CODEOWNERS is repo-controlled while review 
 The base branch is used, not the PR's head branch, to prevent a PR from relaxing its own approval requirements by modifying CODEOWNERS.
 
 Approval is checked at the time of `schemabot apply` and `schemabot apply-confirm`. Once an apply is executing, there is no ongoing approval check. If a PR is force-pushed after approval, GitHub may dismiss approvals; `apply-confirm` re-checks the gate and blocks if the approval no longer satisfies the policy. Team membership and CODEOWNERS are evaluated fresh at each gate check.
+
+## Authentication
+
+By default (`auth.type: none` or unset) the SchemaBot API is unauthenticated — every request is allowed, which suits local development and deployments where the network is the only boundary. Setting `auth.type` turns on per-request authentication and a two-tier authorization model:
+
+- **Read tier** — visibility: `status`, `progress`, `logs`, `locks` (list), history, database discovery, and `pull` (read a live schema).
+- **Write tier** — anything that stages or makes a change: `plan`, `apply`, controls (`stop`/`start`/`cutover`/`volume`/`revert`/`skip-revert`/`rollback`), `unlock`, and settings mutation. `plan` is a write because it stages a change against a database.
+
+Any unclassified `/api` route is treated as write (fail-closed). The `/webhook` and health/metrics endpoints are exempt — webhooks authenticate themselves via HMAC. Two authenticators are available.
+
+### OIDC (Bearer tokens)
+
+The server validates a JWT on each request against the issuer's public keys (JWKS) — it never calls the provider at request time, so it works with any OIDC provider.
+
+```yaml
+auth:
+  type: oidc
+  issuer: "https://issuer.example.com"   # required
+  audience: "schemabot"                   # required — the expected aud claim
+  groups_claim: "groups"                  # optional (default "groups")
+```
+
+A valid token clears the read tier. The write tier additionally requires the token's groups to include an admin team from `pr_command_authorization.admin_teams`. Machine callers pass a token via `--token` / `SCHEMABOT_TOKEN`; a group-less service token (client-credentials grant) gets read access.
+
+### Forward-auth (authenticating proxy)
+
+Use this when SchemaBot runs behind an authenticating reverse proxy that has already verified the caller and forwards the identity as HTTP headers — the pattern used by the Kubernetes API server's authenticating proxy, Grafana's auth proxy, and oauth2-proxy.
+
+```yaml
+auth:
+  type: forward_auth
+  forward_auth:
+    user_header: X-Forwarded-User        # optional (default)
+    groups_header: X-Forwarded-Groups     # optional (default)
+    groups_delimiter: ","                 # optional (default)
+    # Trust anchor — configure at least one (neither is individually required):
+    trusted_proxy_spiffe:                 # proxy SPIFFE IDs, read from the Envoy XFCC header
+      - spiffe://example.org/ns/ingress/sa/proxy
+    trusted_proxy_cidrs:                  # and/or source networks allowed to be the proxy
+      - 127.0.0.1/32
+    read_groups: [readers]                # groups granted read (empty = any authenticated caller)
+    write_groups: [operators]             # groups granted write (empty = no writes)
+```
+
+The authorizer proves the request came from the trusted proxy, then reads the forwarded identity:
+
+- **Trust anchor (required, fail-closed).** With neither `trusted_proxy_cidrs` nor `trusted_proxy_spiffe` set, the server refuses to start. There are three modes: **CIDR only** (trust any request whose source IP is in a trusted network), **SPIFFE only** (trust any request whose XFCC carries a trusted SPIFFE ID), or **both** (require the source CIDR *and* a matching XFCC SPIFFE ID — defense in depth). `X-Forwarded-Client-Cert` (XFCC) is a spoofable HTTP header, so SPIFFE-only is safe only when the proxy sanitizes inbound XFCC and the server is not directly reachable (a service mesh) — the server logs a startup warning in that mode.
+- **Tiers.** Reads are open to any authenticated caller unless `read_groups` is set; writes require membership in `write_groups`. Only the canonical header is read, so a smuggled underscore variant (`X_Forwarded_User`) is ignored.
 
 ## Multi-Environment Deployment
 

--- a/pkg/api/auth_config_test.go
+++ b/pkg/api/auth_config_test.go
@@ -51,4 +51,46 @@ func TestAuthConfigValidate(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "whitespace")
 	})
+
+	t.Run("unknown type message lists forward_auth", func(t *testing.T) {
+		err := (&api.AuthConfig{Type: "ldap"}).Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "forward_auth")
+	})
+
+	t.Run("forward_auth requires a trust anchor", func(t *testing.T) {
+		err := (&api.AuthConfig{Type: "forward_auth"}).Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "trust anchor")
+	})
+
+	t.Run("forward_auth spiffe-only is valid", func(t *testing.T) {
+		require.NoError(t, (&api.AuthConfig{Type: "forward_auth", ForwardAuth: api.ForwardAuthSettings{
+			TrustedProxySPIFFE: []string{"spiffe://example.org/ns/ingress/sa/proxy"},
+			WriteGroups:        []string{"owners"},
+		}}).Validate())
+	})
+
+	t.Run("forward_auth rejects a malformed cidr", func(t *testing.T) {
+		err := (&api.AuthConfig{Type: "forward_auth", ForwardAuth: api.ForwardAuthSettings{
+			TrustedProxyCIDRs: []string{"not-a-cidr"},
+		}}).Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "CIDR")
+	})
+
+	t.Run("forward_auth with a cidr is valid", func(t *testing.T) {
+		require.NoError(t, (&api.AuthConfig{Type: "forward_auth", ForwardAuth: api.ForwardAuthSettings{
+			TrustedProxyCIDRs: []string{"127.0.0.1/32"},
+			WriteGroups:       []string{"owners"},
+		}}).Validate())
+	})
+
+	t.Run("forward_auth with spiffe and a cidr is valid", func(t *testing.T) {
+		require.NoError(t, (&api.AuthConfig{Type: "forward_auth", ForwardAuth: api.ForwardAuthSettings{
+			TrustedProxyCIDRs:  []string{"127.0.0.1/32"},
+			TrustedProxySPIFFE: []string{"spiffe://example.org/ns/ingress/sa/proxy"},
+			WriteGroups:        []string{"owners"},
+		}}).Validate())
+	})
 }

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -941,7 +941,8 @@ func (c *ServerConfig) Validate() error {
 // When Type is empty or "none" (the default), authentication is disabled and
 // all requests are allowed — unchanged from deployments without this config.
 type AuthConfig struct {
-	// Type selects the authenticator: "none" (or "", the default) or "oidc".
+	// Type selects the authenticator: "none" (or "", the default), "oidc", or
+	// "forward_auth".
 	Type string `yaml:"type"`
 
 	// Issuer is the OIDC provider's issuer URL. Required when Type is "oidc".
@@ -955,6 +956,44 @@ type AuthConfig struct {
 	// GroupsClaim is the JWT claim carrying group memberships. Defaults to
 	// "groups" when empty.
 	GroupsClaim string `yaml:"groups_claim"`
+
+	// ForwardAuth configures the "forward_auth" authenticator, used when
+	// SchemaBot runs behind an authenticating reverse proxy that forwards the
+	// verified identity as HTTP headers.
+	ForwardAuth ForwardAuthSettings `yaml:"forward_auth,omitempty"`
+}
+
+// ForwardAuthSettings configures the forward-auth authenticator. The proxy's
+// identity is the trust anchor (a source CIDR, and optionally a SPIFFE ID from
+// the Envoy X-Forwarded-Client-Cert header); only then are the forwarded user
+// and group headers honored.
+type ForwardAuthSettings struct {
+	// UserHeader carries the authenticated user identity (default
+	// "X-Forwarded-User").
+	UserHeader string `yaml:"user_header,omitempty"`
+
+	// GroupsHeader carries the caller's groups (default "X-Forwarded-Groups").
+	GroupsHeader string `yaml:"groups_header,omitempty"`
+
+	// GroupsDelimiter splits a single groups-header value (default ",").
+	GroupsDelimiter string `yaml:"groups_delimiter,omitempty"`
+
+	// TrustedProxySPIFFE lists SPIFFE IDs allowed to act as the proxy, read from
+	// the XFCC header. SPIFFE-only (no TrustedProxyCIDRs) is safe only when the
+	// proxy sanitizes inbound XFCC and the server is not directly reachable — a
+	// service mesh; pair it with TrustedProxyCIDRs for defense in depth otherwise.
+	TrustedProxySPIFFE []string `yaml:"trusted_proxy_spiffe,omitempty"`
+
+	// TrustedProxyCIDRs lists source networks allowed to act as the proxy.
+	TrustedProxyCIDRs []string `yaml:"trusted_proxy_cidrs,omitempty"`
+
+	// ReadGroups are the groups granted the read tier. Empty means any
+	// authenticated caller from the trusted proxy may read.
+	ReadGroups []string `yaml:"read_groups,omitempty"`
+
+	// WriteGroups are the groups granted the write tier. Empty means no caller
+	// can perform write-tier operations.
+	WriteGroups []string `yaml:"write_groups,omitempty"`
 }
 
 // Validate checks the auth configuration. Unknown types are rejected so a
@@ -974,9 +1013,41 @@ func (a *AuthConfig) Validate() error {
 			return fmt.Errorf("audience is required when auth type is oidc")
 		}
 		return nil
+	case "forward_auth":
+		return a.ForwardAuth.validate()
 	default:
-		return fmt.Errorf("unknown auth type %q (supported: none, oidc)", a.Type)
+		return fmt.Errorf("unknown auth type %q (supported: none, oidc, forward_auth)", a.Type)
 	}
+}
+
+// validate checks the forward-auth settings so a misconfigured trust anchor
+// fails closed at startup: it requires at least one anchor (a SPIFFE ID or a
+// CIDR) and checks CIDR syntax so a typo is caught before serving. SPIFFE-only
+// (no CIDR) is allowed for mesh deployments; the authorizer warns about the XFCC
+// precondition at startup.
+func (f *ForwardAuthSettings) validate() error {
+	trimmedCIDRs := make([]string, 0, len(f.TrustedProxyCIDRs))
+	for _, c := range f.TrustedProxyCIDRs {
+		if c = strings.TrimSpace(c); c != "" {
+			trimmedCIDRs = append(trimmedCIDRs, c)
+		}
+	}
+	trimmedSPIFFE := make([]string, 0, len(f.TrustedProxySPIFFE))
+	for _, s := range f.TrustedProxySPIFFE {
+		if s = strings.TrimSpace(s); s != "" {
+			trimmedSPIFFE = append(trimmedSPIFFE, s)
+		}
+	}
+
+	if len(trimmedCIDRs) == 0 && len(trimmedSPIFFE) == 0 {
+		return fmt.Errorf("forward_auth requires at least one trust anchor (trusted_proxy_spiffe or trusted_proxy_cidrs)")
+	}
+	for _, c := range trimmedCIDRs {
+		if _, _, err := net.ParseCIDR(c); err != nil {
+			return fmt.Errorf("forward_auth trusted_proxy_cidrs entry %q is not a valid CIDR: %w", c, err)
+		}
+	}
+	return nil
 }
 
 func validateSupportChannel(c SupportChannelConfig) error {

--- a/pkg/api/enqueue_authorized_apply_integration_test.go
+++ b/pkg/api/enqueue_authorized_apply_integration_test.go
@@ -166,7 +166,7 @@ func TestEnqueueAuthorizedApplyRecordsAuthenticatedCaller(t *testing.T) {
 	ctx := t.Context()
 
 	container, err := mysql.Run(ctx,
-		"mysql:8.0",
+		"mysql:8.4",
 		mysql.WithDatabase("schemabot_test"),
 		mysql.WithUsername("root"),
 		mysql.WithPassword("test"),

--- a/pkg/api/enqueue_authorized_apply_integration_test.go
+++ b/pkg/api/enqueue_authorized_apply_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/mysql"
 
+	"github.com/block/schemabot/pkg/auth"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/storage/mysqlstore"
@@ -154,4 +155,92 @@ func TestEnqueueAuthorizedApplyQueuesDurableApplyAgainstStorage(t *testing.T) {
 	require.NotNil(t, claimed, "queued apply must be operator-claimable")
 	assert.Equal(t, applyID, claimed.ID)
 	assert.Equal(t, state.Apply.Pending, claimed.State)
+}
+
+// When API auth is enabled, an authorized write persists an apply attributed to
+// the authenticated caller — not the client-supplied Caller. This is the
+// storage-backed counterpart to the tier checks: it confirms a write-authorized
+// request actually creates a durable apply row, and that a stamp-free break-glass
+// write is auditable to the verified identity.
+func TestEnqueueAuthorizedApplyRecordsAuthenticatedCaller(t *testing.T) {
+	ctx := t.Context()
+
+	container, err := mysql.Run(ctx,
+		"mysql:8.0",
+		mysql.WithDatabase("schemabot_test"),
+		mysql.WithUsername("root"),
+		mysql.WithPassword("test"),
+	)
+	require.NoError(t, err, "failed to start mysql")
+	t.Cleanup(func() {
+		if err := testcontainers.TerminateContainer(container); err != nil {
+			t.Logf("failed to terminate container: %v", err)
+		}
+	})
+
+	dsn, err := testutil.ContainerConnectionString(ctx, container, "parseTime=true")
+	require.NoError(t, err, "failed to get connection string")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	require.NoError(t, EnsureSchema(dsn, logger), "failed to ensure schema")
+
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err, "failed to open database")
+	require.NoError(t, db.PingContext(ctx), "failed to ping database")
+	t.Cleanup(func() { utils.CloseAndLog(db) })
+
+	stor := mysqlstore.New(db)
+
+	plan := &storage.Plan{
+		PlanIdentifier: "plan-authenticated-caller",
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Deployment:     "default",
+		Target:         "testdb-staging-target",
+		Repository:     "octocat/hello-world",
+		PullRequest:    1,
+		SchemaPath:     "schema/testdb",
+		Environment:    "staging",
+		Namespaces: map[string]*storage.NamespacePlanData{
+			"testdb": {
+				Tables: []storage.TableChange{
+					{
+						Namespace: "testdb",
+						Table:     "users",
+						DDL:       "ALTER TABLE users ADD COLUMN email varchar(255)",
+						Operation: "alter",
+					},
+				},
+			},
+		},
+		CreatedAt: time.Now(),
+	}
+	_, err = stor.Plans().Create(ctx, plan)
+	require.NoError(t, err, "failed to store plan")
+
+	cfg := &ServerConfig{
+		TernDeployments: TernConfig{"default": {"staging": "localhost:9090"}},
+	}
+	svc := New(stor, cfg, map[string]tern.Client{"default/staging": &mockTernClient{isRemote: true}}, logger)
+
+	// A request from an authenticated caller (as the auth middleware would set)
+	// carrying a different, untrusted Caller in the body — the authenticated
+	// identity must win.
+	authCtx := auth.WithUser(ctx, &auth.User{Subject: "bob@example.com"})
+	resp, applyID, err := svc.EnqueueAuthorizedApply(authCtx, ApplyRequest{
+		PlanID:      plan.PlanIdentifier,
+		Environment: "staging",
+		Caller:      "client-supplied-should-be-ignored",
+	})
+	require.NoError(t, err)
+	require.True(t, resp.Accepted)
+	require.Positive(t, applyID)
+
+	// Storage confirmation: the apply row is durable, and its caller is the
+	// authenticated subject rather than the client-supplied request Caller.
+	apply, err := stor.Applies().Get(ctx, applyID)
+	require.NoError(t, err)
+	require.NotNil(t, apply)
+	assert.Equal(t, "bob@example.com", apply.Caller,
+		"apply must be attributed to the authenticated caller, not the client-supplied Caller")
 }

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -20,6 +20,7 @@ import (
 	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/block/schemabot/pkg/apitypes"
+	"github.com/block/schemabot/pkg/auth"
 	"github.com/block/schemabot/pkg/metrics"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/routing"
@@ -939,6 +940,16 @@ func (s *Service) createStoredApply(
 		lockID = lock.ID
 	}
 
+	// Attribute the apply to the authenticated caller when the request carried a
+	// real identity (API auth enabled). This makes a direct-API/CLI apply
+	// auditable to the verified user rather than a client-supplied Caller string.
+	// With auth disabled, or on the PR-comment path (no authenticated user), the
+	// request's Caller is used unchanged.
+	caller := req.Caller
+	if subject, ok := auth.AuthenticatedSubject(ctx); ok {
+		caller = subject
+	}
+
 	apply := &storage.Apply{
 		ApplyIdentifier: applyIdentifier,
 		LockID:          lockID,
@@ -949,7 +960,7 @@ func (s *Service) createStoredApply(
 		PullRequest:     plan.PullRequest,
 		Environment:     req.Environment,
 		Deployment:      targets[0].Deployment,
-		Caller:          req.Caller,
+		Caller:          caller,
 		InstallationID:  req.InstallationID,
 		Engine:          storage.EngineForType(plan.DatabaseType),
 		State:           state.Apply.Pending,

--- a/pkg/auth/context.go
+++ b/pkg/auth/context.go
@@ -7,6 +7,11 @@ package auth
 
 import "context"
 
+// AnonymousSubject is the subject NoneAuthorizer assigns when API auth is
+// disabled. It is a placeholder, not a real identity, so callers that attribute
+// actions to an authenticated user must not treat it as one.
+const AnonymousSubject = "anonymous"
+
 type contextKey struct{}
 
 // User represents an authenticated caller extracted from a request.
@@ -28,4 +33,17 @@ func WithUser(ctx context.Context, user *User) context.Context {
 func UserFromContext(ctx context.Context) *User {
 	user, _ := ctx.Value(contextKey{}).(*User)
 	return user
+}
+
+// AuthenticatedSubject returns the caller's subject and true only when the
+// request carries a real authenticated identity — a user is present and is not
+// the synthetic anonymous user NoneAuthorizer sets when auth is disabled. Use it
+// to attribute an action to the authenticated caller without falling back to the
+// anonymous placeholder.
+func AuthenticatedSubject(ctx context.Context) (string, bool) {
+	u := UserFromContext(ctx)
+	if u == nil || u.Subject == "" || u.Subject == AnonymousSubject {
+		return "", false
+	}
+	return u.Subject, true
 }

--- a/pkg/auth/context_test.go
+++ b/pkg/auth/context_test.go
@@ -26,3 +26,32 @@ func TestUserFromContextReturnsNilWhenNotSet(t *testing.T) {
 	got := auth.UserFromContext(t.Context())
 	assert.Nil(t, got)
 }
+
+func TestAuthenticatedSubject(t *testing.T) {
+	t.Run("real identity is authenticated", func(t *testing.T) {
+		ctx := auth.WithUser(t.Context(), &auth.User{Subject: "user@example.com"})
+		subject, ok := auth.AuthenticatedSubject(ctx)
+		assert.True(t, ok)
+		assert.Equal(t, "user@example.com", subject)
+	})
+
+	t.Run("no user is not authenticated", func(t *testing.T) {
+		subject, ok := auth.AuthenticatedSubject(t.Context())
+		assert.False(t, ok)
+		assert.Empty(t, subject)
+	})
+
+	t.Run("anonymous placeholder is not authenticated", func(t *testing.T) {
+		ctx := auth.WithUser(t.Context(), &auth.User{Subject: auth.AnonymousSubject})
+		subject, ok := auth.AuthenticatedSubject(ctx)
+		assert.False(t, ok)
+		assert.Empty(t, subject)
+	})
+
+	t.Run("empty subject is not authenticated", func(t *testing.T) {
+		ctx := auth.WithUser(t.Context(), &auth.User{Subject: ""})
+		subject, ok := auth.AuthenticatedSubject(ctx)
+		assert.False(t, ok)
+		assert.Empty(t, subject)
+	})
+}

--- a/pkg/auth/none.go
+++ b/pkg/auth/none.go
@@ -10,7 +10,7 @@ type NoneAuthorizer struct{}
 // Middleware passes all requests through with an anonymous user in context.
 func (NoneAuthorizer) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := WithUser(r.Context(), &User{Subject: "anonymous"})
+		ctx := WithUser(r.Context(), &User{Subject: AnonymousSubject})
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/pkg/serve/serve.go
+++ b/pkg/serve/serve.go
@@ -744,6 +744,30 @@ func buildAuthorizer(ctx context.Context, cfg api.AuthConfig, adminGroups []stri
 		}
 		logger.Info("OIDC authentication enabled", "issuer", cfg.Issuer)
 		return authz, nil
+	case "forward_auth":
+		fa := cfg.ForwardAuth
+		logger.Info("initializing forward-auth authentication",
+			"trusted_proxy_cidrs", len(fa.TrustedProxyCIDRs),
+			"trusted_proxy_spiffe", len(fa.TrustedProxySPIFFE),
+			"read_groups", len(fa.ReadGroups),
+			"write_groups", len(fa.WriteGroups))
+		authz, err := auth.NewForwardAuthAuthorizer(auth.ForwardAuthConfig{
+			UserHeader:         fa.UserHeader,
+			GroupsHeader:       fa.GroupsHeader,
+			GroupsDelimiter:    fa.GroupsDelimiter,
+			TrustedProxySPIFFE: fa.TrustedProxySPIFFE,
+			TrustedProxyCIDRs:  fa.TrustedProxyCIDRs,
+			ReadGroups:         fa.ReadGroups,
+			WriteGroups:        fa.WriteGroups,
+		}, logger)
+		if err != nil {
+			return nil, err
+		}
+		if len(fa.WriteGroups) == 0 {
+			logger.Warn("forward-auth enabled with no write groups configured: all write operations will be denied (read still works). Set auth.forward_auth.write_groups to allow writes.")
+		}
+		logger.Info("forward-auth authentication enabled")
+		return authz, nil
 	default:
 		return nil, fmt.Errorf("auth type %q is not yet supported", cfg.Type)
 	}

--- a/pkg/serve/serve.go
+++ b/pkg/serve/serve.go
@@ -766,6 +766,9 @@ func buildAuthorizer(ctx context.Context, cfg api.AuthConfig, adminGroups []stri
 		if len(fa.WriteGroups) == 0 {
 			logger.Warn("forward-auth enabled with no write groups configured: all write operations will be denied (read still works). Set auth.forward_auth.write_groups to allow writes.")
 		}
+		if len(fa.ReadGroups) == 0 {
+			logger.Info("forward-auth enabled with no read groups configured: read operations are open to any authenticated caller from the trusted proxy. Set auth.forward_auth.read_groups to restrict reads.")
+		}
 		logger.Info("forward-auth authentication enabled")
 		return authz, nil
 	default:

--- a/pkg/serve/serve_build_test.go
+++ b/pkg/serve/serve_build_test.go
@@ -71,3 +71,74 @@ func TestServerHandlerServesMetrics(t *testing.T) {
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/metrics", nil))
 	assert.Equal(t, http.StatusOK, rec.Code, "the handler serves /metrics through the auth middleware")
 }
+
+// Enabling auth.type: forward_auth wires the forward-auth authorizer into the
+// real HTTP handler so the API enforces the read/write tiers per request: an
+// unauthenticated caller is rejected, an authenticated read-tier caller cannot
+// write, and an authenticated write-tier caller passes the auth gate. This
+// exercises the full config → buildAuthorizer → middleware → tier path, not just
+// the authorizer in isolation.
+func TestForwardAuthEnforcedThroughServerHandler(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	cfg := &api.ServerConfig{
+		Auth: api.AuthConfig{
+			Type: "forward_auth",
+			ForwardAuth: api.ForwardAuthSettings{
+				// httptest's default RemoteAddr (192.0.2.1) falls in this range,
+				// so it is the trusted proxy; other sources are untrusted.
+				TrustedProxyCIDRs: []string{"192.0.2.0/24"},
+				GroupsHeader:      "X-Forwarded-Capabilities",
+				WriteGroups:       []string{"owners"},
+			},
+		},
+	}
+	svc := api.New(mysqlstore.New(nil), cfg, nil, logger)
+	webhook, err := buildWebhookRuntime(cfg, svc, logger)
+	require.NoError(t, err)
+	authz, err := buildAuthorizer(t.Context(), cfg.Auth, nil, logger)
+	require.NoError(t, err)
+	telemetry, err := api.SetupTelemetry(logger)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+		defer cancel()
+		_ = telemetry.Shutdown(shutdownCtx)
+	})
+
+	srv := &Server{cfg: cfg, svc: svc, logger: logger, webhook: webhook, telemetry: telemetry, authz: authz}
+	handler := srv.Handler()
+
+	const trusted = "192.0.2.1:1234"
+	const untrusted = "203.0.113.5:1234"
+
+	t.Run("unauthenticated request is rejected with 401", func(t *testing.T) {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status", nil)
+		req.RemoteAddr = untrusted
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("authenticated read-tier caller is denied a write with 403", func(t *testing.T) {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/plan", nil)
+		req.RemoteAddr = trusted
+		req.Header.Set("X-Forwarded-User", "alice")
+		req.Header.Set("X-Forwarded-Capabilities", "readers")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
+
+	t.Run("authenticated write-tier caller passes the auth gate", func(t *testing.T) {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/plan", nil)
+		req.RemoteAddr = trusted
+		req.Header.Set("X-Forwarded-User", "bob")
+		req.Header.Set("X-Forwarded-Capabilities", "owners")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		// The authorizer lets a write-group member through; whatever the plan
+		// handler then returns, it must not be an auth rejection.
+		assert.NotEqual(t, http.StatusUnauthorized, rec.Code)
+		assert.NotEqual(t, http.StatusForbidden, rec.Code)
+	})
+}

--- a/pkg/serve/serve_build_test.go
+++ b/pkg/serve/serve_build_test.go
@@ -129,16 +129,17 @@ func TestForwardAuthEnforcedThroughServerHandler(t *testing.T) {
 		assert.Equal(t, http.StatusForbidden, rec.Code)
 	})
 
-	t.Run("authenticated write-tier caller passes the auth gate", func(t *testing.T) {
+	t.Run("authenticated write-tier caller is authorized and reaches the write handler", func(t *testing.T) {
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/plan", nil)
 		req.RemoteAddr = trusted
 		req.Header.Set("X-Forwarded-User", "bob")
 		req.Header.Set("X-Forwarded-Capabilities", "owners")
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)
-		// The authorizer lets a write-group member through; whatever the plan
-		// handler then returns, it must not be an auth rejection.
-		assert.NotEqual(t, http.StatusUnauthorized, rec.Code)
-		assert.NotEqual(t, http.StatusForbidden, rec.Code)
+		// The write is authorized — not rejected at auth — so it reaches the plan
+		// handler, which rejects this empty body with 400. The contrast with the
+		// read-tier caller above (403, blocked before the handler) is the proof
+		// that a write-group member is permitted to perform the write.
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
 	})
 }


### PR DESCRIPTION
Makes the forward-auth authorizer reachable via configuration, documents it, and attributes direct-API applies to the authenticated caller.

- Adds an `auth.forward_auth` config block: `user_header`, `groups_header`, `groups_delimiter`, `trusted_proxy_spiffe`, `trusted_proxy_cidrs`, `read_groups`, `write_groups`.
- Validates it at startup so a bad trust anchor fails closed: requires at least one anchor (a SPIFFE ID or a CIDR) and checks CIDR syntax. **SPIFFE-only (no CIDR) is allowed** for mesh deployments where the proxy sanitizes inbound XFCC and the server isn't directly reachable; the authorizer logs a startup warning in that mode.
- Constructs the authorizer in `buildAuthorizer` for `auth.type: forward_auth`; selecting it with no `write_groups` logs a warning that writes will be denied.
- **Attributes applies to the authenticated caller:** when auth is enabled, the apply's `Caller` is the verified identity (via `auth.AuthenticatedSubject`) rather than the client-supplied `req.Caller`, so stamp-free break-glass writes are auditable. Auth-disabled and PR-comment paths keep using `req.Caller` unchanged (the synthetic anonymous user is never treated as a real caller).
- Documents the `auth:` block (none / oidc / forward_auth), the read/write tiers, and the authenticating-proxy pattern in the configuration reference.

*PR authored by Claude Code (Opus 4.8).*