### PR TITLE
feat(github): per-database change summary in the aggregate check

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -1215,8 +1215,8 @@ Apply in progress
 
 | Database | Type | Change | Status |
 |----------|------|--------|--------|
-| `commerce` | vitess | 2 created, 1 altered · 2 vschema updates | In progress |
-| `orders` | mysql | 1 altered | Applied |
+| `commerce` | vitess | 2 creates, 1 alter · 2 vschema updates | In progress |
+| `orders` | mysql | 1 alter | Applied |
 
 **Tenant deployments**
 

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -1205,6 +1205,28 @@ Production
 ```
 </details>
 
+
+## Aggregate Check — Details summary
+
+<details>
+<summary><strong>Aggregate Check — Details summary</strong></summary>
+
+Apply in progress
+
+| Database | Type | Change | Status |
+|----------|------|--------|--------|
+| `commerce` | vitess | 2 created, 1 altered · 2 vschema updates | In progress |
+| `orders` | mysql | 1 altered | Applied |
+
+**Tenant deployments**
+
+| Tenant | Status |
+|--------|--------|
+| `tenant-b` | Applied |
+| `tenant-c` | In progress |
+
+</details>
+
 ## Locking
 
 ### PR Comments

--- a/pkg/cmd/commands/preview.go
+++ b/pkg/cmd/commands/preview.go
@@ -92,7 +92,7 @@ func (cmd *PreviewCmd) Run(g *Globals) error {
 		templates.PreviewCommentMultiDeployCompleted, templates.PreviewCommentMultiDeployAll,
 		templates.PreviewCLIMultiDeployInProgress, templates.PreviewCLIMultiDeployFailed,
 		templates.PreviewCLIMultiDeployCompleted, templates.PreviewCLIMultiDeployAll,
-		templates.PreviewCommentShardedAll,
+		templates.PreviewCommentShardedAll, templates.PreviewAggregateCheckSummary,
 		templates.PreviewCommentSingleProgress, templates.PreviewCommentSingleComplete,
 		templates.PreviewCommentSingleFailed, templates.PreviewCommentSingleStopped,
 		templates.PreviewCommentSummaryCompleted, templates.PreviewCommentSummaryFailed,

--- a/pkg/cmd/internal/templates/preview.go
+++ b/pkg/cmd/internal/templates/preview.go
@@ -149,6 +149,7 @@ const (
 	PreviewCLIMultiDeployCompleted      PreviewType = "cli_multi_deploy_completed"       // All deployments completed
 	PreviewCLIMultiDeployAll            PreviewType = "cli_multi_deploy_all"             // Show all CLI multi-deployment apply previews
 	PreviewCommentShardedAll            PreviewType = "comment_sharded_all"              // Show all sharded apply + plan previews
+	PreviewAggregateCheckSummary        PreviewType = "aggregate_check_summary"          // Aggregate check Details summary (own databases + tenant deployments)
 
 	// Single-table apply comment previews (most common case)
 	PreviewCommentSingleProgress           PreviewType = "comment_single_progress"             // Single table running

--- a/pkg/cmd/internal/templates/preview_dispatch.go
+++ b/pkg/cmd/internal/templates/preview_dispatch.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/block/schemabot/pkg/webhook"
 	webhooktemplates "github.com/block/schemabot/pkg/webhook/templates"
 )
 
@@ -179,6 +180,8 @@ func PreviewCLIOutput(previewType PreviewType) {
 		previewCommentMultiDeployAllOutput()
 	case PreviewCommentShardedAll:
 		previewCommentShardedAllOutput()
+	case PreviewAggregateCheckSummary:
+		fmt.Print(webhook.PreviewAggregateSummary())
 	case PreviewCLIMultiDeployInProgress:
 		previewCLIMultiDeploymentApplyInProgress()
 	case PreviewCLIMultiDeployFailed:

--- a/pkg/schema/mysql/checks.sql
+++ b/pkg/schema/mysql/checks.sql
@@ -13,6 +13,7 @@ CREATE TABLE `checks` (
   `conclusion` varchar(255) DEFAULT NULL,
   `blocking_reason` varchar(255) DEFAULT NULL,
   `error_message` text,
+  `change_summary` varchar(255) DEFAULT NULL,
   `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),

--- a/pkg/storage/mysqlstore/checks.go
+++ b/pkg/storage/mysqlstore/checks.go
@@ -15,7 +15,7 @@ import (
 const checkColumns = `id, repository, pull_request, head_sha,
 	environment, database_type, database_name,
 	check_run_id, apply_id, has_changes, status, conclusion,
-	blocking_reason, error_message, created_at, updated_at`
+	blocking_reason, error_message, change_summary, created_at, updated_at`
 
 const checkStatusInProgress = "in_progress"
 
@@ -43,8 +43,8 @@ func (s *checkStore) Upsert(ctx context.Context, check *storage.Check) error {
 			INSERT INTO checks (
 				repository, pull_request, head_sha,
 				environment, database_type, database_name,
-				check_run_id, apply_id, has_changes, status, conclusion, blocking_reason, error_message
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				check_run_id, apply_id, has_changes, status, conclusion, blocking_reason, error_message, change_summary
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			ON DUPLICATE KEY UPDATE
 				head_sha = VALUES(head_sha),
 				check_run_id = VALUES(check_run_id),
@@ -53,10 +53,11 @@ func (s *checkStore) Upsert(ctx context.Context, check *storage.Check) error {
 				status = VALUES(status),
 				conclusion = VALUES(conclusion),
 				blocking_reason = VALUES(blocking_reason),
-				error_message = VALUES(error_message)
+				error_message = VALUES(error_message),
+				change_summary = COALESCE(NULLIF(VALUES(change_summary), ''), change_summary)
 		`, check.Repository, check.PullRequest, check.HeadSHA,
 			check.Environment, check.DatabaseType, check.DatabaseName,
-			checkRunID, applyID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage)
+			checkRunID, applyID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage, nullString(check.ChangeSummary))
 		return err
 	})
 }
