### PR TITLE
fix(tern): queue dispatched applies for the operator drive

### DIFF
--- a/deploy/local/config/grpc-tern.yaml
+++ b/deploy/local/config/grpc-tern.yaml
@@ -19,7 +19,7 @@ databases:
       production:
         dsn: "env:TERN_TARGET_DSN"
 
-# Data-plane terns drive applies inline via LocalClient and do not maintain
-# apply_operations rows, so operator recovery claims at the apply level. The
-# server enforces this default in gRPC mode; set here as well for clarity.
+# Data-plane terns queue dispatched applies for their own operator to drive,
+# claiming at the apply level. The server enforces this default in gRPC mode;
+# set here as well for clarity.
 operator_claim_operations: false

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -274,6 +274,8 @@ Increase `drivers` when one SchemaBot server should make operator progress acros
 
 A driver claim means selecting one stale apply and refreshing its heartbeat in the same storage transaction. That heartbeat refresh is the driver's lease while it reloads state and drives the apply to a terminal state.
 
+**Sizing:** each driver drives one claimed apply synchronously to a terminal state, and that includes waiting states such as deferred cutovers and revert windows, so a server's effective apply concurrency is `drivers × replicas`. Size that product to the number of applies you expect to be in flight at once, counting parked ones — a deferred cutover holds its driver for the full wait. A control plane that dispatches to remote servers bounds end-to-end concurrency with its own driver pool the same way.
+
 ## Pending Drops
 
 For MySQL databases executed by the Spirit engine, `DROP TABLE` statements are

--- a/e2e/grpc/helpers_test.go
+++ b/e2e/grpc/helpers_test.go
@@ -379,7 +379,7 @@ func grpcClearSchemabotState(t *testing.T) {
 	}
 	defer utils.CloseAndLog(db)
 
-	rows, err := db.QueryContext(context.Background(), "SHOW TABLES") //nolint:usetesting // cleanup utility
+	rows, err := db.QueryContext(t.Context(), "SHOW TABLES")
 	if err != nil {
 		return
 	}
@@ -393,7 +393,7 @@ func grpcClearSchemabotState(t *testing.T) {
 	}
 
 	for _, table := range tables {
-		_, _ = db.ExecContext(context.Background(), "DELETE FROM `"+table+"`") //nolint:usetesting // cleanup utility
+		_, _ = db.ExecContext(t.Context(), "DELETE FROM `"+table+"`")
 	}
 }
 
@@ -412,7 +412,7 @@ func grpcClearTernStorage(t *testing.T, env string) {
 	}
 	defer utils.CloseAndLog(db)
 
-	rows, err := db.QueryContext(context.Background(), "SHOW TABLES") //nolint:usetesting // cleanup utility
+	rows, err := db.QueryContext(t.Context(), "SHOW TABLES")
 	if err != nil {
 		return
 	}
@@ -426,7 +426,7 @@ func grpcClearTernStorage(t *testing.T, env string) {
 	}
 
 	for _, table := range tables {
-		_, _ = db.ExecContext(context.Background(), "DELETE FROM `"+table+"`") //nolint:usetesting // cleanup utility
+		_, _ = db.ExecContext(t.Context(), "DELETE FROM `"+table+"`")
 	}
 }
 
@@ -452,12 +452,14 @@ func grpcCreateTestTable(t *testing.T, env, tableName, ddl string) {
 			return
 		}
 		defer utils.CloseAndLog(db2)
+		ctx, cancel := testutil.CleanupContext(30 * time.Second)
+		defer cancel()
 		for _, suffix := range []string{"_new", "_old", "_chkpnt", ""} {
 			name := tableName
 			if suffix != "" {
 				name = "_" + tableName + suffix
 			}
-			_, _ = db2.ExecContext(context.Background(), "DROP TABLE IF EXISTS `"+name+"`") //nolint:usetesting // cleanup
+			_, _ = db2.ExecContext(ctx, "DROP TABLE IF EXISTS `"+name+"`")
 		}
 	})
 }

--- a/e2e/local/helpers_test.go
+++ b/e2e/local/helpers_test.go
@@ -411,12 +411,14 @@ func createTestTable(t *testing.T, tableName, ddlStmt string) {
 			return
 		}
 		defer utils.CloseAndLog(db2)
+		ctx, cancel := testutil.CleanupContext(30 * time.Second)
+		defer cancel()
 		for _, suffix := range []string{"_new", "_old", "_chkpnt", ""} {
 			name := tableName
 			if suffix != "" {
 				name = "_" + tableName + suffix
 			}
-			_, _ = db2.ExecContext(context.Background(), "DROP TABLE IF EXISTS `"+name+"`") //nolint:usetesting // runs after test context cancelled
+			_, _ = db2.ExecContext(ctx, "DROP TABLE IF EXISTS `"+name+"`")
 		}
 	})
 }

--- a/e2e/testutil/cleanup.go
+++ b/e2e/testutil/cleanup.go
@@ -1,0 +1,16 @@
+//go:build e2e || integration
+
+package testutil
+
+import (
+	"context"
+	"time"
+)
+
+// CleanupContext returns a bounded context for teardown that must outlive the
+// test: t.Cleanup callbacks and deferred cleanup run after the test's own
+// context is already cancelled, so they need a lifetime of their own. The
+// caller must call the returned cancel.
+func CleanupContext(timeout time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), timeout)
+}

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"bytes"
-	"context"
 	"database/sql"
 	"fmt"
 	"log/slog"
@@ -922,7 +921,7 @@ func startSchemaBotLocal(t *testing.T) string {
 	server := &http.Server{Handler: mux}
 	go func() { _ = server.Serve(listener) }()
 	t.Cleanup(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) //nolint:usetesting // runs after test context cancelled
+		ctx, cancel := testutil.CleanupContext(5 * time.Second)
 		defer cancel()
 		_ = server.Shutdown(ctx)
 	})
@@ -952,7 +951,9 @@ func startSchemaBotLocalDB(t *testing.T, dbName string) string {
 	targetDB, err := sql.Open("mysql", targetDSN+"&multiStatements=true")
 	require.NoError(t, err, "open target db connection")
 	t.Cleanup(func() {
-		_, _ = targetDB.ExecContext(context.Background(), "DROP DATABASE IF EXISTS "+dbName) //nolint:usetesting // runs after test context cancelled
+		ctx, cancel := testutil.CleanupContext(30 * time.Second)
+		defer cancel()
+		_, _ = targetDB.ExecContext(ctx, "DROP DATABASE IF EXISTS "+dbName)
 		_ = targetDB.Close()
 	})
 
@@ -1004,7 +1005,7 @@ func startSchemaBotLocalDB(t *testing.T, dbName string) string {
 	server := &http.Server{Handler: mux}
 	go func() { _ = server.Serve(listener) }()
 	t.Cleanup(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) //nolint:usetesting // runs after test context cancelled
+		ctx, cancel := testutil.CleanupContext(5 * time.Second)
 		defer cancel()
 		_ = server.Shutdown(ctx)
 	})
@@ -1071,7 +1072,7 @@ func startSchemaBotWithGRPC(t *testing.T) string {
 	server := &http.Server{Handler: mux}
 	go func() { _ = server.Serve(listener) }()
 	t.Cleanup(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) //nolint:usetesting // runs after test context cancelled
+		ctx, cancel := testutil.CleanupContext(5 * time.Second)
 		defer cancel()
 		_ = server.Shutdown(ctx)
 	})

--- a/integration/grpc_server_test.go
+++ b/integration/grpc_server_test.go
@@ -3,8 +3,15 @@
 package integration
 
 import (
-	"github.com/block/schemabot/pkg/tern"
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
 	"google.golang.org/grpc"
+
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/tern"
 )
 
 // newGRPCServer creates a new gRPC server wrapping a Client.
@@ -15,4 +22,70 @@ func newGRPCServer(client tern.Client) *tern.Server {
 // registerGRPCServer registers the tern server on the given grpc.Server.
 func registerGRPCServer(srv *tern.Server, grpcSrv *grpc.Server) {
 	srv.Register(grpcSrv)
+}
+
+// remoteTernClients routes a claimed apply to the simulated data-plane client
+// that serves its deployment. Several harness terns share one Tern storage
+// database, so a claim loop can pick up any tern's apply; driving it through
+// the wrong database-bound client would run DDL against the wrong target.
+var remoteTernClients sync.Map // deployment → tern.Client
+
+// registerRemoteTern adds a simulated data-plane client to the routing
+// registry under its deployment (the LocalClient's database), so claim loops
+// can drive its applies. Register before the tern's gRPC server accepts
+// dispatches, or a claimed apply would have no client and burn its lease.
+func registerRemoteTern(deployment string, client tern.Client) {
+	remoteTernClients.Store(deployment, client)
+}
+
+// startRemoteTernOperator mimics the remote data plane's operator loop for the
+// in-process Tern harness. A dispatch to the wrapped gRPC server queues the
+// apply in Tern storage — production data planes drive queued applies from
+// their own operator — so this loop claims work the way an operator driver
+// does (FindNextApply under an owner, the claim's apply lease on the drive
+// context) and drives each claim via the registered client for the apply's
+// deployment, the routing key. Drive failures surface as apply state, which
+// the tests assert on. Returns a stop func.
+func startRemoteTernOperator(stor storage.Storage, logger *slog.Logger, owner string) (stop func()) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				apply, err := stor.Applies().FindNextApply(ctx, owner)
+				if err != nil {
+					// Storage failure, not no-work: without this log a broken claim
+					// only surfaces as tests hanging to their timeouts.
+					if ctx.Err() == nil {
+						logger.Warn("remote tern operator: claim failed", "owner", owner, "error", err)
+					}
+					continue
+				}
+				if apply == nil {
+					// No claimable work — keep polling.
+					continue
+				}
+				clientAny, ok := remoteTernClients.Load(apply.Deployment)
+				if !ok {
+					// The claim burned this lease; the apply is re-claimable once its
+					// heartbeat goes stale, by which point the tern should be registered.
+					logger.Warn("remote tern operator: no registered client for claimed apply",
+						"deployment", apply.Deployment, "apply_id", apply.ApplyIdentifier)
+					continue
+				}
+				client := clientAny.(tern.Client)
+				driveCtx := storage.WithApplyLease(ctx, apply.Lease())
+				go func() {
+					if err := client.ResumeApply(driveCtx, apply); err != nil && ctx.Err() == nil {
+						logger.Warn("remote tern operator: resume apply", "apply_id", apply.ApplyIdentifier, "error", err)
+					}
+				}()
+			}
+		}
+	}()
+	return cancel
 }

--- a/integration/hybrid_mode_test.go
+++ b/integration/hybrid_mode_test.go
@@ -406,6 +406,12 @@ func startTernGRPCForDB(t *testing.T, appDSN, dbName string) (string, error) {
 	}
 	t.Cleanup(func() { utils.CloseAndLog(localClient) })
 
+	// A dispatch queues the apply in Tern storage for the data plane's own
+	// operator; without this loop a dispatched apply would sit pending forever.
+	registerRemoteTern(dbName, localClient)
+	stopOperator := startRemoteTernOperator(storage, logger, "remote-tern-"+dbName)
+	t.Cleanup(stopOperator)
+
 	// Wrap in gRPC server
 	grpcSrv := grpc.NewServer()
 	ternGRPCServer := newGRPCServer(localClient)

--- a/integration/setup_test.go
+++ b/integration/setup_test.go
@@ -303,6 +303,14 @@ func startTernGRPC(ctx context.Context, targetDSN, storageDSN string) (grpcAddre
 	}
 	cleanupFuncs = append(cleanupFuncs, func() { _ = localClient.Close() })
 
+	// A dispatch queues the apply in Tern storage for the data plane's own
+	// operator; without this loop a dispatched apply would sit pending forever.
+	// The harness terns share one Tern storage database, so the claim loop
+	// routes each claim to the registered client for its deployment.
+	registerRemoteTern(databaseName, localClient)
+	stopOperator := startRemoteTernOperator(storage, logger, "remote-tern-"+databaseName)
+	cleanupFuncs = append(cleanupFuncs, stopOperator)
+
 	// Wrap LocalClient in gRPC server (simulates remote Tern)
 	grpcSrv := grpc.NewServer()
 	ternGRPCServer := newGRPCServer(localClient)

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -112,7 +112,12 @@ func (s *Service) wakeOperator(applyIdentifier, database, environment string) {
 	s.operatorMu.Unlock()
 
 	if !running || wake == nil {
-		s.logger.Debug("operator wake skipped because operator is not running",
+		// A wake reaches here for every kind of queued durable work — a queued
+		// apply dispatch as well as control requests — and every drive runs under
+		// an operator claim, so with no operator running none of it will be
+		// picked up. Warn so an operator-less deployment shape is visible before
+		// someone has to debug a queued apply that never starts.
+		s.logger.Warn("operator wake skipped because the operator is not running; queued applies and control requests will not be driven until the operator starts",
 			"apply_id", applyIdentifier,
 			"database", database,
 			"environment", environment)

--- a/pkg/localscale/pull_schema_integration_test.go
+++ b/pkg/localscale/pull_schema_integration_test.go
@@ -3,7 +3,6 @@
 package localscale_test
 
 import (
-	"context"
 	"log/slog"
 	"os"
 	"testing"
@@ -13,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/block/schemabot/e2e/testutil"
 	"github.com/block/schemabot/pkg/localscale"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/storage"
@@ -44,7 +44,7 @@ func TestPullSchemaLoadsLiveVitessSchema(t *testing.T) {
 	require.NoError(t, err, "start LocalScale")
 	if os.Getenv("DEBUG") != "1" {
 		t.Cleanup(func() {
-			cleanupCtx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+			cleanupCtx, cancel := testutil.CleanupContext(30 * time.Second)
 			defer cancel()
 			assert.NoError(t, lsc.Terminate(cleanupCtx), "terminate LocalScale")
 		})

--- a/pkg/serve/serve.go
+++ b/pkg/serve/serve.go
@@ -113,16 +113,16 @@ func Run(ctx context.Context, cfg *api.ServerConfig, opts ...Option) error {
 	}
 	defer utils.CloseAndLog(srv)
 
-	// A configured GRPC_PORT means this process serves the data plane over its
-	// inline LocalClient drive, which does not maintain apply_operations state —
-	// so default operator claiming to the apply level (unless config set it
-	// explicitly). This is a Run convenience, not a server mode: an embedder
-	// sets ServerConfig.OperatorClaimOperations directly. Applied before Start
+	// A configured GRPC_PORT means this process serves the data plane, whose
+	// LocalClient drives claim at the apply level — so default operator claiming
+	// to the apply level (unless config set it explicitly). This is a Run
+	// convenience, not a server mode: an embedder sets
+	// ServerConfig.OperatorClaimOperations directly. Applied before Start
 	// (which launches the operator) so the operator reads the resolved value.
 	if applyDataPlaneClaimDefault(cfg, grpcPort != "") {
 		srv.logger.Info("data-plane gRPC mode: defaulting operator claiming to the apply level", "grpc_port", grpcPort)
 	} else if grpcPort != "" && cfg.ShouldClaimOperations() {
-		srv.logger.Warn("data-plane gRPC mode has operation-level operator claiming enabled; the inline LocalClient drive does not maintain apply_operations state, so stop/start resume will not recover", "grpc_port", grpcPort)
+		srv.logger.Warn("data-plane gRPC mode has operation-level operator claiming enabled; data-plane drives hold apply-level leases, so stop/start resume will not recover", "grpc_port", grpcPort)
 	}
 
 	// Optionally start a gRPC server for the Tern proto (used by
@@ -394,9 +394,16 @@ func (s *Server) RegisterGRPC(ctx context.Context, gs *grpc.Server) error {
 		if err != nil {
 			return fmt.Errorf("build grpc tern client: %w", err)
 		}
-		// Owned by the Server (not the service's default client), so Close
-		// releases it.
+		// Owned by the Server (Close releases it; the service does not close its
+		// default client).
 		s.grpcClient = built
+		// A dispatched apply is queued for this data plane's own operator, which
+		// routes each claim by the apply's deployment/environment. A dispatch can
+		// carry an environment the static database config does not list, so the
+		// operator must fall back to the same client the gRPC transport serves —
+		// without it, every claim of a queued apply would fail "tern deployment
+		// not configured" and the apply would sit re-claimable forever.
+		s.svc.SetDefaultTernClient(built)
 		client = built
 	}
 	tern.NewServer(client).Register(gs)

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -1131,11 +1131,19 @@ func (s *applyStore) FindNextApply(ctx context.Context, owner string) (*storage.
 	// Apply creation/update enforces at most one active apply per
 	// database/type/environment. The claim query only needs to find stale work;
 	// FOR UPDATE SKIP LOCKED prevents concurrent drivers from claiming the same row.
+	//
+	// The pending clause requires child rows so a half-created apply is never
+	// claimed. Creation dual-writes tasks and the apply_operations row in one
+	// transaction, so either proves the create committed fully; a VSchema-only
+	// apply carries an operation row but no tasks, so tasks alone would strand it.
 	row := tx.QueryRowContext(ctx, fmt.Sprintf(`
 		SELECT %s
 		FROM applies a
 		WHERE (
-				(a.state = ? AND EXISTS (SELECT 1 FROM tasks t WHERE t.apply_id = a.id))
+				(a.state = ? AND (
+					EXISTS (SELECT 1 FROM tasks t WHERE t.apply_id = a.id)
+					OR EXISTS (SELECT 1 FROM apply_operations ao WHERE ao.apply_id = a.id)
+				))
 				OR (a.state IN (%s) AND a.updated_at < NOW() - INTERVAL 1 MINUTE)
 				OR (a.state = ? AND a.attempt < ? AND a.updated_at >= NOW() - INTERVAL ? DAY)
 				OR (
@@ -1238,7 +1246,10 @@ func (s *applyStore) ClaimApplyByID(ctx context.Context, applyID int64, owner st
 		FROM applies a
 		WHERE a.id = ?
 			AND (
-				(a.state = ? AND EXISTS (SELECT 1 FROM tasks t WHERE t.apply_id = a.id))
+				(a.state = ? AND (
+					EXISTS (SELECT 1 FROM tasks t WHERE t.apply_id = a.id)
+					OR EXISTS (SELECT 1 FROM apply_operations ao WHERE ao.apply_id = a.id)
+				))
 				OR (a.state IN (%s) AND a.updated_at < NOW() - INTERVAL 1 MINUTE)
 				OR (a.state = ? AND a.attempt < ? AND a.updated_at >= NOW() - INTERVAL ? DAY)
 				OR (

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -2071,6 +2071,51 @@ func TestApplyStore_FindNextApplyRequiresTasksForPendingApply(t *testing.T) {
 	assert.Equal(t, state.Apply.Running, persisted.State)
 }
 
+// A VSchema-only apply carries an apply_operations row but no tasks — the
+// VSchema application is the whole apply. Its dual-written operation row proves
+// the create committed fully, so the pending claim must accept it; gating the
+// claim on tasks alone would strand every queued VSchema-only apply pending
+// forever.
+func TestApplyStore_FindNextApplyClaimsTasklessPendingApplyWithOperation(t *testing.T) {
+	newTasklessApply := func(t *testing.T, store *Storage, database, applyID string) *storage.Apply {
+		t.Helper()
+		lock := createTestLock(t, store, database, storage.DatabaseTypeVitess, "staging")
+		apply := createTestApplyWithStateAndEnv(t, store, lock, applyID, 503, state.Apply.Pending, "staging")
+		now := time.Now()
+		_, err := store.ApplyOperations().Insert(t.Context(), &storage.ApplyOperation{
+			ApplyID:    apply.ID,
+			Deployment: apply.Database,
+			State:      state.ApplyOperation.Pending,
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		})
+		require.NoError(t, err)
+		return apply
+	}
+
+	t.Run("FindNextApply claims it", func(t *testing.T) {
+		clearTables(t)
+		store := New(testDB)
+		apply := newTasklessApply(t, store, "testdb", "apply_vschema_only")
+
+		claimed, err := store.Applies().FindNextApply(t.Context(), "test-owner")
+		require.NoError(t, err)
+		require.NotNil(t, claimed, "a task-less pending apply with an operation row must be claimable")
+		assert.Equal(t, apply.ApplyIdentifier, claimed.ApplyIdentifier)
+	})
+
+	t.Run("ClaimApplyByID acquires the parent lease", func(t *testing.T) {
+		clearTables(t)
+		store := New(testDB)
+		apply := newTasklessApply(t, store, "testdb", "apply_vschema_only_byid")
+
+		claimed, err := store.Applies().ClaimApplyByID(t.Context(), apply.ID, "test-owner")
+		require.NoError(t, err)
+		require.NotNil(t, claimed, "the operation-claim path must acquire the parent lease for a task-less pending apply")
+		assert.Equal(t, apply.ApplyIdentifier, claimed.ApplyIdentifier)
+	})
+}
+
 func TestApplyStore_FindNextApplyClaimsPendingControlRequestWithoutTasks(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -312,14 +312,6 @@ func (c *LocalClient) cancelApplyHandle(handle applyCancelHandle) {
 	c.cancelMu.Unlock()
 }
 
-func (c *LocalClient) startApplyExecution(ctx context.Context, cancelGeneration uint64, cancel context.CancelFunc, apply *storage.Apply, tasks []*storage.Task, plan *storage.Plan, options map[string]string, releaseAtCutoverBarrier bool) {
-	go func() {
-		defer c.clearApplyCancel(cancelGeneration)
-		defer cancel()
-		c.runApplyExecution(ctx, apply, tasks, plan, options, releaseAtCutoverBarrier)
-	}()
-}
-
 func (c *LocalClient) runApplyExecution(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, plan *storage.Plan, options map[string]string, releaseAtCutoverBarrier bool) {
 	if c.usesGroupedApply(apply, options) {
 		c.runWithRecovery(ctx, apply, tasks, func() {

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -1222,9 +1222,10 @@ func (c *LocalClient) syncAtomicTaskProgress(ctx context.Context, tasks []*stora
 // of a live re-query. It runs only inside the operator's lease-held drive: a
 // multi-operation fan-out drive holds the operation lease, a single-operation
 // (whole-apply) drive holds the apply lease, and UpsertShardProgress accepts
-// either. Read-path callers carry neither lease and skip, so a plain progress
-// read never writes. A failed shard write is logged, not fatal — the next
-// reconcile re-applies it.
+// either. Every drive runs under an operator claim, so a poll context without
+// a lease is an invariant violation: the per-shard breakdown would silently
+// stop persisting, which is warned loudly rather than skipped quietly. A
+// failed shard write is logged, not fatal — the next reconcile re-applies it.
 func (c *LocalClient) writeShardProgress(ctx context.Context, table *storage.Task, tp *engine.TableProgress, now time.Time) {
 	if len(tp.Shards) == 0 {
 		return
@@ -1232,6 +1233,8 @@ func (c *LocalClient) writeShardProgress(ctx context.Context, table *storage.Tas
 	_, hasOpLease := storage.OperationLeaseFromContext(ctx)
 	_, hasApplyLease := storage.ApplyLeaseFromContext(ctx)
 	if !hasOpLease && !hasApplyLease {
+		c.logger.Warn("per-shard progress will not be persisted: drive context carries no operation or apply lease",
+			append(table.LogAttrs(), "namespace", table.Namespace, "shard_count", len(tp.Shards))...)
 		return
 	}
 	var operationID int64

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -148,9 +148,10 @@ type LocalConfig struct {
 	// quarantine so DROP TABLE executes directly).
 	Metadata map[string]string
 
-	// WakeOperator notifies the owner loop after an external control request is
-	// recorded. The callback must not execute control actions itself; it only
-	// nudges the storage-claiming operator to process durable intent promptly.
+	// WakeOperator notifies the owner loop after durable work is recorded — a
+	// queued apply from a dispatch, or an external control request. The callback
+	// must not execute the work itself; it only nudges the storage-claiming
+	// operator to pick it up promptly instead of waiting out the poll interval.
 	WakeOperator func(applyIdentifier, database, environment string)
 
 	// EngineFactories supplies engine implementations for database types this
@@ -196,7 +197,9 @@ type LocalClient struct {
 	observers  map[int64]ProgressObserver // keyed by apply ID
 
 	// pendingObserver is consumed by the next direct Apply() call and registered
-	// before Spirit starts.
+	// under the created apply's ID before the operator picks the apply up; the
+	// operator drives through this same client instance, so the drive finds the
+	// observer in the registry.
 	// Protected by observerMu.
 	pendingObserver ProgressObserver
 }
@@ -271,7 +274,11 @@ func (c *LocalClient) IsRemote() bool { return false }
 // Endpoint returns the database name for this local client.
 func (c *LocalClient) Endpoint() string { return c.config.Database }
 
-func (c *LocalClient) wakeOperatorForControlRequest(apply *storage.Apply) {
+// wakeOperator nudges the storage-claiming operator to pick up durable work
+// recorded for the apply — a queued dispatch or a control request — promptly
+// instead of waiting out the poll interval. Without a configured callback
+// (library and test use) the operator's next poll picks the work up.
+func (c *LocalClient) wakeOperator(apply *storage.Apply) {
 	if c.config.WakeOperator == nil {
 		c.logger.Debug("operator wake skipped because no wake callback is configured",
 			"apply_id", apply.ApplyIdentifier,
@@ -1958,13 +1965,14 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 	}
 	apply.ID = applyID
 
-	// Log apply started
+	// Record the queue event in the apply's durable log; the drive itself starts
+	// when an operator claims the apply, which the timeline records separately.
 	c.logApplyEvent(ctx, applyID, nil, storage.LogLevelInfo, storage.LogEventInfo, storage.LogSourceSchemaBot,
-		fmt.Sprintf("Apply started: %s", applyIdentifier), "", state.Apply.Pending)
+		fmt.Sprintf("Apply queued: %s", applyIdentifier), "", state.Apply.Pending)
 
-	// Direct client calls can still register a pending observer before starting
-	// the engine. API-created applies use the service-level observer registry
-	// because operator drivers dispatch them asynchronously.
+	// Register any pending observer under the created apply's ID before queueing.
+	// The operator drives through this same client instance, so the drive finds
+	// the observer in the registry regardless of when the claim happens.
 	if obs := c.consumePendingObserver(); obs != nil {
 		// Set the apply ID on the observer if it supports it (e.g., CommentObserver
 		// needs the ID to look up tracked comments for editing).
@@ -1975,13 +1983,14 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 		c.SetObserver(apply.ID, obs)
 	}
 
-	// Start apply in background with cancellable context (Stop() cancels this)
-	applyCtx, cancelApply := context.WithCancel(context.WithoutCancel(ctx))
-	cancelGeneration := c.setApplyCancel(cancelApply)
-	// A fresh dispatch (including a remote gRPC drive) has no operation context,
-	// so it never auto-parks at the cutover barrier; ordered-cutover parking is
-	// driven by the operator's operation-scoped resume path.
-	c.startApplyExecution(applyCtx, cancelGeneration, cancelApply, apply, tasks, plan, options, false)
+	// The apply is queued, not driven here: every drive — the initial dispatch
+	// included — runs under an operator claim, so lease-guarded writes (per-shard
+	// progress write-through, operation state) always hold the capability they
+	// require. The operator's pending-claim picks the apply up; the wake makes
+	// that prompt instead of waiting out the poll interval.
+	c.logger.Info("Apply: queued for operator drive",
+		append(apply.LogAttrs(), "plan_id", plan.PlanIdentifier)...)
+	c.wakeOperator(apply)
 
 	return &ternv1.ApplyResponse{
 		Accepted:         true,

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -274,13 +274,31 @@ func (c *LocalClient) IsRemote() bool { return false }
 // Endpoint returns the database name for this local client.
 func (c *LocalClient) Endpoint() string { return c.config.Database }
 
-// wakeOperator nudges the storage-claiming operator to pick up durable work
-// recorded for the apply — a queued dispatch or a control request — promptly
-// instead of waiting out the poll interval. Without a configured callback
-// (library and test use) the operator's next poll picks the work up.
+// wakeOperator nudges the storage-claiming operator to pick up a durable
+// control request recorded for the apply promptly instead of waiting out the
+// poll interval. A skipped control-request wake only delays processing — the
+// request is serviced when the operator next claims the (already claimable)
+// apply — so the skip is expected in library and test use and logged at Debug.
+// Queued applies use wakeOperatorForQueuedApply, whose skip can strand work.
 func (c *LocalClient) wakeOperator(apply *storage.Apply) {
 	if c.config.WakeOperator == nil {
-		c.logger.Debug("operator wake skipped because no wake callback is configured",
+		c.logger.Debug("operator wake skipped because no wake callback is configured; the control request will be processed when an operator next claims this apply",
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"environment", apply.Environment)
+		return
+	}
+	c.config.WakeOperator(apply.ApplyIdentifier, apply.Database, apply.Environment)
+}
+
+// wakeOperatorForQueuedApply nudges the operator to claim a newly queued apply.
+// Unlike a control-request wake, a skipped wake here is not benign: every drive
+// runs under an operator claim, so a queued apply makes no progress until an
+// operator polling this storage claims it — and in an embedding that runs no
+// operator at all, it will never be driven.
+func (c *LocalClient) wakeOperatorForQueuedApply(apply *storage.Apply) {
+	if c.config.WakeOperator == nil {
+		c.logger.Warn("operator wake skipped because no wake callback is configured; the queued apply will not be driven until an operator polling this storage claims it",
 			"apply_id", apply.ApplyIdentifier,
 			"database", apply.Database,
 			"environment", apply.Environment)
@@ -1841,20 +1859,15 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 		caller = options["caller"]
 	}
 
-	deferCutover := options["defer_cutover"] == "true"
-	allowUnsafe := options["allow_unsafe"] == "true"
-
-	// Build typed ApplyOptions for storage (booleans, not strings).
-	// Revert window is ON by default — only disabled when skip_revert is explicitly set.
-	skipRevert := options["skip_revert"] == "true"
-	deferDeploy := options["defer_deploy"] == "true"
-	applyOpts := storage.ApplyOptions{
-		DeferCutover: deferCutover,
-		DeferDeploy:  deferDeploy,
-		AllowUnsafe:  allowUnsafe,
-		SkipRevert:   skipRevert,
-		Target:       plan.Target,
-	}
+	// Build typed ApplyOptions for storage from the full wire option map, so
+	// every engine-relevant option the dispatch carried (branch, volume,
+	// rollback, ...) survives the round trip into the stored apply — the queued
+	// operator drive re-derives its options from the stored apply, not from this
+	// request. Revert window is ON by default — only disabled when skip_revert
+	// is explicitly set. The plan's validated target is authoritative over any
+	// target string the request carried.
+	applyOpts := storage.ApplyOptionsFromMap(options)
+	applyOpts.Target = plan.Target
 	if err := rejectUnsafeDDLChangesWithoutOptIn(plan.PlanIdentifier, ddlChanges, applyOpts); err != nil {
 		return &ternv1.ApplyResponse{
 			Accepted:     false,
@@ -1990,7 +2003,7 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 	// that prompt instead of waiting out the poll interval.
 	c.logger.Info("Apply: queued for operator drive",
 		append(apply.LogAttrs(), "plan_id", plan.PlanIdentifier)...)
-	c.wakeOperator(apply)
+	c.wakeOperatorForQueuedApply(apply)
 
 	return &ternv1.ApplyResponse{
 		Accepted:         true,

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -1984,8 +1984,12 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 		fmt.Sprintf("Apply queued: %s", applyIdentifier), "", state.Apply.Pending)
 
 	// Register any pending observer under the created apply's ID before queueing.
-	// The operator drives through this same client instance, so the drive finds
-	// the observer in the registry regardless of when the claim happens.
+	// The observer registry is per-client-instance: in-process dispatchers — the
+	// only callers that set a pending observer — resolve this client from the
+	// same client cache (service client map or target router) the operator's
+	// drive resolves it from, so the drive finds the observer regardless of when
+	// the claim happens. Wire dispatches never set a pending observer, so a
+	// data-plane operator driving through its own client has no observer to lose.
 	if obs := c.consumePendingObserver(); obs != nil {
 		// Set the apply ID on the observer if it supports it (e.g., CommentObserver
 		// needs the ID to look up tracked comments for editing).

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -3983,3 +3983,82 @@ func TestLocalClient_AtomicRetryableFailureQueuesOperatorRetry(t *testing.T) {
 		}
 	}
 }
+
+// A dispatched apply's engine options must survive the queue: the operator
+// drive re-derives its options from the stored apply, so an option dropped at
+// persistence time is silently lost — a --branch the user asked to reuse would
+// see the engine create a fresh branch instead. The full wire option map must
+// round-trip into storage and back out to the engine's ApplyRequest.
+func TestLocalClient_ApplyPersistsBranchOptionForQueuedDrive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+	cleanupTestTables(t, dsn)
+
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	stor := createStorage(t, dsn)
+	defer utils.CloseAndLog(stor)
+
+	client, err := NewLocalClient(LocalConfig{
+		Database:  "testdb",
+		Type:      storage.DatabaseTypeMySQL,
+		TargetDSN: dsn,
+	}, stor, logger)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(client)
+	eng := &stagedGroupedResumeEngine{}
+	client.spiritEngine = eng
+
+	plan := &storage.Plan{
+		PlanIdentifier: fmt.Sprintf("plan-branch-%d", time.Now().UnixNano()),
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Deployment:     "testdb",
+		Environment:    localClientTestEnvironment,
+		CreatedAt:      time.Now(),
+		Namespaces: map[string]*storage.NamespacePlanData{
+			"testdb": {
+				Tables: []storage.TableChange{
+					{Namespace: "testdb", Table: "users", DDL: "ALTER TABLE `users` ADD COLUMN branch_note VARCHAR(255)", Operation: "alter"},
+				},
+			},
+		},
+	}
+	planID, err := stor.Plans().Create(ctx, plan)
+	require.NoError(t, err)
+	plan.ID = planID
+
+	resp, err := client.Apply(ctx, &ternv1.ApplyRequest{
+		PlanId:      plan.PlanIdentifier,
+		Database:    "testdb",
+		Type:        storage.DatabaseTypeMySQL,
+		Environment: localClientTestEnvironment,
+		Options: map[string]string{
+			"branch":        "reuse-me",
+			"defer_cutover": "true",
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, resp.Accepted)
+
+	stored, err := stor.Applies().GetByApplyIdentifier(ctx, resp.ApplyId)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	storedOpts := stored.GetOptions()
+	assert.Equal(t, "reuse-me", storedOpts.Branch, "the dispatched branch option must be persisted on the apply")
+	assert.True(t, storedOpts.DeferCutover, "the dispatched defer_cutover option must be persisted on the apply")
+
+	driveNextQueuedApply(t, stor, client)
+
+	require.NotEmpty(t, eng.applyRequests, "the queued drive must reach the engine")
+	engineOptions := eng.applyRequests[len(eng.applyRequests)-1].Options
+	assert.Equal(t, "reuse-me", engineOptions["branch"],
+		"the queued drive's engine request must carry the dispatched branch option")
+	assert.Equal(t, "true", engineOptions["defer_cutover"],
+		"the queued drive's engine request must carry the dispatched defer_cutover option")
+}

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -221,6 +221,72 @@ func buildSchemaWithAllTables(t *testing.T, dsn string, testTableSchemas map[str
 	return schemaFiles
 }
 
+// startTestOperator mimics the server's operator drivers for tests that
+// dispatch through LocalClient.Apply. Apply queues the apply for the operator
+// (every drive runs under an operator claim), so a test that expects the apply
+// to make progress needs this loop: it claims work exactly like api.Service
+// drivers — FindNextApply under an owner, the claim's apply lease on the drive
+// context — and drives each claim via ResumeApply. Stops when the test ends.
+func startTestOperator(t *testing.T, stor storage.Storage, client *LocalClient) {
+	t.Helper()
+	ctx := t.Context()
+	owner := "test-operator-" + t.Name()
+	// Log through the client's logger, not t.Logf: the drive goroutine can
+	// outlive the test body, and t.Logf after the test ends panics. Drive
+	// failures surface as apply state, which the tests assert on.
+	go func() {
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				apply, err := stor.Applies().FindNextApply(ctx, owner)
+				if err != nil {
+					// Storage failure, not no-work: without this log the test only
+					// hangs to its timeout with zero diagnostics.
+					if ctx.Err() == nil {
+						client.logger.Warn("test operator: claim failed", "owner", owner, "error", err)
+					}
+					continue
+				}
+				if apply == nil {
+					// No claimable work — keep polling.
+					continue
+				}
+				driveCtx := storage.WithApplyLease(ctx, apply.Lease())
+				go func() {
+					if err := client.ResumeApply(driveCtx, apply); err != nil && ctx.Err() == nil {
+						client.logger.Warn("test operator: resume apply failed", "apply_id", apply.ApplyIdentifier, "error", err)
+					}
+				}()
+			}
+		}
+	}()
+}
+
+// driveNextQueuedApply claims the next queued apply the way an operator driver
+// does — FindNextApply under an owner, the claim's apply lease on the drive
+// context — and drives it synchronously until the drive returns. For tests that
+// assert on a settled post-drive state (a retryable-failure pause), where the
+// continuous test operator would immediately re-claim and retry.
+func driveNextQueuedApply(t *testing.T, stor storage.Storage, client *LocalClient) {
+	t.Helper()
+	ctx := t.Context()
+	owner := "test-operator-" + t.Name()
+	var apply *storage.Apply
+	require.Eventually(t, func() bool {
+		var err error
+		apply, err = stor.Applies().FindNextApply(ctx, owner)
+		return err == nil && apply != nil
+	}, 10*time.Second, 50*time.Millisecond, "no queued apply became claimable")
+	driveCtx := storage.WithApplyLease(ctx, apply.Lease())
+	if err := client.ResumeApply(driveCtx, apply); err != nil {
+		t.Logf("drive queued apply %s: %v", apply.ApplyIdentifier, err)
+	}
+}
+
 // waitForApplyComplete polls Progress until the apply reaches a terminal state or times out.
 // Fails the test immediately if the apply enters FAILED state.
 func waitForApplyComplete(t *testing.T, client *LocalClient, ctx context.Context, applyID string) {
@@ -888,6 +954,7 @@ func TestLocalClient_Apply(t *testing.T) {
 	}, stor, logger)
 	require.NoError(t, err, "failed to create client")
 	defer utils.CloseAndLog(client)
+	startTestOperator(t, stor, client)
 
 	// Build schema files including all storage tables to avoid DROP TABLE for them
 	schemaFiles := buildSchemaWithAllTables(t, dsn, map[string]string{
@@ -961,6 +1028,7 @@ func TestLocalClient_Apply_IdempotentDispatch(t *testing.T) {
 	}, stor, logger)
 	require.NoError(t, err, "failed to create client")
 	defer utils.CloseAndLog(client)
+	startTestOperator(t, stor, client)
 
 	schemaFiles := buildSchemaWithAllTables(t, dsn, map[string]string{
 		"users": "CREATE TABLE users (id INT PRIMARY KEY, email VARCHAR(255))",
@@ -1111,6 +1179,9 @@ func TestLocalClient_Apply_WritesApplyOperationRow(t *testing.T) {
 
 	// The apply still runs to completion against the real Spirit engine with the
 	// operation row present (the sequential path is unaffected by the linkage).
+	// The operator starts only after the queued-state assertions above, so the
+	// pending reads are not racing the drive.
+	startTestOperator(t, stor, client)
 	waitForApplyComplete(t, client, ctx, applyResp.ApplyId)
 
 	var columnCount int
@@ -3143,6 +3214,7 @@ func TestLocalClient_Apply_MultiTableSequential(t *testing.T) {
 	}, stor, logger)
 	require.NoError(t, err, "failed to create client")
 	defer utils.CloseAndLog(client)
+	startTestOperator(t, stor, client)
 
 	// Load current schema for all tables (including storage) so the differ
 	// only sees changes for test_users and test_orders.
@@ -3352,6 +3424,7 @@ func TestLocalClient_Apply_AtomicHeartbeat(t *testing.T) {
 	}, stor, logger)
 	require.NoError(t, err)
 	defer utils.CloseAndLog(client)
+	startTestOperator(t, stor, client)
 
 	// Use a short heartbeat interval so the ticker fires during the test
 	client.heartbeatInterval = 1 * time.Second
@@ -3451,6 +3524,7 @@ func TestLocalClient_Apply_AtomicRejectsMultiNamespace(t *testing.T) {
 	}, stor, logger)
 	require.NoError(t, err)
 	defer utils.CloseAndLog(client)
+	startTestOperator(t, stor, client)
 
 	// Create a plan with two namespaces directly in storage
 	plan := &storage.Plan{
@@ -3527,6 +3601,7 @@ func TestLocalClient_Apply_SequentialNamespaceMatchesTask(t *testing.T) {
 	}, stor, logger)
 	require.NoError(t, err)
 	defer utils.CloseAndLog(client)
+	startTestOperator(t, stor, client)
 
 	// Load current schema
 	dbConn, err := sql.Open("mysql", dsn)
@@ -3636,6 +3711,11 @@ func TestLocalClient_Apply_FailedAtomicHasErrorMessage(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, applyResp.Accepted, "apply should be accepted: %s", applyResp.ErrorMessage)
 
+	// Drive exactly one claim: a continuous operator would immediately re-claim
+	// the retryable failure and retry it toward permanent failure, and this test
+	// asserts on the settled first-failure pause.
+	driveNextQueuedApply(t, stor, client)
+
 	// Spirit failures are retryable by default. The first failure should pause
 	// in failed_retryable instead of becoming permanently failed.
 	require.Eventually(t, func() bool {
@@ -3658,6 +3738,91 @@ func TestLocalClient_Apply_FailedAtomicHasErrorMessage(t *testing.T) {
 	assert.Equal(t, state.Task.FailedRetryable, tasks[0].State)
 	assert.Nil(t, tasks[0].CompletedAt)
 	assert.NotEmpty(t, tasks[0].ErrorMessage, "task.ErrorMessage should contain the failure reason")
+}
+
+// A dispatch can create a task-less apply — a sharded dispatch for a shard
+// whose schema already matches produces zero tasks, and a VSchema-only apply
+// carries only the operation row. Queued applies are driven by the operator,
+// so the claim must accept the task-less shape through its dual-written
+// operation row, and the drive must then settle it: here, complete the
+// no-work apply as a no-op rather than leaving it pending forever.
+func TestLocalClient_ResumeApply_TasklessQueuedApplyCompletesNoOp(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+	cleanupTestTables(t, dsn)
+
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	stor := createStorage(t, dsn)
+
+	client, err := NewLocalClient(LocalConfig{
+		Database:  "testdb",
+		Type:      "mysql",
+		TargetDSN: dsn,
+	}, stor, logger)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(client)
+
+	// A plan with DDL work but a dispatch that scoped to no tasks — the
+	// sharded no-op shape (this shard's schema already matches).
+	plan := &storage.Plan{
+		PlanIdentifier: fmt.Sprintf("plan-%d", time.Now().UnixNano()),
+		Database:       "testdb",
+		DatabaseType:   "mysql",
+		CreatedAt:      time.Now(),
+		Namespaces: map[string]*storage.NamespacePlanData{
+			"testdb": {
+				Tables: []storage.TableChange{
+					{Namespace: "testdb", Table: "users", DDL: "ALTER TABLE `users` ADD COLUMN x INT", Operation: "alter"},
+				},
+			},
+		},
+	}
+	planID, err := stor.Plans().Create(ctx, plan)
+	require.NoError(t, err)
+
+	now := time.Now()
+	apply := &storage.Apply{
+		ApplyIdentifier: "apply-taskless-noop",
+		PlanID:          planID,
+		Database:        "testdb",
+		DatabaseType:    "mysql",
+		Deployment:      "testdb",
+		Environment:     "staging",
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Pending,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	applyID, err := stor.Applies().CreateWithTasksAndOperations(ctx, apply, nil, []*storage.ApplyOperation{{
+		Deployment: apply.Deployment,
+		State:      state.ApplyOperation.Pending,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}})
+	require.NoError(t, err)
+	apply.ID = applyID
+
+	// Claim it the way the operator does — the operation row makes the
+	// task-less pending apply claimable.
+	claimed, err := stor.Applies().FindNextApply(ctx, "test-operator-"+t.Name())
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "task-less pending apply with an operation row must be claimable")
+	require.Equal(t, apply.ApplyIdentifier, claimed.ApplyIdentifier)
+
+	driveCtx := storage.WithApplyLease(ctx, claimed.Lease())
+	require.NoError(t, client.ResumeApply(driveCtx, claimed), "driving a task-less no-op apply must succeed")
+
+	persisted, err := stor.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, state.Apply.Completed, persisted.State, "a no-work apply must complete as a no-op, not stay pending or fail")
+	assert.NotNil(t, persisted.CompletedAt, "the no-op completion must stamp completed_at")
 }
 
 func TestLocalClient_AtomicRetryableFailureQueuesOperatorRetry(t *testing.T) {

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -224,7 +224,7 @@ func (c *LocalClient) queueCutoverRequest(ctx context.Context, apply *storage.Ap
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventCutoverTriggered, storage.LogSourceSchemaBot,
 			fmt.Sprintf("Cutover request queued for apply owner%s", callerApplyLogSuffix(requestedBy)), "", "")
 	}
-	c.wakeOperatorForControlRequest(apply)
+	c.wakeOperator(apply)
 	return &ternv1.CutoverResponse{Accepted: true}, nil
 }
 
@@ -399,7 +399,7 @@ func (c *LocalClient) requestCancel(ctx context.Context, req *ternv1.CancelReque
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventCancelRequested, storage.LogSourceSchemaBot,
 			fmt.Sprintf("Cancel request queued for apply owner%s", callerApplyLogSuffix(requestedBy)), "", "")
 	}
-	c.wakeOperatorForControlRequest(apply)
+	c.wakeOperator(apply)
 	return &ternv1.CancelResponse{Accepted: true}, nil
 }
 
@@ -458,7 +458,7 @@ func (c *LocalClient) requestStop(ctx context.Context, req *ternv1.StopRequest, 
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested, storage.LogSourceSchemaBot,
 			fmt.Sprintf("Stop request queued for apply owner%s", callerApplyLogSuffix(requestedBy)), "", "")
 	}
-	c.wakeOperatorForControlRequest(apply)
+	c.wakeOperator(apply)
 	return &ternv1.StopResponse{Accepted: true}, nil
 }
 

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -551,7 +551,17 @@ func (c *LocalClient) stopOwnedApply(ctx context.Context, req *ternv1.StopReques
 	}
 
 	if stoppedCount == 0 && skippedCount == 0 {
-		return nil, fmt.Errorf("no active schema change")
+		// No apply was resolved and the database has no targetable tasks: there
+		// is genuinely nothing to stop.
+		if targetApply == nil {
+			return nil, fmt.Errorf("no active schema change")
+		}
+		// A resolved apply with no targetable tasks is the task-less shape (a
+		// queued apply stopped before its first drive created tasks). The apply
+		// row itself is still active work, so settle it directly — erroring here
+		// would leave the durable stop request pending and the apply re-claimed
+		// on every operator poll forever.
+		return c.settleStopForTasklessApply(ctx, targetApply, caller)
 	}
 
 	// Edge case: stop was requested but every targeted task is already
@@ -627,7 +637,18 @@ func (c *LocalClient) cancelOwnedApply(ctx context.Context, req *ternv1.CancelRe
 			eventMsg, "", "")
 	}
 	if cancelledCount == 0 && skippedCount == 0 {
-		return nil, fmt.Errorf("no active schema change")
+		// No apply was resolved and the database has no targetable tasks: there
+		// is genuinely nothing to cancel.
+		if targetApply == nil {
+			return nil, fmt.Errorf("no active schema change")
+		}
+		// A resolved apply with no targetable tasks is the task-less shape (a
+		// queued apply cancelled before its first drive created tasks, or a
+		// VSchema-only apply that never has any). The apply row itself is still
+		// active work, so settle it directly — erroring here would leave the
+		// durable cancel request pending and the apply re-claimed on every
+		// operator poll forever.
+		return c.settleCancelForTasklessApply(ctx, targetApply, caller)
 	}
 	if cancelledCount == 0 && skippedCount > 0 && applyID > 0 {
 		if targetApply != nil && state.IsState(targetApply.State, state.Apply.Cancelled) {
@@ -642,6 +663,116 @@ func (c *LocalClient) cancelOwnedApply(ctx context.Context, req *ternv1.CancelRe
 		CancelledCount: cancelledCount,
 		SkippedCount:   skippedCount,
 	}, nil
+}
+
+// resolveTasklessApplyForSettle reloads a control-targeted apply and confirms
+// it truly owns no tasks, so a stop or cancel that found no task work can
+// settle the apply row directly. A queued apply claimed before its first drive
+// (and a VSchema-only apply, which never has tasks) is exactly this shape: the
+// apply is active work with nothing for the engine or task paths to act on.
+// Returns the freshly loaded apply. Fails closed — settling would abandon live
+// work — when the apply cannot be reloaded or when it does own tasks that this
+// client's database-scoped task read could not see.
+func (c *LocalClient) resolveTasklessApplyForSettle(ctx context.Context, targetApply *storage.Apply, operation string) (*storage.Apply, error) {
+	tasks, err := c.storage.Tasks().GetByApplyID(ctx, targetApply.ID)
+	if err != nil {
+		return nil, fmt.Errorf("load tasks for apply %s before task-less %s settle: %w", targetApply.ApplyIdentifier, operation, err)
+	}
+	if len(tasks) > 0 {
+		c.logger.Warn(operation+" found no targetable tasks in this client's database scope, but the apply owns tasks; failing closed rather than settling over unseen task work",
+			append(targetApply.LogAttrs(), "task_count", len(tasks), "client_database", c.config.Database)...)
+		return nil, fmt.Errorf("%s cannot settle apply %s: its %d tasks are outside this client's database scope (%s)",
+			operation, targetApply.ApplyIdentifier, len(tasks), c.config.Database)
+	}
+	apply, err := c.storage.Applies().Get(ctx, targetApply.ID)
+	if err != nil {
+		return nil, fmt.Errorf("reload apply %s before task-less %s settle: %w", targetApply.ApplyIdentifier, operation, err)
+	}
+	if apply == nil {
+		return nil, fmt.Errorf("reload apply %s before task-less %s settle: %w", targetApply.ApplyIdentifier, operation, storage.ErrApplyNotFound)
+	}
+	return apply, nil
+}
+
+// settleCancelForTasklessApply terminalizes a cancel whose resolved apply owns
+// no tasks. There is no task or engine work to cancel, but the apply row itself
+// is still active work: it settles to cancelled through the existing
+// markApplyCancelled path so the durable cancel request completes, the terminal
+// observer is notified, and the operator never re-claims the apply — mirroring
+// what the tasked cancel path does after markTasksWithState. Terminal states
+// are never rewritten: an already-cancelled apply is accepted idempotently, and
+// a completed/failed/reverted apply keeps its outcome (only a stopped apply,
+// which cancel may still terminate, is moved to cancelled).
+func (c *LocalClient) settleCancelForTasklessApply(ctx context.Context, targetApply *storage.Apply, caller string) (*ternv1.CancelResponse, error) {
+	apply, err := c.resolveTasklessApplyForSettle(ctx, targetApply, "cancel")
+	if err != nil {
+		return nil, err
+	}
+	if state.IsTerminalApplyState(apply.State) && !state.IsState(apply.State, state.Apply.Stopped) {
+		c.logger.Info("cancel found task-less apply already terminal; accepting without a state change",
+			append(apply.LogAttrs(), "requested_by", caller)...)
+		return &ternv1.CancelResponse{Accepted: true}, nil
+	}
+	previousState := apply.State
+	if err := c.markApplyCancelled(ctx, apply.ID); err != nil {
+		return nil, err
+	}
+	eventMsg := "Cancel requested: task-less apply cancelled before any task work started"
+	if caller != "" {
+		eventMsg += callerApplyLogSuffix(caller)
+	}
+	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventCancelRequested, storage.LogSourceSchemaBot,
+		eventMsg, previousState, state.Apply.Cancelled)
+	now := time.Now()
+	apply.State = state.Apply.Cancelled
+	apply.CompletedAt = &now
+	apply.UpdatedAt = now
+	c.logger.Info("cancel settled task-less apply as cancelled",
+		append(apply.LogAttrs(), "previous_state", previousState, "requested_by", caller)...)
+	c.notifyTerminalObserver(apply, nil)
+	return &ternv1.CancelResponse{Accepted: true}, nil
+}
+
+// settleStopForTasklessApply terminalizes a stop whose resolved apply owns no
+// tasks. There is no task or engine work to stop, but the apply row itself is
+// still active work: it settles to stopped through the existing
+// markApplyStopped path so the durable stop request completes, the terminal
+// observer is notified, and the operator never re-claims the apply — mirroring
+// what the tasked stop path does after markTasksWithState. The apply settles to
+// stopped (not cancelled): stop is the resumable operator verb, and a stopped
+// task-less apply stays eligible for a later cancel. Terminal states are never
+// rewritten: an already-terminal apply (stopped included) is accepted without a
+// state change so the pending stop request resolves.
+func (c *LocalClient) settleStopForTasklessApply(ctx context.Context, targetApply *storage.Apply, caller string) (*ternv1.StopResponse, error) {
+	apply, err := c.resolveTasklessApplyForSettle(ctx, targetApply, "stop")
+	if err != nil {
+		return nil, err
+	}
+	if state.IsTerminalApplyState(apply.State) {
+		c.logger.Info("stop found task-less apply already terminal; accepting without a state change",
+			append(apply.LogAttrs(), "requested_by", caller)...)
+		return &ternv1.StopResponse{
+			Accepted:     true,
+			ErrorMessage: fmt.Sprintf("Schema change already %s", apply.State),
+		}, nil
+	}
+	previousState := apply.State
+	if err := c.markApplyStopped(ctx, apply.ID); err != nil {
+		return nil, err
+	}
+	eventMsg := "Stop requested: task-less apply stopped before any task work started"
+	if caller != "" {
+		eventMsg += callerApplyLogSuffix(caller)
+	}
+	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested, storage.LogSourceSchemaBot,
+		eventMsg, previousState, state.Apply.Stopped)
+	apply.State = state.Apply.Stopped
+	apply.CompletedAt = nil
+	apply.UpdatedAt = time.Now()
+	c.logger.Info("stop settled task-less apply as stopped",
+		append(apply.LogAttrs(), "previous_state", previousState, "requested_by", caller)...)
+	c.notifyTerminalObserver(apply, nil)
+	return &ternv1.StopResponse{Accepted: true}, nil
 }
 
 // stopHandledUnlessStartPending reports a completed stop as handled unless a

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -702,7 +702,9 @@ func (c *LocalClient) resolveTasklessApplyForSettle(ctx context.Context, targetA
 // what the tasked cancel path does after markTasksWithState. Terminal states
 // are never rewritten: an already-cancelled apply is accepted idempotently, and
 // a completed/failed/reverted apply keeps its outcome (only a stopped apply,
-// which cancel may still terminate, is moved to cancelled).
+// which cancel may still terminate, is moved to cancelled). The apply's
+// dual-written apply_operations rows settle to cancelled alongside it, so
+// operation-level claiming never sees a live operation under a cancelled apply.
 func (c *LocalClient) settleCancelForTasklessApply(ctx context.Context, targetApply *storage.Apply, caller string) (*ternv1.CancelResponse, error) {
 	apply, err := c.resolveTasklessApplyForSettle(ctx, targetApply, "cancel")
 	if err != nil {
@@ -729,8 +731,75 @@ func (c *LocalClient) settleCancelForTasklessApply(ctx context.Context, targetAp
 	apply.UpdatedAt = now
 	c.logger.Info("cancel settled task-less apply as cancelled",
 		append(apply.LogAttrs(), "previous_state", previousState, "requested_by", caller)...)
+	c.settleOperationRowsForTasklessApply(ctx, apply, state.ApplyOperation.Cancelled)
 	c.notifyTerminalObserver(apply, nil)
 	return &ternv1.CancelResponse{Accepted: true}, nil
+}
+
+// settleOperationRowsForTasklessApply moves the settled apply's dual-written
+// apply_operations rows to the apply's settled state so the operation rows
+// agree with the apply row the task-less settle just wrote. The settle runs
+// inside a claimed drive, so the lease in ctx guards each write and a lost
+// claim fails closed in storage. A load or write failure is logged, never
+// returned: the apply-level settle is the authoritative outcome, and the next
+// operation claim's terminal-parent reconciliation settles any row this pass
+// could not move.
+func (c *LocalClient) settleOperationRowsForTasklessApply(ctx context.Context, apply *storage.Apply, operationState string) {
+	ops, err := c.storage.ApplyOperations().ListByApply(ctx, apply.ID)
+	if err != nil {
+		c.logger.Error("task-less settle could not load operation rows; the apply is settled and the next operation claim will reconcile them",
+			append(apply.LogAttrs(), "target_operation_state", operationState, "error", err)...)
+		return
+	}
+	for _, op := range ops {
+		if !operationRowSettlesWithTasklessApply(op.State, operationState) {
+			c.logger.Info("task-less settle leaving terminal operation row unchanged",
+				append(apply.LogAttrs(),
+					"apply_operation_id", op.ID,
+					"operation_deployment", op.Deployment,
+					"operation_state", op.State,
+					"target_operation_state", operationState)...)
+			continue
+		}
+		var writeErr error
+		if state.IsState(operationState, state.ApplyOperation.Stopped) {
+			// stopped is resumable: mirror the state but keep completed_at nil,
+			// matching the apply-level convention.
+			writeErr = c.storage.ApplyOperations().UpdateState(ctx, op.ID, operationState)
+		} else {
+			writeErr = c.storage.ApplyOperations().MarkTerminal(ctx, op.ID, operationState)
+		}
+		if writeErr != nil {
+			c.logger.Error("task-less settle could not move operation row to the apply's settled state; the next operation claim will reconcile it",
+				append(apply.LogAttrs(),
+					"apply_operation_id", op.ID,
+					"operation_deployment", op.Deployment,
+					"operation_state", op.State,
+					"target_operation_state", operationState,
+					"error", writeErr)...)
+			continue
+		}
+		c.logger.Info("task-less settle moved operation row to the apply's settled state",
+			append(apply.LogAttrs(),
+				"apply_operation_id", op.ID,
+				"operation_deployment", op.Deployment,
+				"previous_operation_state", op.State,
+				"operation_state", operationState)...)
+	}
+}
+
+// operationRowSettlesWithTasklessApply reports whether a task-less settle may
+// move an operation row from its current state to the apply's settled state.
+// It mirrors the apply-level settle's terminal discipline: a terminal row keeps
+// its outcome, except that a cancel settle still terminalizes a stopped row —
+// stopped is the one terminal state cancel may move, exactly as the apply-level
+// cancel settle moves a stopped apply to cancelled.
+func operationRowSettlesWithTasklessApply(currentState, settledState string) bool {
+	if !state.IsApplyOperationTerminal(currentState) {
+		return true
+	}
+	return state.IsState(settledState, state.ApplyOperation.Cancelled) &&
+		state.IsState(currentState, state.ApplyOperation.Stopped)
 }
 
 // settleStopForTasklessApply terminalizes a stop whose resolved apply owns no
@@ -742,7 +811,9 @@ func (c *LocalClient) settleCancelForTasklessApply(ctx context.Context, targetAp
 // stopped (not cancelled): stop is the resumable operator verb, and a stopped
 // task-less apply stays eligible for a later cancel. Terminal states are never
 // rewritten: an already-terminal apply (stopped included) is accepted without a
-// state change so the pending stop request resolves.
+// state change so the pending stop request resolves. The apply's dual-written
+// apply_operations rows settle to stopped alongside it, keeping the resumable
+// operation rows consistent with the stopped apply.
 func (c *LocalClient) settleStopForTasklessApply(ctx context.Context, targetApply *storage.Apply, caller string) (*ternv1.StopResponse, error) {
 	apply, err := c.resolveTasklessApplyForSettle(ctx, targetApply, "stop")
 	if err != nil {
@@ -771,6 +842,7 @@ func (c *LocalClient) settleStopForTasklessApply(ctx context.Context, targetAppl
 	apply.UpdatedAt = time.Now()
 	c.logger.Info("stop settled task-less apply as stopped",
 		append(apply.LogAttrs(), "previous_state", previousState, "requested_by", caller)...)
+	c.settleOperationRowsForTasklessApply(ctx, apply, state.ApplyOperation.Stopped)
 	c.notifyTerminalObserver(apply, nil)
 	return &ternv1.StopResponse{Accepted: true}, nil
 }

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -57,7 +57,7 @@ func (c *LocalClient) Start(ctx context.Context, req *ternv1.StartRequest) (*ter
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStartRequested, storage.LogSourceSchemaBot,
 			"Start request queued for apply owner", "", "")
 	}
-	c.wakeOperatorForControlRequest(apply)
+	c.wakeOperator(apply)
 	return &ternv1.StartResponse{
 		Accepted:     true,
 		StartedCount: startedCount,
@@ -939,7 +939,10 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 		return fmt.Errorf("get tasks for apply %s: %w", apply.ApplyIdentifier, err)
 	}
 	// Whole-apply scope has no single operation to order, so the stored apply
-	// options govern the drive directly (no automatic barrier park).
+	// options govern the drive directly (no automatic barrier park). A task-less
+	// apply is handled inside the shared resume path: VSchema-only plans are
+	// re-driven so the VSchema is applied, and any other task-less shape (e.g. a
+	// sharded dispatch whose shard already matches) completes as a no-op.
 	return c.resumeApplyWithTasks(ctx, apply, tasks, apply.GetOptions().Map(), false, false)
 }
 

--- a/pkg/tern/local_control_taskless_integration_test.go
+++ b/pkg/tern/local_control_taskless_integration_test.go
@@ -1,0 +1,291 @@
+//go:build integration
+
+package tern
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/engine"
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// invocationTrackingEngine records every engine call so a test can prove a
+// drive settled entirely in storage without touching the engine — the invariant
+// for cancelling or stopping a queued apply that has no tasks yet.
+type invocationTrackingEngine struct {
+	engine.Engine
+
+	mu    sync.Mutex
+	calls []string
+}
+
+func (e *invocationTrackingEngine) record(call string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.calls = append(e.calls, call)
+}
+
+func (e *invocationTrackingEngine) recorded() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return slices.Clone(e.calls)
+}
+
+func (e *invocationTrackingEngine) Name() string { return "invocation-tracking" }
+
+func (e *invocationTrackingEngine) Plan(context.Context, *engine.PlanRequest) (*engine.PlanResult, error) {
+	e.record("Plan")
+	return &engine.PlanResult{}, nil
+}
+
+func (e *invocationTrackingEngine) Apply(context.Context, *engine.ApplyRequest) (*engine.ApplyResult, error) {
+	e.record("Apply")
+	return &engine.ApplyResult{Accepted: true}, nil
+}
+
+func (e *invocationTrackingEngine) Progress(context.Context, *engine.ProgressRequest) (*engine.ProgressResult, error) {
+	e.record("Progress")
+	return &engine.ProgressResult{State: engine.StateCompleted}, nil
+}
+
+func (e *invocationTrackingEngine) Stop(context.Context, *engine.ControlRequest) (*engine.ControlResult, error) {
+	e.record("Stop")
+	return &engine.ControlResult{Accepted: true}, nil
+}
+
+func (e *invocationTrackingEngine) Cancel(context.Context, *engine.ControlRequest) (*engine.ControlResult, error) {
+	e.record("Cancel")
+	return &engine.ControlResult{Accepted: true}, nil
+}
+
+func (e *invocationTrackingEngine) Start(context.Context, *engine.ControlRequest) (*engine.ControlResult, error) {
+	e.record("Start")
+	return &engine.ControlResult{Accepted: true}, nil
+}
+
+// newTasklessControlClient builds a MySQL-type LocalClient backed by the shared
+// container with an invocation-tracking engine installed, for control tests on
+// queued applies.
+func newTasklessControlClient(t *testing.T, dsn string, stor storage.Storage) (*LocalClient, *invocationTrackingEngine) {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	client, err := NewLocalClient(LocalConfig{
+		Database:  "testdb",
+		Type:      storage.DatabaseTypeMySQL,
+		TargetDSN: dsn,
+	}, stor, logger)
+	require.NoError(t, err)
+	t.Cleanup(func() { utils.CloseAndLog(client) })
+	eng := &invocationTrackingEngine{}
+	client.spiritEngine = eng
+	return client, eng
+}
+
+// dispatchQueuedApply dispatches an apply through LocalClient.Apply from a plan
+// with the given table changes (none for the task-less shape) and returns the
+// stored apply row, still pending — queued for the operator, not yet driven.
+func dispatchQueuedApply(t *testing.T, stor storage.Storage, client *LocalClient, tables []storage.TableChange) *storage.Apply {
+	t.Helper()
+	ctx := t.Context()
+	plan := &storage.Plan{
+		PlanIdentifier: fmt.Sprintf("plan-taskless-%d", time.Now().UnixNano()),
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Deployment:     "testdb",
+		Environment:    localClientTestEnvironment,
+		CreatedAt:      time.Now(),
+		Namespaces: map[string]*storage.NamespacePlanData{
+			"testdb": {Tables: tables},
+		},
+	}
+	planID, err := stor.Plans().Create(ctx, plan)
+	require.NoError(t, err)
+	plan.ID = planID
+
+	resp, err := client.Apply(ctx, &ternv1.ApplyRequest{
+		PlanId:      plan.PlanIdentifier,
+		Database:    "testdb",
+		Type:        storage.DatabaseTypeMySQL,
+		Environment: localClientTestEnvironment,
+	})
+	require.NoError(t, err)
+	require.True(t, resp.Accepted)
+
+	apply, err := stor.Applies().GetByApplyIdentifier(ctx, resp.ApplyId)
+	require.NoError(t, err)
+	require.NotNil(t, apply)
+	require.Equal(t, state.Apply.Pending, apply.State, "a dispatched apply must be queued, not driven inline")
+	return apply
+}
+
+// requireControlRequestStatus asserts the durable control request for the apply
+// operation reached the given status — the signal that the operator retry loop
+// has stopped re-running the request.
+func requireControlRequestStatus(t *testing.T, stor storage.Storage, applyID int64, operation storage.ControlOperation, want storage.ControlRequestStatus) {
+	t.Helper()
+	req, err := stor.ControlRequests().GetByOperation(t.Context(), applyID, operation)
+	require.NoError(t, err)
+	require.NotNil(t, req, "the %s control request must exist", operation)
+	assert.Equal(t, want, req.Status, "the %s control request must be %s", operation, want)
+}
+
+// A queued apply can be claimed by an operator driver before its first drive
+// has created any tasks, and a cancel can land while it is still queued. The
+// drive that claims it must settle the apply to cancelled directly — there is
+// no task or engine work to cancel — complete the durable cancel request, and
+// leave nothing claimable. Without the settle the cancel would error with "no
+// active schema change", the request would stay pending, and the operator would
+// re-claim and re-drive the apply forever.
+func TestLocalClient_CancelQueuedTasklessApplySettlesCancelled(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+	cleanupTestTables(t, dsn)
+
+	ctx := t.Context()
+	stor := createStorage(t, dsn)
+	defer utils.CloseAndLog(stor)
+	client, eng := newTasklessControlClient(t, dsn, stor)
+
+	apply := dispatchQueuedApply(t, stor, client, nil)
+
+	cancelResp, err := client.Cancel(ctx, &ternv1.CancelRequest{
+		ApplyId:     apply.ApplyIdentifier,
+		Environment: localClientTestEnvironment,
+	})
+	require.NoError(t, err)
+	require.True(t, cancelResp.Accepted)
+	requireControlRequestStatus(t, stor, apply.ID, storage.ControlOperationCancel, storage.ControlRequestPending)
+
+	engineCallsBeforeDrive := eng.recorded()
+	driveNextQueuedApply(t, stor, client)
+
+	settled, err := stor.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, settled)
+	assert.Equal(t, state.Apply.Cancelled, settled.State, "a cancelled queued task-less apply must settle to cancelled")
+	assert.NotNil(t, settled.CompletedAt, "a cancelled apply must carry its completion time")
+
+	requireControlRequestStatus(t, stor, apply.ID, storage.ControlOperationCancel, storage.ControlRequestCompleted)
+	assert.Equal(t, engineCallsBeforeDrive, eng.recorded(),
+		"settling a task-less cancel must never invoke the engine")
+
+	reclaimed, err := stor.Applies().FindNextApply(ctx, "test-reclaim-"+t.Name())
+	require.NoError(t, err)
+	assert.Nil(t, reclaimed, "a cancelled apply must not be claimable again")
+}
+
+// The stop counterpart: a stop that lands on a queued task-less apply (non-Vitess,
+// where stop is supported) settles it to stopped — the resumable operator verb —
+// completes the durable stop request, and leaves nothing claimable.
+func TestLocalClient_StopQueuedTasklessApplySettlesStopped(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+	cleanupTestTables(t, dsn)
+
+	ctx := t.Context()
+	stor := createStorage(t, dsn)
+	defer utils.CloseAndLog(stor)
+	client, eng := newTasklessControlClient(t, dsn, stor)
+
+	apply := dispatchQueuedApply(t, stor, client, nil)
+
+	stopResp, err := client.Stop(ctx, &ternv1.StopRequest{
+		ApplyId:     apply.ApplyIdentifier,
+		Environment: localClientTestEnvironment,
+	})
+	require.NoError(t, err)
+	require.True(t, stopResp.Accepted)
+	requireControlRequestStatus(t, stor, apply.ID, storage.ControlOperationStop, storage.ControlRequestPending)
+
+	engineCallsBeforeDrive := eng.recorded()
+	driveNextQueuedApply(t, stor, client)
+
+	settled, err := stor.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, settled)
+	assert.Equal(t, state.Apply.Stopped, settled.State, "a stopped queued task-less apply must settle to stopped")
+
+	requireControlRequestStatus(t, stor, apply.ID, storage.ControlOperationStop, storage.ControlRequestCompleted)
+	assert.Equal(t, engineCallsBeforeDrive, eng.recorded(),
+		"settling a task-less stop must never invoke the engine")
+
+	reclaimed, err := stor.Applies().FindNextApply(ctx, "test-reclaim-"+t.Name())
+	require.NoError(t, err)
+	assert.Nil(t, reclaimed, "a stopped apply with no pending start must not be claimable again")
+}
+
+// Regression guard for the tasked shape: a cancel that lands on a queued apply
+// WITH tasks still settles through the existing task path — the tasks are marked
+// cancelled, the apply follows, and the durable cancel request completes.
+func TestLocalClient_CancelQueuedApplyWithTasksSettlesViaTaskPath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+	cleanupTestTables(t, dsn)
+
+	ctx := t.Context()
+	stor := createStorage(t, dsn)
+	defer utils.CloseAndLog(stor)
+	client, _ := newTasklessControlClient(t, dsn, stor)
+
+	apply := dispatchQueuedApply(t, stor, client, []storage.TableChange{{
+		Namespace: "testdb",
+		Table:     "users",
+		DDL:       "ALTER TABLE `users` ADD COLUMN cancel_note VARCHAR(255)",
+		Operation: "alter",
+	}})
+
+	tasks, err := stor.Tasks().GetByApplyID(ctx, apply.ID)
+	require.NoError(t, err)
+	require.Len(t, tasks, 1, "the dispatched apply must carry its task")
+
+	cancelResp, err := client.Cancel(ctx, &ternv1.CancelRequest{
+		ApplyId:     apply.ApplyIdentifier,
+		Environment: localClientTestEnvironment,
+	})
+	require.NoError(t, err)
+	require.True(t, cancelResp.Accepted)
+
+	driveNextQueuedApply(t, stor, client)
+
+	settled, err := stor.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, settled)
+	assert.Equal(t, state.Apply.Cancelled, settled.State)
+	assert.NotNil(t, settled.CompletedAt)
+
+	settledTasks, err := stor.Tasks().GetByApplyID(ctx, apply.ID)
+	require.NoError(t, err)
+	require.Len(t, settledTasks, 1)
+	assert.Equal(t, state.Task.Cancelled, settledTasks[0].State,
+		"a cancelled queued apply's task must settle via the task path")
+
+	requireControlRequestStatus(t, stor, apply.ID, storage.ControlOperationCancel, storage.ControlRequestCompleted)
+}

--- a/pkg/tern/local_control_taskless_integration_test.go
+++ b/pkg/tern/local_control_taskless_integration_test.go
@@ -183,6 +183,15 @@ func TestLocalClient_CancelQueuedTasklessApplySettlesCancelled(t *testing.T) {
 	assert.Equal(t, state.Apply.Cancelled, settled.State, "a cancelled queued task-less apply must settle to cancelled")
 	assert.NotNil(t, settled.CompletedAt, "a cancelled apply must carry its completion time")
 
+	ops, err := stor.ApplyOperations().ListByApply(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, ops, "a dispatched apply must dual-write its operation row")
+	for _, op := range ops {
+		assert.Equal(t, state.ApplyOperation.Cancelled, op.State,
+			"the operation row must settle to cancelled alongside its apply")
+		assert.NotNil(t, op.CompletedAt, "a cancelled operation row must carry its completion time")
+	}
+
 	requireControlRequestStatus(t, stor, apply.ID, storage.ControlOperationCancel, storage.ControlRequestCompleted)
 	assert.Equal(t, engineCallsBeforeDrive, eng.recorded(),
 		"settling a task-less cancel must never invoke the engine")
@@ -227,6 +236,15 @@ func TestLocalClient_StopQueuedTasklessApplySettlesStopped(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, settled)
 	assert.Equal(t, state.Apply.Stopped, settled.State, "a stopped queued task-less apply must settle to stopped")
+
+	ops, err := stor.ApplyOperations().ListByApply(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, ops, "a dispatched apply must dual-write its operation row")
+	for _, op := range ops {
+		assert.Equal(t, state.ApplyOperation.Stopped, op.State,
+			"the operation row must settle to stopped alongside its apply")
+		assert.Nil(t, op.CompletedAt, "a stopped operation row is resumable and must keep completed_at nil")
+	}
 
 	requireControlRequestStatus(t, stor, apply.ID, storage.ControlOperationStop, storage.ControlRequestCompleted)
 	assert.Equal(t, engineCallsBeforeDrive, eng.recorded(),


### PR DESCRIPTION
## Why this matters

A dispatch through the Tern client — including the data plane's gRPC `Apply` — drove the initial copy inline on the request context, which carries no operator lease. Lease-guarded writes silently skipped for that entire drive: the per-shard progress write-through checks the in-context lease and returns, so a sharded apply driven from a dispatch never persisted its per-shard breakdown, while every unguarded write on the same drive succeeded. The control plane is a reader of data-plane state, so it had no shards to mirror — an operator watching a multi-shard apply saw aggregate progress with no per-shard visibility, and nothing in the logs said why.

## What it does

- `LocalClient.Apply` now records the apply and **queues it for the operator**, matching the API enqueue path: every drive — initial dispatch included — runs under an operator claim, so lease-guarded writes always hold the capability they require. The existing wake callback makes the claim prompt (milliseconds); without one the poll interval picks the apply up.

```
before:  dispatch ──▶ Apply: create rows ──▶ drive inline (request ctx, NO lease)
                                              └▶ per-shard write-through silently skips

after:   dispatch ──▶ Apply: create apply+operation+tasks (pending), wake
         operator ──▶ claim (lease) ──▶ ResumeApply under the lease
                                        └▶ per-shard write-through holds
```

- The pending claim previously required task rows, which the inline drive made moot. A queued **task-less apply** (VSchema-only, or a sharded dispatch whose shard already matches) carries an operation row but no tasks, so the claim — and the operation path's parent-lease acquisition — now accepts either child row; both are dual-written with the apply in one transaction. The resume path's existing task-less handling then settles it: VSchema-only plans re-drive so the VSchema is applied, and no-work applies complete as no-ops.
- The now-unreachable no-lease skip in the per-shard write-through **warns loudly** instead of returning silently, with the task's triage attributes — if a future drive path loses its lease context, the degraded per-shard visibility is in the logs instead of costing another multi-day hunt.
- Tests: integration tests dispatching through the client get operator-faithful drive helpers (claim under an owner, apply lease on the drive context, resume); the in-process gRPC harness gets a claim loop that routes each claim to the client registered for the apply's deployment, since harness terns share one storage database.

## How it moves toward the northstar

The data plane is a thin executor with its own operator; the control plane reads and mirrors its state. Driving dispatches through the operator makes the lease the single write-capability model for every drive — no privileged inline path — which is what makes lease-gated invariants (single writer per operation's rows) trustworthy enough to hang per-shard progress, and future per-shard fan-out, on.

*Drafted by Claude Code (Opus 4.8).*