### PR TITLE
fix(api): contain apply-drive panics to the claimed apply

### DIFF
--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/block/schemabot/pkg/metrics"
+	"github.com/block/schemabot/pkg/panicsafe"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/tern"
@@ -154,7 +155,7 @@ func (s *Service) operatorDriver(ctx context.Context, driverID int, stop <-chan 
 
 	s.logger.Debug("operator driver started", "driver", driverID)
 
-	s.recoverApplies(ctx, driverID)
+	s.driveTick(ctx, driverID)
 
 	for {
 		select {
@@ -166,11 +167,41 @@ func (s *Service) operatorDriver(ctx context.Context, driverID int, stop <-chan 
 			return
 		case <-wake:
 			s.logger.Debug("operator driver woke for queued apply", "driver", driverID)
-			s.recoverApplies(ctx, driverID)
+			s.driveTick(ctx, driverID)
 		case <-ticker.C:
-			s.recoverApplies(ctx, driverID)
+			s.driveTick(ctx, driverID)
 		}
 	}
+}
+
+// driveTick runs one claim-and-drive pass behind a panic boundary so a
+// poisoned claim degrades only this tick: the panic is logged with its stack
+// and counted, and the driver keeps polling. Panics raised inside the engine
+// drive are already converted to errors (and fail the claimed apply) at the
+// resumeClaimedApply seam, so a panic reaching this boundary comes from the
+// claim or projection machinery itself and leaves no apply marked failed —
+// that work is retried on a later tick.
+func (s *Service) driveTick(ctx context.Context, driverID int) {
+	err := panicsafe.Call(func() error {
+		s.recoverApplies(ctx, driverID)
+		return nil
+	})
+	if err == nil {
+		return
+	}
+	var tickPanic *panicsafe.Error
+	if !errors.As(err, &tickPanic) {
+		// recoverApplies handles its own failures and never returns an error, so
+		// only a contained panic reaches here today; keep the signal if that
+		// invariant ever changes.
+		s.logger.Error("operator: drive tick failed", "driver", driverID, "error", err)
+		return
+	}
+	s.logger.Error("operator: drive tick panicked; the driver continues and retries on the next tick",
+		"driver", driverID,
+		"panic", fmt.Sprint(tickPanic.Value),
+		"stack", string(tickPanic.Stack))
+	metrics.RecordRecoveredPanic(ctx, "operator_tick")
 }
 
 // expireRetryableApplies runs the retryable-apply expiry maintenance pass,
@@ -452,8 +483,18 @@ func (s *Service) recoverSingleApplyOperation(ctx context.Context, driverID int,
 			// never make progress. Terminalize it now rather than leaving it to
 			// be re-leased on every poll once its heartbeat goes stale.
 			s.failOperationWithoutTasks(operationLeaseCtx, applyLeaseCtx, driverID, op, apply)
+			return
 		}
-		return
+		var drivePanic *panicsafe.Error
+		if !errors.As(resumeErr, &drivePanic) {
+			// Transient drive failures leave the operation claimable so a later
+			// poll retries it; resumeClaimedApply already logged the cause.
+			return
+		}
+		// A contained drive panic already failed this operation's tasks and the
+		// parent apply. Fall through so the operation row is persisted from its
+		// now-failed tasks immediately instead of waiting to be re-leased once
+		// its heartbeat goes stale.
 	}
 
 	// Persist the operation row from its OWN drive outcome — the aggregate of
