### PR TITLE
fix(github): require -t for rollback and control ops in tenant mode

### DIFF
--- a/pkg/webhook/aggregate_participant_fanout_test.go
+++ b/pkg/webhook/aggregate_participant_fanout_test.go
@@ -42,20 +42,33 @@ func TestSkipUnownedUnscopedCommand(t *testing.T) {
 		"a real error is not the not-owned case and must still surface")
 }
 
-// Fan-out applies only to actionable unscoped commands. A complete command
-// (Found) fans out; a plan without -e fans out as a multi-env plan; but a
-// missing-env error for apply/rollback does NOT fan out — otherwise every
-// participant on a shared repo would post its own duplicate "missing
-// environment" comment (the leader posts that error once).
+// Fan-out applies only to unscoped commands a participant can serve on its own
+// databases: plan, apply, and unlock. A complete command (Found) fans out; a
+// plan without -e fans out as a multi-env plan; but a missing-env apply does NOT
+// fan out — otherwise every participant on a shared repo would post its own
+// duplicate "missing environment" comment (the leader posts that error once).
+// Commands that target a single apply owned by one tenant — rollback and the
+// lifecycle controls — never fan out; they require an explicit -t so only the
+// owning tenant acts instead of every participant reporting "apply not found".
 func TestUnscopedCommandFansOut(t *testing.T) {
 	assert.True(t, unscopedCommandFansOut(CommandResult{Found: true, Action: action.Apply}),
-		"a complete command fans out")
+		"a complete apply fans out")
 	assert.True(t, unscopedCommandFansOut(CommandResult{MissingEnv: true, Action: action.Plan}),
 		"plan without -e fans out as a multi-env plan")
+	assert.True(t, unscopedCommandFansOut(CommandResult{Found: true, Action: action.Unlock}),
+		"unlock fans out: it releases only this participant's own database locks")
 	assert.False(t, unscopedCommandFansOut(CommandResult{MissingEnv: true, Action: action.Apply}),
 		"apply without -e is an error and must not fan out (no duplicate missing-env comments)")
-	assert.False(t, unscopedCommandFansOut(CommandResult{MissingEnv: true, Action: action.Rollback}),
-		"rollback without -e is an error and must not fan out")
+
+	// Commands targeting a single owned apply require an explicit -t.
+	for _, a := range []string{
+		action.Rollback, action.RollbackConfirm, action.Stop, action.Cancel,
+		action.Start, action.Release, action.Cutover, action.SkipRevert,
+	} {
+		assert.False(t, unscopedCommandFansOut(CommandResult{Found: true, Action: a}),
+			"%s targets a single owned apply and must require -t", a)
+	}
+
 	assert.False(t, unscopedCommandFansOut(CommandResult{}),
 		"an unrecognized command does not fan out")
 }

--- a/pkg/webhook/aggregate_participant_fanout_test.go
+++ b/pkg/webhook/aggregate_participant_fanout_test.go
@@ -42,6 +42,35 @@ func TestSkipUnownedUnscopedCommand(t *testing.T) {
 		"a real error is not the not-owned case and must still surface")
 }
 
+// On an aggregate repo an unscoped command fans out to every deployment, so a
+// deployment that finds no pending work (e.g. apply-confirm after its own
+// databases already auto-applied) stays silent instead of posting noise. A
+// -t-scoped command named a specific deployment, so its "nothing to do" answer
+// still surfaces; a non-aggregate repo is a single deployment whose answer is
+// useful too.
+func TestSilentOnUnscopedFanOut(t *testing.T) {
+	cfg := &api.ServerConfig{Repos: map[string]api.RepoConfig{
+		"octocat/participant-repo": {Aggregate: &api.AggregateConfig{Role: api.AggregateRoleParticipant}},
+		"octocat/leader-repo": {Aggregate: &api.AggregateConfig{
+			Role:            api.AggregateRoleLeader,
+			ExpectedTenants: []api.ExpectedTenant{{Tenant: "tenant-b", Paths: []string{"tenant-b/schema"}, CheckName: "SchemaBot Tenant B"}},
+		}},
+		"octocat/plain-repo": {},
+	}}
+	h := &Handler{service: api.New(nil, cfg, nil, testLogger())}
+
+	assert.True(t, h.silentOnUnscopedFanOut("octocat/participant-repo", ""),
+		"a participant with nothing pending stays silent on an unscoped fan-out")
+	assert.True(t, h.silentOnUnscopedFanOut("octocat/leader-repo", ""),
+		"a leader with nothing pending stays silent on an unscoped fan-out")
+	assert.False(t, h.silentOnUnscopedFanOut("octocat/participant-repo", "tenant-b"),
+		"a -t-scoped command named a deployment, so its nothing-to-do answer surfaces")
+	assert.False(t, h.silentOnUnscopedFanOut("octocat/plain-repo", ""),
+		"a non-aggregate repo is a single deployment — its answer is useful")
+	assert.False(t, h.silentOnUnscopedFanOut("octocat/unknown-repo", ""),
+		"an unconfigured repo has no aggregate role — its answer is useful")
+}
+
 // Fan-out applies only to unscoped commands a participant can serve on its own
 // databases: plan, apply, apply-confirm, and unlock. A complete command (Found)
 // fans out; a plan without -e fans out as a multi-env plan; but a missing-env

