### PR TITLE
fix(storage): index the apply-operation claim ordering

### DIFF
--- a/pkg/api/ensure_schema_integration_test.go
+++ b/pkg/api/ensure_schema_integration_test.go
@@ -260,3 +260,40 @@ func TestEnsureSchema_RemovesObsoleteVitessTasks(t *testing.T) {
 	// ...and the next run is a clean no-op.
 	require.NoError(t, EnsureSchema(dsn, logger), "second EnsureSchema not idempotent")
 }
+
+// A deployment whose live tables drifted from the embedded schema at the index
+// level — a declared index is missing, and an index the schema no longer
+// declares is still present — must be reconciled by EnsureSchema in both
+// directions: the missing index is added and the undeclared one is dropped,
+// with the next run a clean no-op. Index-only drift is common when indexes are
+// tuned over time, so this covers the pure ALTER TABLE ADD/DROP KEY path
+// through the Spirit diff.
+func TestEnsureSchema_ReconcilesIndexDrift(t *testing.T) {
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	container, dsn, db := startEnsureSchemaContainer(t, ctx)
+	// Cleanup runs after the test, when t.Context() is already cancelled.
+	defer func() { _ = container.Terminate(t.Context()) }()
+	defer utils.CloseAndLog(db)
+
+	// Bring the schema up to date, then drift it: drop a declared index and
+	// add one the embedded schema does not declare.
+	require.NoError(t, EnsureSchema(dsn, logger))
+	require.True(t, testutil.IndexExists(t, db, "schemabot", "apply_operations", "idx_created_id"))
+
+	_, err := db.ExecContext(ctx, "ALTER TABLE `apply_operations` DROP KEY `idx_created_id`")
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, "ALTER TABLE `checks` ADD KEY `idx_repo_pr` (`repository`,`pull_request`)")
+	require.NoError(t, err)
+
+	// EnsureSchema reconciles both drifts...
+	require.NoError(t, EnsureSchema(dsn, logger), "EnsureSchema with index drift failed")
+	assert.True(t, testutil.IndexExists(t, db, "schemabot", "apply_operations", "idx_created_id"),
+		"missing declared index should be added back")
+	assert.False(t, testutil.IndexExists(t, db, "schemabot", "checks", "idx_repo_pr"),
+		"undeclared index should be dropped")
+
+	// ...and the next run is a clean no-op.
+	require.NoError(t, EnsureSchema(dsn, logger), "second EnsureSchema not idempotent")
+}

