### PR TITLE
fix(github): leader folds participants on PRs with no leader-managed schema

### DIFF
--- a/pkg/webhook/check_aggregate.go
+++ b/pkg/webhook/check_aggregate.go
@@ -45,6 +45,21 @@ func (h *Handler) isAggregateParticipant(repo string) bool {
 	return config.AggregateRoleForRepo(repo) == api.AggregateRoleParticipant
 }
 
+// leaderExpectsParticipantsForPR reports whether this deployment is the
+// aggregate leader for repo and the PR's changed files touch at least one
+// expected participant's paths. Such a PR carries schema work owned by another
+// deployment even when the leader itself has none, so the leader's aggregate
+// must fold the participants' Check Runs (fail-closed) rather than pass on
+// "no managed schema changes". Returns false for non-leaders — the expected set
+// only exists on the leader.
+func (h *Handler) leaderExpectsParticipantsForPR(repo string, files []ghclient.PRFile) bool {
+	config, ok := h.serverConfig()
+	if !ok {
+		return false
+	}
+	return len(config.ExpectedParticipantChecksForPR(repo, prFilePaths(files))) > 0
+}
+
 func (h *Handler) aggregateCheckNameForRepo(repo string) string {
 	config, ok := h.serverConfig()
 	if !ok {

--- a/pkg/webhook/leader_gate_integration_test.go
+++ b/pkg/webhook/leader_gate_integration_test.go
@@ -416,3 +416,99 @@ func TestE2ELeaderRefoldSkippedForOwnAggregateCheck(t *testing.T) {
 	case <-time.After(time.Second):
 	}
 }
+
+// mockLeaderEmptyTree serves an empty git tree for headSHA so config discovery
+// resolves no schemabot.yaml — the leader manages none of the PR's files.
+func mockLeaderEmptyTree(mux *http.ServeMux, headSHA string) {
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/"+headSHA, func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(gh.Tree{SHA: new(headSHA), Entries: []*gh.TreeEntry{}, Truncated: new(false)})
+	})
+}
+
+// A PR that touches only an expected participant's schema carries schema work
+// the leader must gate on, even though the leader itself manages none of the
+// changed files. The pull_request event routes through the aggregate fold, so
+// the required aggregate blocks (fail-closed) until the participant reports —
+// it must not pass as "no managed schema changes" while the participant's
+// schema change is unplanned, in flight, or its deployment is down.
+func TestE2ELeaderNonSchemaPRTouchingParticipantPathBlocks(t *testing.T) {
+	svc := setupE2EServiceWithConfig(t, leaderRepoConfig())
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	const headSHA = "abc123"
+	mockLeaderPRHead(mux, headSHA)
+	mockLeaderPRFilesTouchTenantB(mux)
+	mockLeaderEmptyTree(mux, headSHA)
+	// The participant has posted no Check Run at all on the head commit.
+	mockParticipantCheckRuns(mux, nil)
+	checkRuns := captureLeaderCheckRuns(mux)
+
+	h := newLeaderHandler(t, svc, client)
+	req := buildPRWebhookRequest(t, prWebhookPayloadOpts{
+		action:  "opened",
+		headSHA: headSHA,
+		headRef: "feature-branch",
+	}, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "aggregate folds expected participants")
+
+	for _, env := range []string{"staging", "production"} {
+		cr := collectAggregate(t, checkRuns, aggregateCheckNameForEnv("SchemaBot", env))
+		assert.Equal(t, headSHA, cr.HeadSHA)
+		assert.Equal(t, checkStatusCompleted, cr.Status)
+		assert.Equal(t, checkConclusionActionRequired, cr.Conclusion,
+			"aggregate for %s must fail closed while the expected participant is silent", env)
+	}
+}
+
+// The expected-tenant set is path-filtered: a leader's non-schema PR touching
+// none of the participants' paths keeps the plain passing aggregate, so
+// unrelated PRs are unaffected by participant gating.
+func TestE2ELeaderNonSchemaPROutsideParticipantPathsPasses(t *testing.T) {
+	svc := setupE2EServiceWithConfig(t, leaderRepoConfig())
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	const headSHA = "abc123"
+	mockLeaderPRHead(mux, headSHA)
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]*gh.CommitFile{
+			{Filename: new("README.md"), Status: new("modified")},
+		})
+	})
+	mockLeaderEmptyTree(mux, headSHA)
+	checkRuns := captureLeaderCheckRuns(mux)
+
+	h := newLeaderHandler(t, svc, client)
+	req := buildPRWebhookRequest(t, prWebhookPayloadOpts{
+		action:  "opened",
+		headSHA: headSHA,
+		headRef: "feature-branch",
+	}, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "no schema files in PR")
+	assert.NotContains(t, rr.Body.String(), "aggregate folds expected participants")
+
+	for _, env := range []string{"staging", "production"} {
+		cr := collectAggregate(t, checkRuns, aggregateCheckNameForEnv("SchemaBot", env))
+		assert.Equal(t, headSHA, cr.HeadSHA)
+		assert.Equal(t, checkStatusCompleted, cr.Status)
+		assert.Equal(t, checkConclusionSuccess, cr.Conclusion,
+			"aggregate for %s keeps passing on a PR outside all participant paths", env)
+	}
+}

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -204,6 +204,29 @@ func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.Install
 			})
 			return "no schema files in PR (aggregate participant, staying silent)"
 		}