--- a/pkg/webhook/aggregate_participant_fanout_test.go
+++ b/pkg/webhook/aggregate_participant_fanout_test.go
@@ -43,16 +43,19 @@ func TestSkipUnownedUnscopedCommand(t *testing.T) {
 }
 
 // Fan-out applies only to unscoped commands a participant can serve on its own
-// databases: plan, apply, and unlock. A complete command (Found) fans out; a
-// plan without -e fans out as a multi-env plan; but a missing-env apply does NOT
-// fan out — otherwise every participant on a shared repo would post its own
-// duplicate "missing environment" comment (the leader posts that error once).
-// Commands that target a single apply owned by one tenant — rollback and the
-// lifecycle controls — never fan out; they require an explicit -t so only the
-// owning tenant acts instead of every participant reporting "apply not found".
+// databases: plan, apply, apply-confirm, and unlock. A complete command (Found)
+// fans out; a plan without -e fans out as a multi-env plan; but a missing-env
+// apply does NOT fan out — otherwise every participant on a shared repo would
+// post its own duplicate "missing environment" comment (the leader posts that
+// error once). Commands that target a single apply owned by one tenant —
+// rollback and the lifecycle controls — never fan out; they require an explicit
+// -t so only the owning tenant acts instead of every participant reporting
+// "apply not found".
 func TestUnscopedCommandFansOut(t *testing.T) {
 	assert.True(t, unscopedCommandFansOut(CommandResult{Found: true, Action: action.Apply}),
 		"a complete apply fans out")
+	assert.True(t, unscopedCommandFansOut(CommandResult{Found: true, Action: action.ApplyConfirm}),
+		"apply-confirm fans out with apply: it is the confirmation step of the same per-participant flow")
 	assert.True(t, unscopedCommandFansOut(CommandResult{MissingEnv: true, Action: action.Plan}),
 		"plan without -e fans out as a multi-env plan")
 	assert.True(t, unscopedCommandFansOut(CommandResult{Found: true, Action: action.Unlock}),
@@ -63,7 +66,7 @@ func TestUnscopedCommandFansOut(t *testing.T) {
 	// Commands targeting a single owned apply require an explicit -t.
 	for _, a := range []string{
 		action.Rollback, action.RollbackConfirm, action.Stop, action.Cancel,
-		action.Start, action.Release, action.Cutover, action.SkipRevert,
+		action.Start, action.Release, action.Cutover, action.SkipRevert, action.Revert,
 	} {
 		assert.False(t, unscopedCommandFansOut(CommandResult{Found: true, Action: a}),
 			"%s targets a single owned apply and must require -t", a)

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -388,6 +388,11 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 		return
 	}
 	if existingLock == nil {
+		if h.silentOnUnscopedFanOut(repo, result.Tenant) {
+			h.logger.Info("unscoped fan-out apply-confirm found no pending confirmation on this deployment; staying silent",
+				"repo", repo, "pr", pr, "database", database, "environment", environment)
+			return
+		}
 		h.logger.Info("apply-confirm rejected: no lock held", "repo", repo, "pr", pr, "database", database, "environment", environment)
 		h.postComment(repo, pr, installationID, templates.RenderApplyConfirmNoLock(database, environment))
 		return

--- a/pkg/webhook/check_runs_test.go
+++ b/pkg/webhook/check_runs_test.go
@@ -347,6 +347,49 @@ func TestTenantScopedWorkCommandRouting(t *testing.T) {
 		require.Equal(t, http.StatusOK, rr.Code)
 		assert.Contains(t, rr.Body.String(), "help posted")
 	})
+
+	// A participant fans out unscoped apply/plan, but commands that target a
+	// single apply owned by one tenant must not: an unscoped rollback or control
+	// op requires an explicit -t so only the owning tenant acts. Critically, a
+	// participant that does not own the targeted apply stays silent — it must not
+	// post "apply not found" for a database owned by another tenant.
+	t.Run("participant requires -t for rollback and control ops without erroring", func(t *testing.T) {
+		for _, comment := range []string{
+			"schemabot rollback a1b2c3 -e staging",
+			"schemabot stop a1b2c3 -e staging",
+			"schemabot cancel a1b2c3 -e staging",
+		} {
+			client, mux := setupGitHubServer(t)
+			mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(http.ResponseWriter, *http.Request) {
+				t.Errorf("participant must not post a comment for unscoped %q on an unowned apply", comment)
+			})
+			mux.HandleFunc("POST /repos/octocat/hello-world/issues/comments/42/reactions", func(http.ResponseWriter, *http.Request) {
+				t.Errorf("participant must not react to unscoped %q on an unowned apply", comment)
+			})
+			factory := &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())}
+
+			service := api.New(nil, &api.ServerConfig{
+				Tenant: "alpha",
+				Repos: map[string]api.RepoConfig{
+					"octocat/hello-world": {Aggregate: &api.AggregateConfig{Role: api.AggregateRoleParticipant}},
+				},
+			}, nil, testLogger())
+
+			h := &Handler{
+				service:   service,
+				ghClients: ghclient.NewSingleClientSet(defaultAppName, factory),
+				logger:    testLogger(),
+			}
+
+			req := buildWebhookRequest(t, webhookPayloadOpts{comment: comment, isPR: true}, nil)
+			rr := httpResponseRecorder()
+			h.ServeHTTP(rr, req)
+
+			require.Equal(t, http.StatusOK, rr.Code)
+			assert.Contains(t, rr.Body.String(), "tenant target required",
+				"unscoped %q must require -t on a participant", comment)
+		}
+	})
 }
 
 //go:fix inline

