### PR TITLE
fix(ddl): ClassifyStatement rejects multi-statement input

### DIFF
--- a/pkg/ddl/helpers.go
+++ b/pkg/ddl/helpers.go
@@ -57,14 +57,17 @@ func ClassifyStatement(stmt string) (statement.StatementType, string, error) {
 }
 
 // statementPreview returns the leading text of a statement for error messages,
-// truncated so multi-statement blobs do not flood logs.
+// truncated so multi-statement blobs do not flood logs. Truncation counts
+// runes, not bytes, so multi-byte identifiers are never split into invalid
+// UTF-8.
 func statementPreview(stmt string) string {
 	const maxPreview = 80
 	s := strings.TrimSpace(stmt)
-	if len(s) <= maxPreview {
+	runes := []rune(s)
+	if len(runes) <= maxPreview {
 		return s
 	}
-	return s[:maxPreview] + "..."
+	return string(runes[:maxPreview]) + "..."
 }
 
 // ClassifyStatementOp is like ClassifyStatement but returns the operation as a

--- a/pkg/ddl/helpers.go
+++ b/pkg/ddl/helpers.go
@@ -31,9 +31,14 @@ func SplitStatements(content string) ([]string, error) {
 	return stmts, nil
 }
 
-// ClassifyStatement classifies a DDL statement using Spirit's parser.
+// ClassifyStatement classifies a single DDL statement using Spirit's parser.
 // Returns the typed StatementType and table name. Handles the Classify
 // boilerplate (nil check, empty results) so callers don't have to.
+//
+// The input must be exactly one statement: a compound string could hide a
+// destructive statement behind the classification of the first one, so
+// multi-statement input is rejected. Callers with multi-statement content
+// must split it with SplitStatements first.
 func ClassifyStatement(stmt string) (statement.StatementType, string, error) {
 	results, err := statement.Classify(stmt)
 	if err != nil {
@@ -42,7 +47,24 @@ func ClassifyStatement(stmt string) (statement.StatementType, string, error) {
 	if len(results) == 0 {
 		return statement.StatementUnknown, "", fmt.Errorf("no classification result for statement %q", stmt)
 	}
+	if len(results) > 1 {
+		return statement.StatementUnknown, "", fmt.Errorf(
+			"expected a single statement but %q parsed as %d statements; split with SplitStatements before classifying",
+			statementPreview(stmt), len(results),
+		)
+	}
 	return results[0].Type, results[0].Table, nil
+}
+
+// statementPreview returns the leading text of a statement for error messages,
+// truncated so multi-statement blobs do not flood logs.
+func statementPreview(stmt string) string {
+	const maxPreview = 80
+	s := strings.TrimSpace(stmt)
+	if len(s) <= maxPreview {
+		return s
+	}
+	return s[:maxPreview] + "..."
 }
 
 // ClassifyStatementOp is like ClassifyStatement but returns the operation as a

--- a/pkg/ddl/helpers_test.go
+++ b/pkg/ddl/helpers_test.go
@@ -3,6 +3,7 @@ package ddl
 import (
 	"testing"
 
+	"github.com/block/spirit/pkg/statement"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -83,6 +84,113 @@ func TestSplitStatements_Content(t *testing.T) {
 	assert.Contains(t, stmts[1], "t2")
 }
 
+// TestClassifyStatement verifies the single-statement contract: each DDL type
+// classifies to its typed StatementType and table, while compound input —
+// where a destructive statement could ride behind the first statement's
+// classification — is rejected with an error that tells the caller to split
+// first. Empty and unparseable input also error.
+func TestClassifyStatement(t *testing.T) {
+	tests := []struct {
+		name       string
+		stmt       string
+		wantType   statement.StatementType
+		wantTable  string
+		wantErrMsg string
+	}{
+		{
+			name:      "create table",
+			stmt:      "CREATE TABLE t1 (id INT)",
+			wantType:  statement.StatementCreateTable,
+			wantTable: "t1",
+		},
+		{
+			name:      "alter table",
+			stmt:      "ALTER TABLE t1 ADD COLUMN x INT",
+			wantType:  statement.StatementAlterTable,
+			wantTable: "t1",
+		},
+		{
+			name:      "drop table",
+			stmt:      "DROP TABLE t1",
+			wantType:  statement.StatementDropTable,
+			wantTable: "t1",
+		},
+		{
+			name:      "rename table",
+			stmt:      "RENAME TABLE t1 TO t2",
+			wantType:  statement.StatementRenameTable,
+			wantTable: "t1",
+		},
+		{
+			name:      "single statement with trailing semicolon",
+			stmt:      "ALTER TABLE t1 ADD COLUMN x INT;",
+			wantType:  statement.StatementAlterTable,
+			wantTable: "t1",
+		},
+		{
+			name:       "alter followed by drop",
+			stmt:       "ALTER TABLE t1 ADD COLUMN x INT; DROP TABLE t2",
+			wantErrMsg: "parsed as 2 statements",
+		},
+		{
+			name:       "two creates",
+			stmt:       "CREATE TABLE t1 (id INT); CREATE TABLE t2 (id INT)",
+			wantErrMsg: "parsed as 2 statements",
+		},
+		{
+			name:       "three statements",
+			stmt:       "CREATE TABLE t1 (id INT); ALTER TABLE t1 ADD COLUMN x INT; DROP TABLE t2",
+			wantErrMsg: "parsed as 3 statements",
+		},
+		{
+			name:       "empty",
+			stmt:       "",
+			wantErrMsg: "classify statement",
+		},
+		{
+			name:       "whitespace only",
+			stmt:       "   ",
+			wantErrMsg: "classify statement",
+		},
+		{
+			name:       "unparseable",
+			stmt:       "not valid sql at all",
+			wantErrMsg: "classify statement",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotType, gotTable, err := ClassifyStatement(tt.stmt)
+			if tt.wantErrMsg != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantType, gotType, "statement type")
+			assert.Equal(t, tt.wantTable, gotTable, "table")
+		})
+	}
+}
+
+// TestClassifyStatement_MultiStatementErrorNamesLeadingText verifies that the
+// multi-statement error includes the leading text of the input (truncated for
+// long blobs) so an operator can identify the offending content from the error
+// alone.
+func TestClassifyStatement_MultiStatementErrorNamesLeadingText(t *testing.T) {
+	_, _, err := ClassifyStatement("ALTER TABLE t1 ADD COLUMN x INT; DROP TABLE t2")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ALTER TABLE t1 ADD COLUMN x INT")
+	assert.Contains(t, err.Error(), "split with SplitStatements")
+
+	long := "ALTER TABLE some_very_long_table_name ADD COLUMN a_very_long_column_name_here INT; DROP TABLE t2"
+	_, _, err = ClassifyStatement(long)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "...")
+	assert.NotContains(t, err.Error(), "DROP TABLE t2")
+}
+
 func TestClassifyStatementOp(t *testing.T) {
 	tests := []struct {
 		stmt      string
@@ -99,6 +207,7 @@ func TestClassifyStatementOp(t *testing.T) {
 		{"CREATE TABLE `backticked` (id INT)", "create", "backticked", false},
 		{"DROP TABLE IF EXISTS t1", "drop", "t1", false},
 		{"not valid sql at all", "", "", true},
+		{"ALTER TABLE t1 ADD COLUMN x INT; DROP TABLE t2", "", "", true},
 	}
 
 	for _, tt := range tests {

--- a/pkg/ddl/helpers_test.go
+++ b/pkg/ddl/helpers_test.go
@@ -1,7 +1,9 @@
 package ddl
 
 import (
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/block/spirit/pkg/statement"
 	"github.com/stretchr/testify/assert"
@@ -189,6 +191,15 @@ func TestClassifyStatement_MultiStatementErrorNamesLeadingText(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "...")
 	assert.NotContains(t, err.Error(), "DROP TABLE t2")
+}
+
+// TestStatementPreview_TruncatesOnRuneBoundary verifies that the preview
+// truncates whole runes, so statements with multi-byte identifiers never
+// produce invalid UTF-8 in error messages.
+func TestStatementPreview_TruncatesOnRuneBoundary(t *testing.T) {
+	got := statementPreview(strings.Repeat("é", 100))
+	assert.Equal(t, strings.Repeat("é", 80)+"...", got)
+	assert.True(t, utf8.ValidString(got))
 }
 
 func TestClassifyStatementOp(t *testing.T) {


### PR DESCRIPTION
## Why this matters

`ClassifyStatement` silently returned the first result when input parsed as multiple statements, so a compound string like `ALTER TABLE t1 ...; DROP TABLE t2` classified as just `alter` — the exact shape that would let a destructive statement ride past classification-based gating. Every current call site splits statements before classifying, so there is no live bypass, but the helper's contract should refuse ambiguity rather than silently pick the first statement.

## What it does

- `ClassifyStatement` (and `ClassifyStatementOp`, which delegates to it) now returns an error when the input parses as more than one statement, directing the caller to `SplitStatements`.
- The error names the leading text of the offending input, truncated on rune boundaries so multi-statement blobs don't flood logs and multi-byte identifiers never produce invalid UTF-8.
- No behavior change on any live path: all callers pass pre-split single statements and already propagate classification errors.

## Before / after

```
before                                                                 ❌
──────
"ALTER TABLE t1 ADD COLUMN x INT"                → alter, t1
"ALTER TABLE t1 ADD COLUMN x INT; DROP TABLE t2" → alter, t1
                                                    (DROP TABLE hidden)
```

```
after                                                                  ✅
─────
"ALTER TABLE t1 ADD COLUMN x INT"                → alter, t1
"ALTER TABLE t1 ADD COLUMN x INT; DROP TABLE t2" → error: parsed as 2
                                                    statements; split with
                                                    SplitStatements first
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
