### PR TITLE
fix(github): omit the unsafe-changes warning on the locked apply comment

### DIFF
--- a/pkg/webhook/plan_test.go
+++ b/pkg/webhook/plan_test.go
@@ -269,34 +269,6 @@ func TestRenderPlanComment_ShowsUnsafeWarning(t *testing.T) {
 	assert.Contains(t, rendered, "⛔ Unsafe Changes Detected")
 	assert.Contains(t, rendered, "`orders`")
 	assert.Contains(t, rendered, "DROP INDEX without making invisible first")
-	// Plan comment should NOT say "--allow-unsafe enabled" since it wasn't
-	assert.NotContains(t, rendered, "--allow-unsafe` enabled")
-}
-
-func TestRenderPlanComment_UnsafeWithAllowUnsafe(t *testing.T) {
-	data := templates.PlanCommentData{
-		Database:    "testdb",
-		Environment: "staging",
-		IsMySQL:     true,
-		IsLocked:    true,
-		AllowUnsafe: true,
-		Changes: []templates.KeyspaceChangeData{{
-			Keyspace:   "testdb",
-			Statements: []string{"DROP TABLE `users`"},
-		}},
-		HasUnsafeChanges: true,
-		UnsafeChanges: []templates.UnsafeChangeData{{
-			Table:  "users",
-			Reason: "DROP TABLE removes all data",
-		}},
-	}
-
-	rendered := templates.RenderPlanComment(data)
-
-	assert.Contains(t, rendered, "--allow-unsafe` enabled")
-	assert.Contains(t, rendered, "`users`")
-	assert.Contains(t, rendered, "Applying automatically")
-	assert.NotContains(t, rendered, "apply-confirm -e staging --allow-unsafe")
 }
 
 func TestRenderPlanComment_TenantScopedHints(t *testing.T) {

--- a/pkg/webhook/templates/plan.go
+++ b/pkg/webhook/templates/plan.go
@@ -128,9 +128,12 @@ func RenderPlanComment(data PlanCommentData) string {
 	// Detailed changes
 	writeKeyspaceChanges(&sb, data)
 
-	// Unsafe changes warning
-	if data.HasUnsafeChanges && len(data.UnsafeChanges) > 0 {
-		writeUnsafeWarning(&sb, data.UnsafeChanges, data.AllowUnsafe, data.IsMySQL)
+	// Unsafe changes warning — shown on the plan comment for review, omitted on
+	// the locked apply comment: unsafe changes only reach an apply after the
+	// operator acknowledged them with --allow-unsafe (apply-confirm re-checks
+	// and blocks otherwise), so repeating them there is noise.
+	if data.HasUnsafeChanges && len(data.UnsafeChanges) > 0 && !data.IsLocked {
+		writeUnsafeWarning(&sb, data.UnsafeChanges, data.IsMySQL)
 	}
 
 	// Lint violations — shown on the plan comment for review, omitted on the
@@ -521,12 +524,8 @@ func planShardList(shards []string) string {
 	return "shards " + strings.Join(quoted, ", ")
 }
 
-func writeUnsafeWarning(sb *strings.Builder, changes []UnsafeChangeData, allowUnsafe bool, isMySQL bool) {
-	if allowUnsafe {
-		sb.WriteString("**🚨 Unsafe Changes** (`--allow-unsafe` enabled):\n")
-	} else {
-		sb.WriteString("**⛔ Unsafe Changes Detected:**\n")
-	}
+func writeUnsafeWarning(sb *strings.Builder, changes []UnsafeChangeData, isMySQL bool) {
+	sb.WriteString("**⛔ Unsafe Changes Detected:**\n")
 	for _, c := range changes {
 		table := "`" + c.Table + "`"
 		if len(c.Shards) > 0 {
@@ -820,7 +819,7 @@ func writeEnvironmentPlanSection(sb *strings.Builder, plan *PlanCommentData) {
 
 	// Unsafe changes warning
 	if plan.HasUnsafeChanges && len(plan.UnsafeChanges) > 0 {
-		writeUnsafeWarning(sb, plan.UnsafeChanges, plan.AllowUnsafe, plan.IsMySQL)
+		writeUnsafeWarning(sb, plan.UnsafeChanges, plan.IsMySQL)
 	}
 
 	// Lint violations

--- a/pkg/webhook/templates/sharded_plan_test.go
+++ b/pkg/webhook/templates/sharded_plan_test.go
@@ -32,6 +32,35 @@ func TestRenderPlanComment_LintShownOnPlanNotOnApply(t *testing.T) {
 	assert.NotContains(t, apply, "Column added without DEFAULT value")
 }
 
+// Unsafe-change warnings belong on the plan comment, where the operator reviews
+// them before applying. Unsafe changes only reach an apply after the operator
+// acknowledged them with --allow-unsafe (apply-confirm re-checks and blocks
+// otherwise), so the locked apply comment omits the warning block as noise.
+func TestRenderPlanComment_UnsafeShownOnPlanNotOnApply(t *testing.T) {
+	data := PlanCommentData{
+		Database: "testapp", Environment: "staging", IsMySQL: true,
+		Changes: []KeyspaceChangeData{{
+			Keyspace:   "testapp",
+			Statements: []string{"ALTER TABLE `users` DROP COLUMN `email`"},
+		}},
+		HasUnsafeChanges: true,
+		AllowUnsafe:      true,
+		UnsafeChanges: []UnsafeChangeData{
+			{Table: "users", Reason: "DROP COLUMN is destructive"},
+		},
+	}
+
+	plan := RenderPlanComment(data)
+	assert.Contains(t, plan, "Unsafe Changes", "the plan comment surfaces unsafe changes for review")
+	assert.Contains(t, plan, "DROP COLUMN is destructive")
+
+	data.IsLocked = true
+	apply := RenderPlanComment(data)
+	assert.NotContains(t, apply, "Unsafe Changes", "the locked apply comment omits the unsafe warning as noise")
+	assert.NotContains(t, apply, "DROP COLUMN is destructive")
+	assert.Contains(t, apply, "DROP COLUMN `email`", "the DDL itself stays visible on the apply comment")
+}
+
 // A sharded plan whose shards diverge renders "what applies where": one DDL
 // block per distinct change set, each labelled with the shards it applies to.
 func TestRenderPlanComment_ShardedDivergent(t *testing.T) {

--- a/pkg/webhook/templates/sharded_plan_test.go
+++ b/pkg/webhook/templates/sharded_plan_test.go
@@ -58,6 +58,7 @@ func TestRenderPlanComment_UnsafeShownOnPlanNotOnApply(t *testing.T) {
 	apply := RenderPlanComment(data)
 	assert.NotContains(t, apply, "⛔ Unsafe Changes Detected", "the locked apply comment omits the unsafe warning as noise")
 	assert.NotContains(t, apply, "DROP COLUMN is destructive")
+	assert.NotContains(t, apply, "Destructive drop guidance", "the drop guidance rides inside the unsafe block and is omitted with it")
 	assert.Contains(t, apply, "DROP COLUMN `email`", "the DDL itself stays visible on the apply comment")
 }
 

--- a/pkg/webhook/templates/sharded_plan_test.go
+++ b/pkg/webhook/templates/sharded_plan_test.go
@@ -51,12 +51,12 @@ func TestRenderPlanComment_UnsafeShownOnPlanNotOnApply(t *testing.T) {
 	}
 
 	plan := RenderPlanComment(data)
-	assert.Contains(t, plan, "Unsafe Changes", "the plan comment surfaces unsafe changes for review")
+	assert.Contains(t, plan, "⛔ Unsafe Changes Detected", "the plan comment surfaces unsafe changes for review")
 	assert.Contains(t, plan, "DROP COLUMN is destructive")
 
 	data.IsLocked = true
 	apply := RenderPlanComment(data)
-	assert.NotContains(t, apply, "Unsafe Changes", "the locked apply comment omits the unsafe warning as noise")
+	assert.NotContains(t, apply, "⛔ Unsafe Changes Detected", "the locked apply comment omits the unsafe warning as noise")
 	assert.NotContains(t, apply, "DROP COLUMN is destructive")
 	assert.Contains(t, apply, "DROP COLUMN `email`", "the DDL itself stays visible on the apply comment")
 }


### PR DESCRIPTION
## Why this matters

The plan comment is where the operator reviews lint warnings and unsafe changes before applying. Lint warnings are already omitted from the locked apply comment as noise, but the unsafe-changes block still repeated there — even though unsafe changes only reach an apply after the operator explicitly acknowledged them with `--allow-unsafe` (and `apply-confirm` re-checks and blocks otherwise).

## What it does

Gates the unsafe-changes warning on `!IsLocked`, exactly like lint: shown on the plan comment (and multi-env plan sections), omitted on the locked apply comment. The DDL itself stays visible on the apply comment, and the `apply-confirm` hint still carries `--allow-unsafe` when set. With no apply-side render left, the banner's `--allow-unsafe`-enabled variant is unreachable and is removed — the plan comment always renders the blocking form.

The unsafe gate is unchanged and fail-closed: an apply without `--allow-unsafe` still blocks with the full unsafe-changes render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)