### PR TITLE
fix(github): finalize the progress comment when an apply outruns its post

### DIFF
--- a/pkg/webhook/apply_comment_integration_test.go
+++ b/pkg/webhook/apply_comment_integration_test.go
@@ -899,3 +899,103 @@ func TestE2EEditTrackedCommentNotFound(t *testing.T) {
 		// expected: no edit
 	}
 }
+
+// An apply can reach a terminal state before its initial progress comment is
+// posted — a metadata-only DDL finishes faster than the handler's post, so the
+// driver's observer has already found nothing to edit at terminal. The handler
+// re-checks the apply after posting and finalizes the comment in place, so the
+// PR never shows a progress comment frozen at "Starting" after the success
+// summary. An apply that is still active is left to the observer to edit.
+func TestE2EInitialProgressCommentFinalizedForFastApply(t *testing.T) {
+	ctx := t.Context()
+
+	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
+	require.NoError(t, err)
+	t.Cleanup(func() { utils.CloseAndLog(schemabotDB) })
+	st := mysqlstore.New(schemabotDB)
+
+	_, _ = schemabotDB.ExecContext(ctx, "DELETE FROM apply_comments WHERE apply_id IN (SELECT id FROM applies WHERE repository = 'org/fastapply-repo')")
+	_, _ = schemabotDB.ExecContext(ctx, "DELETE FROM applies WHERE repository = 'org/fastapply-repo'")
+
+	newApply := func(t *testing.T, applyState string) *storage.Apply {
+		t.Helper()
+		apply := &storage.Apply{
+			ApplyIdentifier: fmt.Sprintf("apply_e2e_fast_%d", time.Now().UnixNano()),
+			PlanID:          1,
+			Database:        "e2e_fast_db",
+			DatabaseType:    "mysql",
+			Repository:      "org/fastapply-repo",
+			PullRequest:     7,
+			Environment:     "staging",
+			InstallationID:  12345,
+			Engine:          "spirit",
+			State:           applyState,
+		}
+		applyID, err := st.Applies().Create(ctx, apply)
+		require.NoError(t, err)
+		apply.ID = applyID
+		return apply
+	}
+
+	newHandler := func(t *testing.T) (*Handler, *commentCapture) {
+		t.Helper()
+		installClient, capture := setupFakeGitHubForComments(t)
+		logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+		svc := api.New(st, &api.ServerConfig{}, nil, logger)
+		h := NewHandler(svc, &fakeClientFactory{client: installClient}, nil, logger)
+		return h, capture
+	}
+
+	t.Run("already-terminal apply finalizes the comment in place", func(t *testing.T) {
+		apply := newApply(t, state.Apply.Completed)
+		h, capture := newHandler(t)
+
+		pending := *apply
+		pending.State = state.Apply.Pending
+		h.postInitialProgressComment(ctx, apply.Repository, apply.PullRequest, apply.InstallationID, apply.ID,
+			formatProgressComment(&pending, nil, nil))
+
+		var created commentCreate
+		select {
+		case created = <-capture.creates:
+			assert.Contains(t, created.Body, "**Status**: Starting")
+		case <-time.After(webhookIntegrationCheckRunDeadline):
+			t.Fatal("timed out waiting for the initial progress comment")
+		}
+
+		select {
+		case edited := <-capture.edits:
+			assert.Equal(t, created.ID, edited.CommentID, "the finalize edits the just-posted comment")
+			assert.Contains(t, edited.Body, "**Status**: Applied")
+			assert.NotContains(t, edited.Body, "**Status**: Starting")
+		case <-time.After(webhookIntegrationCheckRunDeadline):
+			t.Fatal("timed out waiting for the terminal finalize edit")
+		}
+
+		comment, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Progress)
+		require.NoError(t, err)
+		require.NotNil(t, comment)
+		assert.Equal(t, 1, comment.EditCount)
+	})
+
+	t.Run("active apply is left to the observer", func(t *testing.T) {
+		apply := newApply(t, state.Apply.Running)
+		h, capture := newHandler(t)
+
+		h.postInitialProgressComment(ctx, apply.Repository, apply.PullRequest, apply.InstallationID, apply.ID,
+			formatProgressComment(apply, nil, nil))
+
+		select {
+		case <-capture.creates:
+		case <-time.After(webhookIntegrationCheckRunDeadline):
+			t.Fatal("timed out waiting for the initial progress comment")
+		}
+
+		select {
+		case edited := <-capture.edits:
+			t.Fatalf("active apply must not be finalized by the handler, got edit: %q", edited.Body)
+		case <-time.After(500 * time.Millisecond):
+			// expected: the observer owns all further edits
+		}
+	})
+}

--- a/pkg/webhook/apply_comment_integration_test.go
+++ b/pkg/webhook/apply_comment_integration_test.go
@@ -978,6 +978,35 @@ func TestE2EInitialProgressCommentFinalizedForFastApply(t *testing.T) {
 		assert.Equal(t, 1, comment.EditCount)
 	})
 
