### PR TITLE
feat(github): fail the plan check closed on review-time deployment drift

### DIFF
--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -391,6 +391,18 @@ func (s *Service) handlePlan(w http.ResponseWriter, r *http.Request) {
 // and returns the plan response. This is the shared implementation used by both
 // the HTTP handler and the webhook handler.
 func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.PlanResponse, error) {
+	_, resp, err := s.ExecutePlanProto(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// ExecutePlanProto runs a plan and returns both the reviewed primary plan proto
+// and its API projection. The proto is the reviewed baseline the review-time
+// drift rollup compares deployments against, so it is exposed alongside the API
+// response rather than reconstructed from storage.
+func (s *Service) ExecutePlanProto(ctx context.Context, req PlanRequest) (*ternv1.PlanResponse, *apitypes.PlanResponse, error) {
 	ctx, span := otel.Tracer("schemabot").Start(ctx, "ExecutePlan",
 		trace.WithAttributes(
 			attribute.String("database", req.Database),
@@ -403,7 +415,7 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 	if warning, err := validateSchemaFiles(req.SchemaFiles); err != nil {
 		span.RecordError(err)
 		span.SetStatus(otelcodes.Error, "invalid schema files")
-		return nil, err
+		return nil, nil, err
 	} else if warning != "" {
 		s.logger.Warn("plan request has empty schema files", "warning", warning, "database", req.Database)
 	}
@@ -417,7 +429,7 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 		span.SetStatus(otelcodes.Error, "resolve target")
 		metrics.RecordPlan(ctx, req.Repository, req.Database, deployment, req.Environment, "error")
 		metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, deployment, req.Environment, "error")
-		return nil, fmt.Errorf("resolve target for %s/%s: %w", req.Database, req.Environment, err)
+		return nil, nil, fmt.Errorf("resolve target for %s/%s: %w", req.Database, req.Environment, err)
 	}
 	deployment = resolvedTarget.Deployment
 	if req.Type != resolvedTarget.DatabaseType {
@@ -426,7 +438,7 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 		span.SetStatus(otelcodes.Error, "type mismatch")
 		metrics.RecordPlan(ctx, req.Repository, req.Database, deployment, req.Environment, "error")
 		metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, deployment, req.Environment, "error")
-		return nil, typeErr
+		return nil, nil, typeErr
 	}
 
 	prInt := 0
@@ -467,7 +479,7 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 				"schema_path", req.SchemaPath,
 				"reason", reason,
 				"error", err)
-			return nil, fmt.Errorf("source policy: %w", err)
+			return nil, nil, fmt.Errorf("source policy: %w", err)
 		}
 	}
 
@@ -477,7 +489,7 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 		span.SetStatus(otelcodes.Error, "tern client")
 		metrics.RecordPlan(ctx, req.Repository, req.Database, deployment, req.Environment, "error")
 		metrics.RecordPlanDuration(ctx, time.Since(planStart), req.Repository, req.Database, deployment, req.Environment, "error")
-		return nil, fmt.Errorf("database %q (%s): %w", req.Database, req.Environment, err)
+		return nil, nil, fmt.Errorf("database %q (%s): %w", req.Database, req.Environment, err)
 	}
 
 	ternReq := &ternv1.PlanRequest{
@@ -524,13 +536,13 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 			"error", err,
 		)
 		if client.IsRemote() && grpcstatus.Code(err) == grpccodes.Unavailable {
-			return nil, &RemoteDeploymentUnavailableError{
+			return nil, nil, &RemoteDeploymentUnavailableError{
 				Deployment: deployment,
 				Target:     resolvedTarget.Target,
 				Err:        err,
 			}
 		}
-		return nil, err
+		return nil, nil, err
 	}
 	span.SetAttributes(attribute.String("plan_id", resp.PlanId), attribute.Int("change_count", len(resp.Changes)))
 	metrics.RecordPlan(ctx, req.Repository, req.Database, deployment, req.Environment, "success")
@@ -556,10 +568,10 @@ func (s *Service) ExecutePlan(ctx context.Context, req PlanRequest) (*apitypes.P
 		Target:       resolvedTarget.Target,
 	}
 	if err := s.storePlanResponse(ctx, req, resp, route); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return planResponseFromProto(resp), nil
+	return resp, planResponseFromProto(resp), nil
 }
 
 type storedPlanRoute struct {

--- a/pkg/api/plan_review_drift.go
+++ b/pkg/api/plan_review_drift.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+
+	"github.com/block/schemabot/pkg/metrics"
+)
+
+// RollupReviewTimeDrift computes the review-time drift rollup for a
+// database/environment: it diffs every configured deployment against the
+// reviewed primary plan and classifies each as match, diverged, or errored.
+//
+// primaryPlan is the just-reviewed primary plan proto, reused as the rollup's
+// baseline so the comparison is against exactly what the user reviewed rather
+// than a fresh read of the primary's live schema (which could have drifted and
+// tripped a spurious primary-vs-primary mismatch).
+//
+// The expected deployment set is resolved independently from the producer's
+// results so the rollup can enforce that the diffs cover every configured
+// deployment in rollout order — a missing, extra, or reordered deployment fails
+// closed rather than being mistaken for agreement. The returned rollup is Clean
+// only when every deployment matches.
+func (s *Service) RollupReviewTimeDrift(ctx context.Context, req PlanRequest, primaryPlan *ternv1.PlanResponse) (PlanRollup, error) {
+	targets, err := s.config.ResolveDatabaseTargets(req.Database, req.Environment)
+	if err != nil {
+		return PlanRollup{}, fmt.Errorf("resolve deployment targets for %s/%s: %w", req.Database, req.Environment, err)
+	}
+	expectedDeployments := make([]string, len(targets))
+	for i, t := range targets {
+		expectedDeployments[i] = t.Deployment
+	}
+
+	diffs, err := s.PlanDeploymentDiffs(ctx, req, primaryPlan)
+	if err != nil {
+		return PlanRollup{}, fmt.Errorf("plan deployment diffs for %s/%s: %w", req.Database, req.Environment, err)
+	}
+
+	rollup, err := RollupDeploymentDiffs(diffs, expectedDeployments)
+	if err != nil {
+		return PlanRollup{}, fmt.Errorf("roll up deployment diffs for %s/%s: %w", req.Database, req.Environment, err)
+	}
+
+	for _, entry := range rollup.Entries {
+		metrics.RecordReviewDrift(ctx, req.Database, req.Environment, entry.Deployment, entry.Class.String())
+		switch entry.Class {
+		case DeploymentDiverged:
+			s.logger.Warn("review-time drift: deployment diverged from the reviewed plan; the plan check will block the PR until reconciled",
+				"database", req.Database,
+				"environment", req.Environment,
+				"deployment", entry.Deployment,
+				"target", entry.Target)
+		case DeploymentErrored:
+			s.logger.Warn("review-time drift: deployment could not be diffed or compared; the plan check will block the PR closed",
+				"database", req.Database,
+				"environment", req.Environment,
+				"deployment", entry.Deployment,
+				"target", entry.Target,
+				"error", entry.Err)
+		}
+	}
+
+	return rollup, nil
+}

--- a/pkg/api/plan_review_drift.go
+++ b/pkg/api/plan_review_drift.go
@@ -43,17 +43,33 @@ func (s *Service) RollupReviewTimeDrift(ctx context.Context, req PlanRequest, pr
 		return PlanRollup{}, fmt.Errorf("roll up deployment diffs for %s/%s: %w", req.Database, req.Environment, err)
 	}
 