--- a/pkg/api/ensure_schema_integration_test.go
+++ b/pkg/api/ensure_schema_integration_test.go
@@ -241,8 +241,13 @@ func TestEnsureSchema_RemovesObsoleteVitessTasks(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 	container, dsn, db := startEnsureSchemaContainer(t, ctx)
-	// Cleanup runs after the test, when t.Context() is already cancelled.
-	defer func() { _ = container.Terminate(t.Context()) }()
+	// TerminateContainer manages its own context; cleanup runs after the
+	// test, when t.Context() is already cancelled.
+	t.Cleanup(func() {
+		if err := testcontainers.TerminateContainer(container); err != nil {
+			t.Logf("failed to terminate container: %v", err)
+		}
+	})
 	defer utils.CloseAndLog(db)
 
 	// Bring the schema up to date, then simulate a pre-existing deployment by
@@ -273,8 +278,13 @@ func TestEnsureSchema_ReconcilesIndexDrift(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 	container, dsn, db := startEnsureSchemaContainer(t, ctx)
-	// Cleanup runs after the test, when t.Context() is already cancelled.
-	defer func() { _ = container.Terminate(t.Context()) }()
+	// TerminateContainer manages its own context; cleanup runs after the
+	// test, when t.Context() is already cancelled.
+	t.Cleanup(func() {
+		if err := testcontainers.TerminateContainer(container); err != nil {
+			t.Logf("failed to terminate container: %v", err)
+		}
+	})
 	defer utils.CloseAndLog(db)
 
 	// Bring the schema up to date, then drift it: drop a declared index and

--- a/pkg/schema/mysql/applies.sql
+++ b/pkg/schema/mysql/applies.sql
@@ -31,7 +31,6 @@ CREATE TABLE `applies` (
   UNIQUE KEY `idx_idempotency_key` (`idempotency_key`),
   KEY `idx_lock_id` (`lock_id`),
   KEY `idx_plan_id` (`plan_id`),
-  KEY `idx_database_env` (`database_name`,`database_type`,`environment`),
   KEY `idx_database_env_deployment` (`database_name`,`database_type`,`environment`,`deployment`),
   KEY `idx_repo_pr` (`repository`,`pull_request`),
   KEY `idx_created_id` (`created_at`,`id`),

--- a/pkg/schema/mysql/apply_operations.sql
+++ b/pkg/schema/mysql/apply_operations.sql
@@ -24,6 +24,7 @@ CREATE TABLE `apply_operations` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_apply_operation` (`apply_id`,`deployment`,`operation_key`),
   KEY `idx_deployment_state` (`deployment`,`state`),
+  KEY `idx_created_id` (`created_at`,`id`),
   KEY `idx_state_created_id` (`state`,`created_at`,`id`),
   KEY `idx_apply_created_id` (`apply_id`,`created_at`,`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci

--- a/pkg/schema/mysql/checks.sql
+++ b/pkg/schema/mysql/checks.sql
@@ -19,7 +19,6 @@ CREATE TABLE `checks` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_check_key` (`repository`,`pull_request`,`environment`,`database_type`,`database_name`),
   KEY `idx_repo_env_db` (`repository`,`environment`,`database_type`,`database_name`),
-  KEY `idx_repo_pr` (`repository`,`pull_request`),
   KEY `idx_check_run` (`check_run_id`),
   KEY `idx_apply_id` (`apply_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -810,6 +810,13 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 	// non-completed, and
 	// a gated one would be redundant with the pending clause below. Start
 	// requests resume eligible work; they do not reorder the rollout.
+	//
+	// ORDER BY (created_at, id) walks idx_created_id, so under FOR UPDATE
+	// SKIP LOCKED the scan visits candidates in claim order and stops at the
+	// first unlocked match. Without that index the query would materialize
+	// and lock every matching row before LIMIT applies, and concurrent
+	// drivers would skip each other's entire candidate set instead of
+	// claiming distinct rows in parallel.
 	row := tx.QueryRowContext(ctx, fmt.Sprintf(`
 		SELECT %s
 		FROM apply_operations
@@ -1174,6 +1181,9 @@ func (s *applyOperationStore) FindNextApplyOperationCutover(ctx context.Context,
 		state.ApplyOperation.RevertWindow,
 	)
 
+	// ORDER BY (created_at, id) walks idx_created_id so concurrent drivers
+	// stop at the first unlocked candidate instead of locking the whole
+	// candidate set; see FindNextApplyOperation.
 	row := tx.QueryRowContext(ctx, fmt.Sprintf(`
 		SELECT %s
 		FROM apply_operations

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -4234,14 +4234,18 @@ func TestApplyOperationStore_FindNextApplyOperation_ClaimOrderWalksIndex(t *test
 	// The claim's top-level predicate ORs across states, so no state-prefixed
 	// index can serve the ordering; the ordered walk must come from
 	// idx_created_id, with no sort step that would buffer (and under FOR
-	// UPDATE, lock) the whole candidate set.
+	// UPDATE, lock) the whole candidate set. The EXPLAINed SELECT carries the
+	// claim's FOR UPDATE SKIP LOCKED clauses so the plan reflects the locking
+	// read the driver actually issues; EXPLAIN itself executes nothing and
+	// takes no locks.
 	var plan string
 	require.NoError(t, testDB.QueryRowContext(ctx, `
 		EXPLAIN FORMAT=JSON
 		SELECT id FROM apply_operations
 		WHERE state = ? OR (state = ? AND updated_at < NOW() - INTERVAL 1 MINUTE)
 		ORDER BY created_at, id
-		LIMIT 1`,
+		LIMIT 1
+		FOR UPDATE SKIP LOCKED`,
 		state.ApplyOperation.Pending, state.ApplyOperation.Running,
 	).Scan(&plan))
 	assert.Contains(t, plan, `"key": "idx_created_id"`,

--- a/pkg/storage/mysqlstore/apply_operations_test.go
+++ b/pkg/storage/mysqlstore/apply_operations_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -4185,4 +4186,83 @@ func TestApplyOperationStore_MarkPendingStoppedByApply_OperationLease(t *testing
 	again, err := store.ApplyOperations().MarkPendingStoppedByApply(opCtx(apply.ID, ownerID, "op-token"), apply.ID)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), again)
+}
+
+// TestApplyOperationStore_FindNextApplyOperation_ClaimOrderWalksIndex verifies
+// the physical shape of the claim scan: ORDER BY (created_at, id) is served by
+// the idx_created_id index, so a driver's SELECT ... FOR UPDATE SKIP LOCKED
+// visits candidates in claim order and stops at the first unlocked row. If the
+// ordering required a sort instead, the claim would materialize and lock every
+// matching row before LIMIT applies, and concurrent drivers would skip each
+// other's whole candidate set instead of claiming distinct rows in parallel.
+func TestApplyOperationStore_FindNextApplyOperation_ClaimOrderWalksIndex(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	// The claim-order index is declared on the storage schema.
+	var tableName, createTable string
+	require.NoError(t, testDB.QueryRowContext(ctx, "SHOW CREATE TABLE `apply_operations`").Scan(&tableName, &createTable))
+	require.Contains(t, createTable, "KEY `idx_created_id` (`created_at`,`id`)")
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_op_claim_order_index", 1)
+
+	// Seed enough pending candidates that the optimizer's plan choice between
+	// an ordered index walk and a scan+sort reflects real cost, not tiny-table
+	// noise. A single statement keeps created_at identical across rows, so the
+	// claim order falls through to id.
+	const candidates = 1024
+	var sb strings.Builder
+	sb.WriteString("INSERT INTO apply_operations (apply_id, deployment, operation_key) VALUES ")
+	args := make([]any, 0, candidates*3)
+	for i := range candidates {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString("(?, ?, ?)")
+		args = append(args, apply.ID, "region-a", fmt.Sprintf("commerce/shard-%04d/users", i))
+	}
+	_, err := testDB.ExecContext(ctx, sb.String(), args...)
+	require.NoError(t, err)
+
+	analyze, err := testDB.QueryContext(ctx, "ANALYZE TABLE `apply_operations`")
+	require.NoError(t, err)
+	require.NoError(t, analyze.Close())
+	require.NoError(t, analyze.Err())
+
+	// The claim's top-level predicate ORs across states, so no state-prefixed
+	// index can serve the ordering; the ordered walk must come from
+	// idx_created_id, with no sort step that would buffer (and under FOR
+	// UPDATE, lock) the whole candidate set.
+	var plan string
+	require.NoError(t, testDB.QueryRowContext(ctx, `
+		EXPLAIN FORMAT=JSON
+		SELECT id FROM apply_operations
+		WHERE state = ? OR (state = ? AND updated_at < NOW() - INTERVAL 1 MINUTE)
+		ORDER BY created_at, id
+		LIMIT 1`,
+		state.ApplyOperation.Pending, state.ApplyOperation.Running,
+	).Scan(&plan))
+	assert.Contains(t, plan, `"key": "idx_created_id"`,
+		"claim ordering must walk idx_created_id, plan: %s", plan)
+	assert.NotContains(t, plan, `"using_filesort": true`,
+		"claim ordering must not sort the candidate set, plan: %s", plan)
+
+	// The claim itself follows (created_at, id) order: the earliest candidate
+	// is the one leased.
+	var firstID int64
+	require.NoError(t, testDB.QueryRowContext(ctx, "SELECT MIN(id) FROM apply_operations").Scan(&firstID))
+
+	claimed, err := store.ApplyOperations().FindNextApplyOperation(ctx, "test-operator")
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, firstID, claimed.ID, "claim must lease the earliest candidate in (created_at, id) order")
+	assert.Equal(t, "test-operator", claimed.LeaseOwner)
+	assert.NotEmpty(t, claimed.LeaseToken)
+
+	persisted, err := store.ApplyOperations().Get(ctx, claimed.ID)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, state.ApplyOperation.Running, persisted.State)
 }

--- a/pkg/testutil/container.go
+++ b/pkg/testutil/container.go
@@ -84,6 +84,20 @@ func ColumnExists(t *testing.T, db *sql.DB, schemaName, tableName, columnName st
 	return count > 0
 }
 
+// IndexExists reports whether indexName exists on schemaName.tableName.
+func IndexExists(t *testing.T, db *sql.DB, schemaName, tableName, indexName string) bool {
+	t.Helper()
+
+	var count int
+	err := db.QueryRowContext(t.Context(),
+		`SELECT COUNT(DISTINCT index_name) FROM information_schema.statistics
+		 WHERE table_schema = ? AND table_name = ? AND index_name = ?`,
+		schemaName, tableName, indexName,
+	).Scan(&count)
+	require.NoError(t, err)
+	return count > 0
+}
+
 func retryContainerOp(ctx context.Context, opName string, op func() (string, error)) (string, error) {
 	var lastErr error
 	delay := initialDelay


### PR DESCRIPTION
## Why this matters

The apply-operation claim queries (`FindNextApplyOperation` / `FindNextApplyOperationCutover`) order by `(created_at, id)`, but `apply_operations` had no index on that pair — the claim predicate ORs across states, so none of the state-prefixed composites can serve the ordering. MySQL materializes and filesorts the full candidate set, and under `FOR UPDATE` that locks every claimable row before `LIMIT 1` applies — so concurrent drivers `SKIP LOCKED` each other's entire candidate set, and shard fan-out that should claim in parallel collapses to one driver at a time as history grows.

## What it does

- Adds `KEY idx_created_id (created_at, id)` to `apply_operations` — the same index the applies claim already walks (`applies.idx_created_id`) — so both claim paths visit candidates in claim order and stop at the first unlocked row.
- Drops two redundant left-prefix indexes: `checks.idx_repo_pr` (left-prefix of the unique `idx_check_key`) and `applies.idx_database_env` (left-prefix of `idx_database_env_deployment`).
- EnsureSchema reconciles all three at startup as plain online `ALTER TABLE ADD/DROP INDEX` statements — no manual schema change needed.
- Documents on both claim queries why the ordering must walk the index rather than sort.

## Before / after

```
before (no idx_created_id)                                        ❌
──────────────────────────
driver A: scan + filesort ALL claimable rows,
          lock every one, then LIMIT 1 → claims row 1
driver B: SKIP LOCKED skips the whole locked set → claims nothing
          (parallelism collapses to one driver at a time)
```

```
after (idx_created_id)                                            ✅
──────────────────────
driver A: walk (created_at, id) → lock row 1 → claim it
driver B: walk (created_at, id) → row 1 locked, skip →
          lock row 2 → claim it
          (drivers claim distinct operations in parallel)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
