### PR TITLE
feat(observability): warn once when per-shard progress is unavailable

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -356,12 +356,13 @@ const (
 	// DSN, so SHOW VITESS_MIGRATIONS cannot be queried. This persists for the
 	// whole apply — a target-resolution gap (missing vtgate endpoint).
 	PerShardUnavailableNoVtgateDSN = "no_vtgate_dsn"
-	// PerShardUnavailableNoMigrationContext means no migration context is known
-	// for the deploy, so per-shard rows cannot be correlated to this apply.
-	PerShardUnavailableNoMigrationContext = "no_migration_context"
-	// PerShardUnavailableNoMigrationsReported means the per-shard query ran but
-	// returned no rows for the migration context while the apply was active.
-	PerShardUnavailableNoMigrationsReported = "no_migrations_reported"
+	// PerShardUnavailableNoChangeContext means no schema-change context
+	// identifier is known for the deploy yet, so per-shard rows cannot be
+	// correlated to this apply. Transient during setup/recovery.
+	PerShardUnavailableNoChangeContext = "no_change_context"
+	// PerShardUnavailableNoShardRows means the per-shard query ran but returned
+	// no rows for this schema change while the apply was active.
+	PerShardUnavailableNoShardRows = "no_shard_rows"
 )
 
 // TableProgress tracks progress for a single table.

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -361,7 +361,8 @@ const (
 	// correlated to this apply. Transient during setup/recovery.
 	PerShardUnavailableNoChangeContext = "no_change_context"
 	// PerShardUnavailableNoShardRows means the per-shard query ran but returned
-	// no rows for this schema change while the apply was active.
+	// no rows for this schema change while the apply was active. Can occur
+	// transiently at the start of the copy phase, before shard rows register.
 	PerShardUnavailableNoShardRows = "no_shard_rows"
 )
 

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -339,7 +339,30 @@ type ProgressResult struct {
 	// engine surface structured status to the renderer without core decoding the
 	// opaque ResumeState.Metadata or reading an engine-specific side table.
 	Metadata map[string]string
+
+	// PerShardProgressUnavailable is set by sharded engines when a progress poll
+	// cannot produce per-shard/row-copy progress, carrying a machine-readable
+	// reason (one of the PerShardUnavailable* constants). Empty means per-shard
+	// progress was available (or the engine has no per-shard concept). The drive
+	// surfaces this once per apply so an operator sees the degraded visibility in
+	// Datadog without enabling debug logging.
+	PerShardProgressUnavailable string
 }
