### PR TITLE
fix(github): aggregate check fails closed across recomputes and stale commits

### DIFF
--- a/pkg/storage/mysqlstore/checks.go
+++ b/pkg/storage/mysqlstore/checks.go
@@ -272,6 +272,34 @@ func (s *checkStore) MarkStalePlanSuccessful(ctx context.Context, check *storage
 	return isPlanOnlySuccessful(current), nil
 }
 
+// ClearAggregateBlock clears the blocking reason on stored aggregate check
+// state. The WHERE clause pins the head SHA and blocking reason the caller
+// read, making the clear an optimistic-concurrency write: a block recorded
+// concurrently (a different reason, or the same reason re-recorded on a newer
+// commit) does not match and is preserved. Returns true when the row was
+// cleared.
+func (s *checkStore) ClearAggregateBlock(ctx context.Context, check *storage.Check) (bool, error) {
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE checks
+		SET blocking_reason = '',
+		    error_message = ''
+		WHERE repository = ? AND pull_request = ?
+		  AND environment = ? AND database_type = ? AND database_name = ?
+		  AND head_sha = ? AND blocking_reason = ?
+	`, check.Repository, check.PullRequest, check.Environment, check.DatabaseType, check.DatabaseName,
+		check.HeadSHA, check.BlockingReason)
+	if err != nil {
+		return false, fmt.Errorf("clear aggregate blocking reason %q for %s#%d %s (head %s): %w",
+			check.BlockingReason, check.Repository, check.PullRequest, check.Environment, check.HeadSHA, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("rows affected clearing aggregate blocking reason %q for %s#%d %s: %w",
+			check.BlockingReason, check.Repository, check.PullRequest, check.Environment, err)
+	}
+	return rows > 0, nil
+}
+
 // isPlanOnlySuccessful reports whether stored check state is already in the
 // plan-only successful state stale cleanup converges to: a completed, successful
 // check with no started apply and no pending schema change.

--- a/pkg/storage/mysqlstore/checks_test.go
+++ b/pkg/storage/mysqlstore/checks_test.go
@@ -823,6 +823,105 @@ func TestCheckStore_MarkStalePlanSuccessfulLeavesInProgressApplyBlockingUnderCha
 	require.Equal(t, apply.ID, retrieved.ApplyID)
 }
 
+// seedBlockedAggregateRow stores an aggregate check row carrying a blocking
+// reason, as recorded when a PR-level guard fails the aggregate closed.
+func seedBlockedAggregateRow(t *testing.T, store *Storage, headSHA, blockingReason string) {
+	t.Helper()
+	require.NoError(t, store.Checks().Upsert(t.Context(), &storage.Check{
+		Repository:     "org/repo",
+		PullRequest:    123,
+		HeadSHA:        headSHA,
+		Environment:    "_aggregate",
+		DatabaseType:   "_aggregate",
+		DatabaseName:   "_aggregate",
+		CheckRunID:     200,
+		HasChanges:     false,
+		Status:         "completed",
+		Conclusion:     "failure",
+		BlockingReason: blockingReason,
+		ErrorMessage:   "guard failed the aggregate closed",
+	}))
+}
+
+// After the auto-plan guards re-verify a PR, the blocking reason on the stored
+// aggregate row is released so fresh plan results can drive the aggregate
+// again. The clear is pinned to the head SHA and reason the caller read.
+func TestCheckStore_ClearAggregateBlockClearsMatchingRow(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	seedBlockedAggregateRow(t, store, "abc123", "managed_dir_missing_config")
+
+	existing, err := store.Checks().Get(ctx, "org/repo", 123, "_aggregate", "_aggregate", "_aggregate")
+	require.NoError(t, err)
+	require.NotNil(t, existing)
+
+	cleared, err := store.Checks().ClearAggregateBlock(ctx, existing)
+	require.NoError(t, err)
+	require.True(t, cleared)
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "_aggregate", "_aggregate", "_aggregate")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	assert.Empty(t, retrieved.BlockingReason)
+	assert.Empty(t, retrieved.ErrorMessage)
+	assert.Equal(t, "failure", retrieved.Conclusion, "the clear releases only the block; conclusion is replaced by the next aggregate write")
+}
+
+// The clear is an optimistic-concurrency write: when another writer records a
+// block for a newer commit between the caller's read and the clear, the head
+// SHA no longer matches and the newer block stays authoritative.
+func TestCheckStore_ClearAggregateBlockPreservesConcurrentlyMovedRow(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	seedBlockedAggregateRow(t, store, "abc123", "managed_dir_missing_config")
+
+	stale, err := store.Checks().Get(ctx, "org/repo", 123, "_aggregate", "_aggregate", "_aggregate")
+	require.NoError(t, err)
+	require.NotNil(t, stale)
+
+	// Another writer re-records the block on a newer commit before the clear.
+	seedBlockedAggregateRow(t, store, "def456", "managed_dir_missing_config")
+
+	cleared, err := store.Checks().ClearAggregateBlock(ctx, stale)
+	require.NoError(t, err)
+	require.False(t, cleared)
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "_aggregate", "_aggregate", "_aggregate")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	assert.Equal(t, "def456", retrieved.HeadSHA)
+	assert.Equal(t, "managed_dir_missing_config", retrieved.BlockingReason)
+}
+
+// A block recorded for a different reason after the caller's read is a newer
+// guard decision; the clear must not release it.
+func TestCheckStore_ClearAggregateBlockPreservesDifferentReason(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	seedBlockedAggregateRow(t, store, "abc123", "managed_dir_missing_config")
+
+	stale, err := store.Checks().Get(ctx, "org/repo", 123, "_aggregate", "_aggregate", "_aggregate")
+	require.NoError(t, err)
+	require.NotNil(t, stale)
+
+	seedBlockedAggregateRow(t, store, "abc123", "schema_config_discovery_failed")
+
+	cleared, err := store.Checks().ClearAggregateBlock(ctx, stale)
+	require.NoError(t, err)
+	require.False(t, cleared)
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "_aggregate", "_aggregate", "_aggregate")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	assert.Equal(t, "schema_config_discovery_failed", retrieved.BlockingReason)
+}
+
 // newChangedRowsStore opens a Storage on a connection without clientFoundRows so
 // UPDATE ... RowsAffected reflects changed rows, matching production semantics.
 func newChangedRowsStore(t *testing.T) *Storage {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -113,6 +113,14 @@ type CheckStore interface {
 	// Returns true when the row was marked successful.
 	MarkStalePlanSuccessful(ctx context.Context, check *Check) (bool, error)
 
+	// ClearAggregateBlock clears the blocking reason on stored aggregate check
+	// state after the PR-level guards re-verified that the blocking condition
+	// no longer applies. The update is conditional on the head SHA and blocking
+	// reason the caller read, so a block recorded concurrently by another
+	// writer (for example for a newer commit) is never erased. Returns true
+	// when the row was cleared.
+	ClearAggregateBlock(ctx context.Context, check *Check) (bool, error)
+
 	// CompleteForApply updates stored check state to a terminal state only if
 	// it still belongs to the given apply and no newer apply exists for the
 	// same PR/environment/database. Returns false when another driver changed

--- a/pkg/webhook/aggregate_check_integration_test.go
+++ b/pkg/webhook/aggregate_check_integration_test.go
@@ -1298,3 +1298,246 @@ func TestE2EFailingAggregateOnPlanError(t *testing.T) {
 		t.Fatal("timed out waiting for failing aggregate check run")
 	}
 }
+
+// setupFakeGitHubHeadAndCheckRuns registers a fake PR endpoint that always
+// reports headSHA as the PR HEAD, plus check-run create/update capture.
+func setupFakeGitHubHeadAndCheckRuns(t *testing.T, mux *http.ServeMux, headSHA string) chan checkRunCapture {
+	t.Helper()
+
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(gh.PullRequest{
+			Head: &gh.PullRequestBranch{Ref: new("feature-branch"), SHA: new(headSHA)},
+			Base: &gh.PullRequestBranch{Ref: new("main"), SHA: new("def456")},
+			User: &gh.User{Login: new("testuser")},
+		})
+	})
+
+	checkRuns := make(chan checkRunCapture, 10)
+	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		var body checkRunCapture
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		checkRuns <- body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 300})
+	})
+	mux.HandleFunc("PATCH /repos/octocat/hello-world/check-runs/", func(w http.ResponseWriter, r *http.Request) {
+		var body checkRunCapture
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		checkRuns <- body
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 300})
+	})
+	return checkRuns
+}
+
+// A PR-level guard failure (for example a schema change under a managed
+// directory whose schemabot.yaml was removed) records a blocking reason on the
+// stored aggregate state. A later recompute that does not re-verify the guard
+// — an apply finishing on another database in the same PR is the typical
+// trigger — must not replace the failing aggregate with a passing one. The
+// fold skips publishing entirely: no Check Run write, no storage write, and
+// the stored block stays authoritative until the auto-plan guards re-verify
+// the PR.
+func TestE2EAggregateBlockedStateSurvivesRecompute(t *testing.T) {
+	dbName := "webhook_agg_blocked_recompute"
+	svc := setupE2EService(t, dbName)
+	ctx := t.Context()
+
+	// The guard's failing aggregate, blocked on the current commit.
+	require.NoError(t, svc.Storage().Checks().Upsert(ctx, &storage.Check{
+		Repository:     "octocat/hello-world",
+		PullRequest:    1,
+		HeadSHA:        "abc123",
+		Environment:    aggregateSentinel,
+		DatabaseType:   aggregateSentinel,
+		DatabaseName:   aggregateSentinel,
+		CheckRunID:     200,
+		HasChanges:     false,
+		Status:         checkStatusCompleted,
+		Conclusion:     checkConclusionFailure,
+		BlockingReason: managedDirMissingConfigBlock.blockingReason,
+		ErrorMessage:   managedDirMissingConfigBlock.message,
+	}))
+	// Another database in the PR applied successfully on the same commit. On
+	// its own this row would fold to a passing aggregate.
+	require.NoError(t, svc.Storage().Checks().Upsert(ctx, &storage.Check{
+		Repository:   "octocat/hello-world",
+		PullRequest:  1,
+		HeadSHA:      "abc123",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: dbName,
+		CheckRunID:   100,
+		HasChanges:   false,
+		Status:       checkStatusCompleted,
+		Conclusion:   checkConclusionSuccess,
+	}))
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+	checkRuns := setupFakeGitHubHeadAndCheckRuns(t, mux, "abc123")
+
+	h := newE2EHandler(t, svc, client)
+	installClient := ghclient.NewInstallationClient(client, h.logger)
+
+	h.updateAggregateCheck(ctx, installClient, "octocat/hello-world", 1, "abc123")
+
+	// updateAggregateCheck is synchronous: any Check Run write would already be
+	// on the channel. Nothing may be published over the blocked state.
+	select {
+	case cr := <-checkRuns:
+		t.Fatalf("aggregate check run published over blocked stored state: %+v", cr)
+	default:
+	}
+
+	stored, err := svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1,
+		aggregateSentinel, aggregateSentinel, aggregateSentinel)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.Equal(t, managedDirMissingConfigBlock.blockingReason, stored.BlockingReason)
+	assert.Equal(t, managedDirMissingConfigBlock.message, stored.ErrorMessage)
+	assert.Equal(t, checkConclusionFailure, stored.Conclusion)
+	assert.Equal(t, "abc123", stored.HeadSHA)
+}
+
+// Stored per-database results are keyed to the commit they were computed for.
+// When the aggregate is recomputed on a newer commit — for example a CI
+// check_run completion arriving right after a push, before auto-plan has
+// stored anything for the new commit — rows from the previous commit must not
+// carry their old conclusions forward: they hold the aggregate open as
+// blocking in-progress placeholders until the new commit's own plan or apply
+// results land.
+func TestE2EAggregateStaleCommitRowsHoldAggregateOpen(t *testing.T) {
+	dbName := "webhook_agg_stale_sha"
+	svc := setupE2EService(t, dbName)
+	ctx := t.Context()
+
+	// A successful result recorded for the previous commit.
+	require.NoError(t, svc.Storage().Checks().Upsert(ctx, &storage.Check{
+		Repository:   "octocat/hello-world",
+		PullRequest:  1,
+		HeadSHA:      "oldsha111",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: dbName,
+		CheckRunID:   100,
+		HasChanges:   false,
+		Status:       checkStatusCompleted,
+		Conclusion:   checkConclusionSuccess,
+	}))
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+	checkRuns := setupFakeGitHubHeadAndCheckRuns(t, mux, "newsha222")
+
+	h := newE2EHandler(t, svc, client)
+	installClient := ghclient.NewInstallationClient(client, h.logger)
+
+	h.updateAggregateCheck(ctx, installClient, "octocat/hello-world", 1, "newsha222")
+
+	select {
+	case cr := <-checkRuns:
+		assert.Equal(t, aggregateCheckName, cr.Name)
+		assert.Equal(t, "newsha222", cr.HeadSHA)
+		assert.Equal(t, checkStatusInProgress, cr.Status)
+		assert.Empty(t, cr.Conclusion, "a conclusion computed for a previous commit must not pass the aggregate on the current one")
+		require.NotNil(t, cr.Output)
+		assert.Equal(t, awaitingCurrentCommitTitle, cr.Output.Title)
+	case <-time.After(webhookIntegrationCheckRunDeadline):
+		t.Fatal("timed out waiting for blocking aggregate check run on the new commit")
+	}
+
+	stored, err := svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1,
+		aggregateSentinel, aggregateSentinel, aggregateSentinel)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.Equal(t, "newsha222", stored.HeadSHA)
+	assert.Equal(t, checkStatusInProgress, stored.Status)
+	assert.Empty(t, stored.Conclusion)
+
+	// The previous commit's row is untouched — only its fold contribution is
+	// normalized, so the apply history stays intact.
+	dbCheck, err := svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1, "staging", "mysql", dbName)
+	require.NoError(t, err)
+	require.NotNil(t, dbCheck)
+	assert.Equal(t, "oldsha111", dbCheck.HeadSHA)
+	assert.Equal(t, checkConclusionSuccess, dbCheck.Conclusion)
+}
+
+// A stored aggregate block is released only by the auto-plan guard path: when
+// a commit passes config discovery, the managed-directory guard, and
+// environment coverage, the block is cleared and the fresh plan results drive
+// the aggregate again. This keeps a previously blocked PR from being stuck
+// forever once the author fixes the configuration and pushes (or re-runs the
+// checks).
+func TestE2EAggregateBlockClearedByReplan(t *testing.T) {
+	dbName := "webhook_agg_block_clear"
+	svc := setupE2EService(t, dbName)
+	ctx := t.Context()
+
+	// The guard's failing aggregate from the previous commit.
+	require.NoError(t, svc.Storage().Checks().Upsert(ctx, &storage.Check{
+		Repository:     "octocat/hello-world",
+		PullRequest:    1,
+		HeadSHA:        "oldsha111",
+		Environment:    aggregateSentinel,
+		DatabaseType:   aggregateSentinel,
+		DatabaseName:   aggregateSentinel,
+		CheckRunID:     200,
+		HasChanges:     false,
+		Status:         checkStatusCompleted,
+		Conclusion:     checkConclusionFailure,
+		BlockingReason: managedDirMissingConfigBlock.blockingReason,
+		ErrorMessage:   managedDirMissingConfigBlock.message,
+	}))
+
+	// The new commit restores the config: discovery now finds schema files and
+	// a valid schemabot.yaml at the PR HEAD ("abc123").
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+	setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
+
+	h := newE2EHandler(t, svc, client)
+
+	req := buildPRWebhookRequest(t, prWebhookPayloadOpts{
+		action:  "synchronize",
+		headSHA: "abc123",
+	}, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// The guards release the block and the new commit's plan result drives the
+	// aggregate: pending changes on the new HEAD, no blocking reason.
+	deadline := time.After(webhookIntegrationPollDeadline)
+	for {
+		stored, err := svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1,
+			aggregateSentinel, aggregateSentinel, aggregateSentinel)
+		require.NoError(t, err)
+		if stored != nil && stored.HeadSHA == "abc123" && stored.BlockingReason == "" &&
+			stored.Conclusion == checkConclusionActionRequired {
+			assert.Equal(t, checkStatusCompleted, stored.Status)
+			assert.Empty(t, stored.ErrorMessage)
+			assert.True(t, stored.HasChanges)
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for the aggregate block to clear and the re-plan result to land; last stored state: %+v", stored)
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}

--- a/pkg/webhook/check_aggregate.go
+++ b/pkg/webhook/check_aggregate.go
@@ -197,6 +197,45 @@ func hasBlockingCheckForEnvironment(checks []*storage.Check, environment string)
 	return false
 }
 
+// awaitingCurrentCommitTitle is the aggregate title shown when only results
+// recorded for another commit hold the aggregate open — nothing is running for
+// the commit the Check Run is published on, and the current commit's own plan
+// or apply results are still pending.
+const awaitingCurrentCommitTitle = "Awaiting results for the latest commit"
+
+// normalizeStaleContributions returns the fold contributions for headSHA.
+// A row stored for a different commit contributes a blocking in-progress
+// placeholder instead of its stored status and conclusion: results computed
+// for another commit say nothing about the current one, so they must hold the
+// aggregate open until the current commit's plan or apply results replace
+// them. Rows for the current commit pass through unchanged.
+func normalizeStaleContributions(checks []*storage.Check, headSHA string) (contributions []*storage.Check, staleCount int) {
+	contributions = make([]*storage.Check, 0, len(checks))
+	for _, c := range checks {
+		if c.HeadSHA == headSHA {
+			contributions = append(contributions, c)
+			continue
+		}
+		stale := *c
+		stale.Status = checkStatusInProgress
+		stale.Conclusion = ""
+		contributions = append(contributions, &stale)
+		staleCount++
+	}
+	return contributions, staleCount
+}
+
+// anyInProgressOnCommit reports whether any check recorded for headSHA is
+// genuinely in progress, as opposed to a stale-row placeholder.
+func anyInProgressOnCommit(checks []*storage.Check, headSHA string) bool {
+	for _, c := range checks {
+		if c.HeadSHA == headSHA && c.Status == checkStatusInProgress {
+			return true
+		}
+	}
+	return false
+}
+
 // computeAggregate determines the aggregate conclusion and status from per-database checks.
 func computeAggregate(checks []*storage.Check) (conclusion, status string) {
 	// in_progress takes precedence — the aggregate should show running

--- a/pkg/webhook/check_aggregate_test.go
+++ b/pkg/webhook/check_aggregate_test.go
@@ -330,3 +330,54 @@ func TestFilterChecksByEnvironment(t *testing.T) {
 		assert.Empty(t, result)
 	})
 }
+
+func TestNormalizeStaleContributions(t *testing.T) {
+	t.Run("rows for the current commit pass through unchanged", func(t *testing.T) {
+		checks := []*storage.Check{
+			{HeadSHA: "current", DatabaseName: "orders", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess},
+			{HeadSHA: "current", DatabaseName: "users", Status: checkStatusInProgress},
+		}
+		contributions, staleCount := normalizeStaleContributions(checks, "current")
+		require.Len(t, contributions, 2)
+		assert.Zero(t, staleCount)
+		assert.Equal(t, checkConclusionSuccess, contributions[0].Conclusion)
+		assert.Equal(t, checkStatusInProgress, contributions[1].Status)
+	})
+
+	t.Run("rows for another commit become blocking in-progress placeholders", func(t *testing.T) {
+		checks := []*storage.Check{
+			{HeadSHA: "previous", DatabaseName: "orders", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess},
+			{HeadSHA: "previous", DatabaseName: "users", Status: checkStatusCompleted, Conclusion: checkConclusionFailure},
+		}
+		contributions, staleCount := normalizeStaleContributions(checks, "current")
+		require.Len(t, contributions, 2)
+		assert.Equal(t, 2, staleCount)
+		for _, c := range contributions {
+			assert.Equal(t, checkStatusInProgress, c.Status)
+			assert.Empty(t, c.Conclusion)
+		}
+		conclusion, status := computeAggregate(contributions)
+		assert.Empty(t, conclusion)
+		assert.Equal(t, checkStatusInProgress, status)
+	})
+
+	t.Run("normalization copies rows so stored state is untouched", func(t *testing.T) {
+		original := &storage.Check{HeadSHA: "previous", DatabaseName: "orders", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess}
+		contributions, staleCount := normalizeStaleContributions([]*storage.Check{original}, "current")
+		require.Len(t, contributions, 1)
+		assert.Equal(t, 1, staleCount)
+		assert.Equal(t, checkStatusCompleted, original.Status)
+		assert.Equal(t, checkConclusionSuccess, original.Conclusion)
+	})
+}
+
+func TestAnyInProgressOnCommit(t *testing.T) {
+	checks := []*storage.Check{
+		{HeadSHA: "previous", DatabaseName: "orders", Status: checkStatusInProgress},
+		{HeadSHA: "current", DatabaseName: "users", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess},
+	}
+	assert.False(t, anyInProgressOnCommit(checks, "current"), "an in-progress row from another commit is a placeholder, not current work")
+
+	checks = append(checks, &storage.Check{HeadSHA: "current", DatabaseName: "billing", Status: checkStatusInProgress})
+	assert.True(t, anyInProgressOnCommit(checks, "current"))
+}

--- a/pkg/webhook/check_cleanup_integration_test.go
+++ b/pkg/webhook/check_cleanup_integration_test.go
@@ -189,8 +189,11 @@ func TestE2EStaleCheckCleanup(t *testing.T) {
 
 // TestE2EReconcileStaleInProgressCheck verifies that when a check is stuck at
 // "in_progress" from a crashed apply, the next plan or apply command reconciles
-// it to the apply's terminal state. This prevents branch protection from being
-// blocked indefinitely after a server crash mid-apply.
+// it to the apply's terminal state. The reconciled result belongs to the
+// commit the apply ran against, so on the PR's newer HEAD the aggregate stays
+// open (blocking) rather than passing on the old result; the plan that
+// triggered reconciliation stores the current commit's own results and drives
+// the aggregate to its real conclusion.
 func TestE2EReconcileStaleInProgressCheck(t *testing.T) {
 	dbName := "webhook_stale_inprogress"
 	svc := setupE2EService(t, dbName)
@@ -263,12 +266,17 @@ func TestE2EReconcileStaleInProgressCheck(t *testing.T) {
 	assert.Equal(t, checkConclusionSuccess, check.Conclusion)
 	assert.Equal(t, applyID, check.ApplyID)
 
+	// The reconciled success belongs to the previous commit, so the aggregate
+	// published on the current HEAD holds it as a blocking placeholder instead
+	// of passing on a result the current commit never produced.
 	select {
 	case checkRun := <-result.checkRuns:
 		assert.Equal(t, aggregateCheckName, checkRun.Name)
 		assert.Equal(t, "abc123", checkRun.HeadSHA)
-		assert.Equal(t, checkStatusCompleted, checkRun.Status)
-		assert.Equal(t, checkConclusionSuccess, checkRun.Conclusion)
+		assert.Equal(t, checkStatusInProgress, checkRun.Status)
+		assert.Empty(t, checkRun.Conclusion)
+		require.NotNil(t, checkRun.Output)
+		assert.Equal(t, awaitingCurrentCommitTitle, checkRun.Output.Title)
 	case <-time.After(webhookIntegrationPollDeadline):
 		t.Fatal("timed out waiting for aggregate check run")
 	}
@@ -277,14 +285,16 @@ func TestE2EReconcileStaleInProgressCheck(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, aggregate)
 	assert.Equal(t, "abc123", aggregate.HeadSHA)
-	assert.Equal(t, checkStatusCompleted, aggregate.Status)
-	assert.Equal(t, checkConclusionSuccess, aggregate.Conclusion)
+	assert.Equal(t, checkStatusInProgress, aggregate.Status)
+	assert.Empty(t, aggregate.Conclusion)
 }
 
 // TestE2EReconcileStaleInProgressCheckFailure verifies startup/webhook
 // reconciliation for a check that is still in_progress even though its apply
-// already failed. Reconciliation must publish the failure instead of leaving
-// branch protection pending forever.
+// already failed. Reconciliation records the failure on the stored
+// per-database state; because that result belongs to the commit the apply ran
+// against, the aggregate on the PR's newer HEAD keeps blocking as a
+// placeholder until the current commit's own results land.
 func TestE2EReconcileStaleInProgressCheckFailure(t *testing.T) {
 	dbName := "webhook_stale_inprogress_failed"
 	svc := setupE2EService(t, dbName)
@@ -359,13 +369,17 @@ func TestE2EReconcileStaleInProgressCheckFailure(t *testing.T) {
 	assert.Equal(t, checkConclusionFailure, check.Conclusion)
 	assert.Equal(t, applyID, check.ApplyID)
 
+	// The reconciled failure belongs to the previous commit; the aggregate on
+	// the current HEAD holds it as a blocking placeholder. Merge stays blocked
+	// either way, and the current commit's own plan results decide the real
+	// conclusion.
 	select {
 	case checkRun := <-result.checkRuns:
 		assert.Equal(t, aggregateCheckName, checkRun.Name)
 		assert.Equal(t, "abc123", checkRun.HeadSHA)
-		assert.Equal(t, checkStatusCompleted, checkRun.Status)
-		assert.Equal(t, checkConclusionFailure, checkRun.Conclusion)
+		assert.Equal(t, checkStatusInProgress, checkRun.Status)
+		assert.Empty(t, checkRun.Conclusion)
 	case <-time.After(webhookIntegrationPollDeadline):
-		t.Fatal("timed out waiting for failing aggregate check run")
+		t.Fatal("timed out waiting for blocking aggregate check run")
 	}
 }

--- a/pkg/webhook/check_publisher.go
+++ b/pkg/webhook/check_publisher.go
@@ -225,13 +225,66 @@ func prFilePaths(files []ghclient.PRFile) []string {
 // The environment parameter controls the storage key: for per-environment aggregates
 // it is the real environment name (e.g., "staging"), for the global aggregate it is
 // aggregateSentinel. DatabaseType and DatabaseName always use aggregateSentinel.
+//
+// Two fail-closed rules shape the fold:
+//   - Stored aggregate state carrying a blocking reason is never replaced by a
+//     recompute. Blocking reasons record PR-level guard failures (config
+//     discovery, managed-directory coverage, environment coverage) and are
+//     released only after the auto-plan guards re-verify the PR
+//     (clearAggregateBlocksForVerifiedPR).
+//   - Per-database rows recorded for a different commit contribute a blocking
+//     in-progress placeholder instead of their stored conclusion, so results
+//     computed for a previous commit can never pass the aggregate on the
+//     current one.
 func (h *Handler) upsertAggregateCheckRun(
 	ctx context.Context, client *ghclient.InstallationClient,
 	repo string, pr int, headSHA string,
 	dbChecks []*storage.Check, checkName string, environment string,
 ) {
-	conclusion, status := computeAggregate(dbChecks)
-	title, summary := aggregateSummary(dbChecks, conclusion)
+	// Look up existing aggregate check state using the environment-specific key.
+	existing, err := h.service.Storage().Checks().Get(ctx, repo, pr, environment, aggregateSentinel, aggregateSentinel)
+	if err != nil {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:   "aggregate_check_sync",
+			Repository:  repo,
+			Environment: environment,
+			Status:      "error",
+		})
+		h.logger.Error("failed to look up aggregate check", "repo", repo, "pr", pr, "environment", environment, "error", err)
+		return
+	}
+
+	// A stored blocking reason means a PR-level guard failed the aggregate
+	// closed. Recompute paths (apply completion, participant Check Run events,
+	// manual plans, stale cleanup) do not re-verify the guard condition, so
+	// they must leave both the stored state and the failing Check Run in place.
+	if existing != nil && existing.BlockingReason != "" {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:   "aggregate_check_sync",
+			Repository:  repo,
+			Environment: environment,
+			Status:      "blocked",
+		})
+		h.logger.Info("aggregate recompute skipped: stored aggregate state is blocked; the aggregate check will keep blocking merge until auto-plan guards re-verify the PR",
+			"repo", repo, "pr", pr, "check_name", checkName,
+			"environment", environment, "head_sha", headSHA,
+			"blocked_head_sha", existing.HeadSHA,
+			"blocking_reason", existing.BlockingReason,
+			"check_run_id", existing.CheckRunID)
+		return
+	}
+
+	contributions, staleCount := normalizeStaleContributions(dbChecks, headSHA)
+	conclusion, status := computeAggregate(contributions)
+	title, summary := aggregateSummary(contributions, conclusion)
+	if staleCount > 0 {
+		h.logger.Info("aggregate fold holds rows recorded for another commit as blocking until results land for the current commit",
+			"repo", repo, "pr", pr, "check_name", checkName,
+			"environment", environment, "head_sha", headSHA, "stale_rows", staleCount)
+		if status == checkStatusInProgress && !anyInProgressOnCommit(dbChecks, headSHA) {
+			title = awaitingCurrentCommitTitle
+		}
+	}
 
 	opts := ghclient.CheckRunOptions{
 		Name:   checkName,
@@ -244,19 +297,6 @@ func (h *Handler) upsertAggregateCheckRun(
 	// GitHub requires conclusion only when status is "completed"
 	if status == checkStatusCompleted {
 		opts.Conclusion = conclusion
-	}
-
-	// Look up existing aggregate check state using the environment-specific key.
-	existing, err := h.service.Storage().Checks().Get(ctx, repo, pr, environment, aggregateSentinel, aggregateSentinel)
-	if err != nil {
-		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
-			Operation:   "aggregate_check_sync",
-			Repository:  repo,
-			Environment: environment,
-			Status:      "error",
-		})
-		h.logger.Error("failed to look up aggregate check", "repo", repo, "pr", pr, "environment", environment, "error", err)
-		return
 	}
 
 	// Create a new check run if no existing record, or if the HEAD SHA changed
@@ -565,6 +605,37 @@ func (h *Handler) postFailingAggregatesWithBlock(ctx context.Context, client *gh
 			}
 		}
 
+		blockingReason := block.blockingReason
+		errorMessage := ""
+		if blockingReason != "" {
+			errorMessage = summary
+		} else {
+			existing, err := h.service.Storage().Checks().Get(ctx, repo, pr, ec.environment, aggregateSentinel, aggregateSentinel)
+			if err != nil {
+				metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+					Operation:   "aggregate_check_sync",
+					Repository:  repo,
+					Environment: ec.environment,
+					Status:      "error",
+				})
+				h.logger.Error("failed to look up stored aggregate state before failing aggregate; not publishing so any stored block stays authoritative",
+					"repo", repo, "pr", pr, "check_name", ec.name,
+					"environment", ec.environment, "head_sha", headSHA, "error", err)
+				continue
+			}
+			if existing != nil && existing.BlockingReason != "" {
+				// A generic failure must not replace a stored blocking reason —
+				// carry it forward so the block keeps gating until the auto-plan
+				// guards re-verify the PR.
+				blockingReason = existing.BlockingReason
+				errorMessage = existing.ErrorMessage
+				h.logger.Info("failing aggregate carries forward stored blocking reason",
+					"repo", repo, "pr", pr, "check_name", ec.name,
+					"environment", ec.environment, "head_sha", headSHA,
+					"blocking_reason", blockingReason)
+			}
+		}
+
 		opts := ghclient.CheckRunOptions{
 			Name:       ec.name,
 			Status:     checkStatusCompleted,
@@ -588,20 +659,18 @@ func (h *Handler) postFailingAggregatesWithBlock(ctx context.Context, client *gh
 		}
 
 		aggCheck := &storage.Check{
-			Repository:   repo,
-			PullRequest:  pr,
-			HeadSHA:      headSHA,
-			Environment:  ec.environment,
-			DatabaseType: aggregateSentinel,
-			DatabaseName: aggregateSentinel,
-			CheckRunID:   id,
-			HasChanges:   false,
-			Status:       checkStatusCompleted,
-			Conclusion:   checkConclusionFailure,
-		}
-		if block.blockingReason != "" {
-			aggCheck.BlockingReason = block.blockingReason
-			aggCheck.ErrorMessage = summary
+			Repository:     repo,
+			PullRequest:    pr,
+			HeadSHA:        headSHA,
+			Environment:    ec.environment,
+			DatabaseType:   aggregateSentinel,
+			DatabaseName:   aggregateSentinel,
+			CheckRunID:     id,
+			HasChanges:     false,
+			Status:         checkStatusCompleted,
+			Conclusion:     checkConclusionFailure,
+			BlockingReason: blockingReason,
+			ErrorMessage:   errorMessage,
 		}
 		if err := h.service.Storage().Checks().Upsert(ctx, aggCheck); err != nil {
 			metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
@@ -622,5 +691,97 @@ func (h *Handler) postFailingAggregatesWithBlock(ctx context.Context, client *gh
 		})
 		h.logger.Info("posted failing aggregate",
 			"repo", repo, "pr", pr, "check_name", ec.name, "env", ec.environment)
+	}
+}
+
+// clearAggregateBlocksForVerifiedPR releases stored aggregate blocking reasons
+// after the auto-plan guards re-verified the PR at headSHA: config discovery
+// succeeded, every schema change under a server-managed directory resolved a
+// config, and — re-checked here — every discovered database resolves to at
+// least one allowed environment. Recompute paths never release blocks, so this
+// is the only way a blocked aggregate can start passing again; the auto-plan
+// that follows publishes the fresh aggregate state.
+//
+// The storage clear is conditional on the head SHA and reason of the row that
+// was read, so a block recorded concurrently (for example by a newer commit's
+// guards on another pod) stays authoritative.
+func (h *Handler) clearAggregateBlocksForVerifiedPR(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA string, configs []ghclient.DiscoveredConfig) {
+	for _, cfg := range configs {
+		environments, err := h.allowedDatabaseEnvironments(cfg.Config.Database)
+		if err != nil {
+			h.logger.Warn("stored aggregate blocks retained: cannot re-verify allowed environments for database; the aggregate check will keep blocking merge",
+				"repo", repo, "pr", pr, "head_sha", headSHA,
+				"database", cfg.Config.Database, "error", err)
+			return
+		}
+		if len(environments) == 0 {
+			h.logger.Info("stored aggregate blocks retained: database has no allowed configured environments; the aggregate check will keep blocking merge",
+				"repo", repo, "pr", pr, "head_sha", headSHA, "database", cfg.Config.Database)
+			return
+		}
+	}
+
+	if !h.verifyHeadSHAStillCurrentForPR(ctx, client, repo, pr, headSHA, "aggregate_block_clear") {
+		return
+	}
+
+	for _, target := range h.aggregateCheckTargetsForRepo(repo) {
+		existing, err := h.service.Storage().Checks().Get(ctx, repo, pr, target.environment, aggregateSentinel, aggregateSentinel)
+		if err != nil {
+			metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+				Operation:   "aggregate_block_clear",
+				Repository:  repo,
+				Environment: target.environment,
+				Status:      "error",
+			})
+			h.logger.Error("failed to look up aggregate check for block clear; any stored block stays in place",
+				"repo", repo, "pr", pr, "environment", target.environment,
+				"head_sha", headSHA, "error", err)
+			continue
+		}
+		if existing == nil || existing.BlockingReason == "" {
+			h.logger.Debug("no stored aggregate block to clear",
+				"repo", repo, "pr", pr, "environment", target.environment, "head_sha", headSHA)
+			continue
+		}
+		cleared, err := h.service.Storage().Checks().ClearAggregateBlock(ctx, existing)
+		if err != nil {
+			metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+				Operation:   "aggregate_block_clear",
+				Repository:  repo,
+				Environment: target.environment,
+				Status:      "error",
+			})
+			h.logger.Error("failed to clear aggregate block after guard re-verification; the aggregate check will keep blocking merge",
+				"repo", repo, "pr", pr, "environment", target.environment,
+				"head_sha", headSHA, "blocking_reason", existing.BlockingReason, "error", err)
+			continue
+		}
+		if !cleared {
+			// The row changed between the read and the conditional write —
+			// another writer re-blocked or moved the aggregate. That newer
+			// stored state stays authoritative.
+			metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+				Operation:   "aggregate_block_clear",
+				Repository:  repo,
+				Environment: target.environment,
+				Status:      "noop",
+			})
+			h.logger.Info("aggregate block not cleared because stored state changed concurrently; the newer stored state stays authoritative",
+				"repo", repo, "pr", pr, "environment", target.environment,
+				"head_sha", headSHA, "blocked_head_sha", existing.HeadSHA,
+				"blocking_reason", existing.BlockingReason)
+			continue
+		}
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:   "aggregate_block_clear",
+			Repository:  repo,
+			Environment: target.environment,
+			Status:      "success",
+		})
+		h.logger.Info("cleared aggregate block after guards re-verified the PR",
+			"repo", repo, "pr", pr, "environment", target.environment,
+			"head_sha", headSHA, "blocked_head_sha", existing.HeadSHA,
+			"blocking_reason", existing.BlockingReason)
 	}
 }

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -173,6 +173,12 @@ func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.Install
 
 	configs = h.filterManagedDiscoveredConfigs(ctx, repo, pr, headSHA, source, configs)
 
+	// Config discovery and the managed-directory guard just re-verified this
+	// commit, and the clear re-checks allowed-environment coverage for every
+	// discovered database. Together those cover every condition that records
+	// an aggregate blocking reason, so a stored block can now be released.
+	h.clearAggregateBlocksForVerifiedPR(ctx, client, repo, pr, headSHA, configs)
+
 	// Collect database names from discovered configs
 	affectedDatabases := make(map[string]bool)
 	for _, cfg := range configs {


### PR DESCRIPTION
## The bug

When SchemaBot blocks a PR for a PR-level problem — a deleted `schemabot.yaml`, failed config discovery — it records the reason on the stored aggregate check. But every recalculation of that check (triggered by any apply finishing, any CI check completing, any plan) rebuilt it from per-database results alone and overwrote the block.

So a normal sequence turned the required check green while the problem still existed:

1. PR deletes `db2`'s `schemabot.yaml` → SchemaBot blocks the merge gate. ✅
2. The same PR also touches `db1`, which is fine. User applies `db1`.
3. The apply finishing triggers a recalculation. It sees only "db1 succeeded" → publishes a **passing** required check. The PR merges with unmanaged schema changes. ⛔

A second hole with the same root: results are stored per **database**, not per commit. Push a new commit, and until its own plan runs, the stored rows still hold the *previous* commit's verdicts. A recalculation firing in that window (a CI check completing is enough) published the old commit's green onto the new commit — which had never been planned at all.

## The fix

- **Recalculations can't overwrite a recorded block.** If the stored aggregate carries a blocking reason, they skip publishing entirely — whatever triggered them.
- **Only re-checking the actual problem clears a block.** Auto-plan (on push, or GitHub's re-run button) re-runs the same guards that created it; only when they pass is the block cleared, via a conditional write so a concurrently recorded newer block wins.
- **Results from another commit don't count.** They fold as "Awaiting results for the latest commit" (blocking) instead of their old verdict.

```
before:  block recorded ──► db1 apply passes ──► recalc sums per-db only ──► block erased, gate green ⛔
after:   block recorded ──► any recalc ──► sees the block, leaves it alone ──► gate stays red
         next auto-plan ──► re-runs the guards ──► fixed? clear ✅ · still broken? blocked ❌
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

