### PR TITLE
docs(auth): document API authentication (none / oidc / forward_auth)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,9 @@
 - [Repository Allowlist](#repository-allowlist)
 - [PR Checks Gate](#pr-checks-gate)
 - [Review Gate](#review-gate)
+- [Authentication](#authentication)
+  - [OIDC (Bearer tokens)](#oidc-bearer-tokens)
+  - [Forward-auth (authenticating proxy)](#forward-auth-authenticating-proxy)
 - [Multi-Environment Deployment](#multi-environment-deployment)
   - [Staging Instance](#staging-instance)
   - [Production Instance](#production-instance)
@@ -442,6 +445,53 @@ CODEOWNERS support is opt-in because CODEOWNERS is repo-controlled while review 
 The base branch is used, not the PR's head branch, to prevent a PR from relaxing its own approval requirements by modifying CODEOWNERS.
 
 Approval is checked at the time of `schemabot apply` and `schemabot apply-confirm`. Once an apply is executing, there is no ongoing approval check. If a PR is force-pushed after approval, GitHub may dismiss approvals; `apply-confirm` re-checks the gate and blocks if the approval no longer satisfies the policy. Team membership and CODEOWNERS are evaluated fresh at each gate check.
+
+## Authentication
+
+By default (`auth.type: none` or unset) the SchemaBot API is unauthenticated — every request is allowed, which suits local development and deployments where the network is the only boundary. Setting `auth.type` turns on per-request authentication and a two-tier authorization model:
+
+- **Read tier** — visibility: `status`, `progress`, `logs`, `locks` (list), history, database discovery, and `pull` (read a live schema).
+- **Write tier** — anything that stages or makes a change: `plan`, `apply`, controls (`stop`/`start`/`cutover`/`volume`/`revert`/`skip-revert`/`rollback`), `unlock`, and settings mutation. `plan` is a write because it stages a change against a database.
+
+Any unclassified `/api` route is treated as write (fail-closed). The `/webhook` and health/metrics endpoints are exempt — webhooks authenticate themselves via HMAC. Two authenticators are available.
+
+### OIDC (Bearer tokens)
+
+The server validates a JWT on each request against the issuer's public keys (JWKS) — it never calls the provider at request time, so it works with any OIDC provider.
+
+```yaml
+auth:
+  type: oidc
+  issuer: "https://issuer.example.com"   # required
+  audience: "schemabot"                   # required — the expected aud claim
+  groups_claim: "groups"                  # optional (default "groups")
+```
+
+A valid token clears the read tier. The write tier additionally requires the token's groups to include an admin team from `pr_command_authorization.admin_teams`. Machine callers pass a token via `--token` / `SCHEMABOT_TOKEN`; a group-less service token (client-credentials grant) gets read access.
+
+### Forward-auth (authenticating proxy)
+
+Use this when SchemaBot runs behind an authenticating reverse proxy that has already verified the caller and forwards the identity as HTTP headers — the pattern used by the Kubernetes API server's authenticating proxy, Grafana's auth proxy, and oauth2-proxy.
+
+```yaml
+auth:
+  type: forward_auth
+  forward_auth:
+    user_header: X-Forwarded-User        # optional (default)
+    groups_header: X-Forwarded-Groups     # optional (default)
+    groups_delimiter: ","                 # optional (default)
+    trusted_proxy_cidrs:                  # source networks allowed to be the proxy
+      - 127.0.0.1/32
+    trusted_proxy_spiffe:                 # optional: proxy SPIFFE IDs, read from the Envoy XFCC header
+      - spiffe://example.org/ns/ingress/sa/proxy
+    read_groups: [readers]                # groups granted read (empty = any authenticated caller)
+    write_groups: [operators]             # groups granted write (empty = no writes)
+```
+
+The authorizer proves the request came from the trusted proxy, then reads the forwarded identity:
+
+- **Trust anchor (required, fail-closed).** With neither `trusted_proxy_cidrs` nor `trusted_proxy_spiffe` set, the server refuses to start. There are three modes: **CIDR only** (trust any request whose source IP is in a trusted network), **SPIFFE only** (trust any request whose XFCC carries a trusted SPIFFE ID), or **both** (require the source CIDR *and* a matching XFCC SPIFFE ID — defense in depth). `X-Forwarded-Client-Cert` (XFCC) is a spoofable HTTP header, so SPIFFE-only is safe only when the proxy sanitizes inbound XFCC and the server is not directly reachable (a service mesh) — the server logs a startup warning in that mode.
+- **Tiers.** Reads are open to any authenticated caller unless `read_groups` is set; writes require membership in `write_groups`. Only the canonical header is read, so a smuggled underscore variant (`X_Forwarded_User`) is ignored.
 
 ## Multi-Environment Deployment
 


### PR DESCRIPTION
Stacked on #624. Documents the `auth:` block in the configuration reference — there was no authentication section before.

Adds an **Authentication** section covering:
- the `auth.type` selector (`none` default, `oidc`, `forward_auth`) and the read/write tier model (with `plan` classified as write, fail-closed for unclassified routes);
- **OIDC** — JWKS Bearer validation, `issuer`/`audience`/`groups_claim`, admin-team write gating, machine tokens;
- **Forward-auth (authenticating proxy)** — the generic authenticating-proxy pattern (k8s/Grafana/oauth2-proxy), the trusted-proxy CIDR/SPIFFE anchor and why SPIFFE is gated behind a CIDR, forwarded identity headers, and `read_groups`/`write_groups`.

Regenerates the table of contents.

Base this on #624 (which adds the config) — review/merge that first.

*PR authored by Claude Code (Opus 4.8).*