+
+// Reasons a sharded engine could not report per-shard/row-copy progress for a
+// progress poll, carried in ProgressResult.PerShardProgressUnavailable.
+const (
+	// PerShardUnavailableNoVtgateDSN means the target resolved without a vtgate
+	// DSN, so SHOW VITESS_MIGRATIONS cannot be queried. This persists for the
+	// whole apply — a target-resolution gap (missing vtgate endpoint).
+	PerShardUnavailableNoVtgateDSN = "no_vtgate_dsn"
+	// PerShardUnavailableNoMigrationContext means no migration context is known
+	// for the deploy, so per-shard rows cannot be correlated to this apply.
+	PerShardUnavailableNoMigrationContext = "no_migration_context"
+	// PerShardUnavailableNoMigrationsReported means the per-shard query ran but
+	// returned no rows for the migration context while the apply was active.
+	PerShardUnavailableNoMigrationsReported = "no_migrations_reported"
+)
 
 // TableProgress tracks progress for a single table.
 type TableProgress struct {

--- a/pkg/engine/planetscale/progress.go
+++ b/pkg/engine/planetscale/progress.go
@@ -160,21 +160,21 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 				result.Progress = overallProgress
 			}
 		} else {
-			// The query ran against a live migration context but returned no shard
-			// rows. The drive surfaces this once per apply so the gap is visible
+			// The query ran for a live schema change but returned no shard rows.
+			// The drive surfaces this once per apply so the gap is visible
 			// without reading per-poll debug.
-			result.PerShardProgressUnavailable = engine.PerShardUnavailableNoMigrationsReported
+			result.PerShardProgressUnavailable = engine.PerShardUnavailableNoShardRows
 		}
 	} else {
 		// No per-shard/row-copy progress this poll. A missing vtgate DSN is a target
-		// resolution gap that persists for the whole apply; an unset MigrationContext
-		// is transient during setup/recovery. Either way the comment and CLI fall
-		// back to deploy-request state, and the drive surfaces the reason once per
-		// apply.
+		// resolution gap that persists for the whole apply; a missing schema-change
+		// context is transient during setup/recovery. Either way the comment and CLI
+		// fall back to deploy-request state, and the drive surfaces the reason once
+		// per apply.
 		if !hasVtgateDSN {
 			result.PerShardProgressUnavailable = engine.PerShardUnavailableNoVtgateDSN
 		} else {
-			result.PerShardProgressUnavailable = engine.PerShardUnavailableNoMigrationContext
+			result.PerShardProgressUnavailable = engine.PerShardUnavailableNoChangeContext
 		}
 		e.logger.Debug("skipping per-shard progress",
 			"database", req.Database,

--- a/pkg/engine/planetscale/progress.go
+++ b/pkg/engine/planetscale/progress.go
@@ -159,12 +159,23 @@ func (e *Engine) Progress(ctx context.Context, req *engine.ProgressRequest) (*en
 			if overallProgress > 0 {
 				result.Progress = overallProgress
 			}
+		} else {
+			// The query ran against a live migration context but returned no shard
+			// rows. The drive surfaces this once per apply so the gap is visible
+			// without reading per-poll debug.
+			result.PerShardProgressUnavailable = engine.PerShardUnavailableNoMigrationsReported
 		}
 	} else {
 		// No per-shard/row-copy progress this poll. A missing vtgate DSN is a target
-		// resolution gap that persists for the whole apply (warned once at apply
-		// start); an unset MigrationContext is transient during setup/recovery.
-		// Either way the comment and CLI fall back to deploy-request state.
+		// resolution gap that persists for the whole apply; an unset MigrationContext
+		// is transient during setup/recovery. Either way the comment and CLI fall
+		// back to deploy-request state, and the drive surfaces the reason once per
+		// apply.
+		if !hasVtgateDSN {
+			result.PerShardProgressUnavailable = engine.PerShardUnavailableNoVtgateDSN
+		} else {
+			result.PerShardProgressUnavailable = engine.PerShardUnavailableNoMigrationContext
+		}
 		e.logger.Debug("skipping per-shard progress",
 			"database", req.Database,
 			"has_vtgate_dsn", hasVtgateDSN,

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -715,13 +715,13 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 
 	// Surface once, at Warn, when a sharded engine reached an active state but
 	// could not report per-shard/row-copy progress. Gating on the active states
-	// avoids false alarms during setup, where a migration context is still being
-	// discovered. Warn (not Debug) so the degraded visibility is always in
+	// avoids false alarms during setup, where the schema-change context is still
+	// being discovered. Warn (not Debug) so the degraded visibility is always in
 	// Datadog without enabling debug logging; the per-poll detail stays at Debug.
 	if result.PerShardProgressUnavailable != "" && !ps.warnedPerShardUnavailable &&
 		state.IsState(newState, state.Task.Running, state.Task.WaitingForCutover, state.Task.RevertWindow) {
 		c.logger.Warn("per-shard progress unavailable: per-shard and row-copy progress will not be reported for this apply",
-			append(apply.LogAttrs(), "reason", result.PerShardProgressUnavailable, "engine_state", newState)...)
+			append(apply.LogAttrs(), "reason", result.PerShardProgressUnavailable, "task_state", newState)...)
 		ps.warnedPerShardUnavailable = true
 	}
 

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -714,11 +714,14 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 	}
 
 	// Surface once, at Warn, when a sharded engine reached an active state but
-	// could not report per-shard/row-copy progress. Gating on the active states
-	// avoids false alarms during setup, where the schema-change context is still
-	// being discovered. Warn (not Debug) so the degraded visibility is always in
-	// Datadog without enabling debug logging; the per-poll detail stays at Debug.
-	if result.PerShardProgressUnavailable != "" && !ps.warnedPerShardUnavailable &&
+	// could not report per-shard/row-copy progress for a reason that persists for
+	// the whole apply (a missing vtgate DSN). Only the persistent reason warns:
+	// the transient reasons (schema-change context still being discovered, shard
+	// rows not yet registered at copy start) can self-heal on a later poll, so a
+	// one-shot warning for them would be a false alarm that latches forever; they
+	// stay visible in the engine's per-poll Debug. Warn (not Debug) so the
+	// degraded visibility is always in Datadog without enabling debug logging.
+	if result.PerShardProgressUnavailable == engine.PerShardUnavailableNoVtgateDSN && !ps.warnedPerShardUnavailable &&
 		state.IsState(newState, state.Task.Running, state.Task.WaitingForCutover, state.Task.RevertWindow) {
 		c.logger.Warn("per-shard progress unavailable: per-shard and row-copy progress will not be reported for this apply",
 			append(apply.LogAttrs(), "reason", result.PerShardProgressUnavailable, "task_state", newState)...)

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -713,6 +713,18 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		ps.stateEnteredAt = now
 	}
 
+	// Surface once, at Warn, when a sharded engine reached an active state but
+	// could not report per-shard/row-copy progress. Gating on the active states
+	// avoids false alarms during setup, where a migration context is still being
+	// discovered. Warn (not Debug) so the degraded visibility is always in
+	// Datadog without enabling debug logging; the per-poll detail stays at Debug.
+	if result.PerShardProgressUnavailable != "" && !ps.warnedPerShardUnavailable &&
+		state.IsState(newState, state.Task.Running, state.Task.WaitingForCutover, state.Task.RevertWindow) {
+		c.logger.Warn("per-shard progress unavailable: per-shard and row-copy progress will not be reported for this apply",
+			append(apply.LogAttrs(), "reason", result.PerShardProgressUnavailable, "engine_state", newState)...)
+		ps.warnedPerShardUnavailable = true
+	}
+
 	// Log progress every 10 seconds
 	c.logAtomicProgress(ctx, apply, result, ps, now)
 

--- a/pkg/tern/local_apply_sequential.go
+++ b/pkg/tern/local_apply_sequential.go
@@ -259,6 +259,11 @@ type atomicPollState struct {
 	// consecutiveErrors tracks progress poll failures to fail fast when the
 	// engine is unreachable (e.g., branch deleted mid-apply).
 	consecutiveErrors int
+
+	// warnedPerShardUnavailable is set after the drive warns that a sharded
+	// engine could not report per-shard/row-copy progress, so the warning is
+	// emitted once per apply rather than on every poll.
+	warnedPerShardUnavailable bool
 }
 
 // startApplyHeartbeat starts a background goroutine that heartbeats the apply

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -2480,8 +2480,8 @@ func TestHandleAtomicProgressTickReleasesAtCutoverBarrier(t *testing.T) {
 // row-copy progress (e.g. the target resolved without a vtgate DSN), the drive
 // surfaces the reason once per apply at Warn — always visible in Datadog without
 // enabling debug logging. It fires once (not per poll) and stays silent during
-// setup states, where a missing migration context is transient rather than a
-// degraded target resolution.
+// setup states, where a missing schema-change context is transient rather than
+// a degraded target resolution.
 func TestHandleAtomicProgressTickPerShardUnavailableWarn(t *testing.T) {
 	newApply := func() *storage.Apply {
 		return &storage.Apply{

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -2476,6 +2476,78 @@ func TestHandleAtomicProgressTickReleasesAtCutoverBarrier(t *testing.T) {
 	})
 }
 
+// When a sharded engine reaches an active state but cannot report per-shard or
+// row-copy progress (e.g. the target resolved without a vtgate DSN), the drive
+// surfaces the reason once per apply at Warn — always visible in Datadog without
+// enabling debug logging. It fires once (not per poll) and stays silent during
+// setup states, where a missing migration context is transient rather than a
+// degraded target resolution.
+func TestHandleAtomicProgressTickPerShardUnavailableWarn(t *testing.T) {
+	newApply := func() *storage.Apply {
+		return &storage.Apply{
+			ID:              11,
+			ApplyIdentifier: "apply-pershard-unavailable",
+			Database:        "testdb",
+			DatabaseType:    storage.DatabaseTypeVitess,
+			State:           state.Apply.Running,
+		}
+	}
+	engineAt := func(es engine.State) *fakeControlEngine {
+		return &fakeControlEngine{progressResult: &engine.ProgressResult{
+			State:                       es,
+			PerShardProgressUnavailable: engine.PerShardUnavailableNoVtgateDSN,
+		}}
+	}
+	runTicks := func(t *testing.T, eng *fakeControlEngine, ticks int) []capturedLog {
+		t.Helper()
+		apply := newApply()
+		opID := int64(1)
+		tasks := []*storage.Task{{
+			TaskIdentifier:   "task-users",
+			ApplyID:          apply.ID,
+			ApplyOperationID: &opID,
+			State:            state.Task.Running,
+			TableName:        "users",
+			Namespace:        "testdb",
+		}}
+		stor := &exactProgressStorage{
+			applies:         &snapshotApplyStore{stored: *apply},
+			tasks:           &exactProgressTaskStore{tasks: tasks},
+			controlRequests: &testControlRequestStore{},
+			applyOperations: &listApplyOperationStore{ops: []*storage.ApplyOperation{{ID: opID, State: state.ApplyOperation.Running}}},
+		}
+		var records []capturedLog
+		client := &LocalClient{storage: stor, logger: slog.New(captureHandler{records: &records})}
+		ps := &atomicPollState{lastProgressLog: time.Now()}
+		for range ticks {
+			client.handleAtomicProgressTick(t.Context(), eng, apply, tasks, &engine.Credentials{}, nil, ps, apply.GetOptions().Map(), false)
+		}
+		return records
+	}
+
+	unavailableWarnings := func(records []capturedLog) []capturedLog {
+		var out []capturedLog
+		for _, r := range records {
+			if r.level == slog.LevelWarn && r.msg == "per-shard progress unavailable: per-shard and row-copy progress will not be reported for this apply" {
+				out = append(out, r)
+			}
+		}
+		return out
+	}
+
+	t.Run("warns once per apply with the reason on an active state", func(t *testing.T) {
+		warnings := unavailableWarnings(runTicks(t, engineAt(engine.StateRunning), 3))
+		require.Len(t, warnings, 1, "the degraded-visibility warning must fire exactly once across polls")
+		assert.Equal(t, engine.PerShardUnavailableNoVtgateDSN, warnings[0].attrs["reason"])
+		assert.Equal(t, "apply-pershard-unavailable", warnings[0].attrs["apply_id"])
+	})
+
+	t.Run("stays silent during setup states", func(t *testing.T) {
+		warnings := unavailableWarnings(runTicks(t, engineAt(engine.StateWaitingForDeploy), 3))
+		assert.Empty(t, warnings, "no warning before the apply reaches an active copy state")
+	})
+}
+
 // capturedLog records a single emitted log record's level, message, and
 // attributes for assertions.
 type capturedLog struct {

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -2477,11 +2477,12 @@ func TestHandleAtomicProgressTickReleasesAtCutoverBarrier(t *testing.T) {
 }
 
 // When a sharded engine reaches an active state but cannot report per-shard or
-// row-copy progress (e.g. the target resolved without a vtgate DSN), the drive
-// surfaces the reason once per apply at Warn — always visible in Datadog without
-// enabling debug logging. It fires once (not per poll) and stays silent during
-// setup states, where a missing schema-change context is transient rather than
-// a degraded target resolution.
+// row-copy progress for a reason that persists for the whole apply (the target
+// resolved without a vtgate DSN), the drive surfaces it once per apply at Warn —
+// always visible in Datadog without enabling debug logging. It fires once (not
+// per poll), stays silent during setup states, and stays silent for transient
+// reasons (schema-change context still being discovered, shard rows not yet
+// registered) that can self-heal on a later poll.
 func TestHandleAtomicProgressTickPerShardUnavailableWarn(t *testing.T) {
 	newApply := func() *storage.Apply {
 		return &storage.Apply{
@@ -2492,11 +2493,14 @@ func TestHandleAtomicProgressTickPerShardUnavailableWarn(t *testing.T) {
 			State:           state.Apply.Running,
 		}
 	}
-	engineAt := func(es engine.State) *fakeControlEngine {
+	engineWithReason := func(es engine.State, reason string) *fakeControlEngine {
 		return &fakeControlEngine{progressResult: &engine.ProgressResult{
 			State:                       es,
-			PerShardProgressUnavailable: engine.PerShardUnavailableNoVtgateDSN,
+			PerShardProgressUnavailable: reason,
 		}}
+	}
+	engineAt := func(es engine.State) *fakeControlEngine {
+		return engineWithReason(es, engine.PerShardUnavailableNoVtgateDSN)
 	}
 	runTicks := func(t *testing.T, eng *fakeControlEngine, ticks int) []capturedLog {
 		t.Helper()
@@ -2545,6 +2549,13 @@ func TestHandleAtomicProgressTickPerShardUnavailableWarn(t *testing.T) {
 	t.Run("stays silent during setup states", func(t *testing.T) {
 		warnings := unavailableWarnings(runTicks(t, engineAt(engine.StateWaitingForDeploy), 3))
 		assert.Empty(t, warnings, "no warning before the apply reaches an active copy state")
+	})
+
+	t.Run("stays silent for transient reasons that can self-heal", func(t *testing.T) {
+		for _, reason := range []string{engine.PerShardUnavailableNoChangeContext, engine.PerShardUnavailableNoShardRows} {
+			warnings := unavailableWarnings(runTicks(t, engineWithReason(engine.StateRunning, reason), 3))
+			assert.Empty(t, warnings, "reason %s can resolve on a later poll and must not latch a warning", reason)
+		}
 	})
 }
 


### PR DESCRIPTION
## Why this matters

When a sharded (Vitess/PlanetScale) apply cannot produce per-shard or row-copy progress, an operator loses the per-shard view and the drift signal that depends on it. Until now the engine recorded that condition only at `Debug`, on every poll — and since only `info`/`warn`/`error` are retained (debug is dropped), the degraded visibility never showed up unless someone had already enabled debug logging. That makes a live apply opaque exactly when triage needs it, and per-poll debug is too noisy to leave on.

## What it does

- The engine stamps a machine-readable reason on the progress result when per-shard progress is unavailable, distinguishing the causes rather than collapsing them:
  - `no_vtgate_dsn` — the target resolved without a vtgate DSN (a persistent target-resolution gap)
  - `no_change_context` — no schema-change context identifier is known yet (transient during setup/recovery)
  - `no_shard_rows` — the per-shard query ran but returned no rows (can occur transiently at copy start)
- The drive surfaces **only the persistent reason** (`no_vtgate_dsn`) — **once per apply** at `Warn`, with the standard apply triage attributes, so it is always visible without turning on debug. The transient reasons can self-heal on a later poll, and the once-per-apply warning latches, so warning on them would raise a false "will not be reported" that never corrects itself; they stay at the engine's per-poll `Debug`.
- The warning is additionally **gated on an active state** (`running` / `waiting_for_cutover` / `revert_window`), so setup never false-alarms.

```
poll (setup)       -> reason set, state not active        -> silent
poll (running)     -> no_vtgate_dsn, first active tick    -> Warn once (reason=no_vtgate_dsn)
poll (running x N) -> no_vtgate_dsn still set             -> silent (deduped)
poll (running)     -> transient reason (context/rows)     -> Debug only (may self-heal)
```

## How it moves toward the northstar

The control plane is a reader/mirror of the data plane's progress; when per-shard signal is missing, an operator needs to know *why* from logs alone. Promoting the genuinely-persistent condition from debug to a deduped warn — instead of relying on a debug toggle — keeps info+/warn/error as the always-on triage surface and reserves debug for truly noisy or self-healing detail.

*Drafted by Claude Code (Opus 4.8); revised by Claude Code (Fable 5).*