### PR TITLE
fix(github): rollback completion marks the check action_required without passing through success

### DIFF
--- a/pkg/webhook/apply_execute.go
+++ b/pkg/webhook/apply_execute.go
@@ -130,41 +130,12 @@ func (h *Handler) executeApply(
 		SupportChannel: h.supportChannel(),
 		Logger:         h.logger,
 		OnTerminalHook: func(apply *storage.Apply) {
-			updated, err := h.updateCheckRecordForApplyResult(context.Background(), repo, pr, apply)
-			if err != nil {
-				h.logger.Error("observer: failed to update check record",
-					append(apply.LogAttrs(), "error", err)...)
-				return
-			}
-			if !updated {
-				h.logger.Debug("observer: skipping aggregate check update, apply no longer owns check state",
-					"repo", repo, "pr", pr, "apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier)
-				return
-			}
-			ghInstClient, err := factory.ForInstallation(installationID)
-			if err != nil {
-				h.logger.Error("observer: failed to create GitHub client",
-					append(apply.LogAttrs(),
-						"installation_id", installationID, "error", err)...)
-				return
-			}
-			checkRecord, err := h.service.Storage().Checks().Get(context.Background(), repo, pr, apply.Environment, apply.DatabaseType, apply.Database)
-			if err != nil {
-				h.logger.Error("observer: failed to load check record for aggregate update",
-					"repo", repo, "pr", pr, "database", apply.Database,
-					"database_type", apply.DatabaseType, "environment", apply.Environment,
-					"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,
-					"error", err)
-				return
-			}
-			if checkRecord == nil {
-				h.logger.Warn("observer: check record missing for aggregate update",
-					"repo", repo, "pr", pr, "database", apply.Database,
-					"database_type", apply.DatabaseType, "environment", apply.Environment,
-					"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier)
-				return
-			}
-			h.updateAggregateCheck(context.Background(), ghInstClient, repo, pr, checkRecord.HeadSHA)
+			// refreshChecksForTerminalApply routes a completed rollback straight
+			// to action_required. The observer registered here can be consumed by
+			// a rollback apply (pending observers share a per-target key), so the
+			// terminal ordering must honor the rollback intent from the durable
+			// apply, not from the command that registered the observer.
+			h.refreshChecksForTerminalApply(context.Background(), apply, "apply command")
 		},
 	})
 	h.service.SetPendingObserver(database, "", environment, observer)

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -9,7 +9,6 @@ import (
 	"github.com/block/schemabot/pkg/api"
 	"github.com/block/schemabot/pkg/apitypes"
 	ghclient "github.com/block/schemabot/pkg/github"
-	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/webhook/action"
 	"github.com/block/schemabot/pkg/webhook/templates"
@@ -382,53 +381,10 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment 
 		SupportChannel: h.supportChannel(),
 		Logger:         h.logger,
 		OnTerminalHook: func(a *storage.Apply) {
-			updated, err := h.updateCheckRecordForApplyResult(context.Background(), repo, pr, a)
-			if err != nil {
-				h.logger.Error("observer: failed to update check record for rollback",
-					"repo", repo, "pr", pr, "database", a.Database,
-					"database_type", a.DatabaseType, "environment", a.Environment,
-					"apply_id", a.ID, "apply_identifier", a.ApplyIdentifier,
-					"error", err)
-				return
-			}
-			if !updated {
-				h.logger.Debug("observer: skipping aggregate check update for rollback, apply no longer owns check state",
-					"repo", repo, "pr", pr, "database", a.Database,
-					"database_type", a.DatabaseType, "environment", a.Environment,
-					"apply_id", a.ID, "apply_identifier", a.ApplyIdentifier)
-				return
-			}
-			if state.IsState(a.State, state.Apply.Completed) {
-				h.setCheckActionRequired(repo, pr, installationID, a)
-				return
-			}
-
-			ghInstClient, err := factory.ForInstallation(installationID)
-			if err != nil {
-				h.logger.Error("observer: failed to create GitHub client for rollback aggregate update",
-					"repo", repo, "pr", pr, "database", a.Database,
-					"database_type", a.DatabaseType, "environment", a.Environment,
-					"apply_id", a.ID, "apply_identifier", a.ApplyIdentifier,
-					"error", err)
-				return
-			}
-			checkRecord, err := h.service.Storage().Checks().Get(context.Background(), repo, pr, a.Environment, a.DatabaseType, a.Database)
-			if err != nil {
-				h.logger.Error("observer: failed to load check record for rollback aggregate update",
-					"repo", repo, "pr", pr, "database", a.Database,
-					"database_type", a.DatabaseType, "environment", a.Environment,
-					"apply_id", a.ID, "apply_identifier", a.ApplyIdentifier,
-					"error", err)
-				return
-			}
-			if checkRecord == nil {
-				h.logger.Error("observer: missing check record for rollback aggregate update",
-					"repo", repo, "pr", pr, "database", a.Database,
-					"database_type", a.DatabaseType, "environment", a.Environment,
-					"apply_id", a.ID, "apply_identifier", a.ApplyIdentifier)
-				return
-			}
-			h.updateAggregateCheck(context.Background(), ghInstClient, repo, pr, checkRecord.HeadSHA)
+			// refreshChecksForTerminalApply routes a completed rollback straight
+			// to action_required so the stored check state never passes through
+			// success while the PR's schema change is reverted on the target.
+			h.refreshChecksForTerminalApply(context.Background(), a, "rollback confirm")
 		},
 	})
 	h.service.SetPendingObserver(database, rollbackPlan.Deployment, environment, observer)

