### PR TITLE
fix(spirit): scope volume settings to the running schema change

### DIFF
--- a/pkg/engine/spirit/control.go
+++ b/pkg/engine/spirit/control.go
@@ -361,30 +361,44 @@ func (e *Engine) SkipRevert(ctx context.Context, req *engine.ControlRequest) (*e
 
 // Volume adjusts the schema change speed by stopping, reconfiguring, and restarting.
 // Spirit doesn't support dynamic volume changes, so we stop the schema change,
-// update the settings, and restart from checkpoint.
+// update its settings, and restart from checkpoint. The adjustment is scoped to
+// the running schema change: the engine's configured defaults stay untouched,
+// so the next schema change starts from the defaults again.
 func (e *Engine) Volume(ctx context.Context, req *engine.VolumeRequest) (*engine.VolumeResult, error) {
 	e.mu.Lock()
 	rm := e.runningSchemaChange
-	e.mu.Unlock()
-
 	if rm == nil {
+		e.mu.Unlock()
 		return nil, fmt.Errorf("no active schema change to adjust volume")
 	}
+	cpuHint := e.cpuHint
+	database := rm.database
+	previousVolume := rm.volume
+	if previousVolume == 0 {
+		// No explicit volume was set for this schema change; report the
+		// closest level for the settings it started with.
+		previousVolume = settingsToVolume(rm.threads, rm.targetChunkTime)
+	}
+	currentThreads := rm.threads
+	currentChunkTime := rm.targetChunkTime
+	currentLockTimeout := rm.lockWaitTimeout
+	e.mu.Unlock()
 
 	// Calculate settings from volume level (1-11)
-	previousVolume := settingsToVolume(e.threads, e.targetChunkTime)
-	newThreads, newChunkTime, newLockTimeout := volumeToSpiritSettings(req.Volume, e.cpuHint)
+	newThreads, newChunkTime, newLockTimeout := volumeToSpiritSettings(req.Volume, cpuHint)
 
 	e.logger.Info("adjusting volume",
-		"database", rm.database,
+		"database", database,
 		"volume", req.Volume,
 		"previous_volume", previousVolume,
 		"new_threads", newThreads,
 		"new_chunk_time", newChunkTime,
 	)
 
-	// If volume is the same, no need to restart
-	if req.Volume == previousVolume {
+	// When the requested volume maps to the settings the change is already
+	// running with, record the explicit volume and skip the restart.
+	if newThreads == currentThreads && newChunkTime == currentChunkTime && newLockTimeout == currentLockTimeout {
+		e.setSchemaChangeVolume(rm, req.Volume, newThreads, newChunkTime, newLockTimeout)
 		return &engine.VolumeResult{
 			Accepted:       true,
 			PreviousVolume: previousVolume,
@@ -416,10 +430,9 @@ func (e *Engine) Volume(ctx context.Context, req *engine.VolumeRequest) (*engine
 	// Log checkpoint state AFTER stopping (should be same as before)
 	e.logCheckpointState(rm, "after_stop", nil)
 
-	// Update engine configuration
-	e.threads = newThreads
-	e.targetChunkTime = newChunkTime
-	e.lockWaitTimeout = newLockTimeout
+	// Retune the running schema change; the engine's configured defaults stay
+	// untouched so the next schema change starts from the defaults.
+	e.setSchemaChangeVolume(rm, req.Volume, newThreads, newChunkTime, newLockTimeout)
 
 	// Restart the schema change
 	_, err = e.Start(ctx, &engine.ControlRequest{
@@ -446,6 +459,25 @@ func (e *Engine) Volume(ctx context.Context, req *engine.VolumeRequest) (*engine
 		NewVolume:      req.Volume,
 		Message:        fmt.Sprintf("Volume changed: %d -> %d (%d threads, %v chunks)", previousVolume, req.Volume, newThreads, newChunkTime),
 	}, nil
+}
+
+// setSchemaChangeVolume records the explicit volume and its derived Spirit copy
+// settings on the tracked schema change. The settings end with the change, so a
+// volume set during one schema change never carries into a later one.
+func (e *Engine) setSchemaChangeVolume(rm *runningSchemaChange, volume int32, threads int, chunkTime, lockTimeout time.Duration) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.runningSchemaChange != rm {
+		e.logger.Warn("volume adjustment target is no longer the tracked schema change; settings not applied",
+			"database", rm.database,
+			"volume", volume,
+		)
+		return
+	}
+	rm.volume = volume
+	rm.threads = threads
+	rm.targetChunkTime = chunkTime
+	rm.lockWaitTimeout = lockTimeout
 }
 
 func (e *Engine) setVolumeRestartInProgress(rm *runningSchemaChange, inProgress bool) {
@@ -511,7 +543,11 @@ func cpuScaledThreads(cpuHint, divisor, fallback int) int {
 	return threads
 }
 
-// settingsToVolume converts current Spirit settings back to approximate volume level.
+// settingsToVolume approximates the volume level for a schema change that was
+// never given an explicit volume, mapping its starting Spirit copy settings to
+// the closest level. Volume levels that share derived settings map to the
+// lowest such level. Once an operator sets a volume, the explicit value is
+// stored on the running schema change and this approximation is not used.
 func settingsToVolume(threads int, chunkTime time.Duration) int32 {
 	switch {
 	case threads <= 1:

--- a/pkg/engine/spirit/control.go
+++ b/pkg/engine/spirit/control.go
@@ -466,18 +466,20 @@ func (e *Engine) Volume(ctx context.Context, req *engine.VolumeRequest) (*engine
 // volume set during one schema change never carries into a later one.
 func (e *Engine) setSchemaChangeVolume(rm *runningSchemaChange, volume int32, threads int, chunkTime, lockTimeout time.Duration) {
 	e.mu.Lock()
-	defer e.mu.Unlock()
-	if e.runningSchemaChange != rm {
+	tracked := e.runningSchemaChange == rm
+	if tracked {
+		rm.volume = volume
+		rm.threads = threads
+		rm.targetChunkTime = chunkTime
+		rm.lockWaitTimeout = lockTimeout
+	}
+	e.mu.Unlock()
+	if !tracked {
 		e.logger.Warn("volume adjustment target is no longer the tracked schema change; settings not applied",
 			"database", rm.database,
 			"volume", volume,
 		)
-		return
 	}
-	rm.volume = volume
-	rm.threads = threads
-	rm.targetChunkTime = chunkTime
-	rm.lockWaitTimeout = lockTimeout
 }
 
 func (e *Engine) setVolumeRestartInProgress(rm *runningSchemaChange, inProgress bool) {

--- a/pkg/engine/spirit/control_test.go
+++ b/pkg/engine/spirit/control_test.go
@@ -1,6 +1,7 @@
 package spirit
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -291,5 +292,182 @@ func TestVolumeReportsRunningWhileStoredStoppedStateRestarts(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for volume change")
 	}
+	eng.Drain()
+}
+
+// registerRunningSchemaChange installs a simulated running schema change on the
+// engine, carrying the engine's configured default copy settings the same way
+// Apply initializes a change. The caller drives the change's lifecycle through
+// rm.wg.
+func registerRunningSchemaChange(eng *Engine) *runningSchemaChange {
+	rm := &runningSchemaChange{
+		database:        "testdb",
+		tableNamespace:  map[string]string{},
+		state:           engine.StateRunning,
+		host:            "127.0.0.1:1",
+		username:        "root",
+		threads:         eng.threads,
+		targetChunkTime: eng.targetChunkTime,
+		lockWaitTimeout: eng.lockWaitTimeout,
+	}
+	eng.mu.Lock()
+	eng.runningSchemaChange = rm
+	eng.mu.Unlock()
+	return rm
+}
+
+// adjustVolume drives a Volume call through its stop/retune/restart sequence
+// against a schema change whose driver goroutine is simulated via rm.wg, and
+// returns the volume result.
+func adjustVolume(t *testing.T, eng *Engine, rm *runningSchemaChange, volume int32) *engine.VolumeResult {
+	t.Helper()
+	rm.wg.Add(1)
+
+	type volumeOutcome struct {
+		result *engine.VolumeResult
+		err    error
+	}
+	outCh := make(chan volumeOutcome, 1)
+	go func() {
+		result, err := eng.Volume(t.Context(), &engine.VolumeRequest{
+			Database:    rm.database,
+			Volume:      volume,
+			Credentials: &engine.Credentials{DSN: "root@tcp(127.0.0.1:1)/testdb"},
+		})
+		outCh <- volumeOutcome{result: result, err: err}
+	}()
+
+	// Volume stops the change and waits for its driver goroutine before
+	// restarting; release the simulated goroutine once the stop is observed.
+	require.Eventually(t, func() bool {
+		eng.mu.Lock()
+		defer eng.mu.Unlock()
+		return rm.state == engine.StateStopped && rm.volumeRestartInProgress
+	}, 5*time.Second, 10*time.Millisecond, "volume change did not stop the schema change")
+	rm.wg.Done()
+
+	select {
+	case out := <-outCh:
+		require.NoError(t, out.err)
+		return out.result
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for volume change to complete")
+		return nil
+	}
+}
+
+// A volume set while a schema change is running is scoped to that change: the
+// engine's configured defaults are untouched, and the next schema change starts
+// from the defaults again rather than inheriting the earlier retune.
+func TestVolumeScopedToRunningSchemaChange(t *testing.T) {
+	eng := New(Config{})
+	rm := registerRunningSchemaChange(eng)
+
+	result := adjustVolume(t, eng, rm, 11)
+	assert.Equal(t, int32(11), result.NewVolume)
+
+	wantThreads, wantChunkTime, wantLockTimeout := volumeToSpiritSettings(11, 0)
+	eng.mu.Lock()
+	assert.Equal(t, wantThreads, rm.threads)
+	assert.Equal(t, wantChunkTime, rm.targetChunkTime)
+	assert.Equal(t, wantLockTimeout, rm.lockWaitTimeout)
+	assert.Equal(t, int32(11), rm.volume)
+	eng.mu.Unlock()
+
+	// The engine's configured defaults are not modified by the adjustment.
+	assert.Equal(t, DefaultThreads, eng.threads)
+	assert.Equal(t, DefaultTargetChunkTime, eng.targetChunkTime)
+	assert.Equal(t, DefaultLockWaitTimeout, eng.lockWaitTimeout)
+
+	eng.Drain()
+
+	// A new schema change starts from the configured defaults. The apply
+	// targets an unreachable host, so execution fails immediately — the copy
+	// settings are snapshotted when the change is registered, which is what
+	// this scenario verifies.
+	_, err := eng.Apply(t.Context(), &engine.ApplyRequest{
+		Database:    "testdb",
+		Credentials: &engine.Credentials{DSN: "root@tcp(127.0.0.1:1)/testdb"},
+		Changes: []engine.SchemaChange{{
+			Namespace: "testdb",
+			TableChanges: []engine.TableChange{{
+				Table: "users",
+				DDL:   "CREATE TABLE `users` (`id` bigint unsigned NOT NULL AUTO_INCREMENT, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+			}},
+		}},
+	})
+	require.NoError(t, err)
+	defer eng.Drain()
+
+	threads, chunkTime, lockTimeout := eng.copySettings()
+	assert.Equal(t, DefaultThreads, threads)
+	assert.Equal(t, DefaultTargetChunkTime, chunkTime)
+	assert.Equal(t, DefaultLockWaitTimeout, lockTimeout)
+	eng.mu.Lock()
+	assert.Equal(t, int32(0), eng.runningSchemaChange.volume)
+	eng.mu.Unlock()
+}
+
+// Volume reporting reflects the explicit volume set for the running schema
+// change, including neighboring levels that derive the same Spirit settings.
+func TestVolumeReportingUsesExplicitPerChangeValue(t *testing.T) {
+	eng := New(Config{})
+	rm := registerRunningSchemaChange(eng)
+
+	// The change starts on the configured defaults, which map to volume 3.
+	result := adjustVolume(t, eng, rm, 7)
+	assert.Equal(t, int32(3), result.PreviousVolume)
+	assert.Equal(t, int32(7), result.NewVolume)
+
+	// Without a CPU hint, volumes 6 and 7 derive the same Spirit settings, so
+	// no restart is needed — and the reported previous volume is the explicit
+	// value set for this change.
+	result, err := eng.Volume(t.Context(), &engine.VolumeRequest{
+		Database:    "testdb",
+		Volume:      6,
+		Credentials: &engine.Credentials{DSN: "root@tcp(127.0.0.1:1)/testdb"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(7), result.PreviousVolume)
+	assert.Equal(t, int32(6), result.NewVolume)
+	assert.Contains(t, result.Message, "no restart")
+
+	eng.mu.Lock()
+	assert.Equal(t, int32(6), rm.volume)
+	eng.mu.Unlock()
+
+	eng.Drain()
+}
+
+// Copy settings are shared between volume adjustments, progress pollers, and
+// the schema change execution path; adjusting volume while the settings are
+// read concurrently must be safe.
+func TestVolumeConcurrentWithSettingsReads(t *testing.T) {
+	eng := New(Config{})
+	rm := registerRunningSchemaChange(eng)
+
+	stopReaders := make(chan struct{})
+	var readers sync.WaitGroup
+	readers.Go(func() {
+		for {
+			select {
+			case <-stopReaders:
+				return
+			default:
+			}
+			threads, chunkTime, lockTimeout := eng.copySettings()
+			assert.Positive(t, threads)
+			assert.Positive(t, chunkTime)
+			assert.Positive(t, lockTimeout)
+			_, err := eng.Progress(t.Context(), &engine.ProgressRequest{})
+			assert.NoError(t, err)
+		}
+	})
+
+	result := adjustVolume(t, eng, rm, 11)
+	assert.Equal(t, int32(11), result.NewVolume)
+
+	close(stopReaders)
+	readers.Wait()
 	eng.Drain()
 }

--- a/pkg/engine/spirit/execution.go
+++ b/pkg/engine/spirit/execution.go
@@ -262,15 +262,16 @@ func (e *Engine) executeSingleStatement(ctx context.Context, host, username, pas
 		"type", stmtType,
 	)
 
+	threads, chunkTime, lockTimeout := e.copySettings()
 	migration := &spiritmigration.Migration{
 		Host:              host,
 		Username:          username,
 		Password:          &password,
 		Database:          database,
 		Statement:         stmt,
-		TargetChunkTime:   e.targetChunkTime,
-		Threads:           e.threads,
-		LockWaitTimeout:   e.lockWaitTimeout,
+		TargetChunkTime:   chunkTime,
+		Threads:           threads,
+		LockWaitTimeout:   lockTimeout,
 		InterpolateParams: true,
 	}
 
@@ -306,15 +307,16 @@ func (e *Engine) executeSpiritMigration(ctx context.Context, host, username, pas
 		ddls = append(ddls, p.Statement)
 	}
 
+	threads, chunkTime, lockTimeout := e.copySettings()
 	migration := &spiritmigration.Migration{
 		Host:              host,
 		Username:          username,
 		Password:          &password,
 		Database:          database,
 		Statement:         combinedStatement,
-		TargetChunkTime:   e.targetChunkTime,
-		Threads:           e.threads,
-		LockWaitTimeout:   e.lockWaitTimeout,
+		TargetChunkTime:   chunkTime,
+		Threads:           threads,
+		LockWaitTimeout:   lockTimeout,
 		InterpolateParams: true,
 		DeferCutOver:      deferCutover,
 		RespectSentinel:   deferCutover, // Only wait for sentinel when deferring cutover

--- a/pkg/engine/spirit/spirit.go
+++ b/pkg/engine/spirit/spirit.go
@@ -50,13 +50,16 @@ type Engine struct {
 	spiritLogger *slog.Logger // Logger for Spirit (may filter debug logs)
 	linter       *lint.Linter
 
-	// Configuration
+	// Configuration. targetChunkTime, threads, and lockWaitTimeout are the
+	// configured default Spirit copy settings; they are immutable after New.
+	// Each schema change starts from these defaults and carries its own working
+	// copy on runningSchemaChange, which Volume retunes for that change only.
 	targetChunkTime     time.Duration
 	threads             int
 	lockWaitTimeout     time.Duration
 	debugLogs           bool
 	disablePendingDrops bool
-	cpuHint             int // Inferred CPU count from innodb_buffer_pool_instances (0 = unknown)
+	cpuHint             int // Inferred CPU count from innodb_buffer_pool_instances (0 = unknown); guarded by mu
 
 	// Log callback for routing Spirit logs to ApplyLogStore (with table context)
 	onLog func(level slog.Level, table, msg string)
@@ -81,6 +84,15 @@ type runningSchemaChange struct {
 	started                 time.Time
 	deferCutover            bool // Whether to defer cutover until manual trigger
 	volumeRestartInProgress bool // Set while stored stopped state should still be exposed as running progress.
+
+	// Spirit copy settings for this schema change. Initialized from the
+	// engine's configured defaults and retuned by Volume for this change only;
+	// they end with the change, so the next schema change starts from the
+	// configured defaults again.
+	threads         int
+	targetChunkTime time.Duration
+	lockWaitTimeout time.Duration
+	volume          int32 // Explicit volume set via Volume for this change (0 = never set)
 
 	// For resume support
 	cancelFunc context.CancelFunc
@@ -201,6 +213,20 @@ func (e *Engine) Drain() {
 	e.mu.Lock()
 	e.runningSchemaChange = nil
 	e.mu.Unlock()
+}
+
+// copySettings returns the Spirit copy settings for the tracked schema change,
+// falling back to the engine's configured defaults when no change is tracked.
+// Each schema change starts from the configured defaults and may be retuned by
+// Volume; the defaults themselves never change, so a volume set on one schema
+// change never affects a later one.
+func (e *Engine) copySettings() (threads int, chunkTime, lockTimeout time.Duration) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if rm := e.runningSchemaChange; rm != nil {
+		return rm.threads, rm.targetChunkTime, rm.lockWaitTimeout
+	}
+	return e.threads, e.targetChunkTime, e.lockWaitTimeout
 }
 
 // Plan computes the schema changes needed by diffing current schema against desired.
@@ -388,8 +414,14 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 	e.Drain()
 
 	// Query CPU hint for volume scaling (best-effort, falls back to fixed counts)
-	if e.cpuHint == 0 {
-		e.cpuHint = e.queryCPUHint(ctx, req.Credentials.DSN)
+	e.mu.Lock()
+	cpuHint := e.cpuHint
+	e.mu.Unlock()
+	if cpuHint == 0 {
+		cpuHint = e.queryCPUHint(ctx, req.Credentials.DSN)
+		e.mu.Lock()
+		e.cpuHint = cpuHint
+		e.mu.Unlock()
 	}
 
 	// Initialize running state and start background execution.
@@ -406,16 +438,19 @@ func (e *Engine) Apply(ctx context.Context, req *engine.ApplyRequest) (*engine.A
 	}
 
 	rm := &runningSchemaChange{
-		database:       database,
-		tableNamespace: tableNamespace,
-		tables:         nil, // Tables will be populated by executeSchemaChange
-		originalDDLs:   req.FlatDDL(),
-		state:          engine.StateRunning,
-		started:        time.Now(),
-		deferCutover:   deferCutover,
-		host:           host,
-		username:       username,
-		password:       password,
+		database:        database,
+		tableNamespace:  tableNamespace,
+		tables:          nil, // Tables will be populated by executeSchemaChange
+		originalDDLs:    req.FlatDDL(),
+		state:           engine.StateRunning,
+		started:         time.Now(),
+		deferCutover:    deferCutover,
+		host:            host,
+		username:        username,
+		password:        password,
+		threads:         e.threads,
+		targetChunkTime: e.targetChunkTime,
+		lockWaitTimeout: e.lockWaitTimeout,
 	}
 	e.runningSchemaChange = rm
 	e.mu.Unlock()


### PR DESCRIPTION
## Why this matters

A volume adjustment mutated the Spirit engine's long-lived copy settings (threads, target chunk time, lock wait timeout) and nothing ever reset them — the engine instance is per-target and outlives the apply, so a one-time incident bump (volume 11 = 16 threads / 5s chunks / 600s lock wait) silently became the permanent copy profile for every future schema change on that database, applied weeks later to a routine change reporting "default" volume. The fields were also written without the engine mutex while the apply path read them concurrently.

## What it does

- Moves the copy settings onto the running schema change: each change seeds from the engine's configured defaults (immutable after `New`), `Volume` retunes only the tracked change, and the settings end with it.
- Stores the operator's explicit volume per change, so volume reporting reflects what was set instead of a value lossily reconstructed from settings (7 previously reported back as 6, 9 as 8, 11 as 10). The settings-derived approximation is only used to label a change that never had an explicit volume.
- The no-restart short-circuit now compares derived settings, so switching between levels that share the same settings records the new volume without a needless stop/restart.
- All reads and writes of the copy settings and the CPU hint happen under the engine mutex, so a volume call can no longer race a concurrent apply's settings reads.
- The retune is guarded against a stale target: if the change is no longer the tracked one, the settings are not applied and a warning is logged.

## Before / after

```
before                                                              ❌
──────
apply #1 ── volume 11 ──► engine.threads=16, chunk=5s, lock=600s
apply #1 ends              (engine settings never reset)
apply #2, weeks later, reports "default"
        └──► silently runs at 16 threads / 5s chunks / 600s lock
```

```
after                                                               ✅
─────
engine defaults (immutable) ── seed ──► change #1 {threads, chunk,
                                                   lock, volume}
apply #1 ── volume 11 ──► retunes change #1 only; dies with it
apply #2 ── seed ──► starts from the configured defaults again
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
