### PR TITLE
feat(auth): attribute control operations to the authenticated caller

### DIFF
--- a/pkg/api/control_caller_test.go
+++ b/pkg/api/control_caller_test.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/block/schemabot/pkg/auth"
+)
+
+// A control operation or apply is attributed to the authenticated caller when
+// the request carries a real identity; otherwise the client-supplied request
+// caller is used, and the synthetic anonymous user (auth disabled) never
+// overrides it.
+func TestResolveCaller(t *testing.T) {
+	t.Run("authenticated identity wins over the request caller", func(t *testing.T) {
+		ctx := auth.WithUser(t.Context(), &auth.User{Subject: "bob@example.com"})
+		assert.Equal(t, "bob@example.com", resolveCaller(ctx, "client-supplied"))
+	})
+
+	t.Run("no authenticated user falls back to the request caller", func(t *testing.T) {
+		assert.Equal(t, "client-supplied", resolveCaller(t.Context(), "client-supplied"))
+	})
+
+	t.Run("anonymous user falls back to the request caller", func(t *testing.T) {
+		ctx := auth.WithUser(t.Context(), &auth.User{Subject: auth.AnonymousSubject})
+		assert.Equal(t, "client-supplied", resolveCaller(ctx, "client-supplied"))
+	})
+}

--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -1912,6 +1912,7 @@ type VolumeRequest struct {
 	ApplyID     string `json:"apply_id"`
 	Environment string `json:"environment"`
 	Volume      int32  `json:"volume"` // 1-11 (1=conservative, 11=aggressive)
+	Caller      string `json:"caller,omitempty"`
 }
 
 // handleVolume handles POST /api/volume requests.