--- a/pkg/webhook/check_runs_test.go
+++ b/pkg/webhook/check_runs_test.go
@@ -355,9 +355,9 @@ func TestTenantScopedWorkCommandRouting(t *testing.T) {
 	// post "apply not found" for a database owned by another tenant.
 	t.Run("participant requires -t for rollback and control ops without erroring", func(t *testing.T) {
 		for _, comment := range []string{
-			"schemabot rollback a1b2c3 -e staging",
-			"schemabot stop a1b2c3 -e staging",
-			"schemabot cancel a1b2c3 -e staging",
+			"schemabot rollback apply_a1b2c3 -e staging",
+			"schemabot stop apply_a1b2c3 -e staging",
+			"schemabot cancel apply_a1b2c3 -e staging",
 		} {
 			client, mux := setupGitHubServer(t)
 			mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(http.ResponseWriter, *http.Request) {

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -363,14 +363,35 @@ func (h *Handler) fansOutUnscopedCommand(repo string) bool {
 	return h.service.Config().AggregateRoleForRepo(repo) == api.AggregateRoleParticipant
 }
 
+// actionFansOutUnscoped reports whether an action is one a participant can serve
+// without an explicit -t, by acting on its own databases. plan and apply cover
+// the participant's share of a shared PR, and unlock releases only the
+// participant's own database locks (locks are keyed by database, not by apply).
+// Commands that target a single apply owned by one tenant — rollback and the
+// lifecycle controls (stop, cancel, start, release, cutover, skip-revert) — are
+// not in this set: an unscoped one would reach every participant and all but the
+// owner would report "apply not found", so they require an explicit -t instead.
+func actionFansOutUnscoped(a string) bool {
+	switch a {
+	case action.Plan, action.Apply, action.Unlock:
+		return true
+	default:
+		return false
+	}
+}
+
 // unscopedCommandFansOut reports whether an unscoped (no -t) command is one a
 // participant should actually act on when fanning out, as opposed to an error
-// case it should stay silent on. A complete command (Found) fans out, and a
-// plan without -e fans out as a multi-env plan. A missing-env error for
-// apply/rollback does NOT fan out: otherwise every participant on a shared repo
-// would post its own duplicate "missing environment" comment. The leader (which
-// never hits the tenant gate) posts that error once.
+// case it should stay silent on. Only fan-out actions qualify (see
+// actionFansOutUnscoped). A complete command (Found) fans out, and a plan
+// without -e fans out as a multi-env plan. A missing-env apply does NOT fan out:
+// otherwise every participant on a shared repo would post its own duplicate
+// "missing environment" comment. The leader (which never hits the tenant gate)
+// posts that error once.
 func unscopedCommandFansOut(result CommandResult) bool {
+	if !actionFansOutUnscoped(result.Action) {
+		return false
+	}
 	if result.Found {
 		return true
 	}

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -364,16 +364,17 @@ func (h *Handler) fansOutUnscopedCommand(repo string) bool {
 }
 
 // actionFansOutUnscoped reports whether an action is one a participant can serve
-// without an explicit -t, by acting on its own databases. plan and apply cover
-// the participant's share of a shared PR, and unlock releases only the
-// participant's own database locks (locks are keyed by database, not by apply).
-// Commands that target a single apply owned by one tenant — rollback and the
-// lifecycle controls (stop, cancel, start, release, cutover, skip-revert) — are
-// not in this set: an unscoped one would reach every participant and all but the
-// owner would report "apply not found", so they require an explicit -t instead.
+// without an explicit -t, by acting on its own databases. plan, apply, and
+// apply-confirm route by environment/database, so each participant handles its
+// own share of a shared PR; unlock releases only the participant's own database
+// locks (locks are keyed by database, not by apply). Commands that target a
+// single apply owned by one tenant — rollback and the lifecycle controls (stop,
+// cancel, start, release, cutover, skip-revert, revert) — are not in this set:
+// an unscoped one would reach every participant and all but the owner would
+// report "apply not found", so they require an explicit -t instead.
 func actionFansOutUnscoped(a string) bool {
 	switch a {
-	case action.Plan, action.Apply, action.Unlock:
+	case action.Plan, action.Apply, action.ApplyConfirm, action.Unlock:
 		return true
 	default:
 		return false

--- a/pkg/webhook/schema_source_policy.go
+++ b/pkg/webhook/schema_source_policy.go
@@ -31,6 +31,26 @@ func (h *Handler) skipUnownedUnscopedCommand(repo, tenant string, err error) boo
 	return errors.As(err, &notOwned)
 }
 
+// silentOnUnscopedFanOut reports whether a "nothing to do on this deployment"
+// outcome for an unscoped (no -t) command should be a logged silent skip rather
+// than a PR comment. On an aggregate repo (leader or participant) an unscoped
+// command fans out to every deployment, so one that finds no pending work — for
+// example apply-confirm after this deployment's own databases already
+// auto-applied and released their locks — must stay quiet; only the deployment
+// that actually has work to confirm responds. A -t-scoped command (tenant != "")
+// named a specific deployment, so its "nothing to do" answer is useful and still
+// surfaces.
+func (h *Handler) silentOnUnscopedFanOut(repo, tenant string) bool {
+	if tenant != "" {
+		return false
+	}
+	config, ok := h.serverConfig()
+	if !ok {
+		return false
+	}
+	return config.AggregateRoleForRepo(repo) != ""
+}
+
 type schemaConfigOutsideAllowedDirsError struct {
 	Database     string
 	DatabaseType string


### PR DESCRIPTION
## Why this matters

On a shared repo where multiple tenants participate in one aggregate check, an unscoped command (no `-t`) that targets a single apply owned by one tenant fanned out to **every** participant. Only the owner could act; every other participant looked the apply up in its own storage, missed, and posted "apply not found" on the PR. On an N-tenant repo that meant one action plus N−1 error comments.

## What it does

Restricts unscoped fan-out to the commands a participant can legitimately serve on its own databases:

| Fans out unscoped | Requires `-t` |
|---|---|
| `plan`, `apply`, `apply-confirm` — each participant handles its own share of the PR | `rollback`, `rollback-confirm` |
| `unlock` — releases only this participant's own database locks (locks are keyed by database, not by apply) | `stop`, `cancel`, `start`, `release`, `cutover`, `skip-revert`, `revert` |

A command that names one apply owned by one tenant now requires an explicit `-t`: non-owning participants stay silent at the tenant gate (no PR comment), and the owning tenant performs the operation.

`apply-confirm` stays in the fan-out set because it is the confirmation step of the same per-participant apply flow. Since an `apply` can auto-apply some tenants while downgrading others to manual confirmation (per-database drift / unsafe-change / plan-load checks), an unscoped `apply-confirm` must reach the downgraded tenants. Participants that already auto-applied hold no lock, so on the unscoped fan-out path they now log and stay silent instead of posting "no lock held". A `-t`-scoped `apply-confirm` still surfaces that message, since it named a specific deployment.

## How it moves toward northstar

Collapsing per-tenant check sprawl on shared repos depends on participants staying quiet unless they own the work. This removes the duplicate "apply not found" and "no lock held" noise, matching how unscoped `apply`/`plan` already skip databases a participant doesn't own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)