### PR TITLE
fix(github): reject contradictory revert and skip-revert commands

### DIFF
--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -1986,6 +1986,21 @@ func (s *Service) executeRevertForApply(ctx context.Context, client tern.Client,
 		return nil, 0, fmt.Errorf("control request store is not available")
 	}
 
+	// Revert and skip-revert are mutually exclusive intents: one undoes the
+	// change, the other makes it permanent. Reject the contradiction up front
+	// instead of recording both and leaving the drive to pick a winner by
+	// ordering. The check is advisory — under a concurrent race the drive's
+	// ordering remains authoritative — but it catches the common sequential case.
+	skipRevertPending, err := controlStore.GetPending(ctx, apply.ID, storage.ControlOperationSkipRevert)
+	if err != nil {
+		metrics.RecordControlOperation(ctx, "revert", apply.Database, apply.Deployment, apply.Environment, "error")
+		return nil, 0, fmt.Errorf("check pending skip-revert control request before revert for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if skipRevertPending != nil {
+		metrics.RecordControlOperation(ctx, "revert", apply.Database, apply.Deployment, apply.Environment, "rejected")
+		return nil, 0, controlConflictf("skip-revert is already pending for this schema change; the revert window is being closed and the change will become permanent")
+	}
+
 	// Record durable revert intent before the engine call, so a comment-driven
 	// revert survives the API process dying before the call lands, and so the
 	// apply owner (the data-plane operator for a remote apply, not the webhook
@@ -2094,6 +2109,21 @@ func (s *Service) executeSkipRevertForApply(ctx context.Context, client tern.Cli
 	if controlStore == nil {
 		metrics.RecordControlOperation(ctx, "skip_revert", apply.Database, apply.Deployment, apply.Environment, "error")
 		return nil, 0, fmt.Errorf("control request store is not available")
+	}
+
+	// Skip-revert and revert are mutually exclusive intents: one makes the
+	// change permanent, the other undoes it. Reject the contradiction up front
+	// instead of recording both and leaving the drive to pick a winner by
+	// ordering. The check is advisory — under a concurrent race the drive's
+	// ordering remains authoritative — but it catches the common sequential case.
+	revertPending, err := controlStore.GetPending(ctx, apply.ID, storage.ControlOperationRevert)
+	if err != nil {
+		metrics.RecordControlOperation(ctx, "skip_revert", apply.Database, apply.Deployment, apply.Environment, "error")
+		return nil, 0, fmt.Errorf("check pending revert control request before skip-revert for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if revertPending != nil {
+		metrics.RecordControlOperation(ctx, "skip_revert", apply.Database, apply.Deployment, apply.Environment, "rejected")
+		return nil, 0, controlConflictf("revert is already pending for this schema change; it is being undone")
 	}
 
 	// Record durable skip-revert intent before the engine call, so a

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -5195,6 +5195,64 @@ func TestSkipRevertHandler(t *testing.T) {
 	})
 }
 
+// Revert and skip-revert are contradictory intents for the same revert window —
+// one undoes the change, the other makes it permanent. Once either has a
+// pending durable request, the opposite command is rejected with a conflict
+// that names the intent already in flight, instead of recording a second,
+// contradictory request for the drive to arbitrate.
+func TestRevertWindowCommandsRejectContradiction(t *testing.T) {
+	revertWindowApply := func(id string) *storage.Apply {
+		apply := activeTestApply(id)
+		apply.State = state.Apply.RevertWindow
+		apply.Engine = storage.EnginePlanetScale
+		apply.DatabaseType = storage.DatabaseTypeVitess
+		return apply
+	}
+	post := func(t *testing.T, mux *http.ServeMux, path, applyID string) *httptest.ResponseRecorder {
+		t.Helper()
+		body := fmt.Sprintf(`{"environment": "staging", "apply_id": %q}`, applyID)
+		req := httptest.NewRequestWithContext(t.Context(), "POST", path, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		return w
+	}
+
+	t.Run("revert rejected while skip-revert is pending", func(t *testing.T) {
+		// The immediate skip attempt fails, so the durable skip-revert request
+		// stays pending for the apply owner.
+		mock := &mockTernClient{skipRevertErr: errors.New("data plane unavailable")}
+		svc := newControlTestService(mock, revertWindowApply("apply-conflict-rv"))
+		mux := http.NewServeMux()
+		svc.ConfigureRoutes(mux)
+
+		first := post(t, mux, "/api/skip-revert", "apply-conflict-rv")
+		require.Equal(t, http.StatusAccepted, first.Code, first.Body.String())
+
+		second := post(t, mux, "/api/revert", "apply-conflict-rv")
+		assert.Equal(t, http.StatusConflict, second.Code, second.Body.String())
+		assert.Contains(t, second.Body.String(), "skip-revert is already pending")
+		assert.Nil(t, mock.revertReq, "the contradictory revert must not reach the data plane")
+	})
+
+	t.Run("skip-revert rejected while revert is pending", func(t *testing.T) {
+		// The immediate revert attempt fails, so the durable revert request
+		// stays pending for the apply owner.
+		mock := &mockTernClient{revertErr: errors.New("data plane unavailable")}
+		svc := newControlTestService(mock, revertWindowApply("apply-conflict-sr"))
+		mux := http.NewServeMux()
+		svc.ConfigureRoutes(mux)
+
+		first := post(t, mux, "/api/revert", "apply-conflict-sr")
+		require.Equal(t, http.StatusAccepted, first.Code, first.Body.String())
+
+		second := post(t, mux, "/api/skip-revert", "apply-conflict-sr")
+		assert.Equal(t, http.StatusConflict, second.Code, second.Body.String())
+		assert.Contains(t, second.Body.String(), "revert is already pending")
+		assert.Nil(t, mock.skipRevertReq, "the contradictory skip-revert must not reach the data plane")
+	})
+}
+
 func TestDeriveErrorCode(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Why this matters

Revert and skip-revert are mutually exclusive intents for the same revert window — one undoes the change, the other makes it permanent. Both commands recorded a durable control request without checking for the other, so contradictory commands left the drive to pick a winner by ordering, and the user who issued the losing command got an acceptance comment for an intent that would never happen.

## What it does

Each command now rejects up front, with a conflict naming the intent already in flight, when the opposite operation has a pending durable request:

- `revert` while a skip-revert is pending → *"skip-revert is already pending for this schema change; the revert window is being closed and the change will become permanent"*
- `skip-revert` while a revert is pending → *"revert is already pending for this schema change; it is being undone"*

The rejection surfaces on the PR comment through the existing control-command error rendering, and each guard records a `rejected` control-operation metric.

```
revert window
  ├─ skip-revert  ──► pending ──► drive closes the window
  └─ revert       ──► 409 conflict (skip-revert already pending)
```

The guard is advisory: under a truly concurrent race the drive's ordering remains authoritative, and a moot loser is swept once the apply reaches a terminal state — the guard, the drive ordering, and the terminal sweep reinforce each other.

## How it moves toward the northstar

Control commands should tell the operator what will actually happen. Rejecting a contradiction with the name of the intent already in flight beats silently accepting a command that a pending opposite intent will defeat.

— Claude (Fable 5) via Claude Code