@@ -1938,6 +1939,10 @@ func (s *Service) handleVolume(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	metrics.RecordControlOperation(r.Context(), "volume", apply.Database, apply.Deployment, apply.Environment, controlStatus(resp.Accepted))
+	if resp.Accepted {
+		s.logControlOperationForApply(r.Context(), apply, resolveCaller(r.Context(), req.Caller), storage.LogEventInfo,
+			fmt.Sprintf("Volume changed from %d to %d", resp.PreviousVolume, resp.NewVolume))
+	}
 
 	s.writeJSON(w, http.StatusOK, &apitypes.VolumeResponse{
 		Accepted:       resp.Accepted,

--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/block/schemabot/pkg/apitypes"
+	"github.com/block/schemabot/pkg/auth"
 	"github.com/block/schemabot/pkg/metrics"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/state"
@@ -227,6 +228,19 @@ func controlOperationCaller(caller string) string {
 	return caller
 }
 
+// resolveCaller returns the identity an operation is attributed to: the
+// authenticated caller when the request carried a real identity (API auth
+// enabled), otherwise the caller supplied in the request. The authenticated
+// identity wins so a direct-API action is auditable to the verified user rather
+// than a client-supplied string; with auth disabled (or on paths with no
+// authenticated user, like control-plane dispatch) the request caller is used
+// unchanged.
+func resolveCaller(ctx context.Context, requestCaller string) string {
+	if subject, ok := auth.AuthenticatedSubject(ctx); ok {
+		return subject
+	}
+	return requestCaller
+}
 func (s *Service) logControlOperationForApply(ctx context.Context, apply *storage.Apply, caller, eventType, message string) {
 	logStore := s.storage.ApplyLogs()
 	if logStore == nil {
@@ -490,6 +504,7 @@ func (s *Service) ExecuteCutover(ctx context.Context, req apitypes.ControlReques
 // returns a zero status, and callers must derive the response status from the
 // error (e.g. via writeControlError).
 func (s *Service) executeCutoverForApply(ctx context.Context, client tern.Client, apply *storage.Apply, ternApplyID, caller string) (*apitypes.ControlResponse, int, error) {
+	caller = resolveCaller(ctx, caller)
 	controlStore := s.storage.ControlRequests()
 	if controlStore == nil {
 		err := fmt.Errorf("control request store is not available")
@@ -704,6 +719,7 @@ func (s *Service) ExecuteStop(ctx context.Context, req apitypes.ControlRequest) 
 // err == nil; every error path returns a zero status, and callers must derive
 // the response status from the error (e.g. via writeControlError).
 func (s *Service) executeStopForApply(ctx context.Context, client tern.Client, apply *storage.Apply, ternApplyID, environment, caller string) (*apitypes.StopResponse, int, error) {
+	caller = resolveCaller(ctx, caller)
 	if apply.Engine == storage.EnginePlanetScale {
 		metrics.RecordControlOperation(ctx, "stop", apply.Database, apply.Deployment, apply.Environment, "rejected")
 		return nil, 0, controlHTTPErrorf(http.StatusBadRequest, "stop is not supported for this schema change; use cancel to permanently cancel it")
@@ -938,6 +954,7 @@ func (s *Service) ExecuteCancel(ctx context.Context, req apitypes.ControlRequest
 }
 
 func (s *Service) executeCancelForApply(ctx context.Context, client tern.Client, apply *storage.Apply, caller string) (*apitypes.CancelResponse, int, error) {
+	caller = resolveCaller(ctx, caller)
 	if state.IsTerminalApplyState(apply.State) && !state.IsState(apply.State, state.Apply.Stopped) {
 		metrics.RecordControlOperation(ctx, "cancel", apply.Database, apply.Deployment, apply.Environment, "rejected")
 		return nil, 0, controlConflictf("schema change is already terminal (current state: %s)", apply.State)
@@ -1298,6 +1315,7 @@ func (s *Service) ExecuteStart(ctx context.Context, req apitypes.ControlRequest)
 // zero status, and callers must derive the response status from the error (e.g.
 // via writeControlError).
 func (s *Service) executeStartForApply(ctx context.Context, client tern.Client, apply *storage.Apply, caller string) (*apitypes.StartResponse, int, error) {
+	caller = resolveCaller(ctx, caller)
 	if err := validateStartRequestState(apply); err != nil {
 		metrics.RecordControlOperation(ctx, "start", apply.Database, apply.Deployment, apply.Environment, "rejected")
 		return nil, 0, err
@@ -1764,6 +1782,7 @@ func (s *Service) ExecuteRelease(ctx context.Context, req apitypes.ControlReques
 // HTTP status is meaningful only when err == nil; every error path returns a
 // zero status, and callers derive the response status from the error.
 func (s *Service) executeReleaseForApply(ctx context.Context, apply *storage.Apply, caller string) (*apitypes.ReleaseResponse, int, error) {
+	caller = resolveCaller(ctx, caller)
 	if err := s.validateReleaseRequestState(ctx, apply); err != nil {
 		s.recordReleaseRejectionMetric(ctx, apply, err)
 		return nil, 0, err
@@ -1966,6 +1985,7 @@ func (s *Service) ExecuteRevert(ctx context.Context, req apitypes.ControlRequest
 // revert. The returned HTTP status is meaningful only when err == nil; error
 // paths return a zero status and callers derive it from the error.
 func (s *Service) executeRevertForApply(ctx context.Context, client tern.Client, apply *storage.Apply, ternApplyID, caller string) (*apitypes.ControlResponse, int, error) {
+	caller = resolveCaller(ctx, caller)
 	// Revert undoes a PlanetScale deploy request in its revert window; other
 	// engines hard-error it. Gate on the engine so a non-PlanetScale apply can
 	// never accumulate a permanently-pending revert request.
@@ -2078,6 +2098,7 @@ func (s *Service) ExecuteSkipRevert(ctx context.Context, req apitypes.ControlReq
 // immediate skip. The returned HTTP status is meaningful only when err == nil;
 // error paths return a zero status and callers derive it from the error.
 func (s *Service) executeSkipRevertForApply(ctx context.Context, client tern.Client, apply *storage.Apply, ternApplyID, caller string) (*apitypes.ControlResponse, int, error) {
+	caller = resolveCaller(ctx, caller)
 	// Skip-revert closes a PlanetScale revert window; other engines hard-error
 	// it. Gate on the engine so a non-PlanetScale apply can never accumulate a
 	// permanently-pending skip-revert request.

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -20,7 +20,6 @@ import (
 	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/block/schemabot/pkg/apitypes"
-	"github.com/block/schemabot/pkg/auth"
 	"github.com/block/schemabot/pkg/metrics"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/routing"
@@ -941,14 +940,8 @@ func (s *Service) createStoredApply(
 	}
 
 	// Attribute the apply to the authenticated caller when the request carried a
-	// real identity (API auth enabled). This makes a direct-API/CLI apply
-	// auditable to the verified user rather than a client-supplied Caller string.
-	// With auth disabled, or on the PR-comment path (no authenticated user), the
-	// request's Caller is used unchanged.
-	caller := req.Caller
-	if subject, ok := auth.AuthenticatedSubject(ctx); ok {
-		caller = subject
-	}
+	// real identity (API auth enabled); see resolveCaller.
+	caller := resolveCaller(ctx, req.Caller)
 
 	apply := &storage.Apply{
 		ApplyIdentifier: applyIdentifier,

--- a/pkg/api/settings_handlers.go
+++ b/pkg/api/settings_handlers.go
@@ -78,7 +78,8 @@ func (s *Service) handleSettingsSet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.logger.Info("setting updated", "key", req.Key, "value", req.Value)
+	s.logger.Info("setting updated", "key", req.Key, "value", req.Value,
+		"caller", controlOperationCaller(resolveCaller(r.Context(), "")))
 
 	s.writeJSON(w, http.StatusOK, map[string]any{
 		"key":   req.Key,


### PR DESCRIPTION
Extends authenticated-caller attribution from the apply path to the full control surface, completing break-glass audit symmetry.

- Adds a shared `resolveCaller` helper: when API auth is enabled, the authenticated identity wins over the client-supplied request caller; with auth disabled — or on paths with no authenticated user, like control-plane dispatch — the request caller is used unchanged (the synthetic anonymous user never overrides).
- Applies it inside all six control-op execute helpers (`cutover`, `stop`, `cancel`, `start`, `release`, `skip-revert`) — one insertion point each covers both the HTTP handler and the dispatch variant — plus the `revert` handler's audit log line.
- **Volume:** previously had no caller concept and left no apply-log entry at all (only a metric). Adds a `Caller` field and logs the accepted change with the resolved caller, like every other control op.
- **Settings updates:** now log the resolved caller alongside key/value.
- Refactors the apply path's inline attribution onto the same helper, removing the duplication.

Deliberately unchanged: lock `Owner` (functional lock identity — release must match acquire — not audit), and rollback-plan creation (attributed via the eventual apply; plans carry no caller).

With this, every direct-API write and control action is auditable to the verified caller, not a client-supplied string.

*PR authored by Claude Code (Opus 4.8).*