+	t.Run("observer-edited comment is not overwritten by the finalize", func(t *testing.T) {
+		apply := newApply(t, state.Apply.Completed)
+		h, capture := newHandler(t)
+
+		// The observer already found and edited the tracked comment; its
+		// terminal edit carries the full per-operation rendering, so the
+		// handler's no-operations fallback must not overwrite it.
+		require.NoError(t, st.ApplyComments().Upsert(ctx, &storage.ApplyComment{
+			ApplyID: apply.ID, CommentState: state.Comment.Progress, GitHubCommentID: 424242,
+		}))
+		require.NoError(t, st.ApplyComments().IncrementEditCount(ctx, apply.ID, state.Comment.Progress))
+
+		h.postInitialProgressComment(ctx, apply.Repository, apply.PullRequest, apply.InstallationID, apply.ID,
+			formatProgressComment(apply, nil, nil))
+
+		select {
+		case <-capture.creates:
+		case <-time.After(webhookIntegrationCheckRunDeadline):
+			t.Fatal("timed out waiting for the initial progress comment")
+		}
+
+		select {
+		case edited := <-capture.edits:
+			t.Fatalf("an observer-edited comment must not be finalized by the handler, got edit: %q", edited.Body)
+		case <-time.After(500 * time.Millisecond):
+			// expected: the observer's terminal edit owns the final body
+		}
+	})
+
 	t.Run("active apply is left to the observer", func(t *testing.T) {
 		apply := newApply(t, state.Apply.Running)
 		h, capture := newHandler(t)

--- a/pkg/webhook/apply_execute.go
+++ b/pkg/webhook/apply_execute.go
@@ -8,7 +8,6 @@ import (
 	"github.com/block/schemabot/pkg/api"
 	"github.com/block/schemabot/pkg/apitypes"
 	ghclient "github.com/block/schemabot/pkg/github"
-	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/webhook/action"
 	"github.com/block/schemabot/pkg/webhook/templates"
@@ -233,7 +232,7 @@ func (h *Handler) executeApply(
 		State:       apply.State,
 		Engine:      schemaResult.Type,
 	})
-	h.postAndTrackComment(ctx, repo, pr, installationID, applyID, state.Comment.Progress, progressBody)
+	h.postInitialProgressComment(ctx, repo, pr, installationID, applyID, progressBody)
 
 	// Update stored check state to in_progress (transitions action_required to in_progress).
 	if err := h.updateCheckRecordForApplyStart(ctx, client, repo, pr, schemaResult, environment, applyID); err != nil {

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/block/schemabot/pkg/api"
 	"github.com/block/schemabot/pkg/metrics"
+	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/webhook/action"
 	"github.com/block/schemabot/pkg/webhook/templates"
@@ -443,6 +444,67 @@ func (h *Handler) postAndTrackComment(
 	if err := h.service.Storage().ApplyComments().Upsert(ctx, comment); err != nil {
 		h.logger.Error("failed to store comment ID",
 			"applyID", applyID, "commentState", commentState, "commentID", commentID, "error", err)
+	}
+}
+
+// postInitialProgressComment posts the initial progress comment for a freshly
+// accepted apply and, when the apply reached a terminal state before the
+// comment landed, finalizes the comment in place. The driver's observer can
+// only edit a tracked comment that exists: an apply that finishes faster than
+// this post (for example a metadata-only DDL) has already had its terminal
+// callback find nothing to edit, so the freshly posted comment would otherwise
+// stay frozen at its starting state after the summary comment. Re-checking the
+// apply after the post closes that window from this side — whichever of the
+// observer's terminal edit and this finalize runs last converges the comment
+// on the terminal rendering.
+func (h *Handler) postInitialProgressComment(ctx context.Context, repo string, pr int, installationID int64, applyID int64, body string) {
+	h.postAndTrackComment(ctx, repo, pr, installationID, applyID, state.Comment.Progress, body)
+
+	apply, err := h.service.Storage().Applies().Get(ctx, applyID)
+	if err != nil {
+		h.logger.Error("failed to re-check apply state after initial progress comment; if the apply already finished, its progress comment stays at the starting state",
+			"repo", repo, "pr", pr, "apply_id", applyID, "error", err)
+		return
+	}
+	if apply == nil {
+		h.logger.Error("apply missing when re-checking state after initial progress comment",
+			"repo", repo, "pr", pr, "apply_id", applyID)
+		return
+	}
+	if !state.IsTerminalApplyState(apply.State) {
+		// The apply is still active — the observer owns all further edits.
+		return
+	}
+
+	h.logger.Info("apply reached a terminal state before its initial progress comment; finalizing the comment in place",
+		apply.LogAttrs()...)
+
+	comment, err := h.service.Storage().ApplyComments().Get(ctx, applyID, state.Comment.Progress)
+	if err != nil {
+		h.logger.Error("failed to load tracked progress comment for finalization",
+			append(apply.LogAttrs(), "error", err)...)
+		return
+	}
+	if comment == nil {
+		// The post above failed and already logged why — nothing to finalize.
+		return
+	}
+
+	client, err := h.clientForRepo(repo, installationID)
+	if err != nil {
+		h.logger.Error("failed to create GitHub client to finalize progress comment",
+			append(apply.LogAttrs(), "error", err)...)
+		return
+	}
+	finalBody := formatProgressComment(apply, nil, nil)
+	if err := client.EditIssueComment(ctx, repo, comment.GitHubCommentID, h.renderPRComment(finalBody)); err != nil {
+		h.logger.Error("failed to finalize progress comment for already-terminal apply",
+			append(apply.LogAttrs(), "github_comment_id", comment.GitHubCommentID, "error", err)...)
+		return
+	}
+	if err := h.service.Storage().ApplyComments().IncrementEditCount(ctx, applyID, state.Comment.Progress); err != nil {
+		h.logger.Error("failed to increment edit count after finalizing progress comment",
+			append(apply.LogAttrs(), "error", err)...)
 	}
 }
 

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -472,7 +472,8 @@ func (h *Handler) postInitialProgressComment(ctx context.Context, repo string, p
 		return
 	}
 	if !state.IsTerminalApplyState(apply.State) {
-		// The apply is still active — the observer owns all further edits.
+		h.logger.Debug("apply is still active after initial progress comment; the observer owns all further edits",
+			apply.LogAttrs()...)
 		return
 	}
 
@@ -486,7 +487,21 @@ func (h *Handler) postInitialProgressComment(ctx context.Context, repo string, p
 		return
 	}
 	if comment == nil {
-		// The post above failed and already logged why — nothing to finalize.
+		// Nothing to finalize: either the GitHub post itself failed, or the post
+		// succeeded but the tracking upsert did not (postAndTrackComment logged
+		// which). In the latter case a comment exists on the PR with no stored
+		// ID to edit, so it stays at its starting state until reconciliation.
+		h.logger.Debug("no tracked progress comment to finalize for terminal apply",
+			apply.LogAttrs()...)
+		return
+	}
+	if comment.EditCount > 0 {
+		// The observer has already found and edited the tracked comment, so its
+		// terminal edit lands (or has landed) with the full per-operation
+		// rendering. Skipping keeps this no-operations fallback from
+		// overwriting that richer body.
+		h.logger.Debug("observer already edits the tracked progress comment; skipping handler finalize",
+			apply.LogAttrs()...)
 		return
 	}
 

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -463,12 +463,12 @@ func (h *Handler) postInitialProgressComment(ctx context.Context, repo string, p
 	apply, err := h.service.Storage().Applies().Get(ctx, applyID)
 	if err != nil {
 		h.logger.Error("failed to re-check apply state after initial progress comment; if the apply already finished, its progress comment stays at the starting state",
-			"repo", repo, "pr", pr, "apply_id", applyID, "error", err)
+			"repo", repo, "pr", pr, "error", err)
 		return
 	}
 	if apply == nil {
 		h.logger.Error("apply missing when re-checking state after initial progress comment",
-			"repo", repo, "pr", pr, "apply_id", applyID)
+			"repo", repo, "pr", pr)
 		return
 	}
 	if !state.IsTerminalApplyState(apply.State) {

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -476,7 +476,7 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment 
 	// omitted on this first comment — the observer refreshes it from engine
 	// display metadata on the next progress tick.
 	progressBody := formatProgressComment(apply, nil, nil)
-	h.postAndTrackComment(ctx, repo, pr, installationID, applyID, state.Comment.Progress, progressBody)
+	h.postInitialProgressComment(ctx, repo, pr, installationID, applyID, progressBody)
 }
 
 func (h *Handler) rollbackConfirmPlanForPR(ctx context.Context, repo string, pr int, environment, lockOwner string) (*storage.Lock, *storage.Plan, error) {


### PR DESCRIPTION
## Why this matters

The initial progress comment is posted after `ExecuteApply` accepts, while the driver runs concurrently. The observer can only edit a tracked comment that exists — so an apply that reaches a terminal state before the post lands has already had its terminal callback find nothing to edit, and the freshly posted comment stays frozen at **"Status: Starting"** on the PR *after* the success summary. The last SchemaBot comment on the PR then claims the change is starting when it has already finished.

Rollbacks hit this often: they usually revert a just-applied metadata-only DDL (no row copy), and the rollback handler posts its progress comment after the check-record update, widening the window by a GitHub API round-trip. The apply path mitigated the same race by posting first, but a fast enough apply still beats a single round-trip.

## What it does

`postInitialProgressComment` — shared by the apply and rollback paths — posts and tracks the comment as before, then re-checks the apply:

```
handler                                  driver's observer
───────                                  ─────────────────
post + track progress comment            OnTerminal: edit tracked comment
re-read apply                              (skips when none exists yet)
└─ terminal already?  → finalize the
   just-posted comment in place with
   the terminal status rendering
```

Whichever of the observer's terminal edit and the handler's finalize runs last converges the comment on the terminal rendering, so the outcome is correct under every interleaving. An apply that is still active is left to the observer, unchanged.

Integration tests cover both: an already-terminal apply gets its comment posted and immediately finalized to "Applied"; an active apply gets no handler edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)