--- a/pkg/webhook/rollback_integration_test.go
+++ b/pkg/webhook/rollback_integration_test.go
@@ -422,8 +422,8 @@ func (s *recordingCheckStore) Upsert(ctx context.Context, check *storage.Check) 
 	return err
 }
 
-func (s *recordingCheckStore) UpsertPlanResult(ctx context.Context, check *storage.Check) error {
-	err := s.CheckStore.UpsertPlanResult(ctx, check)
+func (s *recordingCheckStore) UpsertPlanResult(ctx context.Context, check *storage.Check, drift storage.PlanDriftState) error {
+	err := s.CheckStore.UpsertPlanResult(ctx, check, drift)
 	if err == nil {
 		s.record("upsert_plan_result", check.DatabaseName, check.Status, check.Conclusion)
 	}
@@ -599,12 +599,21 @@ func TestE2ERollbackConfirmUpdatesCheckToActionRequired(t *testing.T) {
 
 	// The completed rollback's terminal transition must be in_progress →
 	// action_required with nothing in between: a stored success, however brief,
-	// is a passing required check to any concurrent aggregate reader.
+	// is a passing required check to any concurrent aggregate reader. Prove
+	// both halves — the check was marked in_progress while the rollback ran,
+	// and the only completed conclusion ever stored is action_required.
 	writes := recorder.Writes()
 	require.NotEmpty(t, writes, "recorder should observe the rollback's stored check state writes")
+	assert.True(t, slices.ContainsFunc(writes, func(w checkWrite) bool {
+		return w.status == checkStatusInProgress
+	}), "stored check state must be marked in_progress while the rollback executes")
 	for _, w := range writes {
 		assert.NotEqual(t, checkConclusionSuccess, w.conclusion,
 			"stored check state was written as success during rollback finalization (op %s, status %s)", w.op, w.status)
+		if w.status == checkStatusCompleted {
+			assert.Equal(t, checkConclusionActionRequired, w.conclusion,
+				"every completed stored check state write during rollback finalization must be action_required (op %s)", w.op)
+		}
 	}
 	terminal := writes[len(writes)-1]
 	assert.Equal(t, "mark_action_required_for_apply", terminal.op)

--- a/pkg/webhook/rollback_integration_test.go
+++ b/pkg/webhook/rollback_integration_test.go
@@ -378,9 +378,12 @@ type checkWrite struct {
 	conclusion string
 }
 
-// recordingCheckStore records every stored check state write that lands for
-// one database's check row. Recording starts when StartRecording is called so
-// a test can scope the observation window to the flow under test.
+// recordingCheckStore records every conclusion-writing stored check state
+// operation that lands for one database's check row. Operations that clear or
+// delete check state without writing a status/conclusion pass through
+// unrecorded; tests assert on the final stored row to cover those. Recording
+// starts when StartRecording is called so a test can scope the observation
+// window to the flow under test.
 type recordingCheckStore struct {
 	storage.CheckStore
 	databaseName string
@@ -433,7 +436,7 @@ func (s *recordingCheckStore) UpsertPlanResult(ctx context.Context, check *stora
 func (s *recordingCheckStore) RecoverApplyOwnedCheckWithNoOpPlan(ctx context.Context, check *storage.Check) (bool, error) {
 	updated, err := s.CheckStore.RecoverApplyOwnedCheckWithNoOpPlan(ctx, check)
 	if err == nil && updated {
-		s.record("recover_apply_owned_check", check.DatabaseName, checkStatusCompleted, checkConclusionSuccess)
+		s.record("recover_apply_owned_check", check.DatabaseName, check.Status, check.Conclusion)
 	}
 	return updated, err
 }
@@ -441,7 +444,7 @@ func (s *recordingCheckStore) RecoverApplyOwnedCheckWithNoOpPlan(ctx context.Con
 func (s *recordingCheckStore) MarkStalePlanSuccessful(ctx context.Context, check *storage.Check) (bool, error) {
 	updated, err := s.CheckStore.MarkStalePlanSuccessful(ctx, check)
 	if err == nil && updated {
-		s.record("mark_stale_plan_successful", check.DatabaseName, checkStatusCompleted, checkConclusionSuccess)
+		s.record("mark_stale_plan_successful", check.DatabaseName, check.Status, check.Conclusion)
 	}
 	return updated, err
 }
@@ -615,9 +618,19 @@ func TestE2ERollbackConfirmUpdatesCheckToActionRequired(t *testing.T) {
 				"every completed stored check state write during rollback finalization must be action_required (op %s)", w.op)
 		}
 	}
-	terminal := writes[len(writes)-1]
+	// The recorder logs each write after its commit, on the writer's own
+	// goroutine, so recorded order across goroutines is not commit order — the
+	// claim upsert can be recorded after the terminal write it preceded. Assert
+	// on the last completed-status write, which only the terminal path produces.
+	terminalIdx := -1
+	for i, w := range writes {
+		if w.status == checkStatusCompleted {
+			terminalIdx = i
+		}
+	}
+	require.GreaterOrEqual(t, terminalIdx, 0, "recorder should observe the rollback's terminal stored check state write")
+	terminal := writes[terminalIdx]
 	assert.Equal(t, "mark_action_required_for_apply", terminal.op)
-	assert.Equal(t, checkStatusCompleted, terminal.status)
 	assert.Equal(t, checkConclusionActionRequired, terminal.conclusion)
 
 	deadline := time.After(webhookIntegrationPollDeadline)

--- a/pkg/webhook/rollback_integration_test.go
+++ b/pkg/webhook/rollback_integration_test.go
@@ -5,6 +5,7 @@
 package webhook
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -13,7 +14,9 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -355,12 +358,126 @@ func TestE2ERollbackConfirmExecutesAndPostsComments(t *testing.T) {
 	}
 }
 
+// checkWriteRecorder wraps the service's storage so a test can observe every
+// stored check state write for one database's check row. Any concurrent
+// aggregate refresh republishes the stored row to GitHub, so even a transient
+// stored success is an externally visible passing check — asserting on the
+// final row alone cannot prove the invariant that a state was never written.
+type checkWriteRecorder struct {
+	storage.Storage
+	checks *recordingCheckStore
+}
+
+func (s *checkWriteRecorder) Checks() storage.CheckStore { return s.checks }
+
+// checkWrite is one observable stored check state write: the store operation
+// that performed it and the status/conclusion it made visible.
+type checkWrite struct {
+	op         string
+	status     string
+	conclusion string
+}
+
+// recordingCheckStore records every stored check state write that lands for
+// one database's check row. Recording starts when StartRecording is called so
+// a test can scope the observation window to the flow under test.
+type recordingCheckStore struct {
+	storage.CheckStore
+	databaseName string
+
+	mu      sync.Mutex
+	enabled bool
+	writes  []checkWrite
+}
+
+func (s *recordingCheckStore) StartRecording() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.enabled = true
+}
+
+func (s *recordingCheckStore) Writes() []checkWrite {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.writes)
+}
+
+func (s *recordingCheckStore) record(op, databaseName, status, conclusion string) {
+	if databaseName != s.databaseName {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.enabled {
+		return
+	}
+	s.writes = append(s.writes, checkWrite{op: op, status: status, conclusion: conclusion})
+}
+
+func (s *recordingCheckStore) Upsert(ctx context.Context, check *storage.Check) error {
+	err := s.CheckStore.Upsert(ctx, check)
+	if err == nil {
+		s.record("upsert", check.DatabaseName, check.Status, check.Conclusion)
+	}
+	return err
+}
+
+func (s *recordingCheckStore) UpsertPlanResult(ctx context.Context, check *storage.Check) error {
+	err := s.CheckStore.UpsertPlanResult(ctx, check)
+	if err == nil {
+		s.record("upsert_plan_result", check.DatabaseName, check.Status, check.Conclusion)
+	}
+	return err
+}
+
+func (s *recordingCheckStore) RecoverApplyOwnedCheckWithNoOpPlan(ctx context.Context, check *storage.Check) (bool, error) {
+	updated, err := s.CheckStore.RecoverApplyOwnedCheckWithNoOpPlan(ctx, check)
+	if err == nil && updated {
+		s.record("recover_apply_owned_check", check.DatabaseName, checkStatusCompleted, checkConclusionSuccess)
+	}
+	return updated, err
+}
+
+func (s *recordingCheckStore) MarkStalePlanSuccessful(ctx context.Context, check *storage.Check) (bool, error) {
+	updated, err := s.CheckStore.MarkStalePlanSuccessful(ctx, check)
+	if err == nil && updated {
+		s.record("mark_stale_plan_successful", check.DatabaseName, checkStatusCompleted, checkConclusionSuccess)
+	}
+	return updated, err
+}
+
+func (s *recordingCheckStore) CompleteForApply(ctx context.Context, check *storage.Check, apply *storage.Apply) (bool, error) {
+	updated, err := s.CheckStore.CompleteForApply(ctx, check, apply)
+	if err == nil && updated {
+		s.record("complete_for_apply", check.DatabaseName, check.Status, check.Conclusion)
+	}
+	return updated, err
+}
+
+func (s *recordingCheckStore) MarkActionRequiredForApply(ctx context.Context, check *storage.Check, apply *storage.Apply) (bool, error) {
+	updated, err := s.CheckStore.MarkActionRequiredForApply(ctx, check, apply)
+	if err == nil && updated {
+		s.record("mark_action_required_for_apply", check.DatabaseName, check.Status, check.Conclusion)
+	}
+	return updated, err
+}
+
 // TestE2ERollbackConfirmUpdatesCheckToActionRequired verifies that after a
 // rollback-confirm completes, the check run transitions to action_required
-// (not success) since the PR's schema changes have been undone.
+// (not success) since the PR's schema changes have been undone. The stored
+// check state must move to action_required directly: a completed rollback
+// means the PR's change is reverted on the target, so no write in the terminal
+// path may make the stored state read as a passing check, even transiently —
+// a concurrent aggregate refresh (another database's plan, a check_run event,
+// another pod) reading that window would publish a passing required check for
+// a PR whose schema change is gone.
 func TestE2ERollbackConfirmUpdatesCheckToActionRequired(t *testing.T) {
 	dbName := "webhook_rb_check"
-	svc := setupE2EService(t, dbName)
+	recorder := &recordingCheckStore{databaseName: dbName}
+	svc := setupE2EServiceWithStorage(t, dbName, func(st storage.Storage) storage.Storage {
+		recorder.CheckStore = st.Checks()
+		return &checkWriteRecorder{Storage: st, checks: recorder}
+	})
 	ctx := t.Context()
 
 	// Step 1: Create initial table
@@ -451,7 +568,9 @@ func TestE2ERollbackConfirmUpdatesCheckToActionRequired(t *testing.T) {
 		t.Fatal("timed out waiting for rollback plan comment")
 	}
 
-	// Run rollback-confirm
+	// Run rollback-confirm, recording every stored check state write for this
+	// database from here on so the terminal transition can be proven direct.
+	recorder.StartRecording()
 	req = buildWebhookRequest(t, webhookPayloadOpts{
 		comment: "schemabot rollback-confirm -e staging",
 		isPR:    true,
@@ -469,6 +588,28 @@ func TestE2ERollbackConfirmUpdatesCheckToActionRequired(t *testing.T) {
 		return isRollbackActionRequiredWithoutApplyOwnership(check)
 	}, webhookIntegrationPollDeadline, 500*time.Millisecond,
 		"check should transition to action_required without active apply ownership after rollback")
+
+	check, err := svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1, "staging", "mysql", dbName)
+	require.NoError(t, err)
+	require.NotNil(t, check)
+	assert.Equal(t, checkStatusCompleted, check.Status)
+	assert.Equal(t, checkConclusionActionRequired, check.Conclusion)
+	assert.Equal(t, rollbackCompletedBlock.blockingReason, check.BlockingReason)
+	assert.Equal(t, rollbackCompletedBlock.message, check.ErrorMessage)
+
+	// The completed rollback's terminal transition must be in_progress →
+	// action_required with nothing in between: a stored success, however brief,
+	// is a passing required check to any concurrent aggregate reader.
+	writes := recorder.Writes()
+	require.NotEmpty(t, writes, "recorder should observe the rollback's stored check state writes")
+	for _, w := range writes {
+		assert.NotEqual(t, checkConclusionSuccess, w.conclusion,
+			"stored check state was written as success during rollback finalization (op %s, status %s)", w.op, w.status)
+	}
+	terminal := writes[len(writes)-1]
+	assert.Equal(t, "mark_action_required_for_apply", terminal.op)
+	assert.Equal(t, checkStatusCompleted, terminal.status)
+	assert.Equal(t, checkConclusionActionRequired, terminal.conclusion)
 
 	deadline := time.After(webhookIntegrationPollDeadline)
 	for {

--- a/pkg/webhook/webhook_integration_test.go
+++ b/pkg/webhook/webhook_integration_test.go
@@ -147,6 +147,15 @@ func TestMain(m *testing.M) {
 // setupE2EService creates a real api.Service with a LocalClient for the given database.
 func setupE2EService(t *testing.T, appDBName string) *api.Service {
 	t.Helper()
+	return setupE2EServiceWithStorage(t, appDBName, nil)
+}
+
+// setupE2EServiceWithStorage is setupE2EService with a storage decorator hook.
+// A non-nil wrapStorage wraps the service's storage so a test can observe every
+// storage write the handler and observers perform (e.g. record stored check
+// state transitions).
+func setupE2EServiceWithStorage(t *testing.T, appDBName string, wrapStorage func(storage.Storage) storage.Storage) *api.Service {
+	t.Helper()
 	ctx := t.Context()
 
 	// Create the app database on the target
@@ -171,7 +180,10 @@ func setupE2EService(t *testing.T, appDBName string) *api.Service {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = schemabotDB.Close() })
 
-	st := mysqlstore.New(schemabotDB)
+	st := storage.Storage(mysqlstore.New(schemabotDB))
+	if wrapStorage != nil {
+		st = wrapStorage(st)
+	}
 
 	// Clean up any stale data from previous test runs (shared storage DB)
 	_, _ = schemabotDB.ExecContext(ctx, "DELETE FROM checks WHERE database_name = ?", appDBName)


### PR DESCRIPTION
## Why this matters

The aggregate GitHub Check Run is a tier-0 merge gate. When a rollback completed, the stored check state was updated in two writes: an ordinary apply-result write that stored `completed/success`, then a flip to `action_required`. A crash between the writes left the check permanently passing, and any concurrent aggregate refresh reading in that window published a passing required check for a PR whose schema change was just reverted — with auto-merge enabled, that merges the PR.

## What it does

- A completed rollback's stored check state now transitions `in_progress → action_required` directly — no write in the terminal path ever stores `success` for it, even transiently.
- Both command observers' terminal hooks delegate to the shared `refreshChecksForTerminalApply` helper — the same path apply completion and stale-check reconciliation already use. The apply-command hook matters too: pending observers share a per-target key, so a rollback apply can consume an observer registered by a concurrent apply command, and that hook must honor the rollback intent from the durable apply row.
- The failed-rollback path is behaviorally unchanged: ordinary apply-result update, then aggregate refresh.
- The integration test records every conclusion-writing stored check state operation during rollback finalization and proves the transition is direct, with no `success` write at any point.

## Before / after

```
Before
rollback completes ──► terminal hook
  ├─ write 1: CompleteForApply ────► stored: completed/success ✅ ⛔
  │     crash here = check passes forever
  │     concurrent aggregate refresh reads here
  │       └──► publishes passing required check ──► PR auto-merges ⛔
  └─ write 2: MarkActionRequiredForApply ──► completed/action_required
```

```
After
rollback completes ──► terminal hook ──► refreshChecksForTerminalApply
  ├─ completed rollback ──► MarkActionRequiredForApply (the only write)
  │                           stored: in_progress ──► action_required ❌ blocks
  └─ failed rollback ─────► ordinary apply-result update + aggregate refresh
```

Known residual (pre-existing, follow-up): the rollback's check claim lands after the rollback is queued, so a claim failure or crash in that gap can still leave the prior apply's `completed/success` in place with nothing converging it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
