### PR TITLE
fix(api): EnsureSchema refuses destructive storage-schema changes by default

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,7 @@
 - [Hybrid Mode](#hybrid-mode)
 - [Drivers](#drivers)
 - [Pending Drops](#pending-drops)
+- [Storage Schema Changes](#storage-schema-changes)
 - [Support Channel](#support-channel)
 - [Repository Allowlist](#repository-allowlist)
 - [PR Checks Gate](#pr-checks-gate)
@@ -307,6 +308,34 @@ The cleaner only runs against local-mode MySQL databases (environments with a
 process has no target DSN and cannot clean that target. Cleanup runs only if the
 remote deployment is also a SchemaBot server with the target configured as
 local-mode MySQL and `cleanup_enabled: true`.
+
+## Storage Schema Changes
+
+SchemaBot's internal storage schema is self-bootstrapping: on every startup,
+`EnsureSchema` diffs the embedded schema files against the live storage
+database and applies whatever DDL is needed before the server accepts traffic.
+
+By default, destructive statements in that diff — `DROP TABLE`, or an
+`ALTER TABLE` containing `DROP COLUMN` — are refused and skipped, while the
+remaining additive changes still apply and startup proceeds. This protects
+against rolling deploys and rollbacks: a pod running an older binary sees a
+newer binary's tables and columns as surplus, and without the gate would drop
+them (destroying data the newer pods depend on). Each refused statement is
+logged at warn level with the exact DDL, and counted in the
+`schemabot.storage_schema.destructive_refusals_total` metric.
+
+To intentionally remove a storage table or column, first make sure every
+running pod is on a binary whose embedded schema no longer declares it, then
+opt in:
+
+```yaml
+storage:
+  dsn: "env:SCHEMABOT_DSN"
+  allow_destructive_schema_changes: true  # default: false
+```
+
+Leave the flag false during normal operation and revert it after the removal
+converges.
 
 ## Support Channel
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -316,8 +316,10 @@ SchemaBot's internal storage schema is self-bootstrapping: on every startup,
 database and applies whatever DDL is needed before the server accepts traffic.
 
 By default, destructive statements in that diff — `DROP TABLE`, or an
-`ALTER TABLE` containing `DROP COLUMN` — are refused and skipped, while the
-remaining additive changes still apply and startup proceeds. This protects
+`ALTER TABLE` containing `DROP COLUMN` — are refused and skipped whole (a
+mixed `ALTER TABLE` is not rewritten, so its additive clauses are skipped with
+it), while the remaining non-destructive statements still apply and startup
+proceeds. This protects
 against rolling deploys and rollbacks: a pod running an older binary sees a
 newer binary's tables and columns as surplus, and without the gate would drop
 them (destroying data the newer pods depend on). Each refused statement is

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -363,6 +363,17 @@ type StorageConfig struct {
 	// DSNFrom builds the MySQL connection string from separate database config
 	// and password references. It is mutually exclusive with DSN.
 	DSNFrom *DSNFromConfig `yaml:"dsn_from,omitempty"`
+
+	// AllowDestructiveSchemaChanges permits EnsureSchema to execute destructive
+	// DDL (DROP TABLE, or an ALTER TABLE containing DROP COLUMN) when converging
+	// the storage schema at startup. Default false: destructive statements are
+	// refused and skipped while the remaining additive changes still apply and
+	// startup proceeds. This keeps an older binary — starting during a rolling
+	// deploy or rollback — from destroying tables or columns a newer binary's
+	// schema added. Set true only when intentionally removing storage tables or
+	// columns, after every running pod is on a binary whose embedded schema no
+	// longer declares them.
+	AllowDestructiveSchemaChanges bool `yaml:"allow_destructive_schema_changes,omitempty"`
 }
 
 // DSNFromConfig configures a MySQL DSN assembled from separate secret values.

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -367,7 +367,8 @@ type StorageConfig struct {
 	// AllowDestructiveSchemaChanges permits EnsureSchema to execute destructive
 	// DDL (DROP TABLE, or an ALTER TABLE containing DROP COLUMN) when converging
 	// the storage schema at startup. Default false: destructive statements are
-	// refused and skipped while the remaining additive changes still apply and
+	// refused and skipped whole — including additive clauses in a mixed ALTER
+	// TABLE — while the remaining non-destructive statements still apply and
 	// startup proceeds. This keeps an older binary — starting during a rolling
 	// deploy or rollback — from destroying tables or columns a newer binary's
 	// schema added. Set true only when intentionally removing storage tables or

--- a/pkg/api/ensure_schema.go
+++ b/pkg/api/ensure_schema.go
@@ -42,7 +42,8 @@ type ensureSchemaOptions struct {
 // WithAllowDestructiveSchemaChanges controls whether EnsureSchema may execute
 // destructive DDL (DROP TABLE, or an ALTER TABLE containing DROP COLUMN)
 // against the storage database. It defaults to false: destructive statements
-// are refused and skipped while the remaining additive changes still apply.
+// are refused and skipped whole — including additive clauses in a mixed
+// ALTER TABLE — while the remaining non-destructive statements still apply.
 // Wire this from StorageConfig.AllowDestructiveSchemaChanges.
 func WithAllowDestructiveSchemaChanges(allow bool) EnsureSchemaOption {
 	return func(o *ensureSchemaOptions) { o.allowDestructive = allow }
@@ -61,7 +62,9 @@ func WithAllowDestructiveSchemaChanges(allow bool) EnsureSchemaOption {
 //
 // Destructive statements in the diff (DROP TABLE, or an ALTER TABLE containing
 // DROP COLUMN) are refused unless WithAllowDestructiveSchemaChanges(true) is
-// set. Refusal skips the statement, applies the remaining additive changes,
+// set. Refusal skips the statement whole (an ALTER TABLE that mixes additive
+// clauses with a DROP COLUMN is not rewritten — its additive clauses are
+// skipped with it), applies the remaining non-destructive statements,
 // and lets startup proceed — a deliberate exception to fail-closed, because
 // failing here would crash-loop every pod running an older binary during a
 // rolling deploy or rollback where a storage table or column was legitimately

--- a/pkg/api/ensure_schema.go
+++ b/pkg/api/ensure_schema.go
@@ -8,12 +8,15 @@ import (
 	"sort"
 	"time"
 
+	"github.com/block/spirit/pkg/statement"
 	"github.com/block/spirit/pkg/table"
 	"github.com/block/spirit/pkg/utils"
+	"github.com/pingcap/tidb/pkg/parser/ast"
 
 	"github.com/block/schemabot/pkg/ddl"
 	"github.com/block/schemabot/pkg/engine"
 	"github.com/block/schemabot/pkg/engine/spirit"
+	"github.com/block/schemabot/pkg/metrics"
 	"github.com/block/schemabot/pkg/mysqlconn"
 	"github.com/block/schemabot/pkg/schema"
 )
@@ -29,6 +32,22 @@ import (
 // storage uninitialized.
 const EnsureSchemaTimeout = 5 * time.Minute
 
+// EnsureSchemaOption customizes EnsureSchema behavior.
+type EnsureSchemaOption func(*ensureSchemaOptions)
+
+type ensureSchemaOptions struct {
+	allowDestructive bool
+}
+
+// WithAllowDestructiveSchemaChanges controls whether EnsureSchema may execute
+// destructive DDL (DROP TABLE, or an ALTER TABLE containing DROP COLUMN)
+// against the storage database. It defaults to false: destructive statements
+// are refused and skipped while the remaining additive changes still apply.
+// Wire this from StorageConfig.AllowDestructiveSchemaChanges.
+func WithAllowDestructiveSchemaChanges(allow bool) EnsureSchemaOption {
+	return func(o *ensureSchemaOptions) { o.allowDestructive = allow }
+}
+
 // EnsureSchema applies all embedded MySQL schema files to the database using Spirit.
 // It is idempotent - no changes are made if the schema is already up-to-date.
 // Uses the same differ/Spirit mechanism as LocalClient for consistency.
@@ -39,7 +58,20 @@ const EnsureSchemaTimeout = 5 * time.Minute
 // MySQL advisory lock to serialize cleanup and Spirit execution, then re-plans
 // under the lock to confirm changes are still needed (another pod may have
 // applied them while we waited for the lock).
-func EnsureSchema(dsn string, logger *slog.Logger) error {
+//
+// Destructive statements in the diff (DROP TABLE, or an ALTER TABLE containing
+// DROP COLUMN) are refused unless WithAllowDestructiveSchemaChanges(true) is
+// set. Refusal skips the statement, applies the remaining additive changes,
+// and lets startup proceed — a deliberate exception to fail-closed, because
+// failing here would crash-loop every pod running an older binary during a
+// rolling deploy or rollback where a storage table or column was legitimately
+// removed. The invariant is that an old binary can never destroy newer schema
+// state: the surplus table or column stays in place until an operator opts in.
+func EnsureSchema(dsn string, logger *slog.Logger, opts ...EnsureSchemaOption) error {
+	var o ensureSchemaOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), EnsureSchemaTimeout)
 	defer cancel()
 
@@ -151,7 +183,33 @@ func EnsureSchema(dsn string, logger *slog.Logger) error {
 		return nil
 	}
 
-	tableChanges := planResult.FlatTableChanges()
+	changes := planResult.Changes
+	if !o.allowDestructive {
+		allowed, refused, err := partitionDestructiveChanges(changes)
+		if err != nil {
+			return fmt.Errorf("classify storage schema changes: %w", err)
+		}
+		for _, r := range refused {
+			logger.Warn("refusing destructive storage-schema change; the statement will not run and startup continues — set storage.allow_destructive_schema_changes: true to allow it",
+				"database", "schemabot",
+				"table", r.change.Table,
+				"operation", ddl.StatementTypeToOp(r.change.Operation),
+				"reason", r.reason,
+				"ddl", r.change.DDL,
+			)
+			metrics.RecordStorageSchemaDestructiveRefusal(ctx, r.change.Table, ddl.StatementTypeToOp(r.change.Operation))
+		}
+		if len(allowed) == 0 {
+			logger.Warn("all planned storage schema changes are destructive and refused; storage schema left unchanged",
+				"database", "schemabot",
+				"refused_count", len(refused),
+			)
+			return nil
+		}
+		changes = allowed
+	}
+
+	tableChanges := flatTableChanges(changes)
 	logger.Info("applying storage schema changes", "ddl_count", len(tableChanges))
 	for _, tc := range tableChanges {
 		logger.Info("schema change",
@@ -165,7 +223,7 @@ func EnsureSchema(dsn string, logger *slog.Logger) error {
 	applyStart := time.Now()
 	_, err = eng.Apply(ctx, &engine.ApplyRequest{
 		Database:    "schemabot",
-		Changes:     planResult.Changes,
+		Changes:     changes,
 		Credentials: &engine.Credentials{DSN: dsn},
 	})
 	if err != nil {
@@ -236,6 +294,93 @@ func ensureSchemaTimeoutError(ctx context.Context, ddlCount int, logger *slog.Lo
 	)
 	return fmt.Errorf("storage schema change did not complete within %s (%d change(s)); the database may be throttling the online DDL: %w",
 		EnsureSchemaTimeout, ddlCount, ctx.Err())
+}
+
+// refusedStorageChange is a planned storage-schema statement EnsureSchema
+// refused to execute, with the reason it was classified as destructive.
+type refusedStorageChange struct {
+	change engine.TableChange
+	reason string
+}
+
+// partitionDestructiveChanges splits planned storage-schema changes into the
+// statements safe to execute and the destructive statements to refuse. A
+// statement is refused whole: an ALTER TABLE that mixes additive clauses with
+// a DROP COLUMN is not rewritten, because executing a partial statement would
+// diverge from the plan Spirit produced.
+func partitionDestructiveChanges(changes []engine.SchemaChange) (allowed []engine.SchemaChange, refused []refusedStorageChange, err error) {
+	for _, sc := range changes {
+		kept := sc
+		kept.TableChanges = nil
+		for _, tc := range sc.TableChanges {
+			destructive, reason, err := isDestructiveStorageStatement(tc.DDL)
+			if err != nil {
+				return nil, nil, fmt.Errorf("classify storage schema change for table %q (%s): %w", tc.Table, tc.DDL, err)
+			}
+			if destructive {
+				// The caller logs each refusal with the exact DDL and reason.
+				refused = append(refused, refusedStorageChange{change: tc, reason: reason})
+				continue
+			}
+			kept.TableChanges = append(kept.TableChanges, tc)
+		}
+		if len(kept.TableChanges) > 0 {
+			allowed = append(allowed, kept)
+		}
+	}
+	return allowed, refused, nil
+}
+
+// isDestructiveStorageStatement reports whether a storage-schema DDL statement
+// destroys existing data: DROP TABLE, or an ALTER TABLE containing a DROP
+// COLUMN clause. The Spirit diff emits these when the live storage database
+// holds a table or column the starting binary's embedded schema does not
+// declare — during a rolling deploy or rollback that surplus state usually
+// belongs to a newer binary, not to a removal the operator intended.
+func isDestructiveStorageStatement(stmt string) (bool, string, error) {
+	stmtType, _, err := ddl.ClassifyStatement(stmt)
+	if err != nil {
+		return false, "", fmt.Errorf("classify statement: %w", err)
+	}
+	switch stmtType {
+	case statement.StatementDropTable:
+		return true, "DROP TABLE removes the table and its data", nil
+	case statement.StatementAlterTable:
+		return alterDropsColumn(stmt)
+	default:
+		return false, "", nil
+	}
+}
+
+// alterDropsColumn reports whether an ALTER TABLE statement contains a DROP
+// COLUMN clause, and names the first dropped column when it does.
+func alterDropsColumn(stmt string) (bool, string, error) {
+	parsed, err := statement.New(stmt)
+	if err != nil {
+		return false, "", fmt.Errorf("parse ALTER TABLE statement: %w", err)
+	}
+	if len(parsed) != 1 {
+		return false, "", fmt.Errorf("expected exactly 1 parsed ALTER TABLE statement, got %d", len(parsed))
+	}
+	alterStmt, ok := (*parsed[0].StmtNode).(*ast.AlterTableStmt)
+	if !ok {
+		return false, "", fmt.Errorf("statement is not ALTER TABLE: %s", stmt)
+	}
+	for _, spec := range alterStmt.Specs {
+		if spec.Tp == ast.AlterTableDropColumn {
+			return true, fmt.Sprintf("DROP COLUMN `%s` removes the column and its data", spec.OldColumnName.Name.String()), nil
+		}
+	}
+	return false, "", nil
+}
+
+// flatTableChanges returns all table changes across the given schema changes.
+func flatTableChanges(changes []engine.SchemaChange) []engine.TableChange {
+	var tables []engine.TableChange
+	for _, sc := range changes {
+		tables = append(tables, sc.TableChanges...)
+	}
+	return tables
 }
 
 func staleSpiritTableNames(ctx context.Context, dsn string) ([]string, error) {

--- a/pkg/api/ensure_schema_integration_test.go
+++ b/pkg/api/ensure_schema_integration_test.go
@@ -3,11 +3,13 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"fmt"
 	"log/slog"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -233,9 +235,10 @@ func startEnsureSchemaContainer(t *testing.T, ctx context.Context) (testcontaine
 }
 
 // A deployment that predates this change still has a live vitess_tasks table.
-// Now that the embedded schema no longer declares it, EnsureSchema must
-// reconcile the obsolete table away cleanly — succeeding, removing it, and
-// staying idempotent on the next run.
+// Now that the embedded schema no longer declares it, an operator who opts in
+// to destructive storage-schema changes can have EnsureSchema reconcile the
+// obsolete table away cleanly — succeeding, removing it, and staying
+// idempotent on the next run.
 func TestEnsureSchema_RemovesObsoleteVitessTasks(t *testing.T) {
 	ctx := t.Context()
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
@@ -254,9 +257,125 @@ func TestEnsureSchema_RemovesObsoleteVitessTasks(t *testing.T) {
 	require.True(t, testutil.TableExists(t, db, "schemabot", "vitess_tasks"))
 
 	// EnsureSchema reconciles the obsolete table away without error...
-	require.NoError(t, EnsureSchema(dsn, logger), "EnsureSchema with an obsolete vitess_tasks table failed")
+	require.NoError(t, EnsureSchema(dsn, logger, WithAllowDestructiveSchemaChanges(true)),
+		"EnsureSchema with an obsolete vitess_tasks table failed")
 	assert.False(t, testutil.TableExists(t, db, "schemabot", "vitess_tasks"), "obsolete vitess_tasks should be removed")
 
 	// ...and the next run is a clean no-op.
-	require.NoError(t, EnsureSchema(dsn, logger), "second EnsureSchema not idempotent")
+	require.NoError(t, EnsureSchema(dsn, logger, WithAllowDestructiveSchemaChanges(true)),
+		"second EnsureSchema not idempotent")
+}
+
+// seedSurplusStorageState simulates storage state written by a newer binary:
+// a column and a table that exist in the live storage database but that the
+// starting binary's embedded schema does not declare. The Spirit diff turns
+// each into destructive DDL (ALTER ... DROP COLUMN and DROP TABLE).
+func seedSurplusStorageState(t *testing.T, db *sql.DB) (surplusColumn, surplusTable string) {
+	t.Helper()
+	surplusColumn = "newer_binary_col"
+	surplusTable = "newer_binary_feature"
+
+	_, err := db.ExecContext(t.Context(),
+		fmt.Sprintf("ALTER TABLE `tasks` ADD COLUMN `%s` varchar(64) DEFAULT NULL", surplusColumn))
+	require.NoError(t, err)
+	_, err = db.ExecContext(t.Context(),
+		fmt.Sprintf("CREATE TABLE `%s` (`id` bigint unsigned NOT NULL AUTO_INCREMENT, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", surplusTable))
+	require.NoError(t, err)
+	return surplusColumn, surplusTable
+}
+
+// During a rolling deploy or rollback, an older binary's pod starts against a
+// storage database that a newer binary already converged: the database holds a
+// column and a table the older binary's embedded schema does not declare. By
+// default EnsureSchema must refuse the destructive statements the diff emits
+// for that surplus state (so the old binary cannot destroy the newer schema),
+// warn with the exact DDL, and still apply the additive changes the older
+// binary needs — startup proceeds either way.
+func TestEnsureSchema_RefusesDestructiveChangesByDefault(t *testing.T) {
+	ctx := t.Context()
+	var logBuf syncBuffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	container, dsn, db := startEnsureSchemaContainer(t, ctx)
+	defer func() { _ = container.Terminate(t.Context()) }()
+	defer utils.CloseAndLog(db)
+
+	require.NoError(t, EnsureSchema(dsn, logger))
+	surplusColumn, surplusTable := seedSurplusStorageState(t, db)
+
+	// Give EnsureSchema additive work alongside the destructive diff: drop an
+	// embedded table so the diff must re-create it.
+	_, err := db.ExecContext(ctx, "DROP TABLE `locks`")
+	require.NoError(t, err)
+
+	require.NoError(t, EnsureSchema(dsn, logger),
+		"EnsureSchema with a destructive diff must not fail startup")
+
+	// The additive change applied; the surplus state survived.
+	assert.True(t, testutil.TableExists(t, db, "schemabot", "locks"),
+		"additive CREATE TABLE should still be applied when destructive changes are refused")
+	assert.True(t, testutil.ColumnExists(t, db, "schemabot", "tasks", surplusColumn),
+		"surplus column from the newer schema must not be dropped by default")
+	assert.True(t, testutil.TableExists(t, db, "schemabot", surplusTable),
+		"surplus table from the newer schema must not be dropped by default")
+
+	// Each refusal is logged with the exact DDL so an operator can see what was
+	// skipped and how to opt in.
+	logs := logBuf.String()
+	assert.Contains(t, logs, "refusing destructive storage-schema change")
+	assert.Contains(t, logs, "allow_destructive_schema_changes")
+	assert.Contains(t, logs, "DROP COLUMN")
+	assert.Contains(t, logs, surplusColumn)
+	assert.Contains(t, logs, "DROP TABLE")
+	assert.Contains(t, logs, surplusTable)
+
+	// A repeat run keeps refusing without error or changes.
+	require.NoError(t, EnsureSchema(dsn, logger), "repeat EnsureSchema with refused changes failed")
+	assert.True(t, testutil.ColumnExists(t, db, "schemabot", "tasks", surplusColumn))
+	assert.True(t, testutil.TableExists(t, db, "schemabot", surplusTable))
+}
+
+// An operator who intentionally removed a storage table and column opts in to
+// destructive storage-schema changes; EnsureSchema then executes the DROP
+// statements and converges the database to the embedded schema.
+func TestEnsureSchema_AllowDestructiveExecutesDrops(t *testing.T) {
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	container, dsn, db := startEnsureSchemaContainer(t, ctx)
+	defer func() { _ = container.Terminate(t.Context()) }()
+	defer utils.CloseAndLog(db)
+
+	require.NoError(t, EnsureSchema(dsn, logger))
+	surplusColumn, surplusTable := seedSurplusStorageState(t, db)
+
+	require.NoError(t, EnsureSchema(dsn, logger, WithAllowDestructiveSchemaChanges(true)),
+		"EnsureSchema with destructive changes allowed failed")
+
+	assert.False(t, testutil.ColumnExists(t, db, "schemabot", "tasks", surplusColumn),
+		"surplus column should be dropped when destructive changes are allowed")
+	assert.False(t, testutil.TableExists(t, db, "schemabot", surplusTable),
+		"surplus table should be dropped when destructive changes are allowed")
+
+	require.NoError(t, EnsureSchema(dsn, logger, WithAllowDestructiveSchemaChanges(true)),
+		"second EnsureSchema not idempotent")
+}
+
+// syncBuffer is an io.Writer safe for concurrent log writes from EnsureSchema
+// and Spirit's background goroutines.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -358,6 +358,22 @@ func RecordSourcePolicyBlock(ctx context.Context, operation, database, environme
 	)
 }
 
+// RecordStorageSchemaDestructiveRefusal increments the counter for destructive
+// storage-schema DDL statements EnsureSchema refused to execute at startup.
+// A nonzero rate means a starting binary's embedded schema no longer declares
+// a table or column that exists in the storage database — expected briefly
+// from older pods during a rolling deploy or rollback. Operator action: if the
+// removal is intended and every pod runs a binary without the table or column,
+// set storage.allow_destructive_schema_changes to true for one deploy;
+// otherwise investigate which binary is starting against newer storage state.
+func RecordStorageSchemaDestructiveRefusal(ctx context.Context, table, operation string) {
+	addCounter(ctx, "schemabot.storage_schema.destructive_refusals_total",
+		"Total destructive storage-schema DDL statements refused by EnsureSchema", "{statement}",
+		attribute.String("table", table),
+		attribute.String("operation", operation),
+	)
+}
+
 var knownPRCommandActorAuthCommands = map[string]bool{
 	"apply":            true,
 	"apply_confirm":    true,

--- a/pkg/serve/serve.go
+++ b/pkg/serve/serve.go
@@ -404,7 +404,7 @@ func connectStorage(ctx context.Context, cfg *api.ServerConfig, logger *slog.Log
 	if err != nil {
 		return nil, fmt.Errorf("resolve storage DSN: %w", err)
 	}
-	if err := api.EnsureSchema(dsn, logger); err != nil {
+	if err := api.EnsureSchema(dsn, logger, api.WithAllowDestructiveSchemaChanges(cfg.Storage.AllowDestructiveSchemaChanges)); err != nil {
 		return nil, fmt.Errorf("ensure storage schema: %w", err)
 	}
 	db, err := mysqlconn.OpenReloadable(dsn, cfg.StorageDSN)


### PR DESCRIPTION
## Why this matters

EnsureSchema converges the live storage database to whatever binary is starting — bidirectionally and unversioned. During a rolling deploy or rollback, a pod running an older binary sees a newer schema's tables and columns as surplus and emits `DROP TABLE` / `ALTER ... DROP COLUMN` through Spirit: the old pod destroys state the newer pods depend on, and the data is gone even if the column is later re-added.

## What it does

- Classifies every statement in the planned storage-schema diff (TiDB parser, no string matching) and by default refuses `DROP TABLE` and any `ALTER TABLE` containing `DROP COLUMN`. A mixed `ALTER TABLE` is refused whole, not rewritten — executing a partial statement would diverge from the plan Spirit produced.
- Refusal is skip-and-continue, not fail: additive statements still apply and startup proceeds, so rolling deploys keep working. This is a deliberate exception to fail-closed — crash-looping every old pod would be worse. The invariant is that **an old binary can never destroy newer schema state**.
- Each refused statement is logged at warn with the exact DDL and the reason, and counted in a new `schemabot.storage_schema.destructive_refusals_total` metric (attributes: table, operation) so a stuck refusal is visible rather than silent.
- Opt-in via `storage.allow_destructive_schema_changes: true` (default false) for intentional removals, once every running pod is on a binary that no longer declares the table or column. Documented in `docs/configuration.md`.

## Before / after

```
before                                                            ❌
──────
rolling deploy: old-binary pod starts
  plan: ALTER tasks DROP COLUMN x  → executed
        (newer pods error on writes; column data lost)
  plan: CREATE TABLE locks         → executed
```

```
after (default)                                                   ✅
───────────────
rolling deploy: old-binary pod starts
  plan: ALTER tasks DROP COLUMN x  → refused ⛔ (warn + metric)
  plan: CREATE TABLE locks         → applied
startup proceeds; newer pods' schema state intact
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