@@ -76,11 +77,11 @@ func (s *checkStore) UpsertPlanResult(ctx context.Context, check *storage.Check)
 			INSERT INTO checks (
 				repository, pull_request, head_sha,
 				environment, database_type, database_name,
-				check_run_id, apply_id, has_changes, status, conclusion, blocking_reason, error_message
-			) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?)
+				check_run_id, apply_id, has_changes, status, conclusion, blocking_reason, error_message, change_summary
+			) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?)
 		`, check.Repository, check.PullRequest, check.HeadSHA,
 			check.Environment, check.DatabaseType, check.DatabaseName,
-			checkRunID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage)
+			checkRunID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage, nullString(check.ChangeSummary))
 		// Fast path: no existing check state for this PR/environment/database, so
 		// the insert is the complete write. Any non-duplicate error is a real
 		// storage failure; duplicate key means the row exists and needs the
@@ -107,11 +108,12 @@ func (s *checkStore) UpsertPlanResult(ctx context.Context, check *storage.Check)
 			    status = ?,
 			    conclusion = ?,
 			    blocking_reason = ?,
-			    error_message = ?
+			    error_message = ?,
+			    change_summary = ?
 			WHERE repository = ? AND pull_request = ?
 			  AND environment = ? AND database_type = ? AND database_name = ?
 			  AND NOT (status = ? AND apply_id IS NOT NULL)
-		`, check.HeadSHA, checkRunID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage,
+		`, check.HeadSHA, checkRunID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage, nullString(check.ChangeSummary),
 			check.Repository, check.PullRequest, check.Environment, check.DatabaseType, check.DatabaseName,
 			checkStatusInProgress)
 		return err
@@ -139,11 +141,12 @@ func (s *checkStore) RecoverApplyOwnedCheckWithNoOpPlan(ctx context.Context, che
 		    status = ?,
 		    conclusion = ?,
 		    blocking_reason = ?,
-		    error_message = ?
+		    error_message = ?,
+		    change_summary = COALESCE(NULLIF(?, ''), change_summary)
 		WHERE repository = ? AND pull_request = ?
 		  AND environment = ? AND database_type = ? AND database_name = ?
 		  AND status = ? AND head_sha = ? AND apply_id IS NOT NULL
-	`, check.HeadSHA, checkRunID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage,
+	`, check.HeadSHA, checkRunID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage, check.ChangeSummary,
 		check.Repository, check.PullRequest, check.Environment, check.DatabaseType, check.DatabaseName,
 		checkStatusInProgress, check.HeadSHA)
 	if err != nil {
@@ -186,11 +189,12 @@ func (s *checkStore) MarkStalePlanSuccessful(ctx context.Context, check *storage
 		    status = ?,
 		    conclusion = ?,
 		    blocking_reason = ?,
-		    error_message = ?
+		    error_message = ?,
+		    change_summary = COALESCE(NULLIF(?, ''), change_summary)
 		WHERE repository = ? AND pull_request = ?
 		  AND environment = ? AND database_type = ? AND database_name = ?
 		  AND status != ? AND apply_id IS NULL
-	`, check.HeadSHA, checkRunID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage,
+	`, check.HeadSHA, checkRunID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage, check.ChangeSummary,
 		check.Repository, check.PullRequest, check.Environment, check.DatabaseType, check.DatabaseName,
 		checkStatusInProgress)
 	if err != nil {
@@ -241,7 +245,7 @@ func (s *checkStore) CompleteForApply(ctx context.Context, check *storage.Check,
 		checkRunID = check.CheckRunID
 	}
 	leasePredicate := ""
-	args := []any{check.HeadSHA, checkRunID, apply.ID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage,
+	args := []any{check.HeadSHA, checkRunID, apply.ID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage, check.ChangeSummary,
 		check.Repository, check.PullRequest, check.Environment, check.DatabaseType, check.DatabaseName,
 		checkStatusInProgress, apply.ID, apply.ID}
 	lease := apply.Lease()
@@ -264,7 +268,8 @@ func (s *checkStore) CompleteForApply(ctx context.Context, check *storage.Check,
 		    status = ?,
 		    conclusion = ?,
 		    blocking_reason = ?,
-		    error_message = ?
+		    error_message = ?,
+		    change_summary = COALESCE(NULLIF(?, ''), change_summary)
 		WHERE repository = ? AND pull_request = ?
 		  AND environment = ? AND database_type = ? AND database_name = ?
 		  AND status = ?
@@ -305,7 +310,7 @@ func (s *checkStore) MarkActionRequiredForApply(ctx context.Context, check *stor
 		checkRunID = check.CheckRunID
 	}
 	leasePredicate := ""
-	args := []any{check.HeadSHA, checkRunID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage,
+	args := []any{check.HeadSHA, checkRunID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage, check.ChangeSummary,
 		check.Repository, check.PullRequest, check.Environment, check.DatabaseType, check.DatabaseName,
 		apply.ID, apply.ID}
 	lease := apply.Lease()
@@ -328,7 +333,8 @@ func (s *checkStore) MarkActionRequiredForApply(ctx context.Context, check *stor
 		    status = ?,
 		    conclusion = ?,
 		    blocking_reason = ?,
-		    error_message = ?
+		    error_message = ?,
+		    change_summary = COALESCE(NULLIF(?, ''), change_summary)
 		WHERE repository = ? AND pull_request = ?
 		  AND environment = ? AND database_type = ? AND database_name = ?
 		  AND apply_id = ?
@@ -468,13 +474,13 @@ func scanChecks(rows *sql.Rows) ([]*storage.Check, error) {
 func scanCheckInto(s scanner) (*storage.Check, error) {
 	var check storage.Check
 	var checkRunID, applyID sql.NullInt64
-	var conclusion, blockingReason, errorMessage sql.NullString
+	var conclusion, blockingReason, errorMessage, changeSummary sql.NullString
 
 	err := s.Scan(
 		&check.ID, &check.Repository, &check.PullRequest, &check.HeadSHA,
 		&check.Environment, &check.DatabaseType, &check.DatabaseName,
 		&checkRunID, &applyID, &check.HasChanges, &check.Status, &conclusion,
-		&blockingReason, &errorMessage, &check.CreatedAt, &check.UpdatedAt,
+		&blockingReason, &errorMessage, &changeSummary, &check.CreatedAt, &check.UpdatedAt,
 	)
 	if err != nil {
 		return nil, err
@@ -494,6 +500,9 @@ func scanCheckInto(s scanner) (*storage.Check, error) {
 	}
 	if errorMessage.Valid {
 		check.ErrorMessage = errorMessage.String
+	}
+	if changeSummary.Valid {
+		check.ChangeSummary = changeSummary.String
 	}
 
 	return &check, nil

--- a/pkg/storage/mysqlstore/checks_test.go
+++ b/pkg/storage/mysqlstore/checks_test.go
@@ -1056,6 +1056,121 @@ func TestCheckStore_CompleteForApply(t *testing.T) {
 	require.Equal(t, apply.ID, retrieved.ApplyID)
 }
 
+// A plan-time change summary must round-trip through storage and survive the
+// apply lifecycle: once the plan records "N created, M altered", later
+// apply-state transitions (in_progress, terminal completion) must not blank it,
+// so the aggregate check's Change column keeps showing what the PR changes.
+func TestCheckStore_ChangeSummaryRoundTripsAndSurvivesApply(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	// Plan records the summary.
+	require.NoError(t, store.Checks().UpsertPlanResult(ctx, &storage.Check{
+		Repository:    "octocat/hello-world",
+		PullRequest:   7,
+		HeadSHA:       "abc123",
+		Environment:   "staging",
+		DatabaseType:  "vitess",
+		DatabaseName:  "orders",
+		HasChanges:    true,
+		Status:        "completed",
+		Conclusion:    "action_required",
+		ChangeSummary: "5 created, 3 altered · 2 vschema updates",
+	}))
+
+	checks, err := store.Checks().GetByPR(ctx, "octocat/hello-world", 7)
+	require.NoError(t, err)
+	require.Len(t, checks, 1)
+	assert.Equal(t, "5 created, 3 altered · 2 vschema updates", checks[0].ChangeSummary)
+
+	// Apply starts and completes. Neither transition carries a summary, and both
+	// must preserve the plan-time value rather than blanking it.
+	apply := createCheckStoreApply(t, store, "apply-change-summary", state.Apply.Completed)
+
+	require.NoError(t, store.Checks().Upsert(ctx, &storage.Check{
+		Repository:   "octocat/hello-world",
+		PullRequest:  7,
+		HeadSHA:      "abc123",
+		Environment:  "staging",
+		DatabaseType: "vitess",
+		DatabaseName: "orders",
+		ApplyID:      apply.ID,
+		HasChanges:   true,
+		Status:       "in_progress",
+	}))
+
+	afterStart, err := store.Checks().Get(ctx, "octocat/hello-world", 7, "staging", "vitess", "orders")
+	require.NoError(t, err)
+	require.NotNil(t, afterStart)
+	assert.Equal(t, "in_progress", afterStart.Status)
+	assert.Equal(t, "5 created, 3 altered · 2 vschema updates", afterStart.ChangeSummary,
+		"apply-start upsert must preserve the plan-time change summary")
+
+	updated, err := store.Checks().CompleteForApply(ctx, &storage.Check{
+		Repository:   "octocat/hello-world",
+		PullRequest:  7,
+		HeadSHA:      "abc123",
+		Environment:  "staging",
+		DatabaseType: "vitess",
+		DatabaseName: "orders",
+		ApplyID:      apply.ID,
+		HasChanges:   false,
+		Status:       "completed",
+		Conclusion:   "success",
+	}, apply)
+	require.NoError(t, err)
+	require.True(t, updated)
+
+	afterComplete, err := store.Checks().Get(ctx, "octocat/hello-world", 7, "staging", "vitess", "orders")
+	require.NoError(t, err)
+	require.NotNil(t, afterComplete)
+	assert.Equal(t, "completed", afterComplete.Status)
+	assert.Equal(t, "success", afterComplete.Conclusion)
+	assert.Equal(t, "5 created, 3 altered · 2 vschema updates", afterComplete.ChangeSummary,
+		"terminal apply completion must preserve the plan-time change summary")
+}
+
+// The plan is authoritative for its own summary on a plan-only row: a re-plan
+// overwrites the summary, and a re-plan that finds no changes clears it (rather
+// than leaving a stale summary on a now-up-to-date check).
+func TestCheckStore_ReplanUpdatesChangeSummary(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	planCheck := func(summary string) *storage.Check {
+		hasChanges := summary != ""
+		conclusion := "success"
+		if hasChanges {
+			conclusion = "action_required"
+		}
+		return &storage.Check{
+			Repository: "octocat/hello-world", PullRequest: 7, HeadSHA: "abc123",
+			Environment: "staging", DatabaseType: "mysql", DatabaseName: "orders",
+			HasChanges: hasChanges, Status: "completed", Conclusion: conclusion,
+			ChangeSummary: summary,
+		}
+	}
+	get := func() *storage.Check {
+		c, err := store.Checks().Get(ctx, "octocat/hello-world", 7, "staging", "mysql", "orders")
+		require.NoError(t, err)
+		require.NotNil(t, c)
+		return c
+	}
+
+	require.NoError(t, store.Checks().UpsertPlanResult(ctx, planCheck("5 created")))
+	assert.Equal(t, "5 created", get().ChangeSummary)
+
+	// A new plan with different changes overwrites the summary.
+	require.NoError(t, store.Checks().UpsertPlanResult(ctx, planCheck("2 altered")))
+	assert.Equal(t, "2 altered", get().ChangeSummary)
+
+	// A new plan that finds no changes clears the summary.
+	require.NoError(t, store.Checks().UpsertPlanResult(ctx, planCheck("")))
+	assert.Empty(t, get().ChangeSummary)
+}
+
 func TestCheckStore_CompleteForApplyLeaseGuard(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -176,6 +176,12 @@ type Check struct {
 	// Displayed in the GitHub Check Run details and PR comment.
 	ErrorMessage string
 
+	// ChangeSummary is a human-readable per-database summary of the planned
+	// schema change (e.g. "5 created, 3 altered · 2 vschema updates"). It is set
+	// at plan time and preserved across apply-state transitions. Empty for
+	// aggregate rows and for rows recorded before this field existed.
+	ChangeSummary string
+
 	// CreatedAt is when the check was created.
 	CreatedAt time.Time
 

--- a/pkg/webhook/check_aggregate.go
+++ b/pkg/webhook/check_aggregate.go
@@ -292,17 +292,32 @@ func changeSummaryLabel(c *storage.Check) string {
 
 // renderDatabaseSection renders the leader's own per-database checks as a
 // Database table with each database's type, change summary, and status,
-// truncating to stay within budget bytes. The aggregate check is
-// environment-scoped, so the environment is not repeated per row.
+// truncating to stay within budget bytes. Per-environment aggregates contain a
+// single environment, so the environment is not repeated per row. The global
+// aggregate (no allowed_environments) can fold databases from several
+// environments into one table, so an Environment column is added when the rows
+// span more than one environment — otherwise staging and production rows for the
+// same database would be indistinguishable.
 func renderDatabaseSection(dbChecks []*storage.Check, budget int) string {
 	if len(dbChecks) == 0 {
 		return ""
 	}
+	showEnv := hasMultipleEnvironments(dbChecks)
 	var sb strings.Builder
-	sb.WriteString("| Database | Type | Change | Status |\n")
-	sb.WriteString("|----------|------|--------|--------|\n")
+	if showEnv {
+		sb.WriteString("| Database | Environment | Type | Change | Status |\n")
+		sb.WriteString("|----------|-------------|------|--------|--------|\n")
+	} else {
+		sb.WriteString("| Database | Type | Change | Status |\n")
+		sb.WriteString("|----------|------|--------|--------|\n")
+	}
 	for i, c := range dbChecks {
-		row := fmt.Sprintf("| `%s` | %s | %s | %s |\n", c.DatabaseName, c.DatabaseType, changeSummaryLabel(c), checkStatusLabel(c))
+		var row string
+		if showEnv {
+			row = fmt.Sprintf("| `%s` | %s | %s | %s | %s |\n", c.DatabaseName, c.Environment, c.DatabaseType, changeSummaryLabel(c), checkStatusLabel(c))
+		} else {
+			row = fmt.Sprintf("| `%s` | %s | %s | %s |\n", c.DatabaseName, c.DatabaseType, changeSummaryLabel(c), checkStatusLabel(c))
+		}
 		if sb.Len()+len(row) > budget {
 			fmt.Fprintf(&sb, "\n... and %d more check(s)\n", len(dbChecks)-i)
 			break
@@ -310,6 +325,20 @@ func renderDatabaseSection(dbChecks []*storage.Check, budget int) string {
 		sb.WriteString(row)
 	}
 	return sb.String()
+}
+
+// hasMultipleEnvironments reports whether the per-database checks span more than
+// one distinct environment, which happens for the global aggregate that is not
+// scoped to a single environment.
+func hasMultipleEnvironments(dbChecks []*storage.Check) bool {
+	seen := make(map[string]struct{}, 2)
+	for _, c := range dbChecks {
+		seen[c.Environment] = struct{}{}
+		if len(seen) > 1 {
+			return true
+		}
+	}
+	return false
 }
 
 // renderParticipantSection renders the folded participant deployments as a

--- a/pkg/webhook/check_aggregate.go
+++ b/pkg/webhook/check_aggregate.go
@@ -280,17 +280,29 @@ func buildAggregateTable(checks []*storage.Check) string {
 	return sb.String()
 }
 
+// changeSummaryLabel returns the per-database change summary for the aggregate
+// check's Change column, or an em dash when no summary was recorded (aggregate
+// rows, or rows recorded before the summary was stored).
+func changeSummaryLabel(c *storage.Check) string {
+	if c.ChangeSummary == "" {
+		return "—"
+	}
+	return c.ChangeSummary
+}
+
 // renderDatabaseSection renders the leader's own per-database checks as a
-// Database table, truncating to stay within budget bytes.
+// Database table with each database's type, change summary, and status,
+// truncating to stay within budget bytes. The aggregate check is
+// environment-scoped, so the environment is not repeated per row.
 func renderDatabaseSection(dbChecks []*storage.Check, budget int) string {
 	if len(dbChecks) == 0 {
 		return ""
 	}
 	var sb strings.Builder
-	sb.WriteString("| Database | Environment | Status |\n")
-	sb.WriteString("|----------|-------------|--------|\n")
+	sb.WriteString("| Database | Type | Change | Status |\n")
+	sb.WriteString("|----------|------|--------|--------|\n")
 	for i, c := range dbChecks {
-		row := fmt.Sprintf("| `%s` | %s | %s |\n", c.DatabaseName, c.Environment, checkStatusLabel(c))
+		row := fmt.Sprintf("| `%s` | %s | %s | %s |\n", c.DatabaseName, c.DatabaseType, changeSummaryLabel(c), checkStatusLabel(c))
 		if sb.Len()+len(row) > budget {
 			fmt.Fprintf(&sb, "\n... and %d more check(s)\n", len(dbChecks)-i)
 			break

--- a/pkg/webhook/check_aggregate_test.go
+++ b/pkg/webhook/check_aggregate_test.go
@@ -141,16 +141,20 @@ func TestIsAggregateCheck(t *testing.T) {
 
 func TestAggregateSummary(t *testing.T) {
 	checks := []*storage.Check{
-		{DatabaseName: "orders", Environment: "staging", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess, HasChanges: true},
-		{DatabaseName: "orders", Environment: "production", Status: checkStatusCompleted, Conclusion: checkConclusionActionRequired},
+		{DatabaseName: "orders", DatabaseType: "mysql", Environment: "staging", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess, HasChanges: true, ChangeSummary: "5 created, 3 altered"},
+		{DatabaseName: "users", DatabaseType: "vitess", Environment: "production", Status: checkStatusCompleted, Conclusion: checkConclusionActionRequired, ChangeSummary: "1 dropped · 2 vschema updates"},
 	}
 
 	title, summary := aggregateSummary(checks, checkConclusionActionRequired)
 
 	assert.Contains(t, title, "1 apply pending")
+	assert.Contains(t, summary, "| Database | Type | Change | Status |")
 	assert.Contains(t, summary, "`orders`")
-	assert.Contains(t, summary, "staging")
-	assert.Contains(t, summary, "production")
+	assert.Contains(t, summary, "`users`")
+	assert.Contains(t, summary, "mysql")
+	assert.Contains(t, summary, "vitess")
+	assert.Contains(t, summary, "5 created, 3 altered")
+	assert.Contains(t, summary, "1 dropped · 2 vschema updates")
 	assert.Contains(t, summary, "Applied")
 	assert.Contains(t, summary, "Pending")
 }
@@ -160,7 +164,7 @@ func TestAggregateSummary(t *testing.T) {
 // leader's own per-database rows.
 func TestAggregateSummary_WithParticipants(t *testing.T) {
 	checks := []*storage.Check{
-		{DatabaseType: "mysql", DatabaseName: "orders", Environment: "production", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess, HasChanges: true},
+		{DatabaseType: "mysql", DatabaseName: "orders", Environment: "production", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess, HasChanges: true, ChangeSummary: "2 created"},
 		{DatabaseType: aggregateSentinel, DatabaseName: "tenant-b", Environment: "production", Status: checkStatusCompleted, Conclusion: checkConclusionActionRequired},
 		{DatabaseType: aggregateSentinel, DatabaseName: "tenant-c", Environment: "production", Status: checkStatusInProgress},
 	}
@@ -170,9 +174,12 @@ func TestAggregateSummary_WithParticipants(t *testing.T) {
 	dbSection, tenantSection, found := strings.Cut(summary, "**Tenant deployments**")
 	require.True(t, found, "summary has a Tenant deployments section")
 
-	// The leader's own database renders in the Database section; participants do not.
-	assert.Contains(t, dbSection, "| Database | Environment | Status |")
+	// The leader's own database renders in the Database section with its type and
+	// change summary; participants do not.
+	assert.Contains(t, dbSection, "| Database | Type | Change | Status |")
 	assert.Contains(t, dbSection, "`orders`")
+	assert.Contains(t, dbSection, "mysql")
+	assert.Contains(t, dbSection, "2 created")
 	assert.NotContains(t, dbSection, "tenant-b", "participants must not appear in the Database section")
 	assert.NotContains(t, dbSection, "tenant-c")
 
@@ -218,14 +225,16 @@ func TestAggregateSummary_AllSuccess(t *testing.T) {
 
 func TestAggregateSummary_AllUpToDate(t *testing.T) {
 	checks := []*storage.Check{
-		{DatabaseName: "orders", Environment: "staging", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess},
-		{DatabaseName: "users", Environment: "staging", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess},
+		{DatabaseName: "orders", DatabaseType: "mysql", Environment: "staging", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess},
+		{DatabaseName: "users", DatabaseType: "mysql", Environment: "staging", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess},
 	}
 
 	title, summary := aggregateSummary(checks, checkConclusionSuccess)
 
 	assert.Equal(t, "Schema up to date", title)
+	assert.Contains(t, summary, "| Database | Type | Change | Status |")
 	assert.Contains(t, summary, "Up to date")
+	assert.Contains(t, summary, "—", "an up-to-date database has no change summary and renders an em dash")
 	assert.NotContains(t, summary, "Applied")
 }
 

--- a/pkg/webhook/check_aggregate_test.go
+++ b/pkg/webhook/check_aggregate_test.go
@@ -148,7 +148,11 @@ func TestAggregateSummary(t *testing.T) {
 	title, summary := aggregateSummary(checks, checkConclusionActionRequired)
 
 	assert.Contains(t, title, "1 apply pending")
-	assert.Contains(t, summary, "| Database | Type | Change | Status |")
+	// The rows span staging and production, so the global aggregate table adds an
+	// Environment column and renders both environment names.
+	assert.Contains(t, summary, "| Database | Environment | Type | Change | Status |")
+	assert.Contains(t, summary, "staging")
+	assert.Contains(t, summary, "production")
 	assert.Contains(t, summary, "`orders`")
 	assert.Contains(t, summary, "`users`")
 	assert.Contains(t, summary, "mysql")
@@ -157,6 +161,32 @@ func TestAggregateSummary(t *testing.T) {
 	assert.Contains(t, summary, "1 dropped · 2 vschema updates")
 	assert.Contains(t, summary, "Applied")
 	assert.Contains(t, summary, "Pending")
+}
+
+// A per-environment aggregate contains a single environment, so the Database
+// table omits the Environment column. The global aggregate that folds multiple
+// environments adds the column so same-named databases are unambiguous.
+func TestRenderDatabaseSection_EnvironmentColumn(t *testing.T) {
+	t.Run("single environment omits the column", func(t *testing.T) {
+		checks := []*storage.Check{
+			{DatabaseName: "orders", DatabaseType: "mysql", Environment: "production", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess, HasChanges: true, ChangeSummary: "2 created"},
+			{DatabaseName: "users", DatabaseType: "vitess", Environment: "production", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess, HasChanges: true, ChangeSummary: "1 altered"},
+		}
+		section := renderDatabaseSection(checks, maxCheckRunTextLength)
+		assert.Contains(t, section, "| Database | Type | Change | Status |")
+		assert.NotContains(t, section, "Environment")
+	})
+
+	t.Run("multiple environments add the column", func(t *testing.T) {
+		checks := []*storage.Check{
+			{DatabaseName: "orders", DatabaseType: "mysql", Environment: "staging", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess, HasChanges: true, ChangeSummary: "2 created"},
+			{DatabaseName: "orders", DatabaseType: "mysql", Environment: "production", Status: checkStatusInProgress, ChangeSummary: "2 created"},
+		}
+		section := renderDatabaseSection(checks, maxCheckRunTextLength)
+		assert.Contains(t, section, "| Database | Environment | Type | Change | Status |")
+		assert.Contains(t, section, "| `orders` | staging | mysql |")
+		assert.Contains(t, section, "| `orders` | production | mysql |")
+	})
 }
 
 // When the leader gates on participant deployments, their folded outcomes render

--- a/pkg/webhook/check_aggregate_test.go
+++ b/pkg/webhook/check_aggregate_test.go
@@ -141,8 +141,8 @@ func TestIsAggregateCheck(t *testing.T) {
 
 func TestAggregateSummary(t *testing.T) {
 	checks := []*storage.Check{
-		{DatabaseName: "orders", DatabaseType: "mysql", Environment: "staging", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess, HasChanges: true, ChangeSummary: "5 created, 3 altered"},
-		{DatabaseName: "users", DatabaseType: "vitess", Environment: "production", Status: checkStatusCompleted, Conclusion: checkConclusionActionRequired, ChangeSummary: "1 dropped · 2 vschema updates"},
+		{DatabaseName: "orders", DatabaseType: "mysql", Environment: "staging", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess, HasChanges: true, ChangeSummary: "5 creates, 3 alters"},
+		{DatabaseName: "users", DatabaseType: "vitess", Environment: "production", Status: checkStatusCompleted, Conclusion: checkConclusionActionRequired, ChangeSummary: "1 drop · 2 vschema updates"},
 	}
 
 	title, summary := aggregateSummary(checks, checkConclusionActionRequired)
@@ -157,8 +157,8 @@ func TestAggregateSummary(t *testing.T) {
 	assert.Contains(t, summary, "`users`")
 	assert.Contains(t, summary, "mysql")
 	assert.Contains(t, summary, "vitess")
-	assert.Contains(t, summary, "5 created, 3 altered")
-	assert.Contains(t, summary, "1 dropped · 2 vschema updates")
+	assert.Contains(t, summary, "5 creates, 3 alters")
+	assert.Contains(t, summary, "1 drop · 2 vschema updates")
 	assert.Contains(t, summary, "Applied")
 	assert.Contains(t, summary, "Pending")
 }
@@ -169,8 +169,8 @@ func TestAggregateSummary(t *testing.T) {
 func TestRenderDatabaseSection_EnvironmentColumn(t *testing.T) {
 	t.Run("single environment omits the column", func(t *testing.T) {
 		checks := []*storage.Check{
-			{DatabaseName: "orders", DatabaseType: "mysql", Environment: "production", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess, HasChanges: true, ChangeSummary: "2 created"},
-			{DatabaseName: "users", DatabaseType: "vitess", Environment: "production", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess, HasChanges: true, ChangeSummary: "1 altered"},
+			{DatabaseName: "orders", DatabaseType: "mysql", Environment: "production", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess, HasChanges: true, ChangeSummary: "2 creates"},
+			{DatabaseName: "users", DatabaseType: "vitess", Environment: "production", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess, HasChanges: true, ChangeSummary: "1 alter"},
 		}
 		section := renderDatabaseSection(checks, maxCheckRunTextLength)
 		assert.Contains(t, section, "| Database | Type | Change | Status |")
@@ -179,8 +179,8 @@ func TestRenderDatabaseSection_EnvironmentColumn(t *testing.T) {
 
 	t.Run("multiple environments add the column", func(t *testing.T) {
 		checks := []*storage.Check{
-			{DatabaseName: "orders", DatabaseType: "mysql", Environment: "staging", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess, HasChanges: true, ChangeSummary: "2 created"},
-			{DatabaseName: "orders", DatabaseType: "mysql", Environment: "production", Status: checkStatusInProgress, ChangeSummary: "2 created"},
+			{DatabaseName: "orders", DatabaseType: "mysql", Environment: "staging", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess, HasChanges: true, ChangeSummary: "2 creates"},
+			{DatabaseName: "orders", DatabaseType: "mysql", Environment: "production", Status: checkStatusInProgress, ChangeSummary: "2 creates"},
 		}
 		section := renderDatabaseSection(checks, maxCheckRunTextLength)
 		assert.Contains(t, section, "| Database | Environment | Type | Change | Status |")
@@ -194,7 +194,7 @@ func TestRenderDatabaseSection_EnvironmentColumn(t *testing.T) {
 // leader's own per-database rows.
 func TestAggregateSummary_WithParticipants(t *testing.T) {
 	checks := []*storage.Check{
-		{DatabaseType: "mysql", DatabaseName: "orders", Environment: "production", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess, HasChanges: true, ChangeSummary: "2 created"},
+		{DatabaseType: "mysql", DatabaseName: "orders", Environment: "production", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess, HasChanges: true, ChangeSummary: "2 creates"},
 		{DatabaseType: aggregateSentinel, DatabaseName: "tenant-b", Environment: "production", Status: checkStatusCompleted, Conclusion: checkConclusionActionRequired},
 		{DatabaseType: aggregateSentinel, DatabaseName: "tenant-c", Environment: "production", Status: checkStatusInProgress},
 	}
@@ -209,7 +209,7 @@ func TestAggregateSummary_WithParticipants(t *testing.T) {
 	assert.Contains(t, dbSection, "| Database | Type | Change | Status |")
 	assert.Contains(t, dbSection, "`orders`")
 	assert.Contains(t, dbSection, "mysql")
-	assert.Contains(t, dbSection, "2 created")
+	assert.Contains(t, dbSection, "2 creates")
 	assert.NotContains(t, dbSection, "tenant-b", "participants must not appear in the Database section")
 	assert.NotContains(t, dbSection, "tenant-c")
 

--- a/pkg/webhook/check_records.go
+++ b/pkg/webhook/check_records.go
@@ -10,6 +10,7 @@ import (
 	"github.com/block/schemabot/pkg/metrics"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/webhook/templates"
 )
 
 // storePlanCheckRecord stores per-database check state after a plan is generated.
@@ -109,15 +110,16 @@ func (h *Handler) upsertPlanCheckRecord(ctx context.Context, client *ghclient.In
 	}
 
 	check := &storage.Check{
-		Repository:   repo,
-		PullRequest:  pr,
-		HeadSHA:      headSHA,
-		Environment:  environment,
-		DatabaseType: schema.Type,
-		DatabaseName: schema.Database,
-		HasChanges:   hasChanges,
-		Status:       checkStatusCompleted,
-		Conclusion:   conclusion,
+		Repository:    repo,
+		PullRequest:   pr,
+		HeadSHA:       headSHA,
+		Environment:   environment,
+		DatabaseType:  schema.Type,
+		DatabaseName:  schema.Database,
+		HasChanges:    hasChanges,
+		Status:        checkStatusCompleted,
+		Conclusion:    conclusion,
+		ChangeSummary: summarizePlanChanges(schema, planResp, environment),
 	}
 	if err := h.service.Storage().Checks().UpsertPlanResult(ctx, check); err != nil {
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
@@ -140,6 +142,16 @@ func (h *Handler) upsertPlanCheckRecord(ctx context.Context, client *ghclient.In
 		Status:       "success",
 	})
 	return headSHA, check, nil
+}
+
+// summarizePlanChanges renders the per-database change summary stored on the
+// check and shown in the aggregate check's Change column. It derives the counts
+// from the same PlanCommentData the plan comment renders from, so the summary
+// (e.g. "5 created, 3 altered · 2 vschema updates") always agrees with the plan
+// comment's summary line. Returns "" when the plan has no changes.
+func summarizePlanChanges(schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string) string {
+	commentData := buildPlanCommentData(schema, planResp, environment, "", "")
+	return templates.SummarizeChanges(commentData)
 }
 
 type applyCheckKey struct {

--- a/pkg/webhook/preview_aggregate.go
+++ b/pkg/webhook/preview_aggregate.go
@@ -14,7 +14,7 @@ func PreviewAggregateSummary() string {
 			DatabaseName:  "commerce",
 			HasChanges:    true,
 			Status:        checkStatusInProgress,
-			ChangeSummary: "2 created, 1 altered · 2 vschema updates",
+			ChangeSummary: "2 creates, 1 alter · 2 vschema updates",
 		},
 		{
 			DatabaseType:  "mysql",
@@ -22,7 +22,7 @@ func PreviewAggregateSummary() string {
 			HasChanges:    true,
 			Status:        checkStatusCompleted,
 			Conclusion:    checkConclusionSuccess,
-			ChangeSummary: "1 altered",
+			ChangeSummary: "1 alter",
 		},
 		{
 			DatabaseType: aggregateSentinel,

--- a/pkg/webhook/preview_aggregate.go
+++ b/pkg/webhook/preview_aggregate.go
@@ -1,0 +1,45 @@
+package webhook
+
+import "github.com/block/schemabot/pkg/storage"
+
+// PreviewAggregateSummary renders a representative aggregate-check Details
+// summary for TEMPLATES.md: the leader's own per-database checks with their
+// change summaries and statuses, plus a folded Tenant deployments section. The
+// mix of running, applied, and pending rows produces a blocking conclusion so
+// both tables and a non-passing title are exercised.
+func PreviewAggregateSummary() string {
+	checks := []*storage.Check{
+		{
+			DatabaseType:  "vitess",
+			DatabaseName:  "commerce",
+			HasChanges:    true,
+			Status:        checkStatusInProgress,
+			ChangeSummary: "2 created, 1 altered · 2 vschema updates",
+		},
+		{
+			DatabaseType:  "mysql",
+			DatabaseName:  "orders",
+			HasChanges:    true,
+			Status:        checkStatusCompleted,
+			Conclusion:    checkConclusionSuccess,
+			ChangeSummary: "1 altered",
+		},
+		{
+			DatabaseType: aggregateSentinel,
+			DatabaseName: "tenant-b",
+			HasChanges:   true,
+			Status:       checkStatusCompleted,
+			Conclusion:   checkConclusionSuccess,
+		},
+		{
+			DatabaseType: aggregateSentinel,
+			DatabaseName: "tenant-c",
+			HasChanges:   true,
+			Status:       checkStatusInProgress,
+		},
+	}
+
+	conclusion, _ := computeAggregate(checks)
+	title, summary := aggregateSummary(checks, conclusion)
+	return title + "\n\n" + summary
+}

--- a/pkg/webhook/templates/plan.go
+++ b/pkg/webhook/templates/plan.go
@@ -319,25 +319,26 @@ func writeNoChangesDetected(sb *strings.Builder, data PlanCommentData) {
 }
 
 // SummarizeChanges renders a compact one-line summary of a plan's changes for
-// the aggregate check's Change column, e.g. "5 created, 3 altered, 1 dropped ·
-// 2 vschema updates". Zero categories are omitted. The vschema clause is only
-// included for non-MySQL engines, matching the plan comment's summary. Returns
-// "" only when the plan has no changes at all. The create/alter/drop and vschema
-// counting is identical to the plan comment's summary (countStatementTypes /
-// countChanges) so the two always agree.
+// the aggregate check's Change column, e.g. "5 creates, 3 alters, 1 drop ·
+// 2 vschema updates". Each category is a pluralized noun so the phrasing stays
+// consistent with the vschema clause. Zero categories are omitted. The vschema
+// clause is only included for non-MySQL engines, matching the plan comment's
+// summary. Returns "" only when the plan has no changes at all. The
+// create/alter/drop and vschema counting is identical to the plan comment's
+// summary (countStatementTypes / countChanges) so the two always agree.
 func SummarizeChanges(data PlanCommentData) string {
 	creates, alters, drops := countStatementTypes(data.Changes)
 	totalStatements, keyspacesWithVSchema := countChanges(data.Changes)
 
 	var parts []string
 	if creates > 0 {
-		parts = append(parts, fmt.Sprintf("%d created", creates))
+		parts = append(parts, fmt.Sprintf("%d %s", creates, pluralize("create", creates)))
 	}
 	if alters > 0 {
-		parts = append(parts, fmt.Sprintf("%d altered", alters))
+		parts = append(parts, fmt.Sprintf("%d %s", alters, pluralize("alter", alters)))
 	}
 	if drops > 0 {
-		parts = append(parts, fmt.Sprintf("%d dropped", drops))
+		parts = append(parts, fmt.Sprintf("%d %s", drops, pluralize("drop", drops)))
 	}
 	ddlSummary := strings.Join(parts, ", ")
 

--- a/pkg/webhook/templates/plan.go
+++ b/pkg/webhook/templates/plan.go
@@ -318,6 +318,39 @@ func writeNoChangesDetected(sb *strings.Builder, data PlanCommentData) {
 	}
 }
 
+// SummarizeChanges renders a compact one-line summary of a plan's changes for
+// the aggregate check's Change column, e.g. "5 created, 3 altered, 1 dropped ·
+// 2 vschema updates". Zero categories are omitted. The vschema clause is only
+// included for non-MySQL engines, matching the plan comment's summary. Returns
+// "" when the plan has no changes. The create/alter/drop and vschema counting
+// is identical to the plan comment's summary (countStatementTypes / countChanges)
+// so the two always agree.
+func SummarizeChanges(data PlanCommentData) string {
+	creates, alters, drops := countStatementTypes(data.Changes)
+	_, keyspacesWithVSchema := countChanges(data.Changes)
+
+	var parts []string
+	if creates > 0 {
+		parts = append(parts, fmt.Sprintf("%d created", creates))
+	}
+	if alters > 0 {
+		parts = append(parts, fmt.Sprintf("%d altered", alters))
+	}
+	if drops > 0 {
+		parts = append(parts, fmt.Sprintf("%d dropped", drops))
+	}
+	ddlSummary := strings.Join(parts, ", ")
+
+	if keyspacesWithVSchema > 0 && !data.IsMySQL {
+		vschemaSummary := fmt.Sprintf("%d vschema %s", keyspacesWithVSchema, pluralize("update", keyspacesWithVSchema))
+		if ddlSummary == "" {
+			return vschemaSummary
+		}
+		return ddlSummary + " · " + vschemaSummary
+	}
+	return ddlSummary
+}
+
 // countStatementTypes counts CREATE, ALTER, and DROP statements across all keyspaces.
 func countStatementTypes(changes []KeyspaceChangeData) (creates, alters, drops int) {
 	for _, ks := range changes {

--- a/pkg/webhook/templates/plan.go
+++ b/pkg/webhook/templates/plan.go
@@ -322,12 +322,12 @@ func writeNoChangesDetected(sb *strings.Builder, data PlanCommentData) {
 // the aggregate check's Change column, e.g. "5 created, 3 altered, 1 dropped ·
 // 2 vschema updates". Zero categories are omitted. The vschema clause is only
 // included for non-MySQL engines, matching the plan comment's summary. Returns
-// "" when the plan has no changes. The create/alter/drop and vschema counting
-// is identical to the plan comment's summary (countStatementTypes / countChanges)
-// so the two always agree.
+// "" only when the plan has no changes at all. The create/alter/drop and vschema
+// counting is identical to the plan comment's summary (countStatementTypes /
+// countChanges) so the two always agree.
 func SummarizeChanges(data PlanCommentData) string {
 	creates, alters, drops := countStatementTypes(data.Changes)
-	_, keyspacesWithVSchema := countChanges(data.Changes)
+	totalStatements, keyspacesWithVSchema := countChanges(data.Changes)
 
 	var parts []string
 	if creates > 0 {
@@ -340,6 +340,14 @@ func SummarizeChanges(data PlanCommentData) string {
 		parts = append(parts, fmt.Sprintf("%d dropped", drops))
 	}
 	ddlSummary := strings.Join(parts, ", ")
+
+	// Fallback matching the plan comment: statements that classify as none of
+	// create/alter/drop — or per-shard-only DDL that countStatementTypes does not
+	// walk — still count. Report the raw statement total so the Change column
+	// never implies "no changes" for a plan that has them.
+	if ddlSummary == "" && totalStatements > 0 {
+		ddlSummary = fmt.Sprintf("%d DDL %s", totalStatements, pluralize("statement", totalStatements))
+	}
 
 	if keyspacesWithVSchema > 0 && !data.IsMySQL {
 		vschemaSummary := fmt.Sprintf("%d vschema %s", keyspacesWithVSchema, pluralize("update", keyspacesWithVSchema))

--- a/pkg/webhook/templates/summarize_changes_test.go
+++ b/pkg/webhook/templates/summarize_changes_test.go
@@ -1,0 +1,70 @@
+package templates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// SummarizeChanges powers the aggregate check's Change column. It must never
+// return an empty summary for a plan that has changes — an em dash there would
+// read as "no changes" on a safety-critical surface — and its create/alter/drop
+// and vschema counts must match the plan comment's summary.
+func TestSummarizeChanges(t *testing.T) {
+	t.Run("counts create, alter, drop", func(t *testing.T) {
+		data := PlanCommentData{
+			IsMySQL: true,
+			Changes: []KeyspaceChangeData{{
+				Keyspace: "orders",
+				Statements: []string{
+					"CREATE TABLE a (id INT)",
+					"CREATE TABLE b (id INT)",
+					"ALTER TABLE c ADD COLUMN d INT",
+					"DROP TABLE e",
+				},
+			}},
+		}
+		assert.Equal(t, "2 created, 1 altered, 1 dropped", SummarizeChanges(data))
+	})
+
+	t.Run("appends vschema updates for non-MySQL", func(t *testing.T) {
+		data := PlanCommentData{
+			IsMySQL: false,
+			Changes: []KeyspaceChangeData{{
+				Keyspace:       "orders",
+				Statements:     []string{"CREATE TABLE a (id INT)"},
+				VSchemaChanged: true,
+			}},
+		}
+		assert.Equal(t, "1 created · 1 vschema update", SummarizeChanges(data))
+	})
+
+	t.Run("vschema-only change for non-MySQL", func(t *testing.T) {
+		data := PlanCommentData{
+			IsMySQL: false,
+			Changes: []KeyspaceChangeData{{Keyspace: "orders", VSchemaChanged: true}},
+		}
+		assert.Equal(t, "1 vschema update", SummarizeChanges(data))
+	})
+
+	t.Run("per-shard-only DDL falls back to a statement count", func(t *testing.T) {
+		data := PlanCommentData{
+			IsMySQL: false,
+			Changes: []KeyspaceChangeData{{
+				Keyspace: "orders",
+				Shards: []KeyspaceShardChange{
+					{Shard: "-80", Statements: []string{"ALTER TABLE a ADD COLUMN b INT"}},
+					{Shard: "80-", Statements: []string{"ALTER TABLE a ADD COLUMN b INT"}},
+				},
+			}},
+		}
+		// countStatementTypes does not walk per-shard statements, so the
+		// create/alter/drop tally is zero; the fallback reports the deduped total
+		// rather than implying "no changes".
+		assert.Equal(t, "1 DDL statement", SummarizeChanges(data))
+	})
+
+	t.Run("no changes returns empty", func(t *testing.T) {
+		assert.Empty(t, SummarizeChanges(PlanCommentData{IsMySQL: true}))
+	})
+}

--- a/pkg/webhook/templates/summarize_changes_test.go
+++ b/pkg/webhook/templates/summarize_changes_test.go
@@ -24,7 +24,7 @@ func TestSummarizeChanges(t *testing.T) {
 				},
 			}},
 		}
-		assert.Equal(t, "2 created, 1 altered, 1 dropped", SummarizeChanges(data))
+		assert.Equal(t, "2 creates, 1 alter, 1 drop", SummarizeChanges(data))
 	})
 
 	t.Run("appends vschema updates for non-MySQL", func(t *testing.T) {
@@ -36,7 +36,7 @@ func TestSummarizeChanges(t *testing.T) {
 				VSchemaChanged: true,
 			}},
 		}
-		assert.Equal(t, "1 created · 1 vschema update", SummarizeChanges(data))
+		assert.Equal(t, "1 create · 1 vschema update", SummarizeChanges(data))
 	})
 
 	t.Run("vschema-only change for non-MySQL", func(t *testing.T) {

--- a/scripts/update-templates.sh
+++ b/scripts/update-templates.sh
@@ -138,8 +138,29 @@ render_cli_snapshot_section() {
     echo "" >> "$SNAPSHOT"
 }
 
+# Helper: render a single markdown preview wrapped in a collapsible block.
+# Used for Check Run output.summary text (rendered markdown, not a code fence).
+render_markdown_section() {
+    local heading="$1"
+    local preview_type="$2"
+
+    {
+        echo ""
+        echo "## ${heading}"
+        echo ""
+        echo "<details>"
+        echo "<summary><strong>${heading}</strong></summary>"
+        echo ""
+        "$BINARY" preview "$preview_type" 2>&1
+        echo ""
+        echo "</details>"
+        echo ""
+    } >> "$SNAPSHOT"
+}
+
 # === Paired sections (PR + CLI) ===
 render_paired_section "Plan & Status"  "comment_plan_all"       "cli_plan_all"
+render_markdown_section "Aggregate Check — Details summary" "aggregate_check_summary"
 render_paired_section "Locking"        "comment_locking_all"    "cli_locking_all"
 render_paired_section "Apply Flow"     "comment_apply_flow_all" "cli_apply_all"
 


### PR DESCRIPTION
Stacked on #620. Renders the per-database **Change summary** in the aggregate check's Details, completing the agreed breakdown UX: `| Database | Type | Change | Status |` with Change like `5 created, 3 altered · 2 vschema updates`, alongside the Tenant deployments section.

- Adds a `ChangeSummary` column to stored check state (schema + storage layer, threaded through every statement).
- Populates it at plan time from the plan response, reusing the plan comment's create/alter/drop + vschema counting so the two always agree.
- The plan is authoritative for a plan-only row (a re-plan overwrites, and a revert-to-no-changes clears); apply/rollback transitions preserve the plan-time summary so a state change never blanks it.
- Adds a `TEMPLATES.md` preview (`aggregate_check_summary`) of the full Details summary.

*Drafted by Claude Code (claude-opus-4-8).*