### PR TITLE
fix(github): PR close retains apply-owned blocking check state

### DIFF
--- a/pkg/storage/mysqlstore/checks.go
+++ b/pkg/storage/mysqlstore/checks.go
@@ -508,8 +508,8 @@ func (s *checkStore) Delete(ctx context.Context, id int64) error {
 	return checkRowsAffected(result, storage.ErrCheckNotFound)
 }
 
-// DeleteByPRExcludingApplyOwned removes stored check state for a PR, except
-// apply-owned rows that still block the PR. Once an apply has started, its
+// DeleteByPRRetainingBlockingApplyOwned removes stored check state for a PR,
+// retaining apply-owned rows that still block the PR. Once an apply has started, its
 // stored check state is authoritative until an operator reconciles the target
 // environment — closing and reopening the PR must not convert it into a
 // passing aggregate. A row is retained when apply_id is set and either:
@@ -525,7 +525,7 @@ func (s *checkStore) Delete(ctx context.Context, id int64) error {
 // Apply-owned rows whose conclusion is success are deleted: the apply
 // finished cleanly and matches the PR contents, so nothing remains for the
 // row to block and a reopened PR must not inherit a stale gate.
-func (s *checkStore) DeleteByPRExcludingApplyOwned(ctx context.Context, repo string, pr int) error {
+func (s *checkStore) DeleteByPRRetainingBlockingApplyOwned(ctx context.Context, repo string, pr int) error {
 	_, err := s.db.ExecContext(ctx, `
 		DELETE FROM checks
 		WHERE repository = ? AND pull_request = ?

--- a/pkg/storage/mysqlstore/checks.go
+++ b/pkg/storage/mysqlstore/checks.go
@@ -17,7 +17,10 @@ const checkColumns = `id, repository, pull_request, head_sha,
 	check_run_id, apply_id, has_changes, status, conclusion,
 	blocking_reason, error_message, change_summary, created_at, updated_at`
 
-const checkStatusInProgress = "in_progress"
+const (
+	checkStatusInProgress  = "in_progress"
+	checkConclusionSuccess = "success"
+)
 
 // checkStore implements storage.CheckStore using MySQL.
 type checkStore struct {
@@ -506,15 +509,28 @@ func (s *checkStore) Delete(ctx context.Context, id int64) error {
 }
 
 // DeleteByPRExcludingApplyOwned removes stored check state for a PR, except
-// rows owned by an in-flight apply. A row with apply_id set and status
-// in_progress must keep blocking until the apply reaches a terminal state,
-// even when PR-close cleanup found no non-terminal apply in the applies table.
+// apply-owned rows that still block the PR. Once an apply has started, its
+// stored check state is authoritative until an operator reconciles the target
+// environment — closing and reopening the PR must not convert it into a
+// passing aggregate. A row is retained when apply_id is set and either:
+//
+//   - status is in_progress: the apply may still be changing the live
+//     database, even when PR-close cleanup found no non-terminal apply in the
+//     applies table; or
+//   - conclusion is anything but success (action_required, failure, or
+//     unset): the apply reached the live database and the row records that
+//     operator attention is still required, e.g. the schema change was
+//     removed from the PR after the apply started or a rollback completed.
+//
+// Apply-owned rows whose conclusion is success are deleted: the apply
+// finished cleanly and matches the PR contents, so nothing remains for the
+// row to block and a reopened PR must not inherit a stale gate.
 func (s *checkStore) DeleteByPRExcludingApplyOwned(ctx context.Context, repo string, pr int) error {
 	_, err := s.db.ExecContext(ctx, `
 		DELETE FROM checks
 		WHERE repository = ? AND pull_request = ?
-		  AND NOT (apply_id IS NOT NULL AND status = ?)
-	`, repo, pr, checkStatusInProgress)
+		  AND (apply_id IS NULL OR (status != ? AND conclusion = ?))
+	`, repo, pr, checkStatusInProgress, checkConclusionSuccess)
 	if err != nil {
 		return fmt.Errorf("delete checks for closed PR %s#%d: %w", repo, pr, err)
 	}

--- a/pkg/storage/mysqlstore/checks.go
+++ b/pkg/storage/mysqlstore/checks.go
@@ -205,7 +205,7 @@ func (s *checkStore) RecoverApplyOwnedCheckWithNoOpPlan(ctx context.Context, che
 func successfulNoOpPlanResult(check *storage.Check) bool {
 	return check != nil &&
 		check.Status == "completed" &&
-		check.Conclusion == "success" &&
+		check.Conclusion == checkConclusionSuccess &&
 		!check.HasChanges
 }
 
@@ -308,7 +308,7 @@ func (s *checkStore) ClearAggregateBlock(ctx context.Context, check *storage.Che
 // check with no started apply and no pending schema change.
 func isPlanOnlySuccessful(check *storage.Check) bool {
 	return check.Status == "completed" &&
-		check.Conclusion == "success" &&
+		check.Conclusion == checkConclusionSuccess &&
 		check.ApplyID == 0 &&
 		!check.HasChanges
 }
@@ -508,31 +508,57 @@ func (s *checkStore) Delete(ctx context.Context, id int64) error {
 	return checkRowsAffected(result, storage.ErrCheckNotFound)
 }
 
-// DeleteByPRRetainingBlockingApplyOwned removes stored check state for a PR,
-// retaining apply-owned rows that still block the PR. Once an apply has started, its
-// stored check state is authoritative until an operator reconciles the target
-// environment — closing and reopening the PR must not convert it into a
-// passing aggregate. A row is retained when apply_id is set and either:
+// DeleteByPRRetainingBlockingApplyOwned removes stored check state for a
+// closed PR, retaining apply-owned rows the close must not unblock. Once an
+// apply has started, its stored check state is authoritative until an
+// operator reconciles the target environment — closing and reopening the PR
+// must not convert it into a passing aggregate.
 //
-//   - status is in_progress: the apply may still be changing the live
-//     database, even when PR-close cleanup found no non-terminal apply in the
-//     applies table; or
-//   - conclusion is anything but success (action_required, failure, or
+// Plan-only rows (apply_id unset) are always deleted: no apply ever reached
+// the live database for them, so a reopened PR starts clean.
+//
+// On a merged close, an apply-owned row is retained when it is either:
+//
+//   - in_progress: the apply may still be changing the live database, even
+//     when PR-close cleanup found no non-terminal apply in the applies
+//     table; or
+//   - concluded as anything but success (action_required, failure, or
 //     unset): the apply reached the live database and the row records that
 //     operator attention is still required, e.g. the schema change was
 //     removed from the PR after the apply started or a rollback completed.
 //
-// Apply-owned rows whose conclusion is success are deleted: the apply
-// finished cleanly and matches the PR contents, so nothing remains for the
-// row to block and a reopened PR must not inherit a stale gate.
-func (s *checkStore) DeleteByPRRetainingBlockingApplyOwned(ctx context.Context, repo string, pr int) error {
+// Apply-owned rows whose conclusion is success are deleted on a merged
+// close: the apply finished cleanly and the merged PR carries the applied
+// schema, so nothing remains for the row to block.
+//
+// On an unmerged close, every apply-owned row is retained, including rows
+// whose conclusion is success. A stored success only proves the database
+// matched the PR when the row was last written — a commit that removed the
+// applied change may close the PR before stale cleanup converts the row to
+// action_required, and the unmerged branch means the change never landed.
+// Reopen-time stale cleanup converges the retained row: it converts it to
+// action_required when the schema change is gone from the PR, or a fresh
+// plan result replaces it when the change is still present.
+func (s *checkStore) DeleteByPRRetainingBlockingApplyOwned(ctx context.Context, repo string, pr int, merged bool) error {
+	if merged {
+		_, err := s.db.ExecContext(ctx, `
+			DELETE FROM checks
+			WHERE repository = ? AND pull_request = ?
+			  AND (apply_id IS NULL OR (status != ? AND conclusion = ?))
+		`, repo, pr, checkStatusInProgress, checkConclusionSuccess)
+		if err != nil {
+			return fmt.Errorf("delete checks for merged closed PR %s#%d: %w", repo, pr, err)
+		}
+		return nil
+	}
+
 	_, err := s.db.ExecContext(ctx, `
 		DELETE FROM checks
 		WHERE repository = ? AND pull_request = ?
-		  AND (apply_id IS NULL OR (status != ? AND conclusion = ?))
-	`, repo, pr, checkStatusInProgress, checkConclusionSuccess)
+		  AND apply_id IS NULL
+	`, repo, pr)
 	if err != nil {
-		return fmt.Errorf("delete checks for closed PR %s#%d: %w", repo, pr, err)
+		return fmt.Errorf("delete plan-only checks for unmerged closed PR %s#%d: %w", repo, pr, err)
 	}
 	return nil
 }

--- a/pkg/storage/mysqlstore/checks_test.go
+++ b/pkg/storage/mysqlstore/checks_test.go
@@ -197,16 +197,16 @@ func TestCheckStore_Delete(t *testing.T) {
 	require.ErrorIs(t, store.Checks().Delete(ctx, 99999), storage.ErrCheckNotFound)
 }
 
-// TestCheckStore_DeleteByPRExcludingApplyOwned verifies PR-close cleanup at the
-// storage layer: all of a PR's stored check state is deleted except apply-owned
-// rows that still block the PR. An apply-owned row that is in_progress must keep
+// TestCheckStore_DeleteByPRRetainingBlockingApplyOwned verifies PR-close cleanup
+// at the storage layer: all of a PR's stored check state is deleted except
+// apply-owned rows that still block the PR. An apply-owned row that is in_progress must keep
 // blocking until the apply reaches a terminal state, and an apply-owned row that
 // finished without a successful conclusion (action_required, failure) must keep
 // blocking until an operator reconciles the target environment — closing and
 // reopening the PR must not bypass either block. Plan-only rows and apply-owned
 // rows that concluded successfully are deleted so a reopened PR starts clean.
 // Rows for other PRs are untouched.
-func TestCheckStore_DeleteByPRExcludingApplyOwned(t *testing.T) {
+func TestCheckStore_DeleteByPRRetainingBlockingApplyOwned(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
 	store := New(testDB)
@@ -238,7 +238,7 @@ func TestCheckStore_DeleteByPRExcludingApplyOwned(t *testing.T) {
 		Status:       "pending",
 	}))
 
-	require.NoError(t, store.Checks().DeleteByPRExcludingApplyOwned(ctx, "org/repo", 123))
+	require.NoError(t, store.Checks().DeleteByPRRetainingBlockingApplyOwned(ctx, "org/repo", 123))
 
 	// Only the apply-owned rows that still block survive for PR 123.
 	retrieved, err := store.Checks().GetByPR(ctx, "org/repo", 123)
@@ -275,7 +275,7 @@ func TestCheckStore_DeleteByPRExcludingApplyOwned(t *testing.T) {
 	assert.Equal(t, "db1", retrieved[0].DatabaseName)
 
 	// Deleting for a non-existent PR is a no-op, not an error.
-	require.NoError(t, store.Checks().DeleteByPRExcludingApplyOwned(ctx, "org/repo", 999))
+	require.NoError(t, store.Checks().DeleteByPRRetainingBlockingApplyOwned(ctx, "org/repo", 999))
 }
 
 func TestCheckStore_GetByPR_DBError(t *testing.T) {

--- a/pkg/storage/mysqlstore/checks_test.go
+++ b/pkg/storage/mysqlstore/checks_test.go
@@ -198,22 +198,30 @@ func TestCheckStore_Delete(t *testing.T) {
 }
 
 // TestCheckStore_DeleteByPRExcludingApplyOwned verifies PR-close cleanup at the
-// storage layer: all of a PR's stored check state is deleted except rows owned
-// by an in-flight apply (apply_id set and status in_progress), which must keep
-// blocking the PR until the apply reaches a terminal state. Rows for other PRs
-// are untouched.
+// storage layer: all of a PR's stored check state is deleted except apply-owned
+// rows that still block the PR. An apply-owned row that is in_progress must keep
+// blocking until the apply reaches a terminal state, and an apply-owned row that
+// finished without a successful conclusion (action_required, failure) must keep
+// blocking until an operator reconciles the target environment — closing and
+// reopening the PR must not bypass either block. Plan-only rows and apply-owned
+// rows that concluded successfully are deleted so a reopened PR starts clean.
+// Rows for other PRs are untouched.
 func TestCheckStore_DeleteByPRExcludingApplyOwned(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
 	store := New(testDB)
 
-	// Checks for the closed PR: two deletable rows, one apply-owned in-flight
-	// row that must survive, and one terminal apply-owned row that is deletable.
 	checksToCreate := []*storage.Check{
+		// Plan-only rows: deleted regardless of status or conclusion.
 		{Repository: "org/repo", PullRequest: 123, HeadSHA: "abc", Environment: "staging", DatabaseType: "vitess", DatabaseName: "db1", Status: "pending"},
-		{Repository: "org/repo", PullRequest: 123, HeadSHA: "abc", Environment: "staging", DatabaseType: "mysql", DatabaseName: "db2", Status: "pending"},
+		{Repository: "org/repo", PullRequest: 123, HeadSHA: "abc", Environment: "staging", DatabaseType: "mysql", DatabaseName: "db2", Status: "completed", Conclusion: "action_required"},
+		// Apply-owned in-flight row: must survive.
 		{Repository: "org/repo", PullRequest: 123, HeadSHA: "abc", Environment: "production", DatabaseType: "mysql", DatabaseName: "db3", Status: "in_progress", ApplyID: 77},
+		// Apply-owned row that concluded successfully: deleted.
 		{Repository: "org/repo", PullRequest: 123, HeadSHA: "abc", Environment: "production", DatabaseType: "mysql", DatabaseName: "db4", Status: "completed", ApplyID: 88, Conclusion: "success"},
+		// Apply-owned terminal rows that still block: must survive.
+		{Repository: "org/repo", PullRequest: 123, HeadSHA: "abc", Environment: "production", DatabaseType: "mysql", DatabaseName: "db5", Status: "completed", ApplyID: 99, Conclusion: "action_required", BlockingReason: "schema_removed_after_apply_started"},
+		{Repository: "org/repo", PullRequest: 123, HeadSHA: "abc", Environment: "production", DatabaseType: "mysql", DatabaseName: "db6", Status: "completed", ApplyID: 111, Conclusion: "failure"},
 	}
 	for _, c := range checksToCreate {
 		require.NoError(t, store.Checks().Upsert(ctx, c))
@@ -232,13 +240,33 @@ func TestCheckStore_DeleteByPRExcludingApplyOwned(t *testing.T) {
 
 	require.NoError(t, store.Checks().DeleteByPRExcludingApplyOwned(ctx, "org/repo", 123))
 
-	// Only the apply-owned in-flight row survives for PR 123.
+	// Only the apply-owned rows that still block survive for PR 123.
 	retrieved, err := store.Checks().GetByPR(ctx, "org/repo", 123)
 	require.NoError(t, err)
-	require.Len(t, retrieved, 1)
-	assert.Equal(t, "db3", retrieved[0].DatabaseName)
-	assert.Equal(t, "in_progress", retrieved[0].Status)
-	assert.Equal(t, int64(77), retrieved[0].ApplyID)
+	require.Len(t, retrieved, 3)
+
+	byDatabase := make(map[string]*storage.Check, len(retrieved))
+	for _, c := range retrieved {
+		byDatabase[c.DatabaseName] = c
+	}
+
+	inFlight, ok := byDatabase["db3"]
+	require.True(t, ok, "apply-owned in-flight row must survive PR close")
+	assert.Equal(t, "in_progress", inFlight.Status)
+	assert.Equal(t, int64(77), inFlight.ApplyID)
+
+	removedAfterApply, ok := byDatabase["db5"]
+	require.True(t, ok, "apply-owned action_required row must survive PR close")
+	assert.Equal(t, "completed", removedAfterApply.Status)
+	assert.Equal(t, "action_required", removedAfterApply.Conclusion)
+	assert.Equal(t, int64(99), removedAfterApply.ApplyID)
+	assert.Equal(t, "schema_removed_after_apply_started", removedAfterApply.BlockingReason)
+
+	failed, ok := byDatabase["db6"]
+	require.True(t, ok, "apply-owned failed row must survive PR close")
+	assert.Equal(t, "completed", failed.Status)
+	assert.Equal(t, "failure", failed.Conclusion)
+	assert.Equal(t, int64(111), failed.ApplyID)
 
 	// PR 456's check still exists.
 	retrieved, err = store.Checks().GetByPR(ctx, "org/repo", 456)

--- a/pkg/storage/mysqlstore/checks_test.go
+++ b/pkg/storage/mysqlstore/checks_test.go
@@ -197,29 +197,22 @@ func TestCheckStore_Delete(t *testing.T) {
 	require.ErrorIs(t, store.Checks().Delete(ctx, 99999), storage.ErrCheckNotFound)
 }
 
-// TestCheckStore_DeleteByPRRetainingBlockingApplyOwned verifies PR-close cleanup
-// at the storage layer: all of a PR's stored check state is deleted except
-// apply-owned rows that still block the PR. An apply-owned row that is in_progress must keep
-// blocking until the apply reaches a terminal state, and an apply-owned row that
-// finished without a successful conclusion (action_required, failure) must keep
-// blocking until an operator reconciles the target environment — closing and
-// reopening the PR must not bypass either block. Plan-only rows and apply-owned
-// rows that concluded successfully are deleted so a reopened PR starts clean.
-// Rows for other PRs are untouched.
-func TestCheckStore_DeleteByPRRetainingBlockingApplyOwned(t *testing.T) {
-	clearTables(t)
+// seedPRCloseRetentionChecks stores one row of every retention shape PR-close
+// cleanup distinguishes for PR 123, plus a row on another PR that cleanup must
+// never touch.
+func seedPRCloseRetentionChecks(t *testing.T, store storage.Storage) {
+	t.Helper()
 	ctx := t.Context()
-	store := New(testDB)
 
 	checksToCreate := []*storage.Check{
-		// Plan-only rows: deleted regardless of status or conclusion.
+		// Plan-only rows: deleted on every close kind regardless of status or conclusion.
 		{Repository: "org/repo", PullRequest: 123, HeadSHA: "abc", Environment: "staging", DatabaseType: "vitess", DatabaseName: "db1", Status: "pending"},
 		{Repository: "org/repo", PullRequest: 123, HeadSHA: "abc", Environment: "staging", DatabaseType: "mysql", DatabaseName: "db2", Status: "completed", Conclusion: "action_required"},
-		// Apply-owned in-flight row: must survive.
+		// Apply-owned in-flight row: survives every close kind.
 		{Repository: "org/repo", PullRequest: 123, HeadSHA: "abc", Environment: "production", DatabaseType: "mysql", DatabaseName: "db3", Status: "in_progress", ApplyID: 77},
-		// Apply-owned row that concluded successfully: deleted.
+		// Apply-owned row that concluded successfully: retention depends on the close kind.
 		{Repository: "org/repo", PullRequest: 123, HeadSHA: "abc", Environment: "production", DatabaseType: "mysql", DatabaseName: "db4", Status: "completed", ApplyID: 88, Conclusion: "success"},
-		// Apply-owned terminal rows that still block: must survive.
+		// Apply-owned terminal rows that still block: survive every close kind.
 		{Repository: "org/repo", PullRequest: 123, HeadSHA: "abc", Environment: "production", DatabaseType: "mysql", DatabaseName: "db5", Status: "completed", ApplyID: 99, Conclusion: "action_required", BlockingReason: "schema_removed_after_apply_started"},
 		{Repository: "org/repo", PullRequest: 123, HeadSHA: "abc", Environment: "production", DatabaseType: "mysql", DatabaseName: "db6", Status: "completed", ApplyID: 111, Conclusion: "failure"},
 	}
@@ -237,18 +230,30 @@ func TestCheckStore_DeleteByPRRetainingBlockingApplyOwned(t *testing.T) {
 		DatabaseName: "db1",
 		Status:       "pending",
 	}))
+}
 
-	require.NoError(t, store.Checks().DeleteByPRRetainingBlockingApplyOwned(ctx, "org/repo", 123))
+// retainedChecksByDatabase asserts how many of PR 123's rows survived cleanup
+// and returns them keyed by database name.
+func retainedChecksByDatabase(t *testing.T, store storage.Storage, wantRetained int) map[string]*storage.Check {
+	t.Helper()
+	ctx := t.Context()
 
-	// Only the apply-owned rows that still block survive for PR 123.
 	retrieved, err := store.Checks().GetByPR(ctx, "org/repo", 123)
 	require.NoError(t, err)
-	require.Len(t, retrieved, 3)
+	require.Len(t, retrieved, wantRetained)
 
 	byDatabase := make(map[string]*storage.Check, len(retrieved))
 	for _, c := range retrieved {
 		byDatabase[c.DatabaseName] = c
 	}
+	return byDatabase
+}
+
+// assertAlwaysBlockingRowsRetained verifies the apply-owned rows every close
+// kind must retain: the in-flight row and the terminal rows that concluded
+// without success (action_required, failure).
+func assertAlwaysBlockingRowsRetained(t *testing.T, byDatabase map[string]*storage.Check) {
+	t.Helper()
 
 	inFlight, ok := byDatabase["db3"]
 	require.True(t, ok, "apply-owned in-flight row must survive PR close")
@@ -267,15 +272,72 @@ func TestCheckStore_DeleteByPRRetainingBlockingApplyOwned(t *testing.T) {
 	assert.Equal(t, "completed", failed.Status)
 	assert.Equal(t, "failure", failed.Conclusion)
 	assert.Equal(t, int64(111), failed.ApplyID)
+}
 
-	// PR 456's check still exists.
-	retrieved, err = store.Checks().GetByPR(ctx, "org/repo", 456)
+// assertOtherPRUntouched verifies that PR-close cleanup for PR 123 never
+// touches another PR's stored check state.
+func assertOtherPRUntouched(t *testing.T, store storage.Storage) {
+	t.Helper()
+
+	retrieved, err := store.Checks().GetByPR(t.Context(), "org/repo", 456)
 	require.NoError(t, err)
 	require.Len(t, retrieved, 1)
 	assert.Equal(t, "db1", retrieved[0].DatabaseName)
+}
 
-	// Deleting for a non-existent PR is a no-op, not an error.
-	require.NoError(t, store.Checks().DeleteByPRRetainingBlockingApplyOwned(ctx, "org/repo", 999))
+// TestCheckStore_DeleteByPRRetainingBlockingApplyOwned verifies PR-close cleanup
+// at the storage layer. On every close kind, plan-only rows are deleted, rows
+// for other PRs are untouched, and apply-owned rows that still block survive:
+// an in_progress row must keep blocking until the apply reaches a terminal
+// state, and a terminal row without a successful conclusion (action_required,
+// failure) must keep blocking until an operator reconciles the target
+// environment — closing and reopening the PR must not bypass either block.
+//
+// The close kinds differ on apply-owned rows that concluded successfully. A
+// merged close deletes them: the merged PR carries the applied schema, so
+// nothing remains to block. An unmerged close retains them: the stored success
+// may predate a commit that removed the applied change (the PR can close
+// before stale cleanup converts the row), so only reopen-time cleanup may
+// decide whether the row still matches the PR contents.
+func TestCheckStore_DeleteByPRRetainingBlockingApplyOwned(t *testing.T) {
+	t.Run("merged close deletes successful apply-owned rows", func(t *testing.T) {
+		clearTables(t)
+		ctx := t.Context()
+		store := New(testDB)
+		seedPRCloseRetentionChecks(t, store)
+
+		require.NoError(t, store.Checks().DeleteByPRRetainingBlockingApplyOwned(ctx, "org/repo", 123, true))
+
+		byDatabase := retainedChecksByDatabase(t, store, 3)
+		assertAlwaysBlockingRowsRetained(t, byDatabase)
+		_, ok := byDatabase["db4"]
+		assert.False(t, ok, "apply-owned success row is deleted on merged close")
+		assertOtherPRUntouched(t, store)
+
+		// Deleting for a non-existent PR is a no-op, not an error.
+		require.NoError(t, store.Checks().DeleteByPRRetainingBlockingApplyOwned(ctx, "org/repo", 999, true))
+	})
+
+	t.Run("unmerged close retains successful apply-owned rows", func(t *testing.T) {
+		clearTables(t)
+		ctx := t.Context()
+		store := New(testDB)
+		seedPRCloseRetentionChecks(t, store)
+
+		require.NoError(t, store.Checks().DeleteByPRRetainingBlockingApplyOwned(ctx, "org/repo", 123, false))
+
+		byDatabase := retainedChecksByDatabase(t, store, 4)
+		assertAlwaysBlockingRowsRetained(t, byDatabase)
+		successful, ok := byDatabase["db4"]
+		require.True(t, ok, "apply-owned success row must survive unmerged close")
+		assert.Equal(t, "completed", successful.Status)
+		assert.Equal(t, "success", successful.Conclusion)
+		assert.Equal(t, int64(88), successful.ApplyID)
+		assertOtherPRUntouched(t, store)
+
+		// Deleting for a non-existent PR is a no-op, not an error.
+		require.NoError(t, store.Checks().DeleteByPRRetainingBlockingApplyOwned(ctx, "org/repo", 999, false))
+	})
 }
 
 func TestCheckStore_GetByPR_DBError(t *testing.T) {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -151,10 +151,12 @@ type CheckStore interface {
 	Delete(ctx context.Context, id int64) error
 
 	// DeleteByPRExcludingApplyOwned removes stored check state for a PR,
-	// except rows owned by an in-flight apply (apply_id set and status
-	// in_progress). Used for cleanup when a PR is closed or merged:
-	// apply-owned rows must keep blocking until the apply reaches a terminal
-	// state, even across a close and reopen.
+	// except apply-owned rows that still block the PR: rows with apply_id set
+	// that are in_progress or whose conclusion is anything but success. Used
+	// for cleanup when a PR is closed or merged: once an apply has started,
+	// its stored check state stays authoritative across a close and reopen
+	// until the apply both reaches a terminal state and concludes
+	// successfully, or an operator reconciles the target environment.
 	DeleteByPRExcludingApplyOwned(ctx context.Context, repo string, pr int) error
 }
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -150,14 +150,15 @@ type CheckStore interface {
 	// Delete removes stored check state by ID.
 	Delete(ctx context.Context, id int64) error
 
-	// DeleteByPRExcludingApplyOwned removes stored check state for a PR,
-	// except apply-owned rows that still block the PR: rows with apply_id set
-	// that are in_progress or whose conclusion is anything but success. Used
+	// DeleteByPRRetainingBlockingApplyOwned removes stored check state for a
+	// PR, retaining apply-owned rows that still block the PR: rows with
+	// apply_id set that are in_progress or whose conclusion is anything but
+	// success. Apply-owned rows that concluded successfully are deleted. Used
 	// for cleanup when a PR is closed or merged: once an apply has started,
 	// its stored check state stays authoritative across a close and reopen
 	// until the apply both reaches a terminal state and concludes
 	// successfully, or an operator reconciles the target environment.
-	DeleteByPRExcludingApplyOwned(ctx context.Context, repo string, pr int) error
+	DeleteByPRRetainingBlockingApplyOwned(ctx context.Context, repo string, pr int) error
 }
 
 // SettingsStore manages admin-level SchemaBot settings (global config).

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -151,14 +151,25 @@ type CheckStore interface {
 	Delete(ctx context.Context, id int64) error
 
 	// DeleteByPRRetainingBlockingApplyOwned removes stored check state for a
-	// PR, retaining apply-owned rows that still block the PR: rows with
-	// apply_id set that are in_progress or whose conclusion is anything but
-	// success. Apply-owned rows that concluded successfully are deleted. Used
-	// for cleanup when a PR is closed or merged: once an apply has started,
-	// its stored check state stays authoritative across a close and reopen
-	// until the apply both reaches a terminal state and concludes
-	// successfully, or an operator reconciles the target environment.
-	DeleteByPRRetainingBlockingApplyOwned(ctx context.Context, repo string, pr int) error
+	// closed PR, retaining apply-owned rows the close must not unblock. Once
+	// an apply has started, its stored check state stays authoritative across
+	// a close and reopen until an operator reconciles the target environment.
+	// Plan-only rows (no apply_id) are always deleted. Apply-owned rows are
+	// handled by close kind:
+	//
+	//   - merged close: rows that are in_progress or whose conclusion is
+	//     anything but success are retained; rows that concluded successfully
+	//     are deleted, because the merged PR carries the applied schema and
+	//     nothing remains for the row to block.
+	//   - unmerged close: every apply-owned row is retained, including rows
+	//     whose conclusion is success. A stored success only proves the
+	//     database matched the PR when the row was last written — a commit
+	//     that removed the applied change may not have been reconciled into
+	//     the row yet, and the unmerged branch means the change never landed.
+	//     Reopen-time stale cleanup converges the retained row: it converts
+	//     it to action_required when the schema change is gone from the PR,
+	//     or a fresh plan result replaces it when the change is still present.
+	DeleteByPRRetainingBlockingApplyOwned(ctx context.Context, repo string, pr int, merged bool) error
 }
 
 // SettingsStore manages admin-level SchemaBot settings (global config).

--- a/pkg/webhook/check_cleanup_integration_test.go
+++ b/pkg/webhook/check_cleanup_integration_test.go
@@ -383,3 +383,145 @@ func TestE2EReconcileStaleInProgressCheckFailure(t *testing.T) {
 		t.Fatal("timed out waiting for blocking aggregate check run")
 	}
 }
+
+// TestE2EPRCloseReopenRetainsStartedApplyBlock verifies that closing and
+// reopening a PR cannot bypass a block that requires operator reconciliation.
+// Scenario: an apply for the PR completes, then a later commit removes the
+// schema change from the PR, leaving the stored check state terminal,
+// action_required, and still owned by the apply — the live database no longer
+// matches the PR contents. Closing the PR deletes the PR's plan-only check
+// state but retains the blocked apply-owned row. Reopening the PR (whose net
+// diff no longer touches schema files) folds the retained row back into the
+// aggregate on the current head SHA, which reports action_required instead of
+// passing.
+func TestE2EPRCloseReopenRetainsStartedApplyBlock(t *testing.T) {
+	dbName := "webhook_close_reopen_block"
+	svc := setupE2EService(t, dbName)
+	ctx := t.Context()
+
+	// The apply completed before the schema change was removed from the PR.
+	applyID, err := svc.Storage().Applies().Create(ctx, &storage.Apply{
+		ApplyIdentifier: "apply-close-reopen",
+		Database:        dbName,
+		DatabaseType:    "mysql",
+		Environment:     "staging",
+		Repository:      "octocat/hello-world",
+		PullRequest:     1,
+		State:           state.Apply.Completed,
+		Engine:          "spirit",
+	})
+	require.NoError(t, err)
+
+	// Stored check state after stale cleanup blocked the removed schema change:
+	// terminal, action_required, still owned by the apply.
+	require.NoError(t, svc.Storage().Checks().Upsert(ctx, &storage.Check{
+		Repository:     "octocat/hello-world",
+		PullRequest:    1,
+		HeadSHA:        "oldsha111",
+		Environment:    "staging",
+		DatabaseType:   "mysql",
+		DatabaseName:   dbName,
+		CheckRunID:     42,
+		ApplyID:        applyID,
+		HasChanges:     true,
+		Status:         checkStatusCompleted,
+		Conclusion:     checkConclusionActionRequired,
+		BlockingReason: schemaRemovedAfterApplyBlock.blockingReason,
+		ErrorMessage:   schemaRemovedAfterApplyBlock.message,
+	}))
+
+	// Plan-only check state for another database on the same PR: PR close
+	// deletes it because no apply ever started for it.
+	require.NoError(t, svc.Storage().Checks().Upsert(ctx, &storage.Check{
+		Repository:   "octocat/hello-world",
+		PullRequest:  1,
+		HeadSHA:      "oldsha111",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "webhook_close_reopen_planonly",
+		CheckRunID:   43,
+		HasChanges:   true,
+		Status:       checkStatusCompleted,
+		Conclusion:   checkConclusionActionRequired,
+	}))
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	// Fake GitHub serves a PR whose current diff has no schema files, matching
+	// a PR whose later commit reverted the applied schema change.
+	result := setupFakeGitHubForPlan(t, mux, nil, "", dbName)
+	h := newE2EHandler(t, svc, client)
+
+	// Close the PR. Close cleanup runs async, so wait for the plan-only row to
+	// be deleted before asserting on the retained row.
+	req := buildPRWebhookRequest(t, prWebhookPayloadOpts{action: "closed"}, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	require.Eventually(t, func() bool {
+		check, err := svc.Storage().Checks().Get(t.Context(), "octocat/hello-world", 1, "staging", "mysql", "webhook_close_reopen_planonly")
+		return err == nil && check == nil
+	}, webhookIntegrationPollDeadline, 100*time.Millisecond, "plan-only check state should be deleted on PR close")
+
+	// The blocked apply-owned row survives the close with its block intact.
+	check, err := svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1, "staging", "mysql", dbName)
+	require.NoError(t, err)
+	require.NotNil(t, check, "blocked apply-owned check state must survive PR close")
+	assert.Equal(t, checkStatusCompleted, check.Status)
+	assert.Equal(t, checkConclusionActionRequired, check.Conclusion)
+	assert.Equal(t, applyID, check.ApplyID)
+	assert.Equal(t, schemaRemovedAfterApplyBlock.blockingReason, check.BlockingReason)
+
+	// Reopen the PR. Auto-plan finds no schema files, and stale-check cleanup
+	// re-blocks the retained row on the current head SHA.
+	req = buildPRWebhookRequest(t, prWebhookPayloadOpts{action: "reopened"}, nil)
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	require.Eventually(t, func() bool {
+		check, err := svc.Storage().Checks().Get(t.Context(), "octocat/hello-world", 1, "staging", "mysql", dbName)
+		return err == nil && check != nil && check.HeadSHA == "abc123"
+	}, webhookIntegrationPollDeadline, 100*time.Millisecond, "retained check state should be re-blocked on the reopened PR's head SHA")
+
+	check, err = svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1, "staging", "mysql", dbName)
+	require.NoError(t, err)
+	require.NotNil(t, check)
+	assert.Equal(t, checkStatusCompleted, check.Status)
+	assert.Equal(t, checkConclusionActionRequired, check.Conclusion)
+	assert.Equal(t, applyID, check.ApplyID)
+	assert.Equal(t, schemaRemovedAfterApplyBlock.blockingReason, check.BlockingReason)
+
+	// The aggregate on the reopened head SHA folds the retained block in and
+	// stays action_required — never success.
+	deadline := time.After(webhookIntegrationPollDeadline)
+	for {
+		var blocked bool
+		select {
+		case checkRun := <-result.checkRuns:
+			require.NotEqual(t, checkConclusionSuccess, checkRun.Conclusion,
+				"close and reopen must not produce a passing check run while the block stands")
+			blocked = checkRun.Name == aggregateCheckName &&
+				checkRun.Conclusion == checkConclusionActionRequired &&
+				checkRun.HeadSHA == "abc123"
+		case <-deadline:
+			t.Fatal("timed out waiting for blocking aggregate check run after reopen")
+		}
+		if blocked {
+			break
+		}
+	}
+
+	aggregate, err := svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1, aggregateSentinel, aggregateSentinel, aggregateSentinel)
+	require.NoError(t, err)
+	require.NotNil(t, aggregate)
+	assert.Equal(t, "abc123", aggregate.HeadSHA)
+	assert.Equal(t, checkStatusCompleted, aggregate.Status)
+	assert.Equal(t, checkConclusionActionRequired, aggregate.Conclusion)
+}

--- a/pkg/webhook/check_cleanup_integration_test.go
+++ b/pkg/webhook/check_cleanup_integration_test.go
@@ -74,7 +74,7 @@ func TestE2EPRCloseCleanup(t *testing.T) {
 	// Close the PR while the apply is running. The handler is invoked directly
 	// (not through the async webhook goroutine) so the retention assertions
 	// below observe a finished cleanup pass.
-	h.handlePRClosed("octocat/hello-world", 1, 12345)
+	h.handlePRClosed("octocat/hello-world", 1, 12345, false)
 
 	lock, err := svc.Storage().Locks().Get(t.Context(), dbName, "mysql")
 	require.NoError(t, err)
@@ -507,6 +507,153 @@ func TestE2EPRCloseReopenRetainsStartedApplyBlock(t *testing.T) {
 		case checkRun := <-result.checkRuns:
 			require.NotEqual(t, checkConclusionSuccess, checkRun.Conclusion,
 				"close and reopen must not produce a passing check run while the block stands")
+			blocked = checkRun.Name == aggregateCheckName &&
+				checkRun.Conclusion == checkConclusionActionRequired &&
+				checkRun.HeadSHA == "abc123"
+		case <-deadline:
+			t.Fatal("timed out waiting for blocking aggregate check run after reopen")
+		}
+		if blocked {
+			break
+		}
+	}
+
+	aggregate, err := svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1, aggregateSentinel, aggregateSentinel, aggregateSentinel)
+	require.NoError(t, err)
+	require.NotNil(t, aggregate)
+	assert.Equal(t, "abc123", aggregate.HeadSHA)
+	assert.Equal(t, checkStatusCompleted, aggregate.Status)
+	assert.Equal(t, checkConclusionActionRequired, aggregate.Conclusion)
+}
+
+// TestE2EUnmergedCloseRetainsSuccessfulApplyOwnedCheck verifies that closing a
+// PR without merging cannot bypass a started apply's block via a stale success
+// conclusion. Scenario: an apply for the PR completes and its stored check
+// state concludes success, then a later commit removes the applied schema
+// change and the PR is closed — without merging — before stale cleanup runs,
+// so the row still reads success at close time. The unmerged close retains the
+// apply-owned success row: the stored success only proves the database matched
+// the PR when the row was written, and the unmerged branch means the change
+// never landed. Reopening the PR (whose diff no longer touches schema files)
+// runs stale cleanup, which converts the retained row to action_required and
+// folds it into an aggregate that blocks merge instead of passing.
+func TestE2EUnmergedCloseRetainsSuccessfulApplyOwnedCheck(t *testing.T) {
+	dbName := "webhook_unmerged_close_success"
+	svc := setupE2EService(t, dbName)
+	ctx := t.Context()
+
+	// The apply completed before the schema change was removed from the PR.
+	applyID, err := svc.Storage().Applies().Create(ctx, &storage.Apply{
+		ApplyIdentifier: "apply-unmerged-close",
+		Database:        dbName,
+		DatabaseType:    "mysql",
+		Environment:     "staging",
+		Repository:      "octocat/hello-world",
+		PullRequest:     1,
+		State:           state.Apply.Completed,
+		Engine:          "spirit",
+	})
+	require.NoError(t, err)
+
+	// Stored check state as the apply left it: terminal, success, still owned
+	// by the apply. Stale cleanup for the commit that removed the schema change
+	// has not run, so nothing has converted the row yet.
+	require.NoError(t, svc.Storage().Checks().Upsert(ctx, &storage.Check{
+		Repository:   "octocat/hello-world",
+		PullRequest:  1,
+		HeadSHA:      "oldsha222",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: dbName,
+		CheckRunID:   42,
+		ApplyID:      applyID,
+		HasChanges:   true,
+		Status:       checkStatusCompleted,
+		Conclusion:   checkConclusionSuccess,
+	}))
+
+	// Plan-only check state for another database on the same PR. The unmerged
+	// close deletes it, which doubles as the signal that the async close
+	// cleanup pass finished before the retention assertions below run.
+	require.NoError(t, svc.Storage().Checks().Upsert(ctx, &storage.Check{
+		Repository:   "octocat/hello-world",
+		PullRequest:  1,
+		HeadSHA:      "oldsha222",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "webhook_unmerged_close_planonly",
+		CheckRunID:   43,
+		HasChanges:   true,
+		Status:       checkStatusCompleted,
+		Conclusion:   checkConclusionActionRequired,
+	}))
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	// Fake GitHub serves a PR whose current diff has no schema files, matching
+	// a PR whose later commit reverted the applied schema change.
+	result := setupFakeGitHubForPlan(t, mux, nil, "", dbName)
+	h := newE2EHandler(t, svc, client)
+
+	// Close the PR without merging. Close cleanup runs async, so wait for the
+	// plan-only row to be deleted — the same cleanup statement decides the
+	// retained row's fate — before asserting on the retained row.
+	req := buildPRWebhookRequest(t, prWebhookPayloadOpts{action: "closed", merged: false}, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	require.Eventually(t, func() bool {
+		check, err := svc.Storage().Checks().Get(t.Context(), "octocat/hello-world", 1, "staging", "mysql", "webhook_unmerged_close_planonly")
+		return err == nil && check == nil
+	}, webhookIntegrationPollDeadline, 100*time.Millisecond, "plan-only check state should be deleted on unmerged PR close")
+
+	// The apply-owned success row survives the unmerged close untouched.
+	check, err := svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1, "staging", "mysql", dbName)
+	require.NoError(t, err)
+	require.NotNil(t, check, "apply-owned success row must survive an unmerged close")
+	assert.Equal(t, checkStatusCompleted, check.Status)
+	assert.Equal(t, checkConclusionSuccess, check.Conclusion)
+	assert.Equal(t, applyID, check.ApplyID)
+
+	// Reopen the PR. Auto-plan finds no schema files; stale-check cleanup
+	// converts the retained row on the current head SHA before the aggregate
+	// for that commit is published.
+	req = buildPRWebhookRequest(t, prWebhookPayloadOpts{action: "reopened"}, nil)
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	require.Eventually(t, func() bool {
+		check, err := svc.Storage().Checks().Get(t.Context(), "octocat/hello-world", 1, "staging", "mysql", dbName)
+		return err == nil && check != nil && check.Conclusion == checkConclusionActionRequired
+	}, webhookIntegrationPollDeadline, 100*time.Millisecond, "retained success row should be converted to action_required on reopen")
+
+	check, err = svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1, "staging", "mysql", dbName)
+	require.NoError(t, err)
+	require.NotNil(t, check)
+	assert.Equal(t, "abc123", check.HeadSHA)
+	assert.Equal(t, checkStatusCompleted, check.Status)
+	assert.Equal(t, checkConclusionActionRequired, check.Conclusion)
+	assert.Equal(t, applyID, check.ApplyID)
+	assert.Equal(t, schemaRemovedAfterApplyBlock.blockingReason, check.BlockingReason)
+
+	// The aggregate on the reopened head SHA folds the converted block in and
+	// reports action_required — never success, even though the "no managed
+	// schema changes" path also runs for this reopen: the retained apply-owned
+	// row blocks the passing aggregate until it is converted.
+	deadline := time.After(webhookIntegrationPollDeadline)
+	for {
+		var blocked bool
+		select {
+		case checkRun := <-result.checkRuns:
+			require.NotEqual(t, checkConclusionSuccess, checkRun.Conclusion,
+				"unmerged close and reopen must not produce a passing check run while the block stands")
 			blocked = checkRun.Name == aggregateCheckName &&
 				checkRun.Conclusion == checkConclusionActionRequired &&
 				checkRun.HeadSHA == "abc123"

--- a/pkg/webhook/pr_closed_test.go
+++ b/pkg/webhook/pr_closed_test.go
@@ -62,11 +62,13 @@ func (s *failingPRApplyLookupStore) GetByPR(_ context.Context, _ string, _ int) 
 
 type prClosedCheckStore struct {
 	storage.CheckStore
-	deleteCalls int
+	deleteCalls  int
+	deleteMerged []bool
 }
 
-func (s *prClosedCheckStore) DeleteByPRRetainingBlockingApplyOwned(_ context.Context, _ string, _ int) error {
+func (s *prClosedCheckStore) DeleteByPRRetainingBlockingApplyOwned(_ context.Context, _ string, _ int, merged bool) error {
 	s.deleteCalls++
+	s.deleteMerged = append(s.deleteMerged, merged)
 	return nil
 }
 
@@ -118,7 +120,7 @@ func TestPRClosedRetainsLockAndChecksForInFlightApply(t *testing.T) {
 	}
 
 	h := prClosedTestHandler(t, st)
-	h.handlePRClosed("octocat/hello-world", 1, 12345)
+	h.handlePRClosed("octocat/hello-world", 1, 12345, true)
 
 	assert.Empty(t, lockStore.released, "lock for a database with an in-flight apply must not be released on PR close")
 	assert.Equal(t, 0, checkStore.deleteCalls, "stored check state must not be deleted while an apply is in flight")
@@ -142,7 +144,7 @@ func TestPRClosedReleasesOnlyLocksWithoutInFlightApply(t *testing.T) {
 	}
 
 	h := prClosedTestHandler(t, st)
-	h.handlePRClosed("octocat/hello-world", 1, 12345)
+	h.handlePRClosed("octocat/hello-world", 1, 12345, true)
 
 	assert.Equal(t, []string{"billing"}, lockStore.released, "only the lock without an in-flight apply is released")
 	assert.Equal(t, 0, checkStore.deleteCalls, "stored check state must not be deleted while any apply is in flight")
@@ -164,15 +166,19 @@ func TestPRClosedCleansUpWhenAllAppliesTerminal(t *testing.T) {
 	}
 
 	h := prClosedTestHandler(t, st)
-	h.handlePRClosed("octocat/hello-world", 1, 12345)
+	h.handlePRClosed("octocat/hello-world", 1, 12345, true)
 
 	assert.Equal(t, []string{"orders", "billing"}, lockStore.released, "all locks are released when applies are terminal")
 	assert.Equal(t, 1, checkStore.deleteCalls, "stored check state is deleted when applies are terminal")
+	assert.Equal(t, []bool{true}, checkStore.deleteMerged, "the storage delete must run in merged mode for a merged close")
 }
 
 // TestPRClosedCleansUpWhenPRHasNoApplies verifies that a PR with no recorded
 // applies (e.g., plan-only PRs) gets full cleanup on close: locks released and
-// stored check state deleted.
+// stored check state deleted. An unmerged close must run the storage delete in
+// unmerged mode so apply-owned rows — including success rows whose stored
+// conclusion may predate a commit that removed the applied change — are
+// retained.
 func TestPRClosedCleansUpWhenPRHasNoApplies(t *testing.T) {
 	lockStore := &prClosedLockStore{locks: []*storage.Lock{prClosedLock("orders")}}
 	checkStore := &prClosedCheckStore{}
@@ -183,10 +189,11 @@ func TestPRClosedCleansUpWhenPRHasNoApplies(t *testing.T) {
 	}
 
 	h := prClosedTestHandler(t, st)
-	h.handlePRClosed("octocat/hello-world", 1, 12345)
+	h.handlePRClosed("octocat/hello-world", 1, 12345, false)
 
 	assert.Equal(t, []string{"orders"}, lockStore.released, "locks are released when the PR has no applies")
 	assert.Equal(t, 1, checkStore.deleteCalls, "stored check state is deleted when the PR has no applies")
+	assert.Equal(t, []bool{false}, checkStore.deleteMerged, "the storage delete must run in unmerged mode for a close without merge")
 }
 
 // TestPRClosedSkipsCleanupWhenApplyLookupFails verifies that PR-close cleanup
@@ -203,7 +210,7 @@ func TestPRClosedSkipsCleanupWhenApplyLookupFails(t *testing.T) {
 	}
 
 	h := prClosedTestHandler(t, st)
-	h.handlePRClosed("octocat/hello-world", 1, 12345)
+	h.handlePRClosed("octocat/hello-world", 1, 12345, true)
 
 	assert.Empty(t, lockStore.released, "no lock is released when apply state is unknown")
 	assert.Equal(t, 0, checkStore.deleteCalls, "no check state is deleted when apply state is unknown")

--- a/pkg/webhook/pr_closed_test.go
+++ b/pkg/webhook/pr_closed_test.go
@@ -65,7 +65,7 @@ type prClosedCheckStore struct {
 	deleteCalls int
 }
 
-func (s *prClosedCheckStore) DeleteByPRExcludingApplyOwned(_ context.Context, _ string, _ int) error {
+func (s *prClosedCheckStore) DeleteByPRRetainingBlockingApplyOwned(_ context.Context, _ string, _ int) error {
 	s.deleteCalls++
 	return nil
 }

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -18,7 +18,8 @@ type pullRequestPayload struct {
 	Action      string `json:"action"`
 	Before      string `json:"before"`
 	PullRequest struct {
-		Number int `json:"number"`
+		Number int  `json:"number"`
+		Merged bool `json:"merged"`
 		Head   struct {
 			SHA string `json:"sha"`
 			Ref string `json:"ref"`
@@ -54,7 +55,7 @@ func (h *Handler) handlePullRequest(ctx context.Context, metricApp string, w htt
 		// proceed to auto-plan below
 	case "closed":
 		h.goSafe(payload.Repository.FullName, payload.PullRequest.Number, installationID, func() {
-			h.handlePRClosed(payload.Repository.FullName, payload.PullRequest.Number, installationID)
+			h.handlePRClosed(payload.Repository.FullName, payload.PullRequest.Number, installationID, payload.PullRequest.Merged)
 		})
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "PR close cleanup started"})
 		return
@@ -329,9 +330,13 @@ func (h *Handler) aggregateMessagesForAllEnvironments(message string) map[string
 // so a close-and-reopen cannot convert in-flight apply state into a passing
 // check. Apply-owned check state that reached a terminal state without
 // concluding successfully is also retained, so a close-and-reopen cannot
-// bypass a block that requires operator reconciliation. If apply state cannot
-// be read, cleanup fails closed and nothing is released or deleted.
-func (h *Handler) handlePRClosed(repo string, pr int, _ int64) {
+// bypass a block that requires operator reconciliation. On a close without
+// merge, apply-owned check state that concluded successfully is retained too:
+// the stored success may predate a commit that removed the applied change,
+// and only reopen-time cleanup can re-verify it against the PR contents. If
+// apply state cannot be read, cleanup fails closed and nothing is released
+// or deleted.
+func (h *Handler) handlePRClosed(repo string, pr int, _ int64, merged bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -369,21 +374,30 @@ func (h *Handler) handlePRClosed(repo string, pr int, _ int64) {
 	// applies table missed the in-flight work above) and terminal rows whose
 	// conclusion is not success, such as a schema change removed from the PR
 	// after its apply started. Those blocks require operator reconciliation
-	// and must persist across a close and reopen.
-	if err := h.service.Storage().Checks().DeleteByPRRetainingBlockingApplyOwned(ctx, repo, pr); err != nil {
+	// and must persist across a close and reopen. On an unmerged close,
+	// apply-owned rows that concluded successfully survive too: the stored
+	// success may predate a commit that removed the applied change, so
+	// reopen-time cleanup must re-verify it before the row can stop blocking.
+	if err := h.service.Storage().Checks().DeleteByPRRetainingBlockingApplyOwned(ctx, repo, pr, merged); err != nil {
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
 			Operation:  "pr_close_cleanup",
 			Repository: repo,
 			Status:     "error",
 		})
-		h.logger.Error("failed to delete checks for closed PR", "repo", repo, "pr", pr, "error", err)
+		h.logger.Error("failed to delete checks for closed PR", "repo", repo, "pr", pr, "merged", merged, "error", err)
 	} else {
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
 			Operation:  "pr_close_cleanup",
 			Repository: repo,
 			Status:     "success",
 		})
-		h.logger.Info("deleted checks for closed PR", "repo", repo, "pr", pr)
+		if merged {
+			h.logger.Info("deleted checks for merged PR; apply-owned rows that still block are retained",
+				"repo", repo, "pr", pr)
+		} else {
+			h.logger.Info("deleted plan-only checks for unmerged closed PR; all apply-owned rows are retained",
+				"repo", repo, "pr", pr)
+		}
 	}
 }
 

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -370,7 +370,7 @@ func (h *Handler) handlePRClosed(repo string, pr int, _ int64) {
 	// conclusion is not success, such as a schema change removed from the PR
 	// after its apply started. Those blocks require operator reconciliation
 	// and must persist across a close and reopen.
-	if err := h.service.Storage().Checks().DeleteByPRExcludingApplyOwned(ctx, repo, pr); err != nil {
+	if err := h.service.Storage().Checks().DeleteByPRRetainingBlockingApplyOwned(ctx, repo, pr); err != nil {
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
 			Operation:  "pr_close_cleanup",
 			Repository: repo,

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -327,8 +327,10 @@ func (h *Handler) aggregateMessagesForAllEnvironments(message string) map[string
 // non-terminal, that apply's database lock is retained so another PR cannot
 // acquire the database mid-apply, and the PR's stored check state is retained
 // so a close-and-reopen cannot convert in-flight apply state into a passing
-// check. If apply state cannot be read, cleanup fails closed and nothing is
-// released or deleted.
+// check. Apply-owned check state that reached a terminal state without
+// concluding successfully is also retained, so a close-and-reopen cannot
+// bypass a block that requires operator reconciliation. If apply state cannot
+// be read, cleanup fails closed and nothing is released or deleted.
 func (h *Handler) handlePRClosed(repo string, pr int, _ int64) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -362,9 +364,12 @@ func (h *Handler) handlePRClosed(repo string, pr int, _ int64) {
 		return
 	}
 
-	// Delete stored check state for this PR. Rows owned by an in-flight apply
-	// survive the delete at the storage layer even if the applies table missed
-	// the in-flight work above.
+	// Delete stored check state for this PR. Apply-owned rows that still block
+	// survive the delete at the storage layer: in-flight rows (even if the
+	// applies table missed the in-flight work above) and terminal rows whose
+	// conclusion is not success, such as a schema change removed from the PR
+	// after its apply started. Those blocks require operator reconciliation
+	// and must persist across a close and reopen.
 	if err := h.service.Storage().Checks().DeleteByPRExcludingApplyOwned(ctx, repo, pr); err != nil {
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
 			Operation:  "pr_close_cleanup",

--- a/pkg/webhook/testhelpers_test.go
+++ b/pkg/webhook/testhelpers_test.go
@@ -61,6 +61,7 @@ func setupGitHubServer(t *testing.T) (*gh.Client, *http.ServeMux) {
 // prWebhookPayloadOpts configures how buildPRWebhookRequest constructs the payload.
 type prWebhookPayloadOpts struct {
 	action    string // "opened", "synchronize", "reopened", "closed", etc.
+	merged    bool   // for "closed": whether the PR merged or was closed without merging
 	beforeSHA string
 	headSHA   string
 	headRef   string
@@ -91,6 +92,7 @@ func buildPRWebhookRequest(t *testing.T, opts prWebhookPayloadOpts, secret []byt
 		"action": opts.action,
 		"pull_request": map[string]any{
 			"number": 1,
+			"merged": opts.merged,
 			"head": map[string]any{
 				"sha": opts.headSHA,
 				"ref": opts.headRef,


### PR DESCRIPTION
## Why this matters

Once an apply has started, its stored check state is authoritative until an operator reconciles the target environment — for example, a commit that removes the schema change after its apply ran leaves a terminal `action_required` row blocking the aggregate. PR close cleanup retained only *in-flight* apply-owned rows, so closing and reopening the PR deleted that terminal block and the reopened PR converged to a passing merge gate while the live database no longer matched the PR contents. A two-click close/reopen bypassed operator reconciliation.

## What it does

- PR close now retains apply-owned stored check state that still blocks: `in_progress` rows, and terminal rows whose conclusion is anything but `success` (`action_required`, `failure`, or unset — fail closed).
- Apply-owned rows that concluded successfully are still deleted on close, so a reopened PR doesn't inherit a stale gate from a cleanly finished apply.
- Plan-only rows (no apply ever started) are still deleted on close.
- On reopen, stale-check cleanup re-blocks the retained row on the new head SHA and the aggregate folds it back in as `action_required` until an operator reconciles.

## Before / after

The scenario: an apply ran (the database was changed), then a later commit removed that schema change from the PR. The stored check row blocks the merge until an operator reconciles the database.

```
Before — close + reopen washes the block away

  step                        stored check row                    merge gate
  ─────────────────────────   ─────────────────────────────────   ──────────
  apply completes             db1: success (apply-owned)          ✅
  commit removes the change   db1: action_required 🔒 blocked     ❌ correct
  CLOSE the PR                row DELETED (only in_progress       —
                              rows were kept)
  REOPEN the PR               no schema in diff → no row written  —
  aggregate recalculates      nothing to fold → "no changes"     ✅ ⛔ WRONG
                              (database still ≠ PR contents)
```

```
After — close keeps every apply-owned row that still blocks

  what close does with each row kind:
    in_progress apply-owned            → kept   (unchanged)
    terminal, conclusion ≠ success     → kept   ◄── the fix
    terminal, success                  → deleted (nothing left to block)
    plan-only (no apply ever ran)      → deleted (regenerates on re-plan)

  step                        stored check row                    merge gate
  ─────────────────────────   ─────────────────────────────────   ──────────
  CLOSE the PR                db1: action_required 🔒 KEPT        —
  REOPEN the PR               row re-attached to the new head     —
  aggregate recalculates      folds the blocked row               ❌ correct
                              (until an operator reconciles)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
