### PR TITLE
feat(tern): review-time drift rollup and per-deployment classification

### DIFF
--- a/pkg/api/plan_rollup.go
+++ b/pkg/api/plan_rollup.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"fmt"
+
+	"github.com/block/schemabot/pkg/tern"
+)
+
+// DeploymentClassification is how a deployment's review-time diff compares to the
+// reviewed primary plan.
+type DeploymentClassification int
+
+const (
+	// DeploymentMatch means the deployment would plan exactly the reviewed
+	// changes. The primary is always Match against itself.
+	DeploymentMatch DeploymentClassification = iota
+	// DeploymentDiverged means the deployment would plan a different set of
+	// changes than were reviewed — schema drift that must block approval.
+	DeploymentDiverged
+	// DeploymentErrored means the deployment's diff could not be computed or
+	// compared. It must be treated as blocking, never as agreement.
+	DeploymentErrored
+)
+
+func (c DeploymentClassification) String() string {
+	switch c {
+	case DeploymentMatch:
+		return "match"
+	case DeploymentDiverged:
+		return "diverged"
+	case DeploymentErrored:
+		return "errored"
+	default:
+		return fmt.Sprintf("unknown(%d)", int(c))
+	}
+}
+
+// DeploymentRollupEntry is one deployment's place in the review-time rollup: how
+// it classified against the reviewed plan, the diff when it diverged, and the
+// error when it could not be computed or compared.
+type DeploymentRollupEntry struct {
+	DatabaseType string
+	Deployment   string
+	Target       string
+
+	Class DeploymentClassification
+	Diff  tern.ChangeSetDiff
+	Err   error
+}
+
+// PlanRollup aggregates every deployment's review-time classification for a
+// database. Clean is true only when every deployment matches the reviewed plan;
+// any divergence, error, or the primary baseline itself being unusable makes it
+// false so the review gate fails closed.
+type PlanRollup struct {
+	Entries []DeploymentRollupEntry
+	Clean   bool
+}
+
+// RollupDeploymentDiffs classifies each deployment's review-time diff against the
+// reviewed primary plan and reports whether the rollup is clean.
+//
+// The primary (index 0) is the reviewed baseline and classifies Match against
+// itself; every other deployment is compared to it with tern.CompareChangeSets.
+// The result fails closed: an empty result set, a primary baseline that errored
+// or is otherwise unusable, or any deployment that errored or diverged makes the
+// rollup not Clean. It relies on PlanDeploymentDiffs' contract that the input
+// carries exactly one entry per configured deployment, primary first, so a
+// missing deployment cannot silently pass.
+func RollupDeploymentDiffs(diffs []DeploymentPlanDiff) (PlanRollup, error) {
+	if len(diffs) == 0 {
+		return PlanRollup{}, fmt.Errorf("no deployment diffs to roll up")
+	}
+
+	baseline := tern.ChangeSet{Changes: diffs[0].Changes, Shards: diffs[0].Shards}
+	baselineUsable := diffs[0].Err == nil
+
+	entries := make([]DeploymentRollupEntry, len(diffs))
+	clean := true
+	for i, d := range diffs {
+		entry := DeploymentRollupEntry{
+			DatabaseType: d.DatabaseType,
+			Deployment:   d.Deployment,
+			Target:       d.Target,
+		}
+		switch {
+		case d.Err != nil:
+			entry.Class = DeploymentErrored
+			entry.Err = d.Err
+			clean = false
+		case i == 0:
+			// The reviewed primary plan is the baseline; it matches itself.
+			entry.Class = DeploymentMatch
+		case !baselineUsable:
+			// Without a usable baseline no deployment can be confirmed to match, so
+			// every deployment blocks rather than being compared to nothing.
+			entry.Class = DeploymentErrored
+			entry.Err = fmt.Errorf("primary reviewed plan unavailable; cannot confirm deployment matches the reviewed changes")
+			clean = false
+		default:
+			diff, err := tern.CompareChangeSets(baseline, tern.ChangeSet{Changes: d.Changes, Shards: d.Shards})
+			switch {
+			case err != nil:
+				entry.Class = DeploymentErrored
+				entry.Err = err
+				clean = false
+			case !diff.Empty():
+				entry.Class = DeploymentDiverged
+				entry.Diff = diff
+				clean = false
+			default:
+				entry.Class = DeploymentMatch
+			}
+		}
+		entries[i] = entry
+	}
+
+	return PlanRollup{Entries: entries, Clean: clean}, nil
+}