+		// A PR with no leader-managed schema can still touch schema owned by
+		// expected participant deployments. The leader's aggregate is the
+		// required check, so it must gate on those participants' Check Runs —
+		// route through the aggregate fold, which fails closed until every
+		// expected participant reports terminal success, instead of posting an
+		// unconditional passing aggregate. The fold re-runs as participants'
+		// Check Run events arrive, converging to passing once they succeed.
+		if h.leaderExpectsParticipantsForPR(repo, files) {
+			h.logger.Info("no leader-managed schema in PR but expected participant paths are touched; aggregate gate will block until participants report",
+				"repo", repo, "pr", pr, "head_sha", headSHA, "source", source)
+			h.goSafe(repo, pr, installationID, func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+				c, err := h.clientForRepo(repo, installationID)
+				if err != nil {
+					h.logger.Error("failed to create GitHub client for participant-gated aggregate",
+						"repo", repo, "pr", pr, "head_sha", headSHA, "error", err)
+					return
+				}
+				h.updateAggregateCheck(ctx, c, repo, pr, headSHA)
+			})
+			return "no schema files in PR (aggregate folds expected participants)"
+		}
 		// Post passing aggregates on the current HEAD SHA so branch protection
 		// isn't blocked on PRs that don't touch schema files. Always post —
 		// on synchronize events the HEAD SHA changes, so the aggregate must be


### PR DESCRIPTION
## Why this matters

The aggregate leader's fold is fail-closed for every expected participant — but only on the paths that invoke it. A PR touching **only a participant's schema** is, from the leader's view, a no-schema PR: it took the `postPassingAggregates` fast path and posted a passing "No managed schema changes" aggregate without ever looking for the participant's Check Run. If the participant deployment was down or misconfigured — exactly the failure the gate exists to catch — the required check stayed green forever. Even in the healthy case, the aggregate was green in the window before the participant's first `check_run` event triggered a re-fold.

## What it does

Routes the leader's no-schema path through the aggregate fold whenever the PR's changed files touch an expected participant's paths:

```
pull_request event, no leader-managed schema in PR
        │
        ├─ participant role                     → stay silent
        ├─ leader + expected participant paths  → aggregate fold (fail-closed:
        │  touched                                blocks until participants report;
        │                                         check_run re-fold turns it green)
        └─ otherwise                            → passing aggregate (unchanged)
```

New `leaderExpectsParticipantsForPR` helper (leader-guarded, path-filtered via `ExpectedParticipantChecksForPR`). Integration tests drive the real `pull_request` webhook: a participant-path PR blocks `action_required` per environment while the participant is silent; a PR outside all participant paths keeps the passing fast path.

## How it moves toward northstar

Closes the last fail-open route into the multi-tenant aggregate gate before required checks are enabled on shared repos: every path that can write the leader's required check now consults the expected-participant contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)