+	// Include repo/pr/head SHA so an operator can tell which PR is blocked from
+	// the drift warn log alone.
+	var pr int32
+	if req.PullRequest != nil {
+		pr = *req.PullRequest
+	}
+	var headSHA string
+	if req.HeadSHA != nil {
+		headSHA = *req.HeadSHA
+	}
 	for _, entry := range rollup.Entries {
 		metrics.RecordReviewDrift(ctx, req.Database, req.Environment, entry.Deployment, entry.Class.String())
 		switch entry.Class {
 		case DeploymentDiverged:
 			s.logger.Warn("review-time drift: deployment diverged from the reviewed plan; the plan check will block the PR until reconciled",
+				"repository", req.Repository,
+				"pr", pr,
+				"head_sha", headSHA,
 				"database", req.Database,
 				"environment", req.Environment,
 				"deployment", entry.Deployment,
 				"target", entry.Target)
 		case DeploymentErrored:
 			s.logger.Warn("review-time drift: deployment could not be diffed or compared; the plan check will block the PR closed",
+				"repository", req.Repository,
+				"pr", pr,
+				"head_sha", headSHA,
 				"database", req.Database,
 				"environment", req.Environment,
 				"deployment", entry.Deployment,

--- a/pkg/api/plan_review_drift_test.go
+++ b/pkg/api/plan_review_drift_test.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+)
+
+func reviewedUsersPlan(ddl string) *ternv1.PlanResponse {
+	return &ternv1.PlanResponse{
+		PlanId: "plan_eu",
+		Engine: ternv1.Engine_ENGINE_SPIRIT,
+		Changes: []*ternv1.SchemaChange{{
+			Namespace: "testapp",
+			TableChanges: []*ternv1.TableChange{{
+				TableName:  "users",
+				ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER,
+				Ddl:        ddl,
+				Namespace:  "testapp",
+			}},
+		}},
+	}
+}
+
+// When every deployment would plan the reviewed change, the rollup is clean and
+// classifies the primary as its own baseline plus each deployment as a match.
+func TestRollupReviewTimeDrift_CleanWhenAllMatch(t *testing.T) {
+	ddl := "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"
+	eu := &mockTernClient{}
+	us := &mockTernClient{planDiffResp: alterUsersDiff(ddl)}
+	svc := twoDeploymentService(t, eu, us)
+
+	rollup, err := svc.RollupReviewTimeDrift(t.Context(), planDiffReq(t), reviewedUsersPlan(ddl))
+	require.NoError(t, err)
+	assert.True(t, rollup.Clean, "matching deployments must roll up clean")
+	require.Len(t, rollup.Entries, 2)
+	assert.Equal(t, "eu", rollup.Entries[0].Deployment)
+	assert.Equal(t, DeploymentMatch, rollup.Entries[0].Class)
+	assert.Equal(t, "us", rollup.Entries[1].Deployment)
+	assert.Equal(t, DeploymentMatch, rollup.Entries[1].Class)
+}
+
+// A non-primary deployment that would plan different DDL than was reviewed
+// diverges, so the rollup is not clean and the diverging deployment is named.
+func TestRollupReviewTimeDrift_DivergingDeploymentBlocks(t *testing.T) {
+	eu := &mockTernClient{}
+	us := &mockTernClient{planDiffResp: alterUsersDiff("ALTER TABLE `users` ADD COLUMN `phone` varchar(32)")}
+	svc := twoDeploymentService(t, eu, us)
+
+	reviewed := reviewedUsersPlan("ALTER TABLE `users` ADD COLUMN `email` varchar(255)")
+	rollup, err := svc.RollupReviewTimeDrift(t.Context(), planDiffReq(t), reviewed)
+	require.NoError(t, err)
+	assert.False(t, rollup.Clean, "a diverging deployment must block the rollup")
+	require.Len(t, rollup.Entries, 2)
+	assert.Equal(t, DeploymentMatch, rollup.Entries[0].Class)
+	assert.Equal(t, "us", rollup.Entries[1].Deployment)
+	assert.Equal(t, DeploymentDiverged, rollup.Entries[1].Class)
+}
+
+// A deployment that fails to diff cannot be confirmed to match, so it is
+// classified as errored and blocks the rollup rather than being treated as
+// agreement.
+func TestRollupReviewTimeDrift_UnreachableDeploymentBlocks(t *testing.T) {
+	ddl := "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"
+	eu := &mockTernClient{}
+	us := &mockTernClient{planDiffErr: errors.New("us unreachable")}
+	svc := twoDeploymentService(t, eu, us)
+
+	rollup, err := svc.RollupReviewTimeDrift(t.Context(), planDiffReq(t), reviewedUsersPlan(ddl))
+	require.NoError(t, err)
+	assert.False(t, rollup.Clean, "an unreachable deployment must block the rollup")
+	require.Len(t, rollup.Entries, 2)
+	assert.Equal(t, "us", rollup.Entries[1].Deployment)
+	assert.Equal(t, DeploymentErrored, rollup.Entries[1].Class)
+	require.Error(t, rollup.Entries[1].Err)
+}
+
+// A request for an unconfigured database cannot resolve deployment targets, so
+// the rollup fails rather than silently reporting clean.
+func TestRollupReviewTimeDrift_UnresolvedTargetsError(t *testing.T) {
+	eu := &mockTernClient{}
+	us := &mockTernClient{}
+	svc := twoDeploymentService(t, eu, us)
+
+	req := planDiffReq(t)
+	req.Database = "unknown"
+	_, err := svc.RollupReviewTimeDrift(t.Context(), req, reviewedUsersPlan("ALTER TABLE `users` ADD COLUMN `email` varchar(255)"))
+	require.Error(t, err)
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -263,6 +263,32 @@ func RecordTransientPlanRetry(ctx context.Context, database, environment, outcom
 	)
 }
 
+var knownReviewDriftClassifications = map[string]bool{
+	"match":    true,
+	"diverged": true,
+	"errored":  true,
+}
+
+// RecordReviewDrift increments the counter for a deployment's review-time drift
+// classification against the reviewed primary plan. A spike with
+// classification="diverged" means a deployment's live schema no longer matches
+// what was reviewed — an operator must reconcile that deployment before the PR
+// can apply. classification="errored" means the deployment could not be diffed
+// or compared and is failing the check closed; investigate connectivity to that
+// deployment or the plan input.
+func RecordReviewDrift(ctx context.Context, database, environment, deployment, classification string) {
+	if !knownReviewDriftClassifications[classification] {
+		classification = "errored"
+	}
+	addCounter(ctx, "schemabot.review_drift.total",
+		"review-time per-deployment drift classifications against the reviewed primary plan", "{deployment}",
+		attribute.String("database", database),
+		EnvironmentAttribute(environment),
+		attribute.String("deployment", deployment),
+		attribute.String("classification", classification),
+	)
+}
+
 var knownSourcePolicyOperations = map[string]bool{
 	"plan":  true,
 	"apply": true,

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -278,7 +278,10 @@ var knownReviewDriftClassifications = map[string]bool{
 // deployment or the plan input.
 func RecordReviewDrift(ctx context.Context, database, environment, deployment, classification string) {
 	if !knownReviewDriftClassifications[classification] {
-		classification = "errored"
+		// An unrecognized classification is a coding gap, not a drift signal.
+		// Coercing it to "errored" would inflate the blocking-failure count, so
+		// bucket it as "unknown" and keep the real failure classes accurate.
+		classification = "unknown"
 	}
 	addCounter(ctx, "schemabot.review_drift.total",
 		"review-time per-deployment drift classifications against the reviewed primary plan", "{deployment}",

--- a/pkg/storage/mysqlstore/checks.go
+++ b/pkg/storage/mysqlstore/checks.go
@@ -64,7 +64,13 @@ func (s *checkStore) Upsert(ctx context.Context, check *storage.Check) error {
 
 // UpsertPlanResult stores plan-derived check state without overwriting
 // in-progress apply-owned state for the same PR/environment/database.
-func (s *checkStore) UpsertPlanResult(ctx context.Context, check *storage.Check) error {
+//
+// drift declares whether this write evaluated review-time deployment drift. A
+// not-evaluated write (an apply-time plan) must not silently clear a stored
+// drift block: the block depends on live deployment state, not PR content, so
+// only a write that re-ran the rollup and found the deployments clean may clear
+// it. See storage.PlanDriftState.
+func (s *checkStore) UpsertPlanResult(ctx context.Context, check *storage.Check, drift storage.PlanDriftState) error {
 	var checkRunID any
 	if check.CheckRunID != 0 {
 		checkRunID = check.CheckRunID
@@ -99,6 +105,40 @@ func (s *checkStore) UpsertPlanResult(ctx context.Context, check *storage.Check)
 		// recovery path releases it. A plan result — even from a newer PR commit that
 		// diffs cleanly against the mid-apply database — must not take ownership or
 		// convert the row into a passing check.
+		//
+		// A not-evaluated write additionally preserves the full gating state of an
+		// existing review-time drift block: it may refresh the head SHA and check
+		// run id so the current-head aggregate stays aligned, but it must not clear
+		// the block's conclusion, blocking reason, or summary. Only a write that
+		// re-ran the rollup (clean or blocked) rewrites those columns.
+		if drift == storage.PlanDriftNotEvaluated {
+			_, err = s.db.ExecContext(ctx, `
+				UPDATE checks
+				SET head_sha = ?,
+				    check_run_id = ?,
+				    apply_id     = CASE WHEN COALESCE(blocking_reason, '') = ? THEN apply_id     ELSE NULL END,
+				    has_changes  = CASE WHEN COALESCE(blocking_reason, '') = ? THEN has_changes  ELSE ?    END,
+				    status       = CASE WHEN COALESCE(blocking_reason, '') = ? THEN status       ELSE ?    END,
+				    conclusion   = CASE WHEN COALESCE(blocking_reason, '') = ? THEN conclusion   ELSE ?    END,
+				    blocking_reason = CASE WHEN COALESCE(blocking_reason, '') = ? THEN blocking_reason ELSE ? END,
+				    error_message   = CASE WHEN COALESCE(blocking_reason, '') = ? THEN error_message   ELSE ? END,
+				    change_summary  = CASE WHEN COALESCE(blocking_reason, '') = ? THEN change_summary  ELSE ? END
+				WHERE repository = ? AND pull_request = ?
+				  AND environment = ? AND database_type = ? AND database_name = ?
+				  AND NOT (status = ? AND apply_id IS NOT NULL)
+			`, check.HeadSHA, checkRunID,
+				storage.ReviewTimeDeploymentDriftBlockingReason,
+				storage.ReviewTimeDeploymentDriftBlockingReason, check.HasChanges,
+				storage.ReviewTimeDeploymentDriftBlockingReason, check.Status,
+				storage.ReviewTimeDeploymentDriftBlockingReason, check.Conclusion,
+				storage.ReviewTimeDeploymentDriftBlockingReason, check.BlockingReason,
+				storage.ReviewTimeDeploymentDriftBlockingReason, check.ErrorMessage,
+				storage.ReviewTimeDeploymentDriftBlockingReason, nullString(check.ChangeSummary),
+				check.Repository, check.PullRequest, check.Environment, check.DatabaseType, check.DatabaseName,
+				checkStatusInProgress)
+			return err
+		}
+
 		_, err = s.db.ExecContext(ctx, `
 			UPDATE checks
 			SET head_sha = ?,
@@ -174,6 +214,11 @@ func successfulNoOpPlanResult(check *storage.Check) bool {
 // database. Returns true when the row is in the plan-only successful state after
 // this call (whether this call wrote it or it already was), and false only when a
 // started apply still owns it.
+//
+// This deliberately clears a review-time deployment drift block too: once a later
+// commit removes the database from the PR and no apply has started, the reviewed
+// plan is no longer part of the merge gate, so the plan-only drift block should
+// stop blocking. A started apply still owns the row and is left untouched.
 func (s *checkStore) MarkStalePlanSuccessful(ctx context.Context, check *storage.Check) (bool, error) {
 	var checkRunID any
 	if check.CheckRunID != 0 {

--- a/pkg/storage/mysqlstore/checks_test.go
+++ b/pkg/storage/mysqlstore/checks_test.go
@@ -374,7 +374,7 @@ func TestCheckStore_UpsertPlanResultPreservesInProgressApply(t *testing.T) {
 		HasChanges:   true,
 		Status:       "completed",
 		Conclusion:   "action_required",
-	})
+	}, storage.PlanDriftClean)
 	require.NoError(t, err)
 
 	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
@@ -417,7 +417,7 @@ func TestCheckStore_RecoverApplyOwnedCheckWithNoOpPlanRecoversStoredCheckState(t
 		HasChanges:   false,
 		Status:       "completed",
 		Conclusion:   "success",
-	})
+	}, storage.PlanDriftClean)
 	require.NoError(t, err)
 
 	recovered, err := store.Checks().RecoverApplyOwnedCheckWithNoOpPlan(ctx, &storage.Check{
@@ -475,7 +475,7 @@ func TestCheckStore_UpsertPlanResultPreservesApplyOwnedCheckStateOnNoOpSuccess(t
 		HasChanges:   false,
 		Status:       "completed",
 		Conclusion:   "success",
-	})
+	}, storage.PlanDriftClean)
 	require.NoError(t, err)
 
 	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
@@ -546,7 +546,7 @@ func TestCheckStore_RecoverApplyOwnedCheckWithNoOpPlanRequiresNoOpSuccess(t *tes
 				HasChanges:   tc.hasChanges,
 				Status:       tc.status,
 				Conclusion:   tc.conclusion,
-			})
+			}, storage.PlanDriftClean)
 			require.NoError(t, err)
 
 			recovered, err := store.Checks().RecoverApplyOwnedCheckWithNoOpPlan(ctx, &storage.Check{
@@ -863,7 +863,7 @@ func TestCheckStore_UpsertPlanResultReplacesUnownedInProgressCheck(t *testing.T)
 		HasChanges:   true,
 		Status:       "completed",
 		Conclusion:   "action_required",
-	})
+	}, storage.PlanDriftClean)
 	require.NoError(t, err)
 
 	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
@@ -909,7 +909,7 @@ func TestCheckStore_UpsertPlanResultPreservesInProgressApplyOnNewHead(t *testing
 		HasChanges:   false,
 		Status:       "completed",
 		Conclusion:   "success",
-	})
+	}, storage.PlanDriftClean)
 	require.NoError(t, err)
 
 	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
@@ -968,7 +968,7 @@ func TestCheckStore_UpsertPlanResultReplacesUnownedInProgressCheckOnNewHead(t *t
 		HasChanges:   true,
 		Status:       "completed",
 		Conclusion:   "action_required",
-	})
+	}, storage.PlanDriftClean)
 	require.NoError(t, err)
 
 	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
@@ -1009,7 +1009,7 @@ func TestCheckStore_UpsertPlanResultClearsApplyIDWhenNotInProgress(t *testing.T)
 		HasChanges:   true,
 		Status:       "completed",
 		Conclusion:   "action_required",
-	})
+	}, storage.PlanDriftClean)
 	require.NoError(t, err)
 
 	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
@@ -1077,7 +1077,7 @@ func TestCheckStore_ChangeSummaryRoundTripsAndSurvivesApply(t *testing.T) {
 		Status:        "completed",
 		Conclusion:    "action_required",
 		ChangeSummary: "5 created, 3 altered · 2 vschema updates",
-	}))
+	}, storage.PlanDriftClean))
 
 	checks, err := store.Checks().GetByPR(ctx, "octocat/hello-world", 7)
 	require.NoError(t, err)
@@ -1159,15 +1159,15 @@ func TestCheckStore_ReplanUpdatesChangeSummary(t *testing.T) {
 		return c
 	}
 
-	require.NoError(t, store.Checks().UpsertPlanResult(ctx, planCheck("5 created")))
+	require.NoError(t, store.Checks().UpsertPlanResult(ctx, planCheck("5 created"), storage.PlanDriftClean))
 	assert.Equal(t, "5 created", get().ChangeSummary)
 
 	// A new plan with different changes overwrites the summary.
-	require.NoError(t, store.Checks().UpsertPlanResult(ctx, planCheck("2 altered")))
+	require.NoError(t, store.Checks().UpsertPlanResult(ctx, planCheck("2 altered"), storage.PlanDriftClean))
 	assert.Equal(t, "2 altered", get().ChangeSummary)
 
 	// A new plan that finds no changes clears the summary.
-	require.NoError(t, store.Checks().UpsertPlanResult(ctx, planCheck("")))
+	require.NoError(t, store.Checks().UpsertPlanResult(ctx, planCheck(""), storage.PlanDriftClean))
 	assert.Empty(t, get().ChangeSummary)
 }
 
@@ -1513,4 +1513,199 @@ func createCheckStoreApply(t *testing.T, store storage.Storage, applyIdentifier,
 	require.NoError(t, err)
 	require.NotNil(t, created)
 	return created
+}
+
+// A review-time deployment drift block is stored on a plan-only row as a first-
+// class BlockingReason with conclusion=failure, so the aggregate fails closed.
+func TestCheckStore_UpsertPlanResultStoresDriftBlock(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	err := store.Checks().UpsertPlanResult(ctx, &storage.Check{
+		Repository:     "org/repo",
+		PullRequest:    123,
+		HeadSHA:        "sha1",
+		Environment:    "production",
+		DatabaseType:   "mysql",
+		DatabaseName:   "testdb",
+		HasChanges:     false,
+		Status:         "completed",
+		Conclusion:     "failure",
+		BlockingReason: storage.ReviewTimeDeploymentDriftBlockingReason,
+		ChangeSummary:  "drift blocks apply — diverged: au",
+	}, storage.PlanDriftBlocked)
+	require.NoError(t, err)
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "production", "mysql", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	assert.Equal(t, "failure", retrieved.Conclusion)
+	assert.Equal(t, storage.ReviewTimeDeploymentDriftBlockingReason, retrieved.BlockingReason)
+}
+
+// An apply-time plan (a not-evaluated write) must not clear a stored drift
+// block: drift depends on live deployment state, not PR content, so an apply on
+// the same head cannot re-open the gate. The head SHA is refreshed but the block
+// is preserved.
+func TestCheckStore_UpsertPlanResultNotEvaluatedPreservesDriftBlock(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	require.NoError(t, store.Checks().UpsertPlanResult(ctx, &storage.Check{
+		Repository:     "org/repo",
+		PullRequest:    123,
+		HeadSHA:        "sha1",
+		Environment:    "production",
+		DatabaseType:   "mysql",
+		DatabaseName:   "testdb",
+		Status:         "completed",
+		Conclusion:     "failure",
+		BlockingReason: storage.ReviewTimeDeploymentDriftBlockingReason,
+		ChangeSummary:  "drift blocks apply — diverged: au",
+	}, storage.PlanDriftBlocked))
+
+	// Apply-time plan on the same head: no drift evaluated, primary plan clean.
+	err := store.Checks().UpsertPlanResult(ctx, &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "sha1",
+		Environment:  "production",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		HasChanges:   false,
+		Status:       "completed",
+		Conclusion:   "success",
+	}, storage.PlanDriftNotEvaluated)
+	require.NoError(t, err)
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "production", "mysql", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	assert.Equal(t, "failure", retrieved.Conclusion, "drift block conclusion preserved")
+	assert.Equal(t, storage.ReviewTimeDeploymentDriftBlockingReason, retrieved.BlockingReason, "drift block preserved")
+	assert.Equal(t, "drift blocks apply — diverged: au", retrieved.ChangeSummary, "drift summary preserved")
+}
+
+// A fresh clean rollup (an evaluated write) clears a stored drift block: the
+// deployments now match the reviewed plan, so the gate may pass.
+func TestCheckStore_UpsertPlanResultCleanReplanClearsDriftBlock(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	require.NoError(t, store.Checks().UpsertPlanResult(ctx, &storage.Check{
+		Repository:     "org/repo",
+		PullRequest:    123,
+		HeadSHA:        "sha1",
+		Environment:    "production",
+		DatabaseType:   "mysql",
+		DatabaseName:   "testdb",
+		Status:         "completed",
+		Conclusion:     "failure",
+		BlockingReason: storage.ReviewTimeDeploymentDriftBlockingReason,
+		ChangeSummary:  "drift blocks apply — diverged: au",
+	}, storage.PlanDriftBlocked))
+
+	err := store.Checks().UpsertPlanResult(ctx, &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "sha1",
+		Environment:  "production",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		HasChanges:   false,
+		Status:       "completed",
+		Conclusion:   "success",
+	}, storage.PlanDriftClean)
+	require.NoError(t, err)
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "production", "mysql", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	assert.Equal(t, "success", retrieved.Conclusion, "clean re-plan cleared the block")
+	assert.Empty(t, retrieved.BlockingReason, "clean re-plan cleared the blocking reason")
+}
+
+// A not-evaluated write on a row that is not drift-blocked behaves like a normal
+// plan-result replacement (no drift block to preserve).
+func TestCheckStore_UpsertPlanResultNotEvaluatedReplacesNonDriftRow(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	require.NoError(t, store.Checks().UpsertPlanResult(ctx, &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "sha1",
+		Environment:  "production",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		HasChanges:   true,
+		Status:       "completed",
+		Conclusion:   "action_required",
+	}, storage.PlanDriftClean))
+
+	err := store.Checks().UpsertPlanResult(ctx, &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "sha2",
+		Environment:  "production",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		HasChanges:   false,
+		Status:       "completed",
+		Conclusion:   "success",
+	}, storage.PlanDriftNotEvaluated)
+	require.NoError(t, err)
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "production", "mysql", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	assert.Equal(t, "sha2", retrieved.HeadSHA)
+	assert.Equal(t, "success", retrieved.Conclusion, "non-drift row is replaced normally")
+	assert.False(t, retrieved.HasChanges)
+}
+
+// Stale cleanup clears a plan-only drift block: once a later commit removes the
+// database from the PR and no apply has started, the reviewed plan no longer
+// gates the merge.
+func TestCheckStore_MarkStalePlanSuccessfulClearsDriftBlock(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	require.NoError(t, store.Checks().UpsertPlanResult(ctx, &storage.Check{
+		Repository:     "org/repo",
+		PullRequest:    123,
+		HeadSHA:        "sha1",
+		Environment:    "production",
+		DatabaseType:   "mysql",
+		DatabaseName:   "testdb",
+		Status:         "completed",
+		Conclusion:     "failure",
+		BlockingReason: storage.ReviewTimeDeploymentDriftBlockingReason,
+		ChangeSummary:  "drift blocks apply — diverged: au",
+	}, storage.PlanDriftBlocked))
+
+	ok, err := store.Checks().MarkStalePlanSuccessful(ctx, &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "sha1",
+		Environment:  "production",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		HasChanges:   false,
+		Status:       "completed",
+		Conclusion:   "success",
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "production", "mysql", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	assert.Equal(t, "success", retrieved.Conclusion)
+	assert.Empty(t, retrieved.BlockingReason)
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -94,7 +94,13 @@ type CheckStore interface {
 	// released only by apply completion (CompleteForApply), rollback completion
 	// (MarkActionRequiredForApply), or the explicit same-head no-op recovery
 	// path (RecoverApplyOwnedCheckWithNoOpPlan).
-	UpsertPlanResult(ctx context.Context, check *Check) error
+	//
+	// drift declares how this write treats a review-time deployment drift block:
+	// a write from a path that re-ran the drift rollup can clear a stale block
+	// (PlanDriftClean) or set one (PlanDriftBlocked); a write from a path that
+	// did not evaluate drift (PlanDriftNotEvaluated, e.g. an apply-time plan)
+	// must preserve any existing drift block rather than silently clearing it.
+	UpsertPlanResult(ctx context.Context, check *Check, drift PlanDriftState) error
 
 	// RecoverApplyOwnedCheckWithNoOpPlan updates same-head apply-owned stored check state
 	// from in_progress to a successful no-op plan result. Returns true when recovery occurred.

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -127,6 +127,34 @@ type Lock struct {
 // updates the visible GitHub Check Run, then writes an aggregate stored state
 // row whose CheckRunID points at that GitHub object. Later GitHub check_run
 // webhooks use CheckRunID to find the matching stored state.
+
+// PlanDriftState declares how a plan-result write treats a stored review-time
+// deployment drift block. It lets UpsertPlanResult tell "the drift rollup ran
+// and this deployment set is clean" apart from "drift was not evaluated on this
+// write" — two cases that both carry an empty BlockingReason but must clear vs
+// preserve an existing drift block respectively.
+type PlanDriftState int
+
+const (
+	// PlanDriftNotEvaluated means the write did not run the drift rollup (e.g. an
+	// apply-time plan). It is the zero value so an unset drift argument fails
+	// safe: an existing drift block is preserved, never silently cleared.
+	PlanDriftNotEvaluated PlanDriftState = iota
+	// PlanDriftClean means the rollup ran and every deployment matched the
+	// reviewed plan, so a stale drift block may be cleared.
+	PlanDriftClean
+	// PlanDriftBlocked means the rollup ran and a deployment diverged or could
+	// not be confirmed, so the write records the drift block.
+	PlanDriftBlocked
+)
+
+// ReviewTimeDeploymentDriftBlockingReason is the stable Check.BlockingReason
+// value for a review-time deployment drift block. It is defined here so the
+// plan-result write guard and the webhook block reason share one source of
+// truth: UpsertPlanResult preserves a row carrying this reason on a
+// not-evaluated write instead of clearing it.
+const ReviewTimeDeploymentDriftBlockingReason = "review_time_deployment_drift"
+
 type Check struct {
 	// ID is the unique identifier (BIGINT AUTO_INCREMENT).
 	ID int64

--- a/pkg/webhook/apply_check_records.go
+++ b/pkg/webhook/apply_check_records.go
@@ -11,8 +11,11 @@ import (
 )
 
 // storeApplyPlanCheckRecord stores a check record when an apply plan is posted.
+// The apply-time plan does not evaluate review-time deployment drift, so it must
+// not clear a stored drift block: the block depends on live deployment state,
+// not PR content, and only a fresh rollup may clear it.
 func (h *Handler) storeApplyPlanCheckRecord(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string) (string, error) {
-	return h.storePlanCheckRecord(ctx, client, repo, pr, schema, planResp, environment, nil)
+	return h.storePlanCheckRecord(ctx, client, repo, pr, schema, planResp, environment, reviewDriftOutcome{state: driftNotEvaluated})
 }
 
 // updateCheckRecordForApplyStart updates the stored check state to "in_progress"
@@ -30,6 +33,28 @@ func (h *Handler) updateCheckRecordForApplyStart(ctx context.Context, client *gh
 		})
 		return fmt.Errorf("look up stored check state for apply start repo %s pr %d environment %s database_type %s database %s apply_id %d: %w",
 			repo, pr, environment, schema.Type, schema.Database, applyID, err)
+	}
+
+	// A stored review-time deployment drift block must not be cleared by starting
+	// an apply: the block means a deployment's live schema no longer matches the
+	// reviewed plan, so transitioning the row to in_progress (which clears the
+	// block) would let the apply proceed against unverified drift. Fail closed and
+	// leave the block for an operator to reconcile.
+	if check != nil && check.BlockingReason == storage.ReviewTimeDeploymentDriftBlockingReason {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:    "apply_started",
+			Repository:   repo,
+			Database:     schema.Database,
+			DatabaseType: schema.Type,
+			Environment:  environment,
+			Status:       "drift_blocked",
+		})
+		h.logger.Warn("apply start refused: review-time deployment drift block is present; reconcile the deployment drift before applying",
+			"repo", repo, "pr", pr, "environment", environment,
+			"database_type", schema.Type, "database", schema.Database,
+			"apply_id", applyID, "head_sha", check.HeadSHA)
+		return fmt.Errorf("apply start refused for repo %s pr %d environment %s database_type %s database %s apply_id %d: review-time deployment drift block present",
+			repo, pr, environment, schema.Type, schema.Database, applyID)
 	}
 
 	if check == nil {

--- a/pkg/webhook/apply_check_records.go
+++ b/pkg/webhook/apply_check_records.go
@@ -12,7 +12,7 @@ import (
 
 // storeApplyPlanCheckRecord stores a check record when an apply plan is posted.
 func (h *Handler) storeApplyPlanCheckRecord(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string) (string, error) {
-	return h.storePlanCheckRecord(ctx, client, repo, pr, schema, planResp, environment)
+	return h.storePlanCheckRecord(ctx, client, repo, pr, schema, planResp, environment, nil)
 }
 
 // updateCheckRecordForApplyStart updates the stored check state to "in_progress"

--- a/pkg/webhook/apply_check_records_test.go
+++ b/pkg/webhook/apply_check_records_test.go
@@ -1,0 +1,71 @@
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/api"
+	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// driftBlockedCheckStore returns a stored check carrying a review-time
+// deployment drift block and records whether Upsert was called so a test can
+// prove the apply-start path did not overwrite (clear) the block.
+type driftBlockedCheckStore struct {
+	storage.CheckStore
+	stored      *storage.Check
+	upsertCalls int
+}
+
+func (s *driftBlockedCheckStore) Get(ctx context.Context, repo string, pr int, environment, dbType, database string) (*storage.Check, error) {
+	return s.stored, nil
+}
+
+func (s *driftBlockedCheckStore) Upsert(ctx context.Context, check *storage.Check) error {
+	s.upsertCalls++
+	return nil
+}
+
+type driftBlockedStorage struct {
+	emptyStorage
+	checks *driftBlockedCheckStore
+}
+
+func (s *driftBlockedStorage) Checks() storage.CheckStore {
+	return s.checks
+}
+
+func TestUpdateCheckRecordForApplyStartRefusesDriftBlock(t *testing.T) {
+	checks := &driftBlockedCheckStore{
+		stored: &storage.Check{
+			Repository:     "octocat/hello-world",
+			PullRequest:    1,
+			HeadSHA:        "abc123",
+			Environment:    "production",
+			DatabaseType:   "mysql",
+			DatabaseName:   "orders",
+			Status:         checkStatusCompleted,
+			Conclusion:     "failure",
+			BlockingReason: storage.ReviewTimeDeploymentDriftBlockingReason,
+		},
+	}
+	service := api.New(&driftBlockedStorage{checks: checks}, &api.ServerConfig{
+		Repos: map[string]api.RepoConfig{},
+	}, nil, testLogger())
+	h := &Handler{service: service, logger: testLogger()}
+
+	schema := &ghclient.SchemaRequestResult{
+		Database: "orders",
+		Type:     "mysql",
+	}
+
+	err := h.updateCheckRecordForApplyStart(t.Context(), nil, "octocat/hello-world", 1, schema, "production", 42)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "review-time deployment drift block present")
+	assert.Zero(t, checks.upsertCalls, "apply start must not overwrite a stored drift block")
+}

--- a/pkg/webhook/check_records.go
+++ b/pkg/webhook/check_records.go
@@ -13,23 +13,57 @@ import (
 	"github.com/block/schemabot/pkg/webhook/templates"
 )
 
-// reviewDriftResult carries the review-time per-deployment drift outcome into
-// the plan check record. When Blocked is true the plan check fails closed
-// regardless of whether the reviewed primary plan itself had changes, because a
-// deployment's live schema no longer matches what was reviewed (or could not be
-// confirmed to match). Summary explains why for the check's Change column and
-// logs. A nil result is non-blocking: either the rollup ran clean or drift was
-// not computed for this path (e.g. apply-time callsites).
-type reviewDriftResult struct {
-	Blocked bool
-	Summary string
+// reviewDriftState is how a plan-check write treats review-time deployment
+// drift. It distinguishes "the rollup ran and was clean" from "drift was not
+// evaluated on this write" — both carry no block, but only the former may clear
+// a stored drift block. See storage.PlanDriftState, which it mirrors.
+type reviewDriftState int
+
+const (
+	// driftNotEvaluated: the write did not run the rollup (e.g. an apply-time
+	// plan). Zero value so an unset outcome fails safe — it preserves, never
+	// clears, an existing drift block.
+	driftNotEvaluated reviewDriftState = iota
+	// driftClean: the rollup ran and every deployment matched the reviewed plan.
+	driftClean
+	// driftBlocked: the rollup ran and a deployment diverged or could not be
+	// confirmed, so the plan check fails closed.
+	driftBlocked
+)
+
+// reviewDriftOutcome carries the review-time per-deployment drift outcome into
+// the plan check record. When the state is driftBlocked the plan check fails
+// closed regardless of whether the reviewed primary plan itself had changes,
+// because a deployment's live schema no longer matches what was reviewed (or
+// could not be confirmed to match). summary explains why for the check's Change
+// column and logs.
+type reviewDriftOutcome struct {
+	state   reviewDriftState
+	summary string
+}
+
+// blocks reports whether this outcome must fail the plan check closed.
+func (o reviewDriftOutcome) blocks() bool { return o.state == driftBlocked }
+
+// planDriftState maps the outcome to the storage-layer write intent that tells
+// UpsertPlanResult whether it may clear, must set, or must preserve a stored
+// drift block.
+func (o reviewDriftOutcome) planDriftState() storage.PlanDriftState {
+	switch o.state {
+	case driftClean:
+		return storage.PlanDriftClean
+	case driftBlocked:
+		return storage.PlanDriftBlocked
+	default:
+		return storage.PlanDriftNotEvaluated
+	}
 }
 
 // storePlanCheckRecord stores per-database check state after a plan is generated.
 // The state is used internally by the aggregate check to compute its overall status.
 // No per-database GitHub Check Run is created — only the aggregate is visible on the PR.
 // Returns the commit SHA used for the plan. Failures are non-fatal.
-func (h *Handler) storePlanCheckRecord(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string, drift *reviewDriftResult) (string, error) {
+func (h *Handler) storePlanCheckRecord(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string, drift reviewDriftOutcome) (string, error) {
 	headSHA, _, err := h.upsertPlanCheckRecord(ctx, client, repo, pr, schema, planResp, environment, drift)
 	return headSHA, err
 }
@@ -37,7 +71,7 @@ func (h *Handler) storePlanCheckRecord(ctx context.Context, client *ghclient.Ins
 // storeManualPlanCheckRecord stores per-database check state after a manual
 // plan and then reconciles same-head apply-owned stored check state when the manual
 // plan proves the target already matches the PR schema.
-func (h *Handler) storeManualPlanCheckRecord(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string, drift *reviewDriftResult) (string, bool, error) {
+func (h *Handler) storeManualPlanCheckRecord(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string, drift reviewDriftOutcome) (string, bool, error) {
 	headSHA, check, err := h.upsertPlanCheckRecord(ctx, client, repo, pr, schema, planResp, environment, drift)
 	if err != nil {
 		return headSHA, false, err
@@ -47,7 +81,7 @@ func (h *Handler) storeManualPlanCheckRecord(ctx context.Context, client *ghclie
 	// diff is empty: a non-primary deployment drifted or could not be confirmed,
 	// so recovering (clearing) apply-owned check state here would wrongly unblock
 	// the PR. Leave the blocking check state in place for an operator to reconcile.
-	if drift != nil && drift.Blocked {
+	if drift.blocks() {
 		return headSHA, false, nil
 	}
 
@@ -95,7 +129,7 @@ func planCheckConclusion(hasChanges, hasPlanErrors, driftBlocked bool) string {
 	}
 }
 
-func (h *Handler) upsertPlanCheckRecord(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string, drift *reviewDriftResult) (string, *storage.Check, error) {
+func (h *Handler) upsertPlanCheckRecord(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string, drift reviewDriftOutcome) (string, *storage.Check, error) {
 	headSHA := schema.HeadSHA
 	if headSHA == "" {
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
@@ -137,28 +171,35 @@ func (h *Handler) upsertPlanCheckRecord(ctx context.Context, client *ghclient.In
 
 	tables := planResp.FlatTables()
 	hasChanges := len(tables) > 0
-	driftBlocked := drift != nil && drift.Blocked
+	driftBlocked := drift.blocks()
 
 	conclusion := planCheckConclusion(hasChanges, len(planResp.Errors) > 0, driftBlocked)
 
+	// Review-time drift is a first-class blocking reason, not an overload of the
+	// plan facts: HasChanges stays "the reviewed primary plan has changes", and
+	// the block rides on BlockingReason + Conclusion so a stored drift block is
+	// legible and durable across write paths.
 	changeSummary := summarizePlanChanges(schema, planResp, environment)
+	blockingReason := ""
 	if driftBlocked {
-		changeSummary = drift.Summary
+		changeSummary = drift.summary
+		blockingReason = reviewTimeDeploymentDriftBlock.blockingReason
 	}
 
 	check := &storage.Check{
-		Repository:    repo,
-		PullRequest:   pr,
-		HeadSHA:       headSHA,
-		Environment:   environment,
-		DatabaseType:  schema.Type,
-		DatabaseName:  schema.Database,
-		HasChanges:    hasChanges || driftBlocked,
-		Status:        checkStatusCompleted,
-		Conclusion:    conclusion,
-		ChangeSummary: changeSummary,
+		Repository:     repo,
+		PullRequest:    pr,
+		HeadSHA:        headSHA,
+		Environment:    environment,
+		DatabaseType:   schema.Type,
+		DatabaseName:   schema.Database,
+		HasChanges:     hasChanges,
+		Status:         checkStatusCompleted,
+		Conclusion:     conclusion,
+		BlockingReason: blockingReason,
+		ChangeSummary:  changeSummary,
 	}
-	if err := h.service.Storage().Checks().UpsertPlanResult(ctx, check); err != nil {
+	if err := h.service.Storage().Checks().UpsertPlanResult(ctx, check, drift.planDriftState()); err != nil {
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
 			Operation:    "plan_check_recorded",
 			Repository:   repo,

--- a/pkg/webhook/check_records.go
+++ b/pkg/webhook/check_records.go
@@ -18,7 +18,8 @@ import (
 // regardless of whether the reviewed primary plan itself had changes, because a
 // deployment's live schema no longer matches what was reviewed (or could not be
 // confirmed to match). Summary explains why for the check's Change column and
-// logs. A nil result means no drift rollup applied to this record.
+// logs. A nil result is non-blocking: either the rollup ran clean or drift was
+// not computed for this path (e.g. apply-time callsites).
 type reviewDriftResult struct {
 	Blocked bool
 	Summary string

--- a/pkg/webhook/check_records.go
+++ b/pkg/webhook/check_records.go
@@ -13,22 +13,41 @@ import (
 	"github.com/block/schemabot/pkg/webhook/templates"
 )
 
+// reviewDriftResult carries the review-time per-deployment drift outcome into
+// the plan check record. When Blocked is true the plan check fails closed
+// regardless of whether the reviewed primary plan itself had changes, because a
+// deployment's live schema no longer matches what was reviewed (or could not be
+// confirmed to match). Summary explains why for the check's Change column and
+// logs. A nil result means no drift rollup applied to this record.
+type reviewDriftResult struct {
+	Blocked bool
+	Summary string
+}
+
 // storePlanCheckRecord stores per-database check state after a plan is generated.
 // The state is used internally by the aggregate check to compute its overall status.
 // No per-database GitHub Check Run is created — only the aggregate is visible on the PR.
 // Returns the commit SHA used for the plan. Failures are non-fatal.
-func (h *Handler) storePlanCheckRecord(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string) (string, error) {
-	headSHA, _, err := h.upsertPlanCheckRecord(ctx, client, repo, pr, schema, planResp, environment)
+func (h *Handler) storePlanCheckRecord(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string, drift *reviewDriftResult) (string, error) {
+	headSHA, _, err := h.upsertPlanCheckRecord(ctx, client, repo, pr, schema, planResp, environment, drift)
 	return headSHA, err
 }
 
 // storeManualPlanCheckRecord stores per-database check state after a manual
 // plan and then reconciles same-head apply-owned stored check state when the manual
 // plan proves the target already matches the PR schema.
-func (h *Handler) storeManualPlanCheckRecord(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string) (string, bool, error) {
-	headSHA, check, err := h.upsertPlanCheckRecord(ctx, client, repo, pr, schema, planResp, environment)
+func (h *Handler) storeManualPlanCheckRecord(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string, drift *reviewDriftResult) (string, bool, error) {
+	headSHA, check, err := h.upsertPlanCheckRecord(ctx, client, repo, pr, schema, planResp, environment, drift)
 	if err != nil {
 		return headSHA, false, err
+	}
+
+	// A drift-blocked check is not a clean no-op plan even when the primary's own
+	// diff is empty: a non-primary deployment drifted or could not be confirmed,
+	// so recovering (clearing) apply-owned check state here would wrongly unblock
+	// the PR. Leave the blocking check state in place for an operator to reconcile.
+	if drift != nil && drift.Blocked {
+		return headSHA, false, nil
 	}
 
 	recoveredApplyOwnedCheckState, err := h.service.Storage().Checks().RecoverApplyOwnedCheckWithNoOpPlan(ctx, check)
@@ -56,7 +75,26 @@ func (h *Handler) storeManualPlanCheckRecord(ctx context.Context, client *ghclie
 	return headSHA, recoveredApplyOwnedCheckState, nil
 }
 
-func (h *Handler) upsertPlanCheckRecord(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string) (string, *storage.Check, error) {
+// planCheckConclusion decides a plan check's stored conclusion. Review-time
+// drift fails the check closed ahead of the plan's own outcome: a deployment
+// whose live schema no longer matches the reviewed plan (or that could not be
+// confirmed to match) must block the PR even when the primary's diff is clean or
+// empty. A primary plan that reported errors likewise fails; otherwise changes
+// require an apply and an empty diff passes.
+func planCheckConclusion(hasChanges, hasPlanErrors, driftBlocked bool) string {
+	switch {
+	case driftBlocked:
+		return checkConclusionFailure
+	case hasPlanErrors:
+		return checkConclusionFailure
+	case hasChanges:
+		return checkConclusionActionRequired
+	default:
+		return checkConclusionSuccess
+	}
+}
+
+func (h *Handler) upsertPlanCheckRecord(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment string, drift *reviewDriftResult) (string, *storage.Check, error) {
 	headSHA := schema.HeadSHA
 	if headSHA == "" {
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
@@ -98,15 +136,13 @@ func (h *Handler) upsertPlanCheckRecord(ctx context.Context, client *ghclient.In
 
 	tables := planResp.FlatTables()
 	hasChanges := len(tables) > 0
+	driftBlocked := drift != nil && drift.Blocked
 
-	var conclusion string
-	switch {
-	case len(planResp.Errors) > 0:
-		conclusion = checkConclusionFailure
-	case hasChanges:
-		conclusion = checkConclusionActionRequired
-	default:
-		conclusion = checkConclusionSuccess
+	conclusion := planCheckConclusion(hasChanges, len(planResp.Errors) > 0, driftBlocked)
+
+	changeSummary := summarizePlanChanges(schema, planResp, environment)
+	if driftBlocked {
+		changeSummary = drift.Summary
 	}
 
 	check := &storage.Check{
@@ -116,10 +152,10 @@ func (h *Handler) upsertPlanCheckRecord(ctx context.Context, client *ghclient.In
 		Environment:   environment,
 		DatabaseType:  schema.Type,
 		DatabaseName:  schema.Database,
-		HasChanges:    hasChanges,
+		HasChanges:    hasChanges || driftBlocked,
 		Status:        checkStatusCompleted,
 		Conclusion:    conclusion,
-		ChangeSummary: summarizePlanChanges(schema, planResp, environment),
+		ChangeSummary: changeSummary,
 	}
 	if err := h.service.Storage().Checks().UpsertPlanResult(ctx, check); err != nil {
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{

--- a/pkg/webhook/check_runs.go
+++ b/pkg/webhook/check_runs.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/block/schemabot/pkg/api"
+	"github.com/block/schemabot/pkg/storage"
 )
 
 // maxCheckRunTextLength is the GitHub API limit for check run output text.
@@ -94,6 +95,17 @@ var configDiscoveryFailedBlock = checkBlockReason{
 var managedDirMissingConfigBlock = checkBlockReason{
 	blockingReason: "managed_dir_missing_config",
 	message:        "A schema change under a SchemaBot-managed directory has no schemabot.yaml config.",
+}
+
+// reviewTimeDeploymentDriftBlock is used when a review-time drift rollup finds a
+// configured deployment whose live schema no longer matches the reviewed plan,
+// or a deployment that could not be diffed or confirmed to match. The plan check
+// fails closed until an operator reconciles the deployment or replans against
+// matching schema. blockingReason is stored so the block survives later writes
+// (e.g. an apply-time plan) that did not re-evaluate drift.
+var reviewTimeDeploymentDriftBlock = checkBlockReason{
+	blockingReason: storage.ReviewTimeDeploymentDriftBlockingReason,
+	message:        "One or more deployments differ from the reviewed plan, or could not be confirmed to match it; reconcile the deployment drift or replan once the deployments match before this check can pass.",
 }
 
 // noAllowedConfiguredEnvironmentsBlock is used when schema files changed but

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -139,10 +139,12 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 
 	// When drift blocked the check but its record could not be persisted, the
 	// aggregate must not be recomputed from stale (possibly passing) stored rows.
-	// Post a failing aggregate from the in-memory drift result so the gate still
-	// blocks closed.
-	if drift != nil && drift.Blocked && checkErr != nil {
-		h.postFailingAggregates(ctx, client, repo, pr, schemaResult.HeadSHA, map[string]string{environment: drift.Summary})
+	// Post a failing aggregate carrying the drift block from the in-memory result
+	// so the gate still blocks closed. This is best-effort visibility: with the
+	// per-database row unstored, a later recompute has no durable drift row to
+	// read, so the store error is logged above and not treated as a safe update.
+	if drift.blocks() && checkErr != nil {
+		h.postFailingAggregatesWithBlock(ctx, client, repo, pr, schemaResult.HeadSHA, map[string]string{environment: drift.summary}, reviewTimeDeploymentDriftBlock)
 	} else if headSHA != "" {
 		h.updateAggregateCheck(ctx, client, repo, pr, headSHA)
 	}
@@ -328,8 +330,8 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName, tenant s
 		}
 		if checkErr != nil {
 			h.logger.Error("failed to store plan check record", "repo", repo, "pr", pr, "env", env, "error", checkErr)
-			if drift != nil && drift.Blocked {
-				driftBlockUnstored[env] = drift.Summary
+			if drift.blocks() {
+				driftBlockUnstored[env] = drift.summary
 			}
 		}
 		if sha != "" {
@@ -361,7 +363,7 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName, tenant s
 	// the stored-row aggregate sync so a stale passing row cannot leave the gate
 	// open. Posted last so it wins over updateAggregateCheck for these envs.
 	if len(driftBlockUnstored) > 0 && multiEnvData.HeadSHA != "" {
-		h.postFailingAggregates(ctx, client, repo, pr, multiEnvData.HeadSHA, driftBlockUnstored)
+		h.postFailingAggregatesWithBlock(ctx, client, repo, pr, multiEnvData.HeadSHA, driftBlockUnstored, reviewTimeDeploymentDriftBlock)
 	}
 
 	// Auto-plan: skip comment if no changes and no errors (reduce PR noise)

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -105,7 +105,7 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 	}
 
 	// Execute plan via the service
-	planResp, err := h.executePlanWithTransientRetry(ctx, planReq, repo, pr)
+	planProto, planResp, err := h.executePlanProtoWithTransientRetry(ctx, planReq, repo, pr)
 	if err != nil {
 		h.logger.Error("plan execution failed", "repo", repo, "pr", pr, "database", schemaResult.Database, "deployment", deployment, "environment", environment, "error", err)
 		metrics.RecordPlan(ctx, repo, schemaResult.Database, deployment, environment, "error")
@@ -118,13 +118,17 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 		return
 	}
 
+	// Roll up every deployment's diff against the reviewed plan so drift on a
+	// non-primary deployment fails the check closed at review time.
+	drift := h.reviewTimeDrift(ctx, planReq, planProto, repo, pr)
+
 	// Build plan comment data
 	commentData := buildPlanCommentData(schemaResult, planResp, environment, tenant, requestedBy)
 
 	metrics.RecordPlan(ctx, repo, schemaResult.Database, deployment, environment, "success")
 
 	// Store per-database check record and update aggregate
-	headSHA, recoveredApplyOwnedCheckState, checkErr := h.storeManualPlanCheckRecord(ctx, client, repo, pr, schemaResult, planResp, environment)
+	headSHA, recoveredApplyOwnedCheckState, checkErr := h.storeManualPlanCheckRecord(ctx, client, repo, pr, schemaResult, planResp, environment, drift)
 	if checkErr != nil {
 		h.logger.Error("failed to store plan check record", "repo", repo, "pr", pr, "database", schemaResult.Database, "deployment", deployment, "environment", environment, "error", checkErr)
 	}
@@ -133,7 +137,13 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 	// Post plan comment
 	h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
 
-	if headSHA != "" {
+	// When drift blocked the check but its record could not be persisted, the
+	// aggregate must not be recomputed from stale (possibly passing) stored rows.
+	// Post a failing aggregate from the in-memory drift result so the gate still
+	// blocks closed.
+	if drift != nil && drift.Blocked && checkErr != nil {
+		h.postFailingAggregates(ctx, client, repo, pr, schemaResult.HeadSHA, map[string]string{environment: drift.Summary})
+	} else if headSHA != "" {
 		h.updateAggregateCheck(ctx, client, repo, pr, headSHA)
 	}
 
@@ -230,6 +240,10 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName, tenant s
 
 	// Collect plans for all environments
 	var headSHA string
+	// Environments whose drift-blocking check record could not be persisted, kept
+	// so a failing aggregate can be posted from the in-memory drift result rather
+	// than letting the post-loop aggregate recompute from stale stored rows.
+	driftBlockUnstored := map[string]string{}
 	multiEnvData := templates.MultiEnvPlanCommentData{
 		RequestedBy:  requestedBy,
 		Tenant:       tenant,
@@ -292,24 +306,31 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName, tenant s
 			SourceTrusted: true,
 		}
 
-		planResp, err := h.executePlanWithTransientRetry(ctx, planReq, repo, pr)
+		planProto, planResp, err := h.executePlanProtoWithTransientRetry(ctx, planReq, repo, pr)
 		if err != nil {
 			h.logger.Error("plan execution failed", "repo", repo, "pr", pr, "env", env, "error", err)
 			multiEnvData.Errors[env] = userFacingError(err)
 			continue
 		}
 
+		// Roll up every deployment's diff against the reviewed plan so drift on a
+		// non-primary deployment fails the check closed at review time.
+		drift := h.reviewTimeDrift(ctx, planReq, planProto, repo, pr)
+
 		// Store per-database check record per environment
 		var recoveredApplyOwnedCheckState bool
 		var sha string
 		var checkErr error
 		if isAutoPlan {
-			sha, checkErr = h.storePlanCheckRecord(ctx, client, repo, pr, schemaResult, planResp, env)
+			sha, checkErr = h.storePlanCheckRecord(ctx, client, repo, pr, schemaResult, planResp, env, drift)
 		} else {
-			sha, recoveredApplyOwnedCheckState, checkErr = h.storeManualPlanCheckRecord(ctx, client, repo, pr, schemaResult, planResp, env)
+			sha, recoveredApplyOwnedCheckState, checkErr = h.storeManualPlanCheckRecord(ctx, client, repo, pr, schemaResult, planResp, env, drift)
 		}
 		if checkErr != nil {
 			h.logger.Error("failed to store plan check record", "repo", repo, "pr", pr, "env", env, "error", checkErr)
+			if drift != nil && drift.Blocked {
+				driftBlockUnstored[env] = drift.Summary
+			}
 		}
 		if sha != "" {
 			headSHA = sha
@@ -333,6 +354,14 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName, tenant s
 		} else {
 			h.postFailingAggregates(ctx, client, repo, pr, prInfo.HeadSHA, multiEnvData.Errors)
 		}
+	}
+
+	// For any environment whose drift-blocking check record could not be
+	// persisted, post a failing aggregate from the in-memory drift result after
+	// the stored-row aggregate sync so a stale passing row cannot leave the gate
+	// open. Posted last so it wins over updateAggregateCheck for these envs.
+	if len(driftBlockUnstored) > 0 && multiEnvData.HeadSHA != "" {
+		h.postFailingAggregates(ctx, client, repo, pr, multiEnvData.HeadSHA, driftBlockUnstored)
 	}
 
 	// Auto-plan: skip comment if no changes and no errors (reduce PR noise)

--- a/pkg/webhook/plan_drift.go
+++ b/pkg/webhook/plan_drift.go
@@ -10,16 +10,28 @@ import (
 )
 
 // reviewTimeDrift computes the review-time drift rollup for a database and
-// environment and turns it into the check-record outcome. It returns nil when
-// every deployment matches the reviewed plan (no block). Any divergence, a
-// deployment that could not be diffed or compared, or a failure to compute the
-// rollup at all blocks the plan check closed: without a trustworthy comparison
-// SchemaBot cannot confirm the reviewed change is safe to apply everywhere.
+// environment and turns it into the check-record outcome. It returns a clean
+// outcome when every deployment matches the reviewed plan, and a blocked outcome
+// on any divergence, a deployment that could not be diffed or compared, or a
+// failure to compute the rollup at all: without a trustworthy comparison
+// SchemaBot cannot confirm the reviewed change is safe to apply everywhere, so
+// the plan check fails closed.
+//
+// The primary plan reporting errors is not a drift signal — that generic plan
+// failure already fails the check on its own — so the rollup is skipped and the
+// outcome is not-evaluated, avoiding N-1 live per-deployment diffs whose result
+// the rollup would classify entirely from the unusable baseline anyway.
 //
 // primaryPlan is the reviewed primary plan proto returned by
 // executePlanProtoWithTransientRetry, reused as the rollup baseline so the
 // comparison is against exactly what was reviewed.
-func (h *Handler) reviewTimeDrift(ctx context.Context, planReq api.PlanRequest, primaryPlan *ternv1.PlanResponse, repo string, pr int) *reviewDriftResult {
+func (h *Handler) reviewTimeDrift(ctx context.Context, planReq api.PlanRequest, primaryPlan *ternv1.PlanResponse, repo string, pr int) reviewDriftOutcome {
+	if len(primaryPlan.GetErrors()) > 0 {
+		h.logger.Debug("skipping review-time drift rollup: primary plan reported errors",
+			"repo", repo, "pr", pr, "database", planReq.Database, "environment", planReq.Environment)
+		return reviewDriftOutcome{state: driftNotEvaluated}
+	}
+
 	rollup, err := h.service.RollupReviewTimeDrift(ctx, planReq, primaryPlan)
 	if err != nil {
 		h.logger.Error("review-time drift rollup failed; the plan check will block the PR closed",
@@ -30,17 +42,17 @@ func (h *Handler) reviewTimeDrift(ctx context.Context, planReq api.PlanRequest, 
 			"error", err)
 		// Keep the stored Change column short and stable; the root cause is in the
 		// log above, and the raw error is untrusted for the aggregate's markdown.
-		return &reviewDriftResult{
-			Blocked: true,
-			Summary: "drift check failed; see logs",
+		return reviewDriftOutcome{
+			state:   driftBlocked,
+			summary: "drift check failed; see logs",
 		}
 	}
 	if rollup.Clean {
-		return nil
+		return reviewDriftOutcome{state: driftClean}
 	}
-	return &reviewDriftResult{
-		Blocked: true,
-		Summary: summarizeReviewDrift(rollup),
+	return reviewDriftOutcome{
+		state:   driftBlocked,
+		summary: summarizeReviewDrift(rollup),
 	}
 }
 

--- a/pkg/webhook/plan_drift.go
+++ b/pkg/webhook/plan_drift.go
@@ -1,0 +1,95 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/block/schemabot/pkg/api"
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+)
+
+// reviewTimeDrift computes the review-time drift rollup for a database and
+// environment and turns it into the check-record outcome. It returns nil when
+// every deployment matches the reviewed plan (no block). Any divergence, a
+// deployment that could not be diffed or compared, or a failure to compute the
+// rollup at all blocks the plan check closed: without a trustworthy comparison
+// SchemaBot cannot confirm the reviewed change is safe to apply everywhere.
+//
+// primaryPlan is the reviewed primary plan proto returned by
+// executePlanProtoWithTransientRetry, reused as the rollup baseline so the
+// comparison is against exactly what was reviewed.
+func (h *Handler) reviewTimeDrift(ctx context.Context, planReq api.PlanRequest, primaryPlan *ternv1.PlanResponse, repo string, pr int) *reviewDriftResult {
+	rollup, err := h.service.RollupReviewTimeDrift(ctx, planReq, primaryPlan)
+	if err != nil {
+		h.logger.Error("review-time drift rollup failed; the plan check will block the PR closed",
+			"repo", repo,
+			"pr", pr,
+			"database", planReq.Database,
+			"environment", planReq.Environment,
+			"error", err)
+		// Keep the stored Change column short and stable; the root cause is in the
+		// log above, and the raw error is untrusted for the aggregate's markdown.
+		return &reviewDriftResult{
+			Blocked: true,
+			Summary: "drift check failed; see logs",
+		}
+	}
+	if rollup.Clean {
+		return nil
+	}
+	return &reviewDriftResult{
+		Blocked: true,
+		Summary: summarizeReviewDrift(rollup),
+	}
+}
+
+// maxDriftSummaryLen bounds the stored drift summary to the checks table's
+// change_summary column width. The summary is truncated on a rune boundary so it
+// never exceeds the column or splits a multibyte character.
+const maxDriftSummaryLen = 255
+
+// summarizeReviewDrift builds the concise operator-facing reason a review-time
+// drift rollup blocked the plan check. It names the deployments that diverged
+// from the reviewed plan and those that could not be diffed or compared, so the
+// check's Change column tells an operator exactly which deployment to reconcile.
+func summarizeReviewDrift(rollup api.PlanRollup) string {
+	var diverged, errored []string
+	for _, entry := range rollup.Entries {
+		switch entry.Class {
+		case api.DeploymentDiverged:
+			diverged = append(diverged, entry.Deployment)
+		case api.DeploymentErrored:
+			errored = append(errored, entry.Deployment)
+		}
+	}
+
+	var parts []string
+	if len(diverged) > 0 {
+		parts = append(parts, fmt.Sprintf("diverged: %s", strings.Join(diverged, ", ")))
+	}
+	if len(errored) > 0 {
+		parts = append(parts, fmt.Sprintf("could not verify: %s", strings.Join(errored, ", ")))
+	}
+	if len(parts) == 0 {
+		// A not-clean rollup always has at least one non-matching entry; guard
+		// anyway so the check never records an empty, uninformative reason.
+		return "drift blocks apply: deployments differ from the reviewed plan"
+	}
+	return clampDriftSummary("drift blocks apply — " + strings.Join(parts, "; "))
+}
+
+// clampDriftSummary makes a drift summary safe to store in the checks table's
+// change_summary column and to render in the aggregate check's markdown: it
+// collapses newlines, neutralizes the table cell separator, and truncates on a
+// rune boundary to the column width.
+func clampDriftSummary(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	s = strings.ReplaceAll(s, "|", "/")
+	runes := []rune(s)
+	if len(runes) > maxDriftSummaryLen {
+		return string(runes[:maxDriftSummaryLen-1]) + "…"
+	}
+	return s
+}

--- a/pkg/webhook/plan_drift_test.go
+++ b/pkg/webhook/plan_drift_test.go
@@ -1,0 +1,74 @@
+package webhook
+
+import (
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/block/schemabot/pkg/api"
+)
+
+// The drift summary names diverged deployments so the check's Change column
+// tells an operator which deployment to reconcile.
+func TestSummarizeReviewDrift_NamesDivergedDeployments(t *testing.T) {
+	rollup := api.PlanRollup{
+		Entries: []api.DeploymentRollupEntry{
+			{Deployment: "eu", Class: api.DeploymentMatch},
+			{Deployment: "au", Class: api.DeploymentDiverged},
+		},
+	}
+	summary := summarizeReviewDrift(rollup)
+	assert.Contains(t, summary, "diverged: au")
+	assert.NotContains(t, summary, "eu")
+}
+
+// A deployment that could not be diffed or compared is reported as unverifiable,
+// separately from divergence, so the two failure modes are distinguishable.
+func TestSummarizeReviewDrift_SeparatesDivergedAndErrored(t *testing.T) {
+	rollup := api.PlanRollup{
+		Entries: []api.DeploymentRollupEntry{
+			{Deployment: "eu", Class: api.DeploymentMatch},
+			{Deployment: "au", Class: api.DeploymentDiverged},
+			{Deployment: "us", Class: api.DeploymentErrored},
+		},
+	}
+	summary := summarizeReviewDrift(rollup)
+	assert.Contains(t, summary, "diverged: au")
+	assert.Contains(t, summary, "could not verify: us")
+}
+
+// The stored drift summary is bounded to the change_summary column width and is
+// kept on a single line with no markdown table separators, so a database with
+// many drifted deployments cannot overflow the column or break the aggregate
+// table rendering.
+func TestSummarizeReviewDrift_BoundedAndSanitized(t *testing.T) {
+	var entries []api.DeploymentRollupEntry
+	entries = append(entries, api.DeploymentRollupEntry{Deployment: "eu", Class: api.DeploymentMatch})
+	for range 200 {
+		entries = append(entries, api.DeploymentRollupEntry{
+			Deployment: "deployment-with-a-fairly-long-name",
+			Class:      api.DeploymentDiverged,
+		})
+	}
+	summary := summarizeReviewDrift(api.PlanRollup{Entries: entries})
+
+	assert.LessOrEqual(t, utf8.RuneCountInString(summary), maxDriftSummaryLen)
+	assert.NotContains(t, summary, "\n")
+	assert.NotContains(t, summary, "|")
+}
+
+// Review-time drift fails the plan check closed even when the reviewed primary
+// plan is a clean no-op, taking precedence over the plan's own outcome.
+func TestPlanCheckConclusion_DriftFailsClosed(t *testing.T) {
+	assert.Equal(t, checkConclusionFailure, planCheckConclusion(false, false, true),
+		"drift must block even a clean no-op primary plan")
+	assert.Equal(t, checkConclusionFailure, planCheckConclusion(true, false, true),
+		"drift must block a plan that also has changes")
+	assert.Equal(t, checkConclusionFailure, planCheckConclusion(false, true, false),
+		"a primary plan with errors fails closed")
+	assert.Equal(t, checkConclusionActionRequired, planCheckConclusion(true, false, false),
+		"changes without drift require an apply")
+	assert.Equal(t, checkConclusionSuccess, planCheckConclusion(false, false, false),
+		"a clean no-op plan with no drift passes")
+}

--- a/pkg/webhook/plan_retry.go
+++ b/pkg/webhook/plan_retry.go
@@ -12,6 +12,7 @@ import (
 	"github.com/block/schemabot/pkg/api"
 	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/metrics"
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 )
 
 const (
@@ -57,9 +58,19 @@ func (h *Handler) planRetryDelay() time.Duration {
 // the gRPC client's retry budget while still surfacing sustained outages
 // within seconds.
 func (h *Handler) executePlanWithTransientRetry(ctx context.Context, planReq api.PlanRequest, repo string, pr int) (*apitypes.PlanResponse, error) {
-	planResp, err := h.service.ExecutePlan(ctx, planReq)
+	_, planResp, err := h.executePlanProtoWithTransientRetry(ctx, planReq, repo, pr)
+	return planResp, err
+}
+
+// executePlanProtoWithTransientRetry runs ExecutePlanProto with the same
+// transient-retry behavior as executePlanWithTransientRetry, additionally
+// returning the reviewed primary plan proto so callers can feed it to the
+// review-time drift rollup without re-planning or reconstructing it from
+// storage.
+func (h *Handler) executePlanProtoWithTransientRetry(ctx context.Context, planReq api.PlanRequest, repo string, pr int) (*ternv1.PlanResponse, *apitypes.PlanResponse, error) {
+	planProto, planResp, err := h.service.ExecutePlanProto(ctx, planReq)
 	if err == nil || !isTransientRemotePlanError(err) {
-		return planResp, err
+		return planProto, planResp, err
 	}
 
 	delay := h.planRetryDelay()
@@ -80,11 +91,11 @@ func (h *Handler) executePlanWithTransientRetry(ctx context.Context, planReq api
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			return nil, fmt.Errorf("plan retry for %s/%s cancelled: %w", planReq.Database, planReq.Environment, ctx.Err())
+			return nil, nil, fmt.Errorf("plan retry for %s/%s cancelled: %w", planReq.Database, planReq.Environment, ctx.Err())
 		case <-timer.C:
 		}
 
-		planResp, retryErr := h.service.ExecutePlan(ctx, planReq)
+		planProto, planResp, retryErr := h.service.ExecutePlanProto(ctx, planReq)
 		if retryErr == nil {
 			metrics.RecordTransientPlanRetry(ctx, planReq.Database, planReq.Environment, "recovered")
 			h.logger.Info("plan retry recovered from transient remote unavailability",
@@ -94,7 +105,7 @@ func (h *Handler) executePlanWithTransientRetry(ctx context.Context, planReq api
 				"environment", planReq.Environment,
 				"retry_attempt", retryAttempt,
 				"plan_id", planResp.PlanID)
-			return planResp, nil
+			return planProto, planResp, nil
 		}
 		if !isTransientRemotePlanError(retryErr) {
 			metrics.RecordTransientPlanRetry(ctx, planReq.Database, planReq.Environment, "stopped_non_transient")
@@ -105,7 +116,7 @@ func (h *Handler) executePlanWithTransientRetry(ctx context.Context, planReq api
 				"environment", planReq.Environment,
 				"retry_attempt", retryAttempt,
 				"error", retryErr)
-			return nil, retryErr
+			return nil, nil, retryErr
 		}
 		lastErr = retryErr
 	}
@@ -119,5 +130,5 @@ func (h *Handler) executePlanWithTransientRetry(ctx context.Context, planReq api
 		"max_retries", maxTransientPlanRetries,
 		"first_error", firstErr,
 		"last_error", lastErr)
-	return nil, firstErr
+	return nil, nil, firstErr
 }


### PR DESCRIPTION
## Summary
Moves per-deployment schema drift detection to review time and makes a drift block **durable**. Every configured deployment's diff is rolled up against the reviewed primary plan when a plan runs, and any deployment that diverges — or cannot be diffed or confirmed to match — fails the plan check **closed**. The block is stored as a first-class `Check.BlockingReason` so no later write path can silently clear it.

## What
- `Service.RollupReviewTimeDrift` resolves the configured deployments, diffs each against the reviewed primary plan proto (reused in-process, no re-read), and classifies them via the shard-aware comparator.
- The webhook plan flow (single-env and multi-env) consumes the rollup: a drift-blocked result forces the stored plan check `conclusion=failure`, even when the primary's own diff is a clean no-op.
- **Durable block:** drift is recorded as `Check.BlockingReason = review_time_deployment_drift`, not overloaded onto `HasChanges`/a free-text summary. `UpsertPlanResult` takes an explicit tri-state (`not-evaluated` / `clean` / `blocked`) that fails safe — a `not-evaluated` write (e.g. an apply-time plan) **preserves** an existing block instead of clearing it, and apply start refuses to transition a drift-blocked row to `in_progress`.
- Fails closed on uncertainty: a rollup that cannot be computed blocks; the store-failure fallback posts a failing aggregate **carrying the block reason** so a later recompute can't republish a passing aggregate; drift-blocked plans skip no-op check recovery.
- Skips the N−1 deployment diffs when the primary plan already reported errors (that generic failure fails the check on its own).
- Adds a `schemabot.review_drift.total` metric (per-deployment classification; unknown classes bucket as `unknown`, not `errored`) and includes repo/pr/head SHA in drift warn logs.

## Why
Only the primary deployment planned at review time, so drift on a non-primary deployment stayed invisible until apply — surfacing late, mid-rollout. Surfacing it at review makes divergence legible before approval and turns the apply-time refusal into a backstop. Because Check Runs are a tier-0 safety gate, the block must also survive every subsequent write path (apply-time plan, aggregate recompute, stale cleanup, apply start), not just the plan that detected it.

## Before / after
```
Before — only the primary is planned; a block, once posted, was fragile
plan primary (eu) ──► reviewed ──► check passes ✅
au, us never planned ──► drift surfaces at APPLY (blocks late)
even when a block was posted, a later apply-time plan / aggregate
recompute on the same head could overwrite it back to passing
```

```
After — every deployment is diffed at review time; the block is durable
plan primary (eu) ──► reviewed baseline
├─ RollupReviewTimeDrift: diff au, us vs reviewed plan
├─ any diverged / unverifiable ──► store BlockingReason=review_time_deployment_drift
│                                   check FAILS CLOSED ⛔ (blocks at review)
└─ later writes (apply-time plan, aggregate recompute, apply start)
must consciously clear it or re-run the rollup — never silently
all match ──► rollup clean ──► block cleared ──► check passes ✅
```