--- a/pkg/api/plan_rollup.go
+++ b/pkg/api/plan_rollup.go
@@ -75,6 +75,19 @@ func RollupDeploymentDiffs(diffs []DeploymentPlanDiff) (PlanRollup, error) {
 	baseline := tern.ChangeSet{Changes: diffs[0].Changes, Shards: diffs[0].Shards}
 	baselineUsable := diffs[0].Err == nil
 
+	// Validate the baseline is internally well-formed before trusting it as the
+	// comparison target. A self-comparison surfaces malformed or unparseable
+	// change content that would otherwise let a single-deployment rollup report
+	// clean, or classify the primary as a match, without a trustworthy comparison
+	// ever running.
+	var baselineErr error
+	if baselineUsable {
+		if _, err := tern.CompareChangeSets(baseline, baseline); err != nil {
+			baselineUsable = false
+			baselineErr = err
+		}
+	}
+
 	entries := make([]DeploymentRollupEntry, len(diffs))
 	clean := true
 	for i, d := range diffs {
@@ -89,13 +102,20 @@ func RollupDeploymentDiffs(diffs []DeploymentPlanDiff) (PlanRollup, error) {
 			entry.Err = d.Err
 			clean = false
 		case i == 0:
-			// The reviewed primary plan is the baseline; it matches itself.
-			entry.Class = DeploymentMatch
+			// The reviewed primary plan is the baseline. It matches itself only when
+			// its own content is well-formed; malformed content makes it unusable.
+			if baselineErr != nil {
+				entry.Class = DeploymentErrored
+				entry.Err = fmt.Errorf("reviewed primary plan is not a usable baseline: %w", baselineErr)
+				clean = false
+			} else {
+				entry.Class = DeploymentMatch
+			}
 		case !baselineUsable:
 			// Without a usable baseline no deployment can be confirmed to match, so
 			// every deployment blocks rather than being compared to nothing.
 			entry.Class = DeploymentErrored
-			entry.Err = fmt.Errorf("primary reviewed plan unavailable; cannot confirm deployment matches the reviewed changes")
+			entry.Err = fmt.Errorf("primary reviewed plan is not a usable baseline; cannot confirm deployment matches the reviewed changes")
 			clean = false
 		default:
 			diff, err := tern.CompareChangeSets(baseline, tern.ChangeSet{Changes: d.Changes, Shards: d.Shards})

--- a/pkg/api/plan_rollup.go
+++ b/pkg/api/plan_rollup.go
@@ -60,33 +60,46 @@ type PlanRollup struct {
 // RollupDeploymentDiffs classifies each deployment's review-time diff against the
 // reviewed primary plan and reports whether the rollup is clean.
 //
+// expectedDeployments is the configured deployment set in rollout order, primary
+// first — the same order PlanDeploymentDiffs produces. The diffs must match it
+// positionally: this turns the producer's structural convention (primary first,
+// one entry per configured deployment) into an enforced contract, so a
+// reordered, short, or otherwise mismatched result is rejected rather than
+// letting a missing or misidentified deployment silently pass the gate.
+//
 // The primary (index 0) is the reviewed baseline and classifies Match against
 // itself; every other deployment is compared to it with tern.CompareChangeSets.
-// The result fails closed: an empty result set, a primary baseline that errored
+// The result fails closed: a contract mismatch, a primary baseline that errored
 // or is otherwise unusable, or any deployment that errored or diverged makes the
-// rollup not Clean. It relies on PlanDeploymentDiffs' contract that the input
-// carries exactly one entry per configured deployment, primary first, so a
-// missing deployment cannot silently pass.
-func RollupDeploymentDiffs(diffs []DeploymentPlanDiff) (PlanRollup, error) {
-	if len(diffs) == 0 {
-		return PlanRollup{}, fmt.Errorf("no deployment diffs to roll up")
+// rollup not Clean.
+func RollupDeploymentDiffs(diffs []DeploymentPlanDiff, expectedDeployments []string) (PlanRollup, error) {
+	if len(expectedDeployments) == 0 {
+		return PlanRollup{}, fmt.Errorf("no expected deployments to roll up")
+	}
+	if len(diffs) != len(expectedDeployments) {
+		return PlanRollup{}, fmt.Errorf("expected %d deployment diffs in rollout order, got %d", len(expectedDeployments), len(diffs))
+	}
+	for i, name := range expectedDeployments {
+		if diffs[i].Deployment != name {
+			return PlanRollup{}, fmt.Errorf("deployment diff %d is %q, expected %q; diffs must be in rollout order with the primary first and every configured deployment present", i, diffs[i].Deployment, name)
+		}
 	}
 
 	baseline := tern.ChangeSet{Changes: diffs[0].Changes, Shards: diffs[0].Shards}
-	baselineUsable := diffs[0].Err == nil
 
-	// Validate the baseline is internally well-formed before trusting it as the
-	// comparison target. A self-comparison surfaces malformed or unparseable
-	// change content that would otherwise let a single-deployment rollup report
-	// clean, or classify the primary as a match, without a trustworthy comparison
-	// ever running.
-	var baselineErr error
-	if baselineUsable {
+	// The baseline is usable only when the primary neither errored in the producer
+	// nor carries malformed content. A self-comparison surfaces malformed or
+	// unparseable change content that would otherwise let a single-deployment
+	// rollup report clean, or classify the primary as a match, without a
+	// trustworthy comparison ever running. A self-comparison of well-formed
+	// content is provably empty, so it never false-diverges a legitimate baseline.
+	baselineCause := diffs[0].Err
+	if baselineCause == nil {
 		if _, err := tern.CompareChangeSets(baseline, baseline); err != nil {
-			baselineUsable = false
-			baselineErr = err
+			baselineCause = err
 		}
 	}
+	baselineUsable := baselineCause == nil
 
 	entries := make([]DeploymentRollupEntry, len(diffs))
 	clean := true
@@ -104,18 +117,21 @@ func RollupDeploymentDiffs(diffs []DeploymentPlanDiff) (PlanRollup, error) {
 		case i == 0:
 			// The reviewed primary plan is the baseline. It matches itself only when
 			// its own content is well-formed; malformed content makes it unusable.
-			if baselineErr != nil {
+			// A producer error on the primary was already handled above, so a cause
+			// here is a content error.
+			if baselineCause != nil {
 				entry.Class = DeploymentErrored
-				entry.Err = fmt.Errorf("reviewed primary plan is not a usable baseline: %w", baselineErr)
+				entry.Err = fmt.Errorf("reviewed primary plan is not a usable baseline: %w", baselineCause)
 				clean = false
 			} else {
 				entry.Class = DeploymentMatch
 			}
 		case !baselineUsable:
 			// Without a usable baseline no deployment can be confirmed to match, so
-			// every deployment blocks rather than being compared to nothing.
+			// every deployment blocks. Wrap the primary's root cause so each entry is
+			// self-contained for triage without cross-referencing the primary's.
 			entry.Class = DeploymentErrored
-			entry.Err = fmt.Errorf("primary reviewed plan is not a usable baseline; cannot confirm deployment matches the reviewed changes")
+			entry.Err = fmt.Errorf("primary reviewed plan is not a usable baseline, cannot confirm deployment matches the reviewed changes: %w", baselineCause)
 			clean = false
 		default:
 			diff, err := tern.CompareChangeSets(baseline, tern.ChangeSet{Changes: d.Changes, Shards: d.Shards})

--- a/pkg/api/plan_rollup_test.go
+++ b/pkg/api/plan_rollup_test.go
@@ -1,0 +1,133 @@
+package api
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+)
+
+func rollupAlterUsers(ddl string) *ternv1.SchemaChange {
+	return &ternv1.SchemaChange{
+		Namespace: "testapp",
+		TableChanges: []*ternv1.TableChange{{
+			TableName:  "users",
+			Ddl:        ddl,
+			ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER,
+			Namespace:  "testapp",
+		}},
+	}
+}
+
+func rollupDeployment(name string, changes ...*ternv1.SchemaChange) DeploymentPlanDiff {
+	return DeploymentPlanDiff{
+		DatabaseType: "vitess",
+		Deployment:   name,
+		Target:       name,
+		Changes:      changes,
+	}
+}
+
+// When every deployment would plan exactly the reviewed changes, the rollup is
+// clean and every entry classifies as a match.
+func TestRollupDeploymentDiffs_AllMatchIsClean(t *testing.T) {
+	change := "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"
+	diffs := []DeploymentPlanDiff{
+		rollupDeployment("eu", rollupAlterUsers(change)),
+		rollupDeployment("au", rollupAlterUsers(change)),
+		rollupDeployment("us", rollupAlterUsers(change)),
+	}
+	rollup, err := RollupDeploymentDiffs(diffs)
+	require.NoError(t, err)
+	assert.True(t, rollup.Clean)
+	require.Len(t, rollup.Entries, 3)
+	for _, e := range rollup.Entries {
+		assert.Equal(t, DeploymentMatch, e.Class, "deployment %q", e.Deployment)
+	}
+}
+
+// A deployment that would plan different DDL than was reviewed is diverged, and
+// the rollup fails closed.
+func TestRollupDeploymentDiffs_DivergenceBlocks(t *testing.T) {
+	diffs := []DeploymentPlanDiff{
+		rollupDeployment("eu", rollupAlterUsers("ALTER TABLE `users` ADD COLUMN `email` varchar(255)")),
+		rollupDeployment("au", rollupAlterUsers("ALTER TABLE `users` ADD COLUMN `phone` varchar(255)")),
+	}
+	rollup, err := RollupDeploymentDiffs(diffs)
+	require.NoError(t, err)
+	assert.False(t, rollup.Clean)
+	assert.Equal(t, DeploymentMatch, rollup.Entries[0].Class)
+	assert.Equal(t, DeploymentDiverged, rollup.Entries[1].Class)
+	assert.False(t, rollup.Entries[1].Diff.Empty())
+}
+
+// A deployment whose diff could not be computed is errored, and the rollup fails
+// closed without hiding the healthy deployments.
+func TestRollupDeploymentDiffs_ProducerErrorBlocks(t *testing.T) {
+	change := "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"
+	errored := rollupDeployment("au")
+	errored.Err = fmt.Errorf("deployment unreachable")
+	diffs := []DeploymentPlanDiff{
+		rollupDeployment("eu", rollupAlterUsers(change)),
+		errored,
+	}
+	rollup, err := RollupDeploymentDiffs(diffs)
+	require.NoError(t, err)
+	assert.False(t, rollup.Clean)
+	assert.Equal(t, DeploymentMatch, rollup.Entries[0].Class)
+	assert.Equal(t, DeploymentErrored, rollup.Entries[1].Class)
+	require.Error(t, rollup.Entries[1].Err)
+}
+
+// Malformed comparison input (unparseable DDL) classifies the deployment as
+// errored rather than silently matching.
+func TestRollupDeploymentDiffs_ComparisonErrorBlocks(t *testing.T) {
+	diffs := []DeploymentPlanDiff{
+		rollupDeployment("eu", rollupAlterUsers("ALTER TABLE `users` ADD COLUMN `email` varchar(255)")),
+		rollupDeployment("au", rollupAlterUsers("not valid sql")),
+	}
+	rollup, err := RollupDeploymentDiffs(diffs)
+	require.NoError(t, err)
+	assert.False(t, rollup.Clean)
+	assert.Equal(t, DeploymentErrored, rollup.Entries[1].Class)
+	require.Error(t, rollup.Entries[1].Err)
+}
+
+// If the reviewed primary baseline itself errored, no deployment can be
+// confirmed to match, so all non-primary deployments block.
+func TestRollupDeploymentDiffs_UnusablePrimaryBlocksAll(t *testing.T) {
+	primary := rollupDeployment("eu")
+	primary.Err = fmt.Errorf("reviewed primary plan reported errors")
+	diffs := []DeploymentPlanDiff{
+		primary,
+		rollupDeployment("au", rollupAlterUsers("ALTER TABLE `users` ADD COLUMN `email` varchar(255)")),
+	}
+	rollup, err := RollupDeploymentDiffs(diffs)
+	require.NoError(t, err)
+	assert.False(t, rollup.Clean)
+	assert.Equal(t, DeploymentErrored, rollup.Entries[0].Class)
+	assert.Equal(t, DeploymentErrored, rollup.Entries[1].Class)
+	require.Error(t, rollup.Entries[1].Err)
+}
+
+// An empty result set is a fail-closed error: there is nothing to prove the
+// deployments agree.
+func TestRollupDeploymentDiffs_EmptyErrors(t *testing.T) {
+	_, err := RollupDeploymentDiffs(nil)
+	require.Error(t, err)
+}
+
+// A single-deployment database rolls up clean: the primary matches itself.
+func TestRollupDeploymentDiffs_SingleDeploymentClean(t *testing.T) {
+	diffs := []DeploymentPlanDiff{
+		rollupDeployment("eu", rollupAlterUsers("ALTER TABLE `users` ADD COLUMN `email` varchar(255)")),
+	}
+	rollup, err := RollupDeploymentDiffs(diffs)
+	require.NoError(t, err)
+	assert.True(t, rollup.Clean)
+	require.Len(t, rollup.Entries, 1)
+	assert.Equal(t, DeploymentMatch, rollup.Entries[0].Class)
+}

--- a/pkg/api/plan_rollup_test.go
+++ b/pkg/api/plan_rollup_test.go
@@ -31,6 +31,16 @@ func rollupDeployment(name string, changes ...*ternv1.SchemaChange) DeploymentPl
 	}
 }
 
+// rollupNames returns the deployment names of diffs in order, the expected
+// deployment contract PlanDeploymentDiffs would produce for them.
+func rollupNames(diffs []DeploymentPlanDiff) []string {
+	names := make([]string, len(diffs))
+	for i, d := range diffs {
+		names[i] = d.Deployment
+	}
+	return names
+}
+
 // When every deployment would plan exactly the reviewed changes, the rollup is
 // clean and every entry classifies as a match.
 func TestRollupDeploymentDiffs_AllMatchIsClean(t *testing.T) {
@@ -40,7 +50,7 @@ func TestRollupDeploymentDiffs_AllMatchIsClean(t *testing.T) {
 		rollupDeployment("au", rollupAlterUsers(change)),
 		rollupDeployment("us", rollupAlterUsers(change)),
 	}
-	rollup, err := RollupDeploymentDiffs(diffs)
+	rollup, err := RollupDeploymentDiffs(diffs, rollupNames(diffs))
 	require.NoError(t, err)
 	assert.True(t, rollup.Clean)
 	require.Len(t, rollup.Entries, 3)
@@ -56,7 +66,7 @@ func TestRollupDeploymentDiffs_DivergenceBlocks(t *testing.T) {
 		rollupDeployment("eu", rollupAlterUsers("ALTER TABLE `users` ADD COLUMN `email` varchar(255)")),
 		rollupDeployment("au", rollupAlterUsers("ALTER TABLE `users` ADD COLUMN `phone` varchar(255)")),
 	}
-	rollup, err := RollupDeploymentDiffs(diffs)
+	rollup, err := RollupDeploymentDiffs(diffs, rollupNames(diffs))
 	require.NoError(t, err)
 	assert.False(t, rollup.Clean)
 	assert.Equal(t, DeploymentMatch, rollup.Entries[0].Class)
@@ -74,7 +84,7 @@ func TestRollupDeploymentDiffs_ProducerErrorBlocks(t *testing.T) {
 		rollupDeployment("eu", rollupAlterUsers(change)),
 		errored,
 	}
-	rollup, err := RollupDeploymentDiffs(diffs)
+	rollup, err := RollupDeploymentDiffs(diffs, rollupNames(diffs))
 	require.NoError(t, err)
 	assert.False(t, rollup.Clean)
 	assert.Equal(t, DeploymentMatch, rollup.Entries[0].Class)
@@ -89,7 +99,7 @@ func TestRollupDeploymentDiffs_ComparisonErrorBlocks(t *testing.T) {
 		rollupDeployment("eu", rollupAlterUsers("ALTER TABLE `users` ADD COLUMN `email` varchar(255)")),
 		rollupDeployment("au", rollupAlterUsers("not valid sql")),
 	}
-	rollup, err := RollupDeploymentDiffs(diffs)
+	rollup, err := RollupDeploymentDiffs(diffs, rollupNames(diffs))
 	require.NoError(t, err)
 	assert.False(t, rollup.Clean)
 	assert.Equal(t, DeploymentErrored, rollup.Entries[1].Class)
@@ -105,7 +115,7 @@ func TestRollupDeploymentDiffs_UnusablePrimaryBlocksAll(t *testing.T) {
 		primary,
 		rollupDeployment("au", rollupAlterUsers("ALTER TABLE `users` ADD COLUMN `email` varchar(255)")),
 	}
-	rollup, err := RollupDeploymentDiffs(diffs)
+	rollup, err := RollupDeploymentDiffs(diffs, rollupNames(diffs))
 	require.NoError(t, err)
 	assert.False(t, rollup.Clean)
 	assert.Equal(t, DeploymentErrored, rollup.Entries[0].Class)
@@ -116,7 +126,7 @@ func TestRollupDeploymentDiffs_UnusablePrimaryBlocksAll(t *testing.T) {
 // An empty result set is a fail-closed error: there is nothing to prove the
 // deployments agree.
 func TestRollupDeploymentDiffs_EmptyErrors(t *testing.T) {
-	_, err := RollupDeploymentDiffs(nil)
+	_, err := RollupDeploymentDiffs(nil, nil)
 	require.Error(t, err)
 }
 
@@ -125,7 +135,7 @@ func TestRollupDeploymentDiffs_SingleDeploymentClean(t *testing.T) {
 	diffs := []DeploymentPlanDiff{
 		rollupDeployment("eu", rollupAlterUsers("ALTER TABLE `users` ADD COLUMN `email` varchar(255)")),
 	}
-	rollup, err := RollupDeploymentDiffs(diffs)
+	rollup, err := RollupDeploymentDiffs(diffs, rollupNames(diffs))
 	require.NoError(t, err)
 	assert.True(t, rollup.Clean)
 	require.Len(t, rollup.Entries, 1)
@@ -139,10 +149,34 @@ func TestRollupDeploymentDiffs_MalformedSingleDeploymentBaselineBlocks(t *testin
 	diffs := []DeploymentPlanDiff{
 		rollupDeployment("eu", rollupAlterUsers("not valid sql")),
 	}
-	rollup, err := RollupDeploymentDiffs(diffs)
+	rollup, err := RollupDeploymentDiffs(diffs, rollupNames(diffs))
 	require.NoError(t, err)
 	assert.False(t, rollup.Clean)
 	require.Len(t, rollup.Entries, 1)
 	assert.Equal(t, DeploymentErrored, rollup.Entries[0].Class)
 	require.Error(t, rollup.Entries[0].Err)
+}
+
+// The rollup enforces the producer contract positionally: a result whose
+// deployments do not match the expected rollout order (wrong primary, wrong
+// order, or a missing deployment) is rejected rather than risking a false clean.
+func TestRollupDeploymentDiffs_ContractMismatchErrors(t *testing.T) {
+	change := "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"
+	diffs := []DeploymentPlanDiff{
+		rollupDeployment("eu", rollupAlterUsers(change)),
+		rollupDeployment("au", rollupAlterUsers(change)),
+	}
+
+	t.Run("wrong primary", func(t *testing.T) {
+		_, err := RollupDeploymentDiffs(diffs, []string{"au", "eu"})
+		require.Error(t, err)
+	})
+	t.Run("missing deployment", func(t *testing.T) {
+		_, err := RollupDeploymentDiffs(diffs, []string{"eu", "au", "us"})
+		require.Error(t, err)
+	})
+	t.Run("extra diff", func(t *testing.T) {
+		_, err := RollupDeploymentDiffs(diffs, []string{"eu"})
+		require.Error(t, err)
+	})
 }

--- a/pkg/api/plan_rollup_test.go
+++ b/pkg/api/plan_rollup_test.go
@@ -131,3 +131,18 @@ func TestRollupDeploymentDiffs_SingleDeploymentClean(t *testing.T) {
 	require.Len(t, rollup.Entries, 1)
 	assert.Equal(t, DeploymentMatch, rollup.Entries[0].Class)
 }
+
+// A single-deployment rollup whose primary baseline carries unparseable DDL
+// fails closed: the primary is errored and the rollup blocks, rather than
+// matching itself without a trustworthy comparison ever running.
+func TestRollupDeploymentDiffs_MalformedSingleDeploymentBaselineBlocks(t *testing.T) {
+	diffs := []DeploymentPlanDiff{
+		rollupDeployment("eu", rollupAlterUsers("not valid sql")),
+	}
+	rollup, err := RollupDeploymentDiffs(diffs)
+	require.NoError(t, err)
+	assert.False(t, rollup.Clean)
+	require.Len(t, rollup.Entries, 1)
+	assert.Equal(t, DeploymentErrored, rollup.Entries[0].Class)
+	require.Error(t, rollup.Entries[0].Err)
+}

--- a/pkg/tern/change_set_compare.go
+++ b/pkg/tern/change_set_compare.go
@@ -1,0 +1,233 @@
+package tern
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+)
+
+// ChangeSet is a deployment's proto plan change set: the namespace-collapsed
+// table changes and the authoritative per-shard changes a Plan or PlanDiff
+// returns. It is the unit the review-time rollup compares across a database's
+// deployments to detect drift before approval.
+type ChangeSet struct {
+	Changes []*ternv1.SchemaChange
+	Shards  []*ternv1.ShardPlan
+}
+
+// ChangeSetDiffItem is one table DDL change that differs between two change sets.
+// The DDL is the canonicalized form the comparison keyed on, so two items for
+// the same namespace/shard/table/operation that differ only in DDL render
+// distinctly instead of looking identical.
+type ChangeSetDiffItem struct {
+	Namespace string
+	Shard     string
+	Table     string
+	Operation string
+	DDL       string
+}
+
+// ChangeSetDiff describes how a candidate change set differs from a baseline.
+// An empty diff means the two change sets are canonically identical.
+type ChangeSetDiff struct {
+	// MissingFromCandidate are changes the baseline would plan that the candidate
+	// would not.
+	MissingFromCandidate []ChangeSetDiffItem
+	// UnexpectedInCandidate are changes the candidate would plan that the baseline
+	// would not.
+	UnexpectedInCandidate []ChangeSetDiffItem
+	// MissingVSchema are namespaces the baseline changes the vschema for that the
+	// candidate does not.
+	MissingVSchema []string
+	// UnexpectedVSchema are namespaces the candidate changes the vschema for that
+	// the baseline does not.
+	UnexpectedVSchema []string
+}
+
+// Empty reports whether the candidate matches the baseline exactly.
+func (d ChangeSetDiff) Empty() bool {
+	return len(d.MissingFromCandidate) == 0 &&
+		len(d.UnexpectedInCandidate) == 0 &&
+		len(d.MissingVSchema) == 0 &&
+		len(d.UnexpectedVSchema) == 0
+}
+
+// CompareChangeSets reports how candidate differs from baseline, comparing table
+// DDL by canonicalized form and vschema by per-namespace parity.
+//
+// It fails closed: malformed proto (nil entries, empty shard/table names, a
+// vschema change carrying table DDL, an inconsistent sharded/non-sharded shape)
+// and DDL that cannot be canonicalized (unparseable, multi-statement, or
+// non-DDL) return an error, so a caller can treat the deployment as blocking
+// rather than mistake a comparison it could not perform for agreement.
+func CompareChangeSets(baseline, candidate ChangeSet) (ChangeSetDiff, error) {
+	baseMS, baseVS, err := changeSetMultiset(baseline)
+	if err != nil {
+		return ChangeSetDiff{}, fmt.Errorf("baseline change set: %w", err)
+	}
+	candMS, candVS, err := changeSetMultiset(candidate)
+	if err != nil {
+		return ChangeSetDiff{}, fmt.Errorf("candidate change set: %w", err)
+	}
+
+	diff := ChangeSetDiff{}
+	for key, want := range baseMS {
+		if candMS[key] < want {
+			diff.MissingFromCandidate = append(diff.MissingFromCandidate, itemFromDriftKey(key))
+		}
+	}
+	for key, have := range candMS {
+		if have > baseMS[key] {
+			diff.UnexpectedInCandidate = append(diff.UnexpectedInCandidate, itemFromDriftKey(key))
+		}
+	}
+	for ns := range baseVS {
+		if !candVS[ns] {
+			diff.MissingVSchema = append(diff.MissingVSchema, ns)
+		}
+	}
+	for ns := range candVS {
+		if !baseVS[ns] {
+			diff.UnexpectedVSchema = append(diff.UnexpectedVSchema, ns)
+		}
+	}
+
+	sortDiffItems(diff.MissingFromCandidate)
+	sortDiffItems(diff.UnexpectedInCandidate)
+	sort.Strings(diff.MissingVSchema)
+	sort.Strings(diff.UnexpectedVSchema)
+	return diff, nil
+}
+
+// changeSetMultiset builds the table DDL multiset and the set of vschema-changed
+// namespaces for a proto change set.
+//
+// Table changes are counted from their authoritative representation: a sharded
+// namespace's changes live per shard on Shards and the namespace-collapsed
+// Changes view of them is lossy (it dedupes tables across shards), so for a
+// namespace carried by shard rows only the shard rows are counted. A non-sharded
+// namespace's changes live only on Changes and are counted there. VSchema
+// carries no table DDL and is compared by per-namespace parity.
+func changeSetMultiset(cs ChangeSet) (driftChangeMultiset, map[string]bool, error) {
+	ms := driftChangeMultiset{}
+	vschema := map[string]bool{}
+
+	// nsInShards: namespace has at least one shard row (possibly empty).
+	// nsShardChanges: namespace has a shard row carrying table changes, so the
+	// shard rows are the authoritative representation for it.
+	nsInShards := map[string]bool{}
+	nsShardChanges := map[string]bool{}
+	for _, sp := range cs.Shards {
+		if sp == nil {
+			return nil, nil, fmt.Errorf("nil shard plan")
+		}
+		shard := strings.TrimSpace(sp.Shard)
+		if shard == "" {
+			return nil, nil, fmt.Errorf("shard plan for namespace %q has an empty shard name", sp.Namespace)
+		}
+		nsInShards[sp.Namespace] = true
+		if len(sp.Changes) > 0 {
+			nsShardChanges[sp.Namespace] = true
+		}
+		for _, tc := range sp.Changes {
+			key, err := driftKeyForTableChange(sp.Namespace, shard, tc)
+			if err != nil {
+				return nil, nil, fmt.Errorf("shard %q: %w", shard, err)
+			}
+			ms[key]++
+		}
+	}
+
+	for _, sc := range cs.Changes {
+		if sc == nil {
+			return nil, nil, fmt.Errorf("nil schema change")
+		}
+		ns := sc.Namespace
+		if sc.Metadata["vschema_changed"] == "true" {
+			vschema[ns] = true
+		}
+		hasTableChanges := false
+		for _, tc := range sc.TableChanges {
+			if tc == nil {
+				return nil, nil, fmt.Errorf("nil table change in namespace %q", ns)
+			}
+			// VSchema carries no table DDL; it is counted by parity above.
+			if tc.ChangeType == ternv1.ChangeType_CHANGE_TYPE_VSCHEMA {
+				continue
+			}
+			hasTableChanges = true
+			// A namespace carried by shard rows is counted authoritatively there;
+			// its collapsed view here would double-count and is lossy.
+			if nsShardChanges[ns] {
+				continue
+			}
+			key, err := driftKeyForTableChange(ns, "", tc)
+			if err != nil {
+				return nil, nil, fmt.Errorf("namespace %q: %w", ns, err)
+			}
+			ms[key]++
+		}
+		// A namespace with collapsed table changes but only empty shard rows is an
+		// inconsistent shape: neither representation carries the change, so fail
+		// closed rather than silently pick one.
+		if hasTableChanges && nsInShards[ns] && !nsShardChanges[ns] {
+			return nil, nil, fmt.Errorf("namespace %q has collapsed table changes but no shard carries them", ns)
+		}
+	}
+	return ms, vschema, nil
+}
+
+// driftKeyForTableChange builds the multiset key for a proto table change,
+// deriving the operation the same way a materialized apply does and
+// canonicalizing the DDL with the fail-closed drift canonicalizer.
+func driftKeyForTableChange(namespace, shard string, tc *ternv1.TableChange) (driftChangeKey, error) {
+	if tc == nil {
+		return driftChangeKey{}, fmt.Errorf("nil table change")
+	}
+	if strings.TrimSpace(tc.TableName) == "" {
+		return driftChangeKey{}, fmt.Errorf("table change has an empty table name")
+	}
+	if tc.ChangeType == ternv1.ChangeType_CHANGE_TYPE_VSCHEMA {
+		return driftChangeKey{}, fmt.Errorf("table %q carries a vschema change; vschema is namespace-level, not table DDL", tc.TableName)
+	}
+	op, err := materializedTableChangeOperation(tc)
+	if err != nil {
+		return driftChangeKey{}, err
+	}
+	canon, err := canonicalDDLForDrift(tc.Ddl)
+	if err != nil {
+		return driftChangeKey{}, fmt.Errorf("table %q: %w", tc.TableName, err)
+	}
+	return driftChangeKey{namespace, shard, tc.TableName, op, canon}, nil
+}
+
+func itemFromDriftKey(k driftChangeKey) ChangeSetDiffItem {
+	return ChangeSetDiffItem{
+		Namespace: k.namespace,
+		Shard:     k.shard,
+		Table:     k.table,
+		Operation: k.operation,
+		DDL:       k.ddl,
+	}
+}
+
+func sortDiffItems(items []ChangeSetDiffItem) {
+	sort.Slice(items, func(i, j int) bool {
+		a, b := items[i], items[j]
+		if a.Namespace != b.Namespace {
+			return a.Namespace < b.Namespace
+		}
+		if a.Shard != b.Shard {
+			return a.Shard < b.Shard
+		}
+		if a.Table != b.Table {
+			return a.Table < b.Table
+		}
+		if a.Operation != b.Operation {
+			return a.Operation < b.Operation
+		}
+		return a.DDL < b.DDL
+	})
+}

--- a/pkg/tern/change_set_compare.go
+++ b/pkg/tern/change_set_compare.go
@@ -153,9 +153,14 @@ func changeSetMultiset(cs ChangeSet) (driftChangeMultiset, map[string]bool, erro
 			if tc == nil {
 				return nil, nil, fmt.Errorf("nil table change in namespace %q", ns)
 			}
-			// VSchema carries no table DDL; it is counted by parity above.
+			// In the plan/proto representation a vschema change is signalled via
+			// Metadata["vschema_changed"] and carries no table DDL. A vschema table
+			// change indicates malformed input (e.g. a change set built from an
+			// apply request's DdlChanges), so fail closed rather than skip it and
+			// risk a false match. Checked before the shard skip so a sharded
+			// namespace cannot smuggle one through.
 			if tc.ChangeType == ternv1.ChangeType_CHANGE_TYPE_VSCHEMA {
-				continue
+				return nil, nil, fmt.Errorf("namespace %q table change %q carries a vschema change; vschema must be represented via metadata, not table DDL", ns, tc.TableName)
 			}
 			hasTableChanges = true
 			// A namespace carried by shard rows is counted authoritatively there;

--- a/pkg/tern/change_set_compare_test.go
+++ b/pkg/tern/change_set_compare_test.go
@@ -229,3 +229,21 @@ func TestCompareChangeSets_InconsistentShardShapeFailsClosed(t *testing.T) {
 	_, err := CompareChangeSets(baseline, candidate)
 	require.Error(t, err)
 }
+
+// A vschema change represented as a table DDL entry (rather than via metadata)
+// is malformed plan/proto input and fails closed.
+func TestCompareChangeSets_VSchemaTableChangeFailsClosed(t *testing.T) {
+	baseline := protoNonShardedSet(protoAlterUsersEmail())
+	candidate := ChangeSet{Changes: []*ternv1.SchemaChange{{
+		Namespace: "testapp",
+		TableChanges: []*ternv1.TableChange{{
+			TableName:  "users",
+			Ddl:        "",
+			ChangeType: ternv1.ChangeType_CHANGE_TYPE_VSCHEMA,
+			Namespace:  "testapp",
+		}},
+	}}}
+
+	_, err := CompareChangeSets(baseline, candidate)
+	require.Error(t, err)
+}

--- a/pkg/tern/change_set_compare_test.go
+++ b/pkg/tern/change_set_compare_test.go
@@ -1,0 +1,231 @@
+package tern
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+)
+
+func protoAlterUsersEmail() *ternv1.TableChange {
+	return &ternv1.TableChange{
+		TableName:  "users",
+		Ddl:        "ALTER TABLE `users` ADD COLUMN `email` varchar(255)",
+		ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER,
+		Namespace:  "testapp",
+	}
+}
+
+func protoAlterUsersPhone() *ternv1.TableChange {
+	return &ternv1.TableChange{
+		TableName:  "users",
+		Ddl:        "ALTER TABLE `users` ADD COLUMN `phone` varchar(255)",
+		ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER,
+		Namespace:  "testapp",
+	}
+}
+
+func protoNonShardedSet(changes ...*ternv1.TableChange) ChangeSet {
+	return ChangeSet{
+		Changes: []*ternv1.SchemaChange{{Namespace: "testapp", TableChanges: changes}},
+	}
+}
+
+// A non-sharded deployment that would plan exactly the reviewed changes is a
+// clean match, even when the DDL differs only in whitespace/backtick style.
+func TestCompareChangeSets_NonShardedMatch(t *testing.T) {
+	baseline := protoNonShardedSet(protoAlterUsersEmail())
+	candidate := ChangeSet{Changes: []*ternv1.SchemaChange{{
+		Namespace: "testapp",
+		TableChanges: []*ternv1.TableChange{{
+			TableName:  "users",
+			Ddl:        "ALTER TABLE users ADD COLUMN email varchar(255)",
+			ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER,
+			Namespace:  "testapp",
+		}},
+	}}}
+
+	diff, err := CompareChangeSets(baseline, candidate)
+	require.NoError(t, err)
+	assert.True(t, diff.Empty(), "canonically identical change sets should match: %+v", diff)
+}
+
+// A deployment missing a reviewed change surfaces it as missing from the
+// candidate so the review gate can block.
+func TestCompareChangeSets_MissingChange(t *testing.T) {
+	baseline := protoNonShardedSet(protoAlterUsersEmail())
+	candidate := protoNonShardedSet()
+
+	diff, err := CompareChangeSets(baseline, candidate)
+	require.NoError(t, err)
+	require.False(t, diff.Empty())
+	require.Len(t, diff.MissingFromCandidate, 1)
+	assert.Equal(t, "users", diff.MissingFromCandidate[0].Table)
+	assert.Equal(t, "alter", diff.MissingFromCandidate[0].Operation)
+	assert.Empty(t, diff.UnexpectedInCandidate)
+}
+
+// A deployment that would plan a change nobody reviewed surfaces it as
+// unexpected.
+func TestCompareChangeSets_UnexpectedChange(t *testing.T) {
+	baseline := protoNonShardedSet(protoAlterUsersEmail())
+	candidate := protoNonShardedSet(protoAlterUsersEmail(), protoAlterUsersPhone())
+
+	diff, err := CompareChangeSets(baseline, candidate)
+	require.NoError(t, err)
+	require.Len(t, diff.UnexpectedInCandidate, 1)
+	assert.Equal(t, "users", diff.UnexpectedInCandidate[0].Table)
+	assert.Contains(t, diff.UnexpectedInCandidate[0].DDL, "phone")
+	assert.Empty(t, diff.MissingFromCandidate)
+}
+
+// The same table/operation with different DDL is drift: the change is both
+// missing (reviewed DDL absent) and unexpected (candidate DDL not reviewed).
+func TestCompareChangeSets_SameTableDifferentDDL(t *testing.T) {
+	baseline := protoNonShardedSet(protoAlterUsersEmail())
+	candidate := protoNonShardedSet(protoAlterUsersPhone())
+
+	diff, err := CompareChangeSets(baseline, candidate)
+	require.NoError(t, err)
+	require.Len(t, diff.MissingFromCandidate, 1)
+	require.Len(t, diff.UnexpectedInCandidate, 1)
+	assert.Contains(t, diff.MissingFromCandidate[0].DDL, "email")
+	assert.Contains(t, diff.UnexpectedInCandidate[0].DDL, "phone")
+}
+
+// Sharded deployments compare per shard on the authoritative Shards rows, so
+// identical per-shard changes match.
+func TestCompareChangeSets_ShardedMatch(t *testing.T) {
+	shard := func() []*ternv1.ShardPlan {
+		return []*ternv1.ShardPlan{
+			{Shard: "-80", Namespace: "testapp", Changes: []*ternv1.TableChange{protoAlterUsersEmail()}},
+			{Shard: "80-", Namespace: "testapp", Changes: []*ternv1.TableChange{protoAlterUsersEmail()}},
+		}
+	}
+	baseline := ChangeSet{
+		Changes: []*ternv1.SchemaChange{{Namespace: "testapp", TableChanges: []*ternv1.TableChange{protoAlterUsersEmail()}}},
+		Shards:  shard(),
+	}
+	candidate := ChangeSet{
+		Changes: []*ternv1.SchemaChange{{Namespace: "testapp", TableChanges: []*ternv1.TableChange{protoAlterUsersEmail()}}},
+		Shards:  shard(),
+	}
+
+	diff, err := CompareChangeSets(baseline, candidate)
+	require.NoError(t, err)
+	assert.True(t, diff.Empty(), "identical sharded change sets should match: %+v", diff)
+}
+
+// Drift on a single shard is caught even when the lossy namespace-collapsed
+// Changes view is identical between the two deployments.
+func TestCompareChangeSets_ShardDriftCaughtDespiteCollapsedParity(t *testing.T) {
+	collapsed := []*ternv1.SchemaChange{{Namespace: "testapp", TableChanges: []*ternv1.TableChange{protoAlterUsersEmail()}}}
+	baseline := ChangeSet{
+		Changes: collapsed,
+		Shards: []*ternv1.ShardPlan{
+			{Shard: "-80", Namespace: "testapp", Changes: []*ternv1.TableChange{protoAlterUsersEmail()}},
+			{Shard: "80-", Namespace: "testapp", Changes: []*ternv1.TableChange{protoAlterUsersEmail()}},
+		},
+	}
+	candidate := ChangeSet{
+		Changes: collapsed,
+		Shards: []*ternv1.ShardPlan{
+			{Shard: "-80", Namespace: "testapp", Changes: []*ternv1.TableChange{protoAlterUsersEmail()}},
+			{Shard: "80-", Namespace: "testapp", Changes: []*ternv1.TableChange{protoAlterUsersPhone()}},
+		},
+	}
+
+	diff, err := CompareChangeSets(baseline, candidate)
+	require.NoError(t, err)
+	require.False(t, diff.Empty(), "per-shard drift must be caught despite identical collapsed views")
+	require.Len(t, diff.MissingFromCandidate, 1)
+	require.Len(t, diff.UnexpectedInCandidate, 1)
+	assert.Equal(t, "80-", diff.MissingFromCandidate[0].Shard)
+	assert.Equal(t, "80-", diff.UnexpectedInCandidate[0].Shard)
+}
+
+// A database mixing a sharded and an unsharded namespace compares each namespace
+// in its authoritative representation; the unsharded namespace is not dropped.
+func TestCompareChangeSets_MixedShardedAndUnsharded(t *testing.T) {
+	build := func(unshardedDDL string) ChangeSet {
+		return ChangeSet{
+			Changes: []*ternv1.SchemaChange{
+				{Namespace: "sharded", TableChanges: []*ternv1.TableChange{protoAlterUsersEmail()}},
+				{Namespace: "unsharded", TableChanges: []*ternv1.TableChange{{
+					TableName:  "orders",
+					Ddl:        unshardedDDL,
+					ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER,
+					Namespace:  "unsharded",
+				}}},
+			},
+			Shards: []*ternv1.ShardPlan{
+				{Shard: "-80", Namespace: "sharded", Changes: []*ternv1.TableChange{protoAlterUsersEmail()}},
+			},
+		}
+	}
+	baseline := build("ALTER TABLE `orders` ADD COLUMN `total` int")
+	candidate := build("ALTER TABLE `orders` ADD COLUMN `discount` int")
+
+	diff, err := CompareChangeSets(baseline, candidate)
+	require.NoError(t, err)
+	require.Len(t, diff.MissingFromCandidate, 1)
+	require.Len(t, diff.UnexpectedInCandidate, 1)
+	assert.Equal(t, "unsharded", diff.MissingFromCandidate[0].Namespace)
+	assert.Empty(t, diff.MissingFromCandidate[0].Shard, "unsharded namespace change has no shard")
+}
+
+// VSchema parity is compared per namespace: a deployment that would not change
+// the vschema when the reviewed plan would is drift.
+func TestCompareChangeSets_VSchemaParity(t *testing.T) {
+	baseline := ChangeSet{Changes: []*ternv1.SchemaChange{{
+		Namespace: "testapp",
+		Metadata:  map[string]string{"vschema_changed": "true"},
+	}}}
+	candidate := ChangeSet{Changes: []*ternv1.SchemaChange{{Namespace: "testapp"}}}
+
+	diff, err := CompareChangeSets(baseline, candidate)
+	require.NoError(t, err)
+	require.Equal(t, []string{"testapp"}, diff.MissingVSchema)
+	assert.Empty(t, diff.UnexpectedVSchema)
+}
+
+// Unparseable DDL fails closed so a comparison that cannot be trusted is never
+// mistaken for agreement.
+func TestCompareChangeSets_UnparseableDDLFailsClosed(t *testing.T) {
+	baseline := protoNonShardedSet(protoAlterUsersEmail())
+	candidate := protoNonShardedSet(&ternv1.TableChange{
+		TableName:  "users",
+		Ddl:        "this is not sql",
+		ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER,
+		Namespace:  "testapp",
+	})
+
+	_, err := CompareChangeSets(baseline, candidate)
+	require.Error(t, err)
+}
+
+// A shard row with an empty shard name is malformed and fails closed.
+func TestCompareChangeSets_EmptyShardNameFailsClosed(t *testing.T) {
+	baseline := protoNonShardedSet(protoAlterUsersEmail())
+	candidate := ChangeSet{Shards: []*ternv1.ShardPlan{
+		{Shard: "", Namespace: "testapp", Changes: []*ternv1.TableChange{protoAlterUsersEmail()}},
+	}}
+
+	_, err := CompareChangeSets(baseline, candidate)
+	require.Error(t, err)
+}
+
+// A namespace whose collapsed view carries table changes but whose only shard
+// rows are empty is an inconsistent shape and fails closed.
+func TestCompareChangeSets_InconsistentShardShapeFailsClosed(t *testing.T) {
+	baseline := protoNonShardedSet(protoAlterUsersEmail())
+	candidate := ChangeSet{
+		Changes: []*ternv1.SchemaChange{{Namespace: "testapp", TableChanges: []*ternv1.TableChange{protoAlterUsersEmail()}}},
+		Shards:  []*ternv1.ShardPlan{{Shard: "-80", Namespace: "testapp"}},
+	}
+
+	_, err := CompareChangeSets(baseline, candidate)
+	require.Error(t, err)
+}

--- a/pkg/tern/change_set_compare_test.go
+++ b/pkg/tern/change_set_compare_test.go
@@ -247,3 +247,55 @@ func TestCompareChangeSets_VSchemaTableChangeFailsClosed(t *testing.T) {
 	_, err := CompareChangeSets(baseline, candidate)
 	require.Error(t, err)
 }
+
+// A namespace represented by per-shard rows on one side but only the collapsed
+// namespace view on the other diverges rather than accidentally matching: the
+// per-shard and collapsed keys occupy disjoint key spaces (shard name vs empty).
+func TestCompareChangeSets_OneSideShardedDiverges(t *testing.T) {
+	sharded := ChangeSet{
+		Changes: []*ternv1.SchemaChange{{Namespace: "testapp", TableChanges: []*ternv1.TableChange{protoAlterUsersEmail()}}},
+		Shards:  []*ternv1.ShardPlan{{Shard: "-80", Namespace: "testapp", Changes: []*ternv1.TableChange{protoAlterUsersEmail()}}},
+	}
+	collapsedOnly := protoNonShardedSet(protoAlterUsersEmail())
+
+	diff, err := CompareChangeSets(sharded, collapsedOnly)
+	require.NoError(t, err)
+	require.False(t, diff.Empty(), "sharded-vs-collapsed for the same namespace must diverge")
+	require.Len(t, diff.MissingFromCandidate, 1)
+	require.Len(t, diff.UnexpectedInCandidate, 1)
+	assert.Equal(t, "-80", diff.MissingFromCandidate[0].Shard)
+	assert.Empty(t, diff.UnexpectedInCandidate[0].Shard)
+}
+
+// Duplicate shard rows are counted as a multiset, so an asymmetric duplication
+// diverges rather than being deduped into a false match.
+func TestCompareChangeSets_DuplicateShardRowsAsymmetricDiverges(t *testing.T) {
+	baseline := ChangeSet{Shards: []*ternv1.ShardPlan{
+		{Shard: "-80", Namespace: "testapp", Changes: []*ternv1.TableChange{protoAlterUsersEmail()}},
+		{Shard: "-80", Namespace: "testapp", Changes: []*ternv1.TableChange{protoAlterUsersEmail()}},
+	}}
+	candidate := ChangeSet{Shards: []*ternv1.ShardPlan{
+		{Shard: "-80", Namespace: "testapp", Changes: []*ternv1.TableChange{protoAlterUsersEmail()}},
+	}}
+
+	diff, err := CompareChangeSets(baseline, candidate)
+	require.NoError(t, err)
+	require.False(t, diff.Empty(), "asymmetric duplicate shard rows must diverge")
+	require.Len(t, diff.MissingFromCandidate, 1)
+	assert.Equal(t, "-80", diff.MissingFromCandidate[0].Shard)
+}
+
+// VSchema parity is symmetric: a namespace the candidate changes the vschema for
+// but the baseline does not surfaces in the unexpected direction.
+func TestCompareChangeSets_VSchemaUnexpectedDirection(t *testing.T) {
+	baseline := ChangeSet{Changes: []*ternv1.SchemaChange{{Namespace: "testapp"}}}
+	candidate := ChangeSet{Changes: []*ternv1.SchemaChange{{
+		Namespace: "testapp",
+		Metadata:  map[string]string{"vschema_changed": "true"},
+	}}}
+
+	diff, err := CompareChangeSets(baseline, candidate)
+	require.NoError(t, err)
+	require.Equal(t, []string{"testapp"}, diff.UnexpectedVSchema)
+	assert.Empty(t, diff.MissingVSchema)
+}


### PR DESCRIPTION
## Summary
Consumes the per-deployment diffs from the PlanDiff producer and classifies each deployment against the reviewed primary plan, producing a single fail-closed rollup the PR preview and check gate will consume. This closes the gap where drift on non-primary deployments stayed invisible until apply.

## What
- `tern.CompareChangeSets`: a canonical, shard-aware comparator over a deployment's proto change set (namespace-collapsed changes + per-shard plans). It reuses the existing fail-closed DDL canonicalization, compares sharded namespaces on their authoritative per-shard rows (so per-shard drift is not hidden by the lossy collapsed view), compares unsharded namespaces on the collapsed view, and compares vschema by per-namespace parity.
- `api.RollupDeploymentDiffs`: classifies each deployment as match / diverged / errored against the reviewed primary baseline, and reports the rollup clean only when every deployment matches. It enforces the producer contract — the diffs must match the expected deployment set positionally, primary first — so a reordered, short, or misidentified result fails closed rather than risking a false clean.

## Why
Moving drift detection to review time needs a comparison across a database's deployments. The primary is the reviewed baseline; any deployment that would plan a different change set has drifted. The rollup fails closed — a contract mismatch, divergence, a deployment that could not be diffed or compared, an unusable baseline, or an empty result all block rather than being treated as agreement.

### Before — only the primary is planned at review time

```
  PR review
     │
     ▼
  plan primary (eu) ──► reviewed ──► approve / merge ✅
     │
     │   au, us are never planned at review
     ▼
  APPLY time on au ──► 💥 drift surfaces mid-rollout (blocks late)
```

### After — every deployment is diffed and classified at review time

```
  PR review
     │
     ▼
  PlanDeploymentDiffs
     ├─ eu (primary) ──► reviewed plan (baseline)
     ├─ au ──────────► PlanDiff (desired-vs-live)
     └─ us ──────────► PlanDiff (desired-vs-live)
     │
     ▼
  RollupDeploymentDiffs(diffs, expectedDeployments)
     ├─ contract: diffs match expected rollout order? ──no──────► ⛔ error
     ├─ validate primary baseline (self-compare) ──malformed────► ⛔ error
     ├─ eu ──► match (baseline)
     ├─ au ──► CompareChangeSets(eu, au) ──► match | diverged | errored
     └─ us ──► CompareChangeSets(eu, us) ──► match | diverged | errored
     │
     ▼
  clean?
     ├─ every deployment matches ───────────────────────────► ✅ approve
     └─ contract mismatch / diverge / err / bad baseline ────► ⛔ blocks
```

### Fail-closed guards — uncertainty is never converted into a pass

```
  guard                                        before             after
  ───────────────────────────────────────     ───────────────    ──────────────────
  missing / reordered / wrong primary          trusted by         ⛔ contract error
    deployment in the result                     convention
  single-deployment malformed baseline         ✅ false clean      ⛔ primary errored
    (unparseable DDL)                                                (self-compare)
  vschema carried as table DDL                 ✅ silently          ⛔ errored
    (mis-shaped input)                            dropped
  non-primary diverged / unreachable           n/a (not planned)  ⛔ diverged / errored
```

This is the classification layer only; the PR-preview rendering and the check gate are follow-ups.