@@ -1141,15 +1182,38 @@ func (s *Service) resumeClaimedApplyWithOptions(ctx context.Context, driverID in
 	// closed when no tasks scope to the operation. The cutover variant drives a
 	// barrier-parked operation through its swap instead of its copy phase. The
 	// legacy whole-apply path (applyOperationID == 0) drives every task.
-	switch {
-	case applyOperationID > 0 && opts.cutover:
-		err = client.ResumeApplyOperationCutover(ctx, apply, applyOperationID)
-	case applyOperationID > 0:
-		err = client.ResumeApplyOperation(ctx, apply, applyOperationID)
-	default:
-		err = client.ResumeApply(ctx, apply)
-	}
+	// The drive runs behind a panic boundary: engine and resume code process
+	// stored metadata, so one poisoned row must degrade only this apply, not
+	// the process. A contained panic surfaces as a *panicsafe.Error and is
+	// handled as a permanent failure below.
+	err = panicsafe.Call(func() error {
+		switch {
+		case applyOperationID > 0 && opts.cutover:
+			return client.ResumeApplyOperationCutover(ctx, apply, applyOperationID)
+		case applyOperationID > 0:
+			return client.ResumeApplyOperation(ctx, apply, applyOperationID)
+		default:
+			return client.ResumeApply(ctx, apply)
+		}
+	})
 	if err != nil {
+		var drivePanic *panicsafe.Error
+		if errors.As(err, &drivePanic) {
+			s.logger.Error("operator: engine drive panicked; the apply will be marked failed so it is not re-claimed and panicked again",
+				append(apply.LogAttrs(),
+					"driver", driverID,
+					"apply_operation_id", applyOperationID,
+					"operation_deployment", deployment,
+					"panic", fmt.Sprint(drivePanic.Value),
+					"stack", string(drivePanic.Stack))...)
+			metrics.RecordRecoveredPanic(ctx, "apply_drive")
+			metrics.RecordOperatorResumeFailure(ctx, apply.Database, deployment, apply.Environment, "drive_panic")
+			// The failed transition below owns the active-apply gauge release, so
+			// the retryable-claim decrement the other failure branches perform is
+			// intentionally omitted here.
+			s.failClaimedApplyAfterDrivePanic(ctx, driverID, apply, applyOperationID, deployment, previousState, drivePanic)
+			return false, err
+		}
 		if errors.Is(err, storage.ErrApplyLeaseLost) {
 			s.logger.Warn("operator: apply lease was lost; driver will stop writing this apply",
 				"driver", driverID,
@@ -1270,6 +1334,141 @@ func (s *Service) logApplyResumeClaim(ctx context.Context, driverID int, apply *
 		CreatedAt: s.clock.Now(),
 	}); err != nil {
 		s.logger.Warn("operator: failed to log apply claim; apply claim will not appear in apply logs",
+			"driver", driverID,
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"error", err)
+	}
+}
+
+// failClaimedApplyAfterDrivePanic contains an engine-drive panic to the
+// claimed work. The tasks in the drive's scope are marked failed so the
+// operation row can settle to a terminal state from its own tasks, and — when
+// this driver holds the parent apply lease — the apply row is marked failed so
+// neither the stale-heartbeat nor the retry recovery path re-claims the same
+// row and panics again. failed (permanent) is deliberate: failed_retryable
+// would queue the apply straight back into the panicking code path. Returns
+// true when this call transitioned the apply row to failed.
+//
+// The apply requires operator intervention afterwards: fix the underlying code
+// or data fault the panic log identifies, then start a new apply for the
+// schema change.
+func (s *Service) failClaimedApplyAfterDrivePanic(ctx context.Context, driverID int, apply *storage.Apply, applyOperationID int64, deployment, previousState string, drivePanic *panicsafe.Error) bool {
+	errMsg := fmt.Sprintf("apply drive panicked: %v", drivePanic.Value)
+	now := s.clock.Now()
+
+	// Fail the tasks the panicked drive was scoped to. The operation-claim
+	// paths derive the operation row from its tasks (markOperationFromOwnResult),
+	// so failing the tasks is what lets the operation row — and through the
+	// rollout projection, the parent apply — settle terminally.
+	var tasks []*storage.Task
+	var tasksErr error
+	if applyOperationID > 0 {
+		tasks, tasksErr = s.storage.Tasks().GetByApplyOperationID(ctx, applyOperationID)
+	} else {
+		tasks, tasksErr = s.storage.Tasks().GetByApplyID(ctx, apply.ID)
+	}
+	if tasksErr != nil {
+		s.logger.Error("operator: failed to load tasks while containing drive panic; the operation row will settle from a later reconcile instead",
+			append(apply.LogAttrs(),
+				"driver", driverID,
+				"apply_operation_id", applyOperationID,
+				"operation_deployment", deployment,
+				"error", tasksErr)...)
+	}
+	for _, task := range tasks {
+		if state.IsTerminalTaskState(task.State) {
+			s.logger.Debug("operator: task already terminal while containing drive panic; leaving its state",
+				append(task.LogAttrs(), "driver", driverID)...)
+			continue
+		}
+		if task.ErrorMessage == "" {
+			task.ErrorMessage = errMsg
+		}
+		task.State = state.Task.Failed
+		task.CompletedAt = &now
+		task.UpdatedAt = now
+		if err := s.storage.Tasks().Update(ctx, task); err != nil {
+			s.logger.Error("operator: failed to mark task failed while containing drive panic; the task will settle from a later reconcile instead",
+				append(task.LogAttrs(), "driver", driverID, "error", err)...)
+		}
+	}
+
+	// A multi-operation drive holds only its operation lease; the parent
+	// applies row is owned by the rollout projection, which settles it from the
+	// now-failed operation row. Only a driver holding the parent apply lease
+	// writes the apply row directly.
+	if _, hasApplyLease := storage.ApplyLeaseFromContext(ctx); !hasApplyLease {
+		s.logger.Info("operator: contained drive panic under the operation lease; the parent apply will settle via the rollout projection",
+			append(apply.LogAttrs(),
+				"driver", driverID,
+				"apply_operation_id", applyOperationID,
+				"operation_deployment", deployment)...)
+		return false
+	}
+
+	// Reload before writing: a stop or a competing driver may have already
+	// terminalized the apply between the claim and the panic, and a terminal
+	// state must not be overwritten.
+	fresh, err := s.storage.Applies().Get(ctx, apply.ID)
+	if err != nil {
+		s.logger.Error("operator: failed to reload apply while containing drive panic; the apply is not marked failed and will be re-claimed on a later poll",
+			append(apply.LogAttrs(), "driver", driverID, "error", err)...)
+		return false
+	}
+	if fresh == nil {
+		s.logger.Error("operator: apply not found while containing drive panic; the apply is not marked failed",
+			append(apply.LogAttrs(), "driver", driverID)...)
+		return false
+	}
+	if state.IsTerminalApplyState(fresh.State) {
+		s.logger.Info("operator: apply already terminal while containing drive panic; leaving its state",
+			append(apply.LogAttrs(), "driver", driverID, "current_state", fresh.State)...)
+		return false
+	}
+
+	apply.State = state.Apply.Failed
+	apply.ErrorMessage = errMsg
+	apply.CompletedAt = &now
+	apply.UpdatedAt = now
+	if err := s.storage.Applies().Update(ctx, apply); err != nil {
+		s.logger.Error("operator: failed to mark apply failed while containing drive panic; the apply will be re-claimed on a later poll",
+			append(apply.LogAttrs(), "driver", driverID, "error", err)...)
+		return false
+	}
+	// The failed transition releases the active-apply gauge the same way an
+	// engine-driven failure would have.
+	metrics.AdjustActiveApplies(ctx, -1, apply.Database, deployment, apply.Environment)
+	s.logApplyDrivePanicFailure(ctx, driverID, apply, previousState, errMsg)
+	return true
+}
+
+// logApplyDrivePanicFailure appends a durable apply log entry recording that a
+// contained drive panic failed the apply, so the timeline explains the terminal
+// state without server logs. Best-effort: a failed append must not block
+// containment.
+func (s *Service) logApplyDrivePanicFailure(ctx context.Context, driverID int, apply *storage.Apply, previousState, errMsg string) {
+	logStore := s.storage.ApplyLogs()
+	if logStore == nil {
+		s.logger.Warn("operator: no apply log store configured; the drive panic will not appear in apply logs",
+			"driver", driverID,
+			"apply_id", apply.ApplyIdentifier)
+		return
+	}
+	logCtx, cancel := context.WithTimeout(ctx, ApplyClaimLogTimeout)
+	defer cancel()
+	if err := logStore.Append(logCtx, &storage.ApplyLog{
+		ApplyID:   apply.ID,
+		Level:     storage.LogLevelError,
+		EventType: storage.LogEventError,
+		Source:    storage.LogSourceSchemaBot,
+		Message:   fmt.Sprintf("Apply failed after a drive panic was contained by operator driver %d: %s. Fix the underlying fault, then start a new apply.", driverID, errMsg),
+		OldState:  previousState,
+		NewState:  apply.State,
+		CreatedAt: s.clock.Now(),
+	}); err != nil {
+		s.logger.Warn("operator: failed to log drive panic failure; the failure will not appear in apply logs",
 			"driver", driverID,
 			"apply_id", apply.ApplyIdentifier,
 			"database", apply.Database,

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -1211,7 +1211,7 @@ func (s *Service) resumeClaimedApplyWithOptions(ctx context.Context, driverID in
 			// The failed transition below owns the active-apply gauge release, so
 			// the retryable-claim decrement the other failure branches perform is
 			// intentionally omitted here.
-			s.failClaimedApplyAfterDrivePanic(ctx, driverID, apply, applyOperationID, deployment, previousState, drivePanic)
+			s.failClaimedApplyAfterDrivePanic(ctx, driverID, apply, applyOperationID, deployment, drivePanic)
 			return false, err
 		}
 		if errors.Is(err, storage.ErrApplyLeaseLost) {
@@ -1354,7 +1354,7 @@ func (s *Service) logApplyResumeClaim(ctx context.Context, driverID int, apply *
 // The apply requires operator intervention afterwards: fix the underlying code
 // or data fault the panic log identifies, then start a new apply for the
 // schema change.
-func (s *Service) failClaimedApplyAfterDrivePanic(ctx context.Context, driverID int, apply *storage.Apply, applyOperationID int64, deployment, previousState string, drivePanic *panicsafe.Error) bool {
+func (s *Service) failClaimedApplyAfterDrivePanic(ctx context.Context, driverID int, apply *storage.Apply, applyOperationID int64, deployment string, drivePanic *panicsafe.Error) bool {
 	errMsg := fmt.Sprintf("apply drive panicked: %v", drivePanic.Value)
 	now := s.clock.Now()
 
@@ -1428,19 +1428,22 @@ func (s *Service) failClaimedApplyAfterDrivePanic(ctx context.Context, driverID 
 		return false
 	}
 
-	apply.State = state.Apply.Failed
-	apply.ErrorMessage = errMsg
-	apply.CompletedAt = &now
-	apply.UpdatedAt = now
-	if err := s.storage.Applies().Update(ctx, apply); err != nil {
+	// Write the reloaded row, not the claim-time pointer: fields a stop or a
+	// peer updated between the claim and the panic must survive this write.
+	previousState := fresh.State
+	fresh.State = state.Apply.Failed
+	fresh.ErrorMessage = errMsg
+	fresh.CompletedAt = &now
+	fresh.UpdatedAt = now
+	if err := s.storage.Applies().Update(ctx, fresh); err != nil {
 		s.logger.Error("operator: failed to mark apply failed while containing drive panic; the apply will be re-claimed on a later poll",
 			append(apply.LogAttrs(), "driver", driverID, "error", err)...)
 		return false
 	}
 	// The failed transition releases the active-apply gauge the same way an
 	// engine-driven failure would have.
-	metrics.AdjustActiveApplies(ctx, -1, apply.Database, deployment, apply.Environment)
-	s.logApplyDrivePanicFailure(ctx, driverID, apply, previousState, errMsg)
+	metrics.AdjustActiveApplies(ctx, -1, fresh.Database, deployment, fresh.Environment)
+	s.logApplyDrivePanicFailure(ctx, driverID, fresh, previousState, errMsg)
 	return true
 }
 

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/block/schemabot/pkg/panicsafe"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/tern"
@@ -1245,4 +1246,280 @@ func TestRecoverApplies_ExpiryErrorDoesNotBlockClaim(t *testing.T) {
 
 	assert.True(t, applyStore.findNextCalled,
 		"FindNextApply must run even when ExpireRetryable fails")
+}
+
+// panickingResumeClient simulates an engine whose resume path hits a code or
+// data fault (for example malformed stored metadata) and panics mid-drive.
+type panickingResumeClient struct {
+	mockTernClient
+	panicValue string
+}
+
+func (c *panickingResumeClient) ResumeApply(context.Context, *storage.Apply) error {
+	panic(c.panicValue)
+}
+
+func (c *panickingResumeClient) ResumeApplyOperation(context.Context, *storage.Apply, int64) error {
+	panic(c.panicValue)
+}
+
+// recordingTaskStore serves a fixed task set and records state writes, so tests
+// can assert what the panic containment persisted.
+type recordingTaskStore struct {
+	storage.TaskStore
+	tasks   []*storage.Task
+	updated []*storage.Task
+}
+
+func (s *recordingTaskStore) GetByApplyID(_ context.Context, applyID int64) ([]*storage.Task, error) {
+	tasks := make([]*storage.Task, 0, len(s.tasks))
+	for _, task := range s.tasks {
+		if task.ApplyID == applyID {
+			tasks = append(tasks, task)
+		}
+	}
+	return tasks, nil
+}
+
+func (s *recordingTaskStore) GetByApplyOperationID(_ context.Context, applyOperationID int64) ([]*storage.Task, error) {
+	tasks := make([]*storage.Task, 0, len(s.tasks))
+	for _, task := range s.tasks {
+		if task.ApplyOperationID != nil && *task.ApplyOperationID == applyOperationID {
+			tasks = append(tasks, task)
+		}
+	}
+	return tasks, nil
+}
+
+func (s *recordingTaskStore) Update(_ context.Context, task *storage.Task) error {
+	s.updated = append(s.updated, task)
+	return nil
+}
+
+// panicContainmentApplyStore claims a single apply, rotating a lease onto it,
+// and records the terminal write the panic containment path performs. Once the
+// apply is terminal it is no longer claimable, matching the durable claim
+// predicate.
+type panicContainmentApplyStore struct {
+	storage.ApplyStore
+	apply        *storage.Apply
+	claims       int
+	updateCalled bool
+}
+
+func (s *panicContainmentApplyStore) ExpireRetryable(context.Context) ([]*storage.RetryableApplyExpiration, error) {
+	return nil, nil
+}
+
+func (s *panicContainmentApplyStore) FindNextApply(_ context.Context, owner string) (*storage.Apply, error) {
+	s.claims++
+	if s.apply == nil || state.IsTerminalApplyState(s.apply.State) {
+		return nil, nil
+	}
+	s.apply.LeaseOwner = owner
+	s.apply.LeaseToken = "lease-token"
+	return s.apply, nil
+}
+
+func (s *panicContainmentApplyStore) Get(context.Context, int64) (*storage.Apply, error) {
+	return s.apply, nil
+}
+
+func (s *panicContainmentApplyStore) Update(_ context.Context, apply *storage.Apply) error {
+	s.updateCalled = true
+	s.apply = apply
+	return nil
+}
+
+// staticOperationLookupStore serves one operation row for routing lookups.
+type staticOperationLookupStore struct {
+	storage.ApplyOperationStore
+	op *storage.ApplyOperation
+}
+
+func (s *staticOperationLookupStore) Get(context.Context, int64) (*storage.ApplyOperation, error) {
+	return s.op, nil
+}
+
+// A panic inside the engine drive must be contained to the claimed apply: the
+// resume call returns an error instead of crashing the driver, the apply is
+// marked failed (permanent) so recovery does not re-claim the poisoned row and
+// panic again, and the apply's tasks are failed so dependent state can settle.
+func TestResumeClaimedApply_DrivePanicFailsApply(t *testing.T) {
+	client := &panickingResumeClient{panicValue: "corrupt engine metadata"}
+	apply := &storage.Apply{
+		ID:              42,
+		ApplyIdentifier: "apply-42",
+		Database:        "appdb",
+		Deployment:      "east",
+		Environment:     "staging",
+		State:           state.Apply.Running,
+		LeaseOwner:      "driver-0",
+		LeaseToken:      "lease-token",
+	}
+	applyStore := &panicContainmentApplyStore{apply: apply}
+	taskStore := &recordingTaskStore{tasks: []*storage.Task{
+		{ID: 9, ApplyID: 42, State: state.Task.Running},
+	}}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(&mockStorageWithApplyStores{
+		plans:   &staticPlanStore{},
+		applies: applyStore,
+		tasks:   taskStore,
+	}, &ServerConfig{}, map[string]tern.Client{
+		"east/staging": client,
+	}, logger)
+
+	ctx := storage.WithApplyLease(t.Context(), apply.Lease())
+	var resumed bool
+	var err error
+	require.NotPanics(t, func() {
+		resumed, err = svc.resumeClaimedApply(ctx, 0, apply, 0, "")
+	})
+
+	require.Error(t, err)
+	var drivePanic *panicsafe.Error
+	require.ErrorAs(t, err, &drivePanic, "a contained drive panic must surface as a panicsafe error")
+	assert.Equal(t, "corrupt engine metadata", drivePanic.Value)
+	assert.False(t, resumed)
+
+	assert.True(t, applyStore.updateCalled, "the apply row must be written to its failed state")
+	assert.True(t, state.IsState(apply.State, state.Apply.Failed),
+		"the apply must be failed (permanent), not failed_retryable, so it is not re-claimed and re-panicked")
+	assert.Contains(t, apply.ErrorMessage, "corrupt engine metadata")
+	require.NotNil(t, apply.CompletedAt)
+
+	require.Len(t, taskStore.updated, 1, "the in-flight task must be settled")
+	assert.True(t, state.IsState(taskStore.updated[0].State, state.Task.Failed))
+	assert.Contains(t, taskStore.updated[0].ErrorMessage, "corrupt engine metadata")
+}
+
+// A drive panic contained while holding only an operation lease fails the
+// operation's tasks but leaves the parent applies row untouched: under the
+// multi-operation fan-out the parent state is owned by the rollout projection,
+// which settles it from the failed operation row.
+func TestResumeClaimedApply_DrivePanicUnderOperationLeaseLeavesParentToProjection(t *testing.T) {
+	client := &panickingResumeClient{panicValue: "corrupt operation metadata"}
+	apply := &storage.Apply{
+		ID:              42,
+		ApplyIdentifier: "apply-42",
+		Database:        "appdb",
+		Deployment:      "east",
+		Environment:     "staging",
+		State:           state.Apply.Running,
+	}
+	operationID := int64(7)
+	applyStore := &panicContainmentApplyStore{apply: apply}
+	taskStore := &recordingTaskStore{tasks: []*storage.Task{
+		{ID: 9, ApplyID: 42, ApplyOperationID: &operationID, State: state.Task.Running},
+	}}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(&mockStorageWithApplyStores{
+		plans:   &staticPlanStore{},
+		applies: applyStore,
+		tasks:   taskStore,
+		operations: &staticOperationLookupStore{op: &storage.ApplyOperation{
+			ID:         operationID,
+			ApplyID:    42,
+			Deployment: "east",
+			State:      state.ApplyOperation.Running,
+		}},
+	}, &ServerConfig{}, map[string]tern.Client{
+		"east/staging": client,
+	}, logger)
+
+	ctx := storage.WithOperationLease(t.Context(), storage.OperationLease{
+		ApplyID:     42,
+		OperationID: operationID,
+		Owner:       "driver-0",
+		Token:       "op-token",
+	})
+	var resumed bool
+	var err error
+	require.NotPanics(t, func() {
+		resumed, err = svc.resumeClaimedApply(ctx, 0, apply, operationID, "east")
+	})
+
+	var drivePanic *panicsafe.Error
+	require.ErrorAs(t, err, &drivePanic)
+	assert.False(t, resumed)
+
+	assert.False(t, applyStore.updateCalled,
+		"an operation-lease-only drive must not write the parent applies row; the rollout projection owns it")
+	assert.True(t, state.IsState(apply.State, state.Apply.Running))
+
+	require.Len(t, taskStore.updated, 1, "the operation's task must be failed so the operation row can settle")
+	assert.True(t, state.IsState(taskStore.updated[0].State, state.Task.Failed))
+	assert.Contains(t, taskStore.updated[0].ErrorMessage, "corrupt operation metadata")
+}
+
+// One poisoned apply must degrade only itself: the drive tick that claims it
+// contains the panic and marks the apply failed, and the driver keeps claiming
+// fresh work on subsequent ticks instead of crashing the process.
+func TestDriveTick_ContainsDrivePanicAndKeepsClaiming(t *testing.T) {
+	client := &panickingResumeClient{panicValue: "corrupt engine metadata"}
+	apply := &storage.Apply{
+		ID:              42,
+		ApplyIdentifier: "apply-42",
+		Database:        "appdb",
+		Deployment:      "east",
+		Environment:     "staging",
+		State:           state.Apply.Running,
+	}
+	applyStore := &panicContainmentApplyStore{apply: apply}
+	taskStore := &recordingTaskStore{tasks: []*storage.Task{
+		{ID: 9, ApplyID: 42, State: state.Task.Running},
+	}}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	claimOperations := false
+	cfg := testServerConfig()
+	cfg.OperatorClaimOperations = &claimOperations
+	svc := New(&mockStorageWithApplyStores{
+		plans:   &staticPlanStore{},
+		applies: applyStore,
+		tasks:   taskStore,
+	}, cfg, map[string]tern.Client{
+		"east/staging": client,
+	}, logger)
+
+	require.NotPanics(t, func() { svc.driveTick(t.Context(), 0) })
+	assert.Equal(t, 1, applyStore.claims)
+	assert.True(t, state.IsState(apply.State, state.Apply.Failed),
+		"the poisoned apply must be failed so it is not re-claimed")
+
+	require.NotPanics(t, func() { svc.driveTick(t.Context(), 0) })
+	assert.Equal(t, 2, applyStore.claims,
+		"the driver must keep claiming after containing the panic, and the failed apply must not be claimable")
+}
+
+// panickingClaimApplyStore simulates a panic in the claim machinery itself
+// (outside the engine drive), counting claim attempts.
+type panickingClaimApplyStore struct {
+	storage.ApplyStore
+	claims int
+}
+
+func (s *panickingClaimApplyStore) ExpireRetryable(context.Context) ([]*storage.RetryableApplyExpiration, error) {
+	return nil, nil
+}
+
+func (s *panickingClaimApplyStore) FindNextApply(context.Context, string) (*storage.Apply, error) {
+	s.claims++
+	panic("claim scan hit a corrupt row")
+}
+
+// A panic in the claim machinery itself (outside the engine drive) must not
+// kill the driver goroutine: the tick boundary contains it and the driver
+// polls again on the next tick.
+func TestDriveTick_ContainsClaimPanic(t *testing.T) {
+	applyStore := &panickingClaimApplyStore{}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	claimOperations := false
+	cfg := testServerConfig()
+	cfg.OperatorClaimOperations = &claimOperations
+	svc := New(&mockStorageWithApplyStores{applies: applyStore}, cfg, nil, logger)
+
+	require.NotPanics(t, func() { svc.driveTick(t.Context(), 0) })
+	require.NotPanics(t, func() { svc.driveTick(t.Context(), 0) })
+	assert.Equal(t, 2, applyStore.claims, "the driver must keep polling after each contained panic")
 }

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -1322,7 +1322,11 @@ func (s *panicContainmentApplyStore) FindNextApply(_ context.Context, owner stri
 }
 
 func (s *panicContainmentApplyStore) Get(context.Context, int64) (*storage.Apply, error) {
-	return s.apply, nil
+	if s.apply == nil {
+		return nil, nil
+	}
+	fresh := *s.apply
+	return &fresh, nil
 }
 
 func (s *panicContainmentApplyStore) Update(_ context.Context, apply *storage.Apply) error {
@@ -1345,6 +1349,9 @@ func (s *staticOperationLookupStore) Get(context.Context, int64) (*storage.Apply
 // resume call returns an error instead of crashing the driver, the apply is
 // marked failed (permanent) so recovery does not re-claim the poisoned row and
 // panic again, and the apply's tasks are failed so dependent state can settle.
+// The containment write persists the reloaded row, so a field a peer wrote
+// between the claim and the panic survives instead of being clobbered by the
+// claim-time snapshot.
 func TestResumeClaimedApply_DrivePanicFailsApply(t *testing.T) {
 	client := &panickingResumeClient{panicValue: "corrupt engine metadata"}
 	apply := &storage.Apply{
@@ -1371,10 +1378,16 @@ func TestResumeClaimedApply_DrivePanicFailsApply(t *testing.T) {
 	}, logger)
 
 	ctx := storage.WithApplyLease(t.Context(), apply.Lease())
+	// The drive holds the claim-time snapshot while a peer writes the stored
+	// row (a skip-revert dispatch) before the panic is contained.
+	claimed := *apply
+	peerWrite := time.Now()
+	apply.RevertSkippedAt = &peerWrite
+
 	var resumed bool
 	var err error
 	require.NotPanics(t, func() {
-		resumed, err = svc.resumeClaimedApply(ctx, 0, apply, 0, "")
+		resumed, err = svc.resumeClaimedApply(ctx, 0, &claimed, 0, "")
 	})
 
 	require.Error(t, err)
@@ -1383,11 +1396,14 @@ func TestResumeClaimedApply_DrivePanicFailsApply(t *testing.T) {
 	assert.Equal(t, "corrupt engine metadata", drivePanic.Value)
 	assert.False(t, resumed)
 
-	assert.True(t, applyStore.updateCalled, "the apply row must be written to its failed state")
-	assert.True(t, state.IsState(apply.State, state.Apply.Failed),
+	require.True(t, applyStore.updateCalled, "the apply row must be written to its failed state")
+	written := applyStore.apply
+	assert.True(t, state.IsState(written.State, state.Apply.Failed),
 		"the apply must be failed (permanent), not failed_retryable, so it is not re-claimed and re-panicked")
-	assert.Contains(t, apply.ErrorMessage, "corrupt engine metadata")
-	require.NotNil(t, apply.CompletedAt)
+	assert.Contains(t, written.ErrorMessage, "corrupt engine metadata")
+	require.NotNil(t, written.CompletedAt)
+	require.NotNil(t, written.RevertSkippedAt,
+		"a peer update stored between the claim and the panic must survive the containment write")
 
 	require.Len(t, taskStore.updated, 1, "the in-flight task must be settled")
 	assert.True(t, state.IsState(taskStore.updated[0].State, state.Task.Failed))
@@ -1484,7 +1500,7 @@ func TestDriveTick_ContainsDrivePanicAndKeepsClaiming(t *testing.T) {
 
 	require.NotPanics(t, func() { svc.driveTick(t.Context(), 0) })
 	assert.Equal(t, 1, applyStore.claims)
-	assert.True(t, state.IsState(apply.State, state.Apply.Failed),
+	assert.True(t, state.IsState(applyStore.apply.State, state.Apply.Failed),
 		"the poisoned apply must be failed so it is not re-claimed")
 
 	require.NotPanics(t, func() { svc.driveTick(t.Context(), 0) })

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -778,6 +778,33 @@ func RecordOperatorTerminalSummaryFailure(ctx context.Context, reason string) {
 	)
 }
 
+// knownRecoveredPanicOperations limits metric cardinality to the panic
+// containment boundaries that exist in the codebase.
+var knownRecoveredPanicOperations = map[string]bool{
+	"apply_drive":            true,
+	"operator_tick":          true,
+	"summary_reconciliation": true,
+	"observer_poll":          true,
+}
+
+// RecordRecoveredPanic increments the recovered-panic counter for a background
+// operation whose panic was contained instead of crashing the process. Any
+// non-zero rate means a code or data bug is being converted into degraded work
+// (a failed apply, a stopped poller, a skipped reconciliation pass). The paired
+// error log carries the panic value, stack, and work identifiers, so the
+// operator action is to find that log, fix the underlying fault, and reconcile
+// the affected work.
+func RecordRecoveredPanic(ctx context.Context, operation string) {
+	if !knownRecoveredPanicOperations[operation] {
+		operation = "unknown"
+	}
+	addCounter(ctx, "schemabot.panic.recovered_total",
+		"Total number of panics recovered at background-work boundaries", "{panic}",
+		EnvironmentAttribute(""),
+		attribute.String("operation", operation),
+	)
+}
+
 // RecordOperatorClaimDuration records how long it took to claim and resume an apply.
 func RecordOperatorClaimDuration(ctx context.Context, duration time.Duration, database, deployment, environment, previousState string) {
 	for _, name := range operatorMetricNames("claim_duration_seconds") {

--- a/pkg/panicsafe/panicsafe.go
+++ b/pkg/panicsafe/panicsafe.go
@@ -1,0 +1,43 @@
+// Package panicsafe converts panics at background-work boundaries into errors.
+//
+// SchemaBot's control plane multiplexes many independent units of work —
+// operator drives, reconciliation loops, observer pollers — onto one process.
+// A panic in any one of them would otherwise kill the process, and because
+// crashed work is re-claimed after restart, a single poisoned row could
+// crash-loop every replica. Call is the containment boundary: it turns a panic
+// into an *Error that the caller routes through its normal failure handling
+// (log, metric, state transition) so one bad unit of work degrades only
+// itself.
+package panicsafe
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+// Error is a recovered panic carrying the panic value and the goroutine stack
+// captured at the recovery point. Callers detect a contained panic with
+// errors.As and log Value and Stack so the fault is triageable from logs
+// alone.
+type Error struct {
+	// Value is the value the panicking code passed to panic().
+	Value any
+	// Stack is the goroutine stack captured where the panic was recovered.
+	Stack []byte
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("panic: %v", e.Value)
+}
+
+// Call invokes fn, converting a panic into an *Error. A nil return means fn
+// completed normally; a non-nil return is either fn's own error or, when
+// errors.As matches *Error, a contained panic.
+func Call(fn func() error) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = &Error{Value: r, Stack: debug.Stack()}
+		}
+	}()
+	return fn()
+}

--- a/pkg/panicsafe/panicsafe_test.go
+++ b/pkg/panicsafe/panicsafe_test.go
@@ -1,0 +1,48 @@
+package panicsafe
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCall_ReturnsNilOnSuccess(t *testing.T) {
+	require.NoError(t, Call(func() error { return nil }))
+}
+
+func TestCall_PassesThroughError(t *testing.T) {
+	want := errors.New("engine failure")
+	err := Call(func() error { return want })
+	require.ErrorIs(t, err, want)
+
+	var contained *Error
+	assert.False(t, errors.As(err, &contained), "an ordinary error must not be reported as a contained panic")
+}
+
+func TestCall_ConvertsPanicToError(t *testing.T) {
+	var err error
+	require.NotPanics(t, func() {
+		err = Call(func() error { panic("poisoned metadata") })
+	})
+	require.Error(t, err)
+
+	var contained *Error
+	require.ErrorAs(t, err, &contained)
+	assert.Equal(t, "poisoned metadata", contained.Value)
+	assert.Contains(t, err.Error(), "poisoned metadata")
+	assert.NotEmpty(t, contained.Stack, "the stack must be captured for triage logging")
+}
+
+func TestCall_ConvertsNonStringPanicToError(t *testing.T) {
+	var err error
+	require.NotPanics(t, func() {
+		err = Call(func() error { panic(fmt.Errorf("nil dereference")) })
+	})
+
+	var contained *Error
+	require.ErrorAs(t, err, &contained)
+	assert.Contains(t, err.Error(), "nil dereference")
+}

--- a/pkg/serve/serve.go
+++ b/pkg/serve/serve.go
@@ -31,6 +31,7 @@ import (
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/metrics"
 	"github.com/block/schemabot/pkg/mysqlconn"
+	"github.com/block/schemabot/pkg/panicsafe"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/storage/mysqlstore"
 	"github.com/block/schemabot/pkg/tern"
@@ -98,7 +99,27 @@ func (r webhookRuntime) StartMissingSummaryReconciliation(ctx context.Context, l
 
 	reconcileCtx := context.WithoutCancel(ctx)
 	go func() {
-		r.reconcileMissingSummaryComments(reconcileCtx)
+		// The reconcile pass renders GitHub comments from stored apply state; a
+		// panic on one poisoned row must degrade only this startup pass, not
+		// kill the process that serves webhooks and drives applies.
+		err := panicsafe.Call(func() error {
+			r.reconcileMissingSummaryComments(reconcileCtx)
+			return nil
+		})
+		if err == nil {
+			return
+		}
+		var reconcilePanic *panicsafe.Error
+		if !errors.As(err, &reconcilePanic) {
+			// The reconcile callback returns nothing, so only a contained panic
+			// reaches here today; keep the signal if that invariant changes.
+			logger.Error("missing-summary reconciliation failed", "error", err)
+			return
+		}
+		logger.Error("missing-summary reconciliation panicked; missing summary comments will not be reconciled until the next restart",
+			"panic", fmt.Sprint(reconcilePanic.Value),
+			"stack", string(reconcilePanic.Stack))
+		metrics.RecordRecoveredPanic(reconcileCtx, "summary_reconciliation")
 	}()
 }
 

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -116,6 +116,7 @@ import (
 
 	"github.com/block/schemabot/pkg/engine"
 	"github.com/block/schemabot/pkg/metrics"
+	"github.com/block/schemabot/pkg/panicsafe"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
@@ -407,7 +408,47 @@ func remoteApplyStateDescription(remoteState ternv1.State) string {
 // pollAndNotifyObserver polls storage for apply state changes and notifies the
 // observer. This is the GRPCClient equivalent of LocalClient's progress poller
 // calling the observer — but driven by storage reads instead of engine polling.
+//
+// The poll runs behind a panic boundary: observer callbacks render
+// GitHub-facing progress and terminal updates from stored state, so a panic on
+// one poisoned apply must stop only this apply's notifications, not the
+// process that drives every apply. On a contained panic the observer is
+// cleared and the poller exits; the apply's drive is unaffected.
 func (c *GRPCClient) pollAndNotifyObserver(applyID int64) {
+	err := panicsafe.Call(func() error {
+		c.notifyObserverUntilTerminal(applyID)
+		return nil
+	})
+	if err == nil {
+		return
+	}
+	var pollPanic *panicsafe.Error
+	if !errors.As(err, &pollPanic) {
+		// The poll loop returns nothing, so only a contained panic reaches here
+		// today; keep the signal if that invariant changes.
+		slog.Error("observer poll failed; progress and terminal notifications for this apply are stopped", "error", err)
+		c.clearObserver(applyID)
+		return
+	}
+	attrs := []any{
+		"panic", fmt.Sprint(pollPanic.Value),
+		"stack", string(pollPanic.Stack),
+	}
+	// Best-effort identifier lookup for triage: the poller may have panicked
+	// before its first successful apply load, so the identifiers may be
+	// unavailable rather than the log being skipped.
+	if apply, lookupErr := c.storage.Applies().Get(context.Background(), applyID); lookupErr == nil && apply != nil {
+		attrs = append(apply.LogAttrs(), attrs...)
+	}
+	slog.Error("observer poll panicked; progress and terminal notifications for this apply are stopped", attrs...)
+	metrics.RecordRecoveredPanic(context.Background(), "observer_poll")
+	c.clearObserver(applyID)
+}
+
+// notifyObserverUntilTerminal is pollAndNotifyObserver's poll loop: it ticks
+// until the apply reaches a terminal state, the observer is cleared, or the
+// apply row disappears.
+func (c *GRPCClient) notifyObserverUntilTerminal(applyID int64) {
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 


### PR DESCRIPTION
## Why this matters

SchemaBot's operator runs many independent apply drives inside one process. That path had no panic recovery: if driving one apply panicked — say the engine tripped over malformed stored metadata — the whole process died, taking the webhook handler, the gRPC server, and every other in-flight apply down with it. Worse, after restart the same apply looked abandoned (stale heartbeat), got picked up again, and panicked again. One bad row could crash-loop every replica: a full control-plane outage.

## What it does

**1. A panic while driving an apply now fails that apply instead of killing the process.** The panic is caught at the drive boundary and converted into an error (new `pkg/panicsafe`). The apply and its tasks are marked failed — *permanently*, not "retry later", because retrying would feed the same poisoned row straight back into the code that panics. The operator fixes the underlying fault and starts a new apply. Before writing the failure, the row is re-read so a concurrent update (for example a stop that just landed) is not clobbered, and every write is lease-guarded so a driver that lost ownership can't stomp a peer.

**2. The driver itself keeps running.** A panic in the claiming machinery — before any apply is even picked up — is contained at the polling-tick boundary: that tick is abandoned with a logged stack trace, no apply is marked failed (there's nothing to blame yet), and the driver polls again on the next tick.

**3. Background helpers get the same protection.** The startup pass that reconciles missing PR summary comments and the poller that streams progress to a waiting PR check both run behind the same boundary. A panic there stops only that one task; the process keeps serving.

**4. Every contained panic is loud.** It's logged with the apply's triage identifiers plus the panic value and full stack, written into the apply's durable log so the timeline explains the terminal state, and counted in a new `schemabot.panic.recovered_total` metric — any non-zero rate means a real code or data bug is being converted into degraded work and someone should go find the paired log.

## Before / after

```
before: drive apply-42 → panic → process dies (all applies, webhooks, gRPC)
        → restart → apply-42 re-claimed → panic again → fleet crash loop ❌

after:  drive apply-42 → panic → apply-42 failed, stack logged, metric bumped
        → driver moves on to the next apply ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
