### PR TITLE
fix(tern): cancel never overwrites a terminal apply; task-state writes propagate errors

### DIFF
--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -217,9 +217,15 @@ func (c *LocalClient) setupSpiritLogging(ctx context.Context, apply *storage.App
 // happened.
 func (c *LocalClient) transitionTaskState(ctx context.Context, task *storage.Task, applyID int64, newState string, logMsg string) error {
 	oldState := task.State
+	oldUpdatedAt := task.UpdatedAt
 	task.State = newState
 	task.UpdatedAt = time.Now()
 	if err := c.storage.Tasks().Update(ctx, task); err != nil {
+		// Restore the in-memory fields this helper mutated so callers that log
+		// or branch on task.State after a failed write see the stored state,
+		// not a transition storage never accepted.
+		task.State = oldState
+		task.UpdatedAt = oldUpdatedAt
 		return fmt.Errorf("update task %s to state %s: %w", task.TaskIdentifier, newState, err)
 	}
 	if logMsg != "" && applyID > 0 {

--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -114,7 +114,11 @@ func (c *LocalClient) tryResolveStaleTask(ctx context.Context, t *storage.Task, 
 			"engine_message", result.Message, "storage_state", t.State)
 		now := time.Now()
 		t.CompletedAt = &now
-		c.transitionTaskState(ctx, t, 0, engineStateToStorage(result.State), "")
+		if err := c.transitionTaskState(ctx, t, 0, engineStateToStorage(result.State), ""); err != nil {
+			c.logger.Warn("conflict check: failed to persist terminal engine state for stale task; task continues to block until a later check persists it",
+				append(t.LogAttrs(), "error", err)...)
+			return false
+		}
 		return true
 	}
 
@@ -136,7 +140,11 @@ func (c *LocalClient) tryResolveStaleTask(ctx context.Context, t *storage.Task, 
 		now := time.Now()
 		t.ErrorMessage = "Task abandoned: engine has no active schema change (server may have crashed)"
 		t.CompletedAt = &now
-		c.transitionTaskState(ctx, t, 0, state.Task.Failed, "")
+		if err := c.transitionTaskState(ctx, t, 0, state.Task.Failed, ""); err != nil {
+			c.logger.Warn("conflict check: failed to persist abandoned task cleanup; task continues to block until a later check persists it",
+				append(t.LogAttrs(), "error", err)...)
+			return false
+		}
 		return true
 	}
 
@@ -203,31 +211,40 @@ func (c *LocalClient) setupSpiritLogging(ctx context.Context, apply *storage.App
 
 // transitionTaskState updates a task's state, persists it, and optionally logs a state transition.
 // Fields like CompletedAt, StartedAt, ErrorMessage, or progress must be set on the task BEFORE calling this.
-func (c *LocalClient) transitionTaskState(ctx context.Context, task *storage.Task, applyID int64, newState string, logMsg string) {
+// A write failure is returned so the caller decides whether the drive can
+// continue: stored task state that lags the in-memory drive is what a crash
+// recovery re-drives from, so most callers must not proceed as if the write
+// happened.
+func (c *LocalClient) transitionTaskState(ctx context.Context, task *storage.Task, applyID int64, newState string, logMsg string) error {
 	oldState := task.State
 	task.State = newState
 	task.UpdatedAt = time.Now()
 	if err := c.storage.Tasks().Update(ctx, task); err != nil {
-		c.logger.Error("failed to update task state", append(task.LogAttrs(), "error", err)...)
+		return fmt.Errorf("update task %s to state %s: %w", task.TaskIdentifier, newState, err)
 	}
 	if logMsg != "" && applyID > 0 {
 		taskID := task.ID
 		c.logApplyEvent(ctx, applyID, &taskID, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
 			logMsg, oldState, newState)
 	}
+	return nil
 }
 
 // markTasksRunning sets DDL tasks to running state with a start timestamp.
-func (c *LocalClient) markTasksRunning(ctx context.Context, tasks []*storage.Task) {
+// The tasks belong to one apply, so the first failed write aborts the batch:
+// a partial batch is not a state the drive can reason about, and the caller
+// must not poll engine work against task rows storage never accepted.
+func (c *LocalClient) markTasksRunning(ctx context.Context, tasks []*storage.Task) error {
 	now := time.Now()
 	for _, task := range tasks {
 		task.State = state.Task.Running
 		task.StartedAt = &now
 		task.UpdatedAt = now
 		if err := c.storage.Tasks().Update(ctx, task); err != nil {
-			c.logger.Error("failed to update task state", append(task.LogAttrs(), "error", err)...)
+			return fmt.Errorf("mark task %s running: %w", task.TaskIdentifier, err)
 		}
 	}
+	return nil
 }
 
 // runWithRecovery wraps an apply function with panic recovery so a single panic

--- a/pkg/tern/local_apply_failure.go
+++ b/pkg/tern/local_apply_failure.go
@@ -22,7 +22,12 @@ func (c *LocalClient) failApplyWithTasks(ctx context.Context, apply *storage.App
 			task.ErrorMessage = errMsg
 		}
 		task.CompletedAt = &now
-		c.transitionTaskState(ctx, task, 0, state.Task.Failed, "")
+		// Best-effort finalization: each task is failed independently so one
+		// write failure does not leave the remaining tasks unmarked.
+		if err := c.transitionTaskState(ctx, task, 0, state.Task.Failed, ""); err != nil {
+			c.logger.Error("failed to persist failed task state while failing apply; stored task row keeps its previous state until operator recovery reconciles it",
+				append(task.LogAttrs(), "error", err)...)
+		}
 	}
 
 	// Re-read the apply from storage — Stop() may have already set a terminal
@@ -56,7 +61,12 @@ func (c *LocalClient) markApplyRetryableWithTasks(ctx context.Context, apply *st
 			task.ErrorMessage = errMsg
 		}
 		task.CompletedAt = nil
-		c.transitionTaskState(ctx, task, 0, state.Task.FailedRetryable, "")
+		// Best-effort pause: each task is marked independently so one write
+		// failure does not leave the remaining tasks unmarked.
+		if err := c.transitionTaskState(ctx, task, 0, state.Task.FailedRetryable, ""); err != nil {
+			c.logger.Error("failed to persist retryable task state while pausing apply; stored task row keeps its previous state until operator recovery reconciles it",
+				append(task.LogAttrs(), "error", err)...)
+		}
 	}
 
 	// Re-read the apply from storage; Stop() may have already moved it to a

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -178,7 +178,11 @@ func (c *LocalClient) executeGroupedApply(ctx context.Context, apply *storage.Ap
 			}
 		}
 	}
-	c.markTasksRunning(ctx, tasks)
+	if err := c.markTasksRunning(ctx, tasks); err != nil {
+		c.logger.Error("failed to persist running task state after engine accepted the apply", append(apply.LogAttrs(), "error", err)...)
+		c.failApplyWithTasks(ctx, apply, tasks, fmt.Sprintf("failed to persist running task state: %v", err))
+		return
+	}
 	if c.config.Type == storage.DatabaseTypeVitess {
 		apply.State = state.Apply.ValidatingDeployRequest
 	} else {
@@ -732,7 +736,11 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 	c.logAtomicProgress(ctx, apply, result, ps, now)
 
 	// Update all tasks with engine progress
-	c.syncAtomicTaskProgress(ctx, tasks, result, newState, now)
+	if err := c.syncAtomicTaskProgress(ctx, tasks, result, newState, now); err != nil {
+		c.logger.Warn("task progress write failed; current apply owner will exit for operator retry",
+			append(apply.LogAttrs(), "error", err)...)
+		return true
+	}
 	if handled, err := c.processPendingCancelOrStopControlRequest(ctx, apply); err != nil {
 		c.logger.Warn("pending stop request processing failed after progress sync; current apply owner will exit for operator retry",
 			"apply_id", apply.ApplyIdentifier, "error", err)
@@ -1161,7 +1169,11 @@ func (c *LocalClient) logAtomicProgress(ctx context.Context, apply *storage.Appl
 }
 
 // syncAtomicTaskProgress updates all tasks with engine state and per-table progress.
-func (c *LocalClient) syncAtomicTaskProgress(ctx context.Context, tasks []*storage.Task, result *engine.ProgressResult, newState string, now time.Time) {
+// The tasks belong to one drive, so the first failed task write aborts the
+// sync and returns the error: the caller must not act on an engine result
+// (terminal finalization, auto-deploy/cutover triggers) that storage does not
+// reflect.
+func (c *LocalClient) syncAtomicTaskProgress(ctx context.Context, tasks []*storage.Task, result *engine.ProgressResult, newState string, now time.Time) error {
 	tableProgress := indexEngineTableProgress(result.Tables)
 	retryableFailure := state.IsState(newState, state.Task.FailedRetryable)
 	instantFromMetadata := false
@@ -1213,8 +1225,11 @@ func (c *LocalClient) syncAtomicTaskProgress(ctx context.Context, tasks []*stora
 		if result.State == engine.StateCompleted {
 			task.ProgressPercent = 100
 		}
-		c.transitionTaskState(ctx, task, 0, taskStateWithNoBackwardProgress(task.State, newState), "")
+		if err := c.transitionTaskState(ctx, task, 0, taskStateWithNoBackwardProgress(task.State, newState), ""); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 // writeShardProgress persists a table's per-shard breakdown as per-shard tasks

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -178,9 +178,14 @@ func (c *LocalClient) executeGroupedApply(ctx context.Context, apply *storage.Ap
 			}
 		}
 	}
+	// The engine already accepted the apply, so its work is in flight and a
+	// storage write failure must not terminalize the apply: recording failed
+	// while the engine keeps running would make the stored outcome contradict
+	// the target. Exit the current owner attempt instead so recovery re-drives
+	// from the stored non-terminal state.
 	if err := c.markTasksRunning(ctx, tasks); err != nil {
-		c.logger.Error("failed to persist running task state after engine accepted the apply", append(apply.LogAttrs(), "error", err)...)
-		c.failApplyWithTasks(ctx, apply, tasks, fmt.Sprintf("failed to persist running task state: %v", err))
+		c.logger.Error("failed to persist running task state after engine accepted the apply; current apply owner will exit for operator retry",
+			append(apply.LogAttrs(), "error", err)...)
 		return
 	}
 	if c.config.Type == storage.DatabaseTypeVitess {

--- a/pkg/tern/local_apply_sequential.go
+++ b/pkg/tern/local_apply_sequential.go
@@ -180,9 +180,9 @@ func (c *LocalClient) runEngineTask(ctx context.Context, apply *storage.Apply, t
 		var err error
 		taskCreds, err = c.credentialsForMySQLNamespace(task.Namespace)
 		if err != nil {
-			c.markTaskFailed(ctx, task, err.Error())
+			action := c.markTaskFailed(ctx, task, err.Error())
 			c.logger.Error("task failed to resolve namespace credentials", append(task.LogAttrs(), "namespace", task.Namespace, "error", err)...)
-			return taskFailed
+			return action
 		}
 	}
 
@@ -192,24 +192,29 @@ func (c *LocalClient) runEngineTask(ctx context.Context, apply *storage.Apply, t
 	result, err := c.getEngine().Apply(ctx, sequentialEngineApplyRequest(task, options, taskCreds))
 
 	if err != nil {
+		var action taskAction
 		if c.shouldRetryEngineError(err) {
-			c.markTaskRetryable(ctx, task, err.Error())
+			action = c.markTaskRetryable(ctx, task, err.Error())
 		} else {
-			c.markTaskFailed(ctx, task, err.Error())
+			action = c.markTaskFailed(ctx, task, err.Error())
 		}
 		c.logger.Error("task failed", append(task.LogAttrs(), "error", err)...)
-		return taskFailed
+		return action
 	}
 	if !result.Accepted {
-		c.markTaskFailed(ctx, task, result.Message)
+		action := c.markTaskFailed(ctx, task, result.Message)
 		c.logger.Error("task rejected", append(task.LogAttrs(), "message", result.Message)...)
-		return taskFailed
+		return action
 	}
 
 	// Mark task running
 	now := time.Now()
 	task.StartedAt = &now
-	c.transitionTaskState(ctx, task, 0, state.Task.Running, "")
+	if err := c.transitionTaskState(ctx, task, 0, state.Task.Running, ""); err != nil {
+		c.logger.Error("failed to persist running task state after engine accepted the task; current apply owner will exit for operator retry",
+			append(task.LogAttrs(), "error", err)...)
+		return taskAbort
+	}
 	c.logger.Info("task running", "task_id", task.TaskIdentifier, "table", task.TableName)
 
 	// Poll to completion. Thread the engine's returned resume state into the
@@ -351,8 +356,7 @@ func (c *LocalClient) pollTaskToCompletion(ctx context.Context, apply *storage.A
 				var permanent *engine.PermanentError
 				if errors.As(err, &permanent) {
 					c.logger.Error("progress check failed with permanent error", append(task.LogAttrs(), "error", err)...)
-					c.markTaskFailed(ctx, task, fmt.Sprintf("progress polling failed: %v", err))
-					return taskFailed
+					return c.markTaskFailed(ctx, task, fmt.Sprintf("progress polling failed: %v", err))
 				}
 				// A transient poll that nonetheless never succeeds must not spin
 				// forever: an apply that cannot reach a terminal state holds the
@@ -362,11 +366,9 @@ func (c *LocalClient) pollTaskToCompletion(ctx context.Context, apply *storage.A
 				c.logger.Warn("progress check failed", append(task.LogAttrs(), "error", err, "consecutive_errors", consecutiveErrors)...)
 				if consecutiveErrors >= 10 {
 					if c.shouldRetryEngineError(err) {
-						c.markTaskRetryable(ctx, task, fmt.Sprintf("progress polling failed after %d consecutive errors: %v", consecutiveErrors, err))
-						return taskFailed
+						return c.markTaskRetryable(ctx, task, fmt.Sprintf("progress polling failed after %d consecutive errors: %v", consecutiveErrors, err))
 					}
-					c.markTaskFailed(ctx, task, fmt.Sprintf("progress polling failed after %d consecutive errors: %v", consecutiveErrors, err))
-					return taskFailed
+					return c.markTaskFailed(ctx, task, fmt.Sprintf("progress polling failed after %d consecutive errors: %v", consecutiveErrors, err))
 				}
 				continue
 			}
@@ -410,7 +412,11 @@ func (c *LocalClient) pollTaskToCompletion(ctx context.Context, apply *storage.A
 					logMsg = fmt.Sprintf("Task %s finished: engine_state=%s message=%q rows=%d/%d",
 						task.TaskIdentifier, result.State, result.Message, task.RowsCopied, task.RowsTotal)
 				}
-				c.transitionTaskState(ctx, task, task.ApplyID, task.State, logMsg)
+				if err := c.transitionTaskState(ctx, task, task.ApplyID, task.State, logMsg); err != nil {
+					c.logger.Error("failed to persist terminal task state after engine finished; current apply owner will exit for operator retry",
+						append(task.LogAttrs(), "error", err)...)
+					return taskAbort
+				}
 				c.logger.Info("task finished",
 					"task_id", task.TaskIdentifier,
 					"table", task.TableName,
@@ -423,7 +429,13 @@ func (c *LocalClient) pollTaskToCompletion(ctx context.Context, apply *storage.A
 				return taskContinue
 			}
 
-			c.transitionTaskState(ctx, task, 0, task.State, "")
+			// A failed progress write is retried by design: the next tick
+			// recomputes and rewrites the full task state, so log and keep
+			// polling rather than abandoning in-flight engine work.
+			if err := c.transitionTaskState(ctx, task, 0, task.State, ""); err != nil {
+				c.logger.Warn("failed to persist task progress; stored task state lags the engine until the next poll write succeeds",
+					append(task.LogAttrs(), "error", err)...)
+			}
 
 			// Notify observer with full apply + tasks context
 			if obs := c.getObserver(task.ApplyID); obs != nil {
@@ -437,19 +449,36 @@ func (c *LocalClient) pollTaskToCompletion(ctx context.Context, apply *storage.A
 	}
 }
 
-// markTaskFailed sets a task to FAILED state with the given error message and persists it.
-func (c *LocalClient) markTaskFailed(ctx context.Context, task *storage.Task, errMsg string) {
+// markTaskFailed sets a task to FAILED state with the given error message and
+// persists it. Returns taskFailed once the failure is recorded. When the write
+// fails, the drive cannot finalize from task rows storage does not reflect, so
+// it returns taskAbort: the current apply owner exits without changing final
+// state and operator recovery re-drives from stored state.
+func (c *LocalClient) markTaskFailed(ctx context.Context, task *storage.Task, errMsg string) taskAction {
 	now := time.Now()
 	task.ErrorMessage = errMsg
 	task.CompletedAt = &now
-	c.transitionTaskState(ctx, task, 0, state.Task.Failed, "")
+	if err := c.transitionTaskState(ctx, task, 0, state.Task.Failed, ""); err != nil {
+		c.logger.Error("failed to persist failed task state; current apply owner will exit for operator retry",
+			append(task.LogAttrs(), "error", err)...)
+		return taskAbort
+	}
+	return taskFailed
 }
 
 // markTaskRetryable records a task failure that operator recovery may retry.
-func (c *LocalClient) markTaskRetryable(ctx context.Context, task *storage.Task, errMsg string) {
+// Returns taskFailed once the pause is recorded, or taskAbort when the write
+// fails and the current apply owner must exit for operator retry instead of
+// finalizing from task rows storage does not reflect.
+func (c *LocalClient) markTaskRetryable(ctx context.Context, task *storage.Task, errMsg string) taskAction {
 	task.ErrorMessage = errMsg
 	task.CompletedAt = nil
-	c.transitionTaskState(ctx, task, 0, state.Task.FailedRetryable, "")
+	if err := c.transitionTaskState(ctx, task, 0, state.Task.FailedRetryable, ""); err != nil {
+		c.logger.Error("failed to persist retryable task state; current apply owner will exit for operator retry",
+			append(task.LogAttrs(), "error", err)...)
+		return taskAbort
+	}
+	return taskFailed
 }
 
 func (c *LocalClient) shouldRetryEngineError(err error) bool {
@@ -490,7 +519,13 @@ func (c *LocalClient) finalizeSequentialApply(ctx context.Context, apply *storag
 		apply.CompletedAt = &now
 		for _, task := range tasks {
 			if task.State == state.Task.Pending {
-				c.transitionTaskState(ctx, task, 0, state.Task.Cancelled, "")
+				// Best-effort finalization: each pending task is cancelled
+				// independently so one write failure does not leave the rest
+				// pending.
+				if err := c.transitionTaskState(ctx, task, 0, state.Task.Cancelled, ""); err != nil {
+					c.logger.Error("failed to persist cancelled state for pending task while finalizing failed apply; stored task row stays pending until operator recovery reconciles it",
+						append(task.LogAttrs(), "error", err)...)
+				}
 			}
 		}
 	case stoppedByUser:

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -3801,7 +3801,7 @@ func TestLocalClient_AtomicRetryableFailureQueuesOperatorRetry(t *testing.T) {
 	// When the operator claims this apply, retryable tasks are queued for the
 	// next dispatch attempt. Completed tasks stay completed so successful table
 	// work is not repeated.
-	client.prepareRetryableTasksForResume(ctx, failedApply, failedTasks)
+	require.NoError(t, client.prepareRetryableTasksForResume(ctx, failedApply, failedTasks))
 
 	preparedTasks, err := stor.Tasks().GetByApplyID(ctx, applyID)
 	require.NoError(t, err)

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -1733,7 +1733,7 @@ func TestPrepareStoppedTasksForResumeQueuesOnlyStoppedTasks(t *testing.T) {
 
 			controlReq, err := pendingControlRequest(t.Context(), client.storage, apply, storage.ControlOperationStart)
 			require.NoError(t, err)
-			client.prepareStoppedTasksForResume(t.Context(), apply, []*storage.Task{stoppedTask, completedTask}, controlReq != nil)
+			require.NoError(t, client.prepareStoppedTasksForResume(t.Context(), apply, []*storage.Task{stoppedTask, completedTask}, controlReq != nil))
 
 			assert.Equal(t, state.Task.Pending, stoppedTask.State)
 			assert.Nil(t, stoppedTask.CompletedAt)
@@ -1758,7 +1758,7 @@ func TestPrepareStoppedTasksForResumeIgnoresApplyWithoutStartRequest(t *testing.
 		logger: slog.Default(),
 	}
 
-	client.prepareStoppedTasksForResume(t.Context(), &storage.Apply{ID: 123, State: state.Apply.Running}, []*storage.Task{task}, false)
+	require.NoError(t, client.prepareStoppedTasksForResume(t.Context(), &storage.Apply{ID: 123, State: state.Apply.Running}, []*storage.Task{task}, false))
 
 	assert.Equal(t, state.Task.Stopped, task.State)
 	assert.Equal(t, &completedAt, task.CompletedAt)

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -523,7 +523,10 @@ func (c *LocalClient) stopOwnedApply(ctx context.Context, req *ternv1.StopReques
 		engineTableProgress = c.snapshotEngineProgress(ctx, eng, stopCreds)
 	}
 
-	stoppedCount, skippedCount, applyID := c.markTasksWithState(ctx, tasks, targetApplyID, engineTableProgress, terminalState)
+	stoppedCount, skippedCount, applyID, err := c.markTasksWithState(ctx, tasks, targetApplyID, engineTableProgress, terminalState)
+	if err != nil {
+		return nil, fmt.Errorf("persist %s task state during stop: %w", terminalState, err)
+	}
 
 	if applyID > 0 && stoppedCount > 0 {
 		eventMsg := fmt.Sprintf("Stop requested: %d tasks stopped, %d skipped", stoppedCount, skippedCount)
@@ -614,7 +617,10 @@ func (c *LocalClient) cancelOwnedApply(ctx context.Context, req *ternv1.CancelRe
 	}
 	c.cancelApplyHandle(applyCancel)
 
-	cancelledCount, skippedCount, applyID := c.markTasksWithState(ctx, tasks, targetApplyID, nil, state.Task.Cancelled)
+	cancelledCount, skippedCount, applyID, err := c.markTasksWithState(ctx, tasks, targetApplyID, nil, state.Task.Cancelled)
+	if err != nil {
+		return nil, fmt.Errorf("persist cancelled task state during cancel: %w", err)
+	}
 	if applyID > 0 && cancelledCount > 0 {
 		if err := c.markApplyCancelled(ctx, applyID); err != nil {
 			return nil, err
@@ -1008,9 +1014,14 @@ func (c *LocalClient) snapshotEngineProgress(ctx context.Context, eng engine.Eng
 	return nil
 }
 
-// markTasksStopped sets all non-terminal targeted tasks to STOPPED, preserving engine progress.
-// Returns (stopped count, skipped count, apply ID for logging).
-func (c *LocalClient) markTasksWithState(ctx context.Context, tasks []*storage.Task, targetApplyID int64, engineProgress map[string]*engine.TableProgress, newState string) (int64, int64, int64) {
+// markTasksWithState sets all non-terminal targeted tasks to the given
+// terminal state, preserving engine progress.
+// Returns (stopped count, skipped count, apply ID for logging). The first
+// failed task write aborts and returns the error: reporting a stop or cancel
+// as accepted while task rows still read as active would let the stored state
+// diverge from what the operator was told, so the control call must fail and
+// be retried instead.
+func (c *LocalClient) markTasksWithState(ctx context.Context, tasks []*storage.Task, targetApplyID int64, engineProgress map[string]*engine.TableProgress, newState string) (int64, int64, int64, error) {
 	var stoppedCount, skippedCount int64
 	var applyID int64
 
@@ -1038,13 +1049,15 @@ func (c *LocalClient) markTasksWithState(ctx context.Context, tasks []*storage.T
 			task.ChecksumRowsTotal = et.ChecksumRowsTotal
 		}
 
-		c.transitionTaskState(ctx, task, task.ApplyID, newState,
-			fmt.Sprintf("Task %s %s", task.TaskIdentifier, newState))
+		if err := c.transitionTaskState(ctx, task, task.ApplyID, newState,
+			fmt.Sprintf("Task %s %s", task.TaskIdentifier, newState)); err != nil {
+			return stoppedCount, skippedCount, applyID, err
+		}
 
 		stoppedCount++
 	}
 
-	return stoppedCount, skippedCount, applyID
+	return stoppedCount, skippedCount, applyID, nil
 }
 
 // firstFailedTaskError returns an apply-level failure reason derived from task
@@ -1159,10 +1172,25 @@ func (c *LocalClient) markApplyStopped(ctx context.Context, applyID int64) error
 	return nil
 }
 
+// cancelPreservesApplyOutcome reports whether a cancel must leave the apply's
+// stored state untouched. Completed, failed, and reverted record the final
+// outcome of engine work that already happened, and a late cancel must never
+// rewrite that outcome — a fully-applied change recorded as cancelled would
+// mislead the merge gate and operators about what is live on the target.
+// Cancelled itself is re-writable (a repeated cancel is idempotent), and
+// stopped is terminal but explicitly cancellable: a driver may cancel a
+// stopped apply to abandon its checkpoint permanently.
+func cancelPreservesApplyOutcome(applyState string) bool {
+	return state.IsTerminalApplyState(applyState) &&
+		!state.IsState(applyState, state.Apply.Cancelled, state.Apply.Stopped)
+}
+
 // markApplyCancelled sets the apply to cancelled. Called by Stop() for Vitess
 // databases where cancelling the deploy request is permanent. This runs before
 // the apply goroutine sees the context cancellation, so failApplyWithTasks
 // will find the apply already terminal and leave it alone.
+// An apply whose stored state already records a final outcome (see
+// cancelPreservesApplyOutcome) keeps that state.
 func (c *LocalClient) markApplyCancelled(ctx context.Context, applyID int64) error {
 	apply, err := c.storage.Applies().Get(ctx, applyID)
 	if err != nil {
@@ -1170,6 +1198,12 @@ func (c *LocalClient) markApplyCancelled(ctx context.Context, applyID int64) err
 	}
 	if apply == nil {
 		return fmt.Errorf("load apply %d for cancelled state: %w", applyID, storage.ErrApplyNotFound)
+	}
+	if cancelPreservesApplyOutcome(apply.State) {
+		c.logger.Info("apply already reached a final outcome, not marking cancelled",
+			"apply_id", apply.ApplyIdentifier,
+			"state", apply.State)
+		return nil
 	}
 	now := time.Now()
 	apply.State = state.Apply.Cancelled

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -334,8 +334,12 @@ func (c *LocalClient) resumeApplySequential(ctx context.Context, apply *storage.
 			now := time.Now()
 			task.ProgressPercent = 100
 			task.CompletedAt = &now
-			c.transitionTaskState(ctx, task, apply.ID, state.Task.Completed,
-				fmt.Sprintf("Task %s already completed (cutover raced with re-plan)", task.TaskIdentifier))
+			if err := c.transitionTaskState(ctx, task, apply.ID, state.Task.Completed,
+				fmt.Sprintf("Task %s already completed (cutover raced with re-plan)", task.TaskIdentifier)); err != nil {
+				c.logger.Error("failed to persist completed task state during sequential resume; current apply owner will exit for operator retry",
+					append(task.LogAttrs(), "error", err)...)
+				return
+			}
 			continue
 		} else if err := verifyReplannedTaskDDL(task, replannedDDL); err != nil {
 			// Live schema drifted since resume began: the DDL this shard now
@@ -343,7 +347,9 @@ func (c *LocalClient) resumeApplySequential(ctx context.Context, apply *storage.
 			// apply unreviewed DDL.
 			c.logger.Error("resume aborting task: live schema drifted from the reviewed plan",
 				append(task.LogAttrs(), "error", err)...)
-			c.markTaskFailed(ctx, task, err.Error())
+			if c.markTaskFailed(ctx, task, err.Error()) == taskAbort {
+				return
+			}
 			failedTask = task
 			break
 		}
@@ -457,8 +463,10 @@ func (c *LocalClient) replanAndFilterTasks(ctx context.Context, apply *storage.A
 			// resume work for it — treat it as completed rather than drifted.
 			task.ProgressPercent = 100
 			task.CompletedAt = &now
-			c.transitionTaskState(ctx, task, apply.ID, state.Task.Completed,
-				fmt.Sprintf("Task %s already completed (live schema matches the reviewed target)", task.TaskIdentifier))
+			if err := c.transitionTaskState(ctx, task, apply.ID, state.Task.Completed,
+				fmt.Sprintf("Task %s already completed (live schema matches the reviewed target)", task.TaskIdentifier)); err != nil {
+				return nil, fmt.Errorf("persist re-plan completion during resume: %w", err)
+			}
 			completedCount++
 		} else {
 			// Fail closed if the re-plan would apply DDL this task was not
@@ -513,9 +521,9 @@ func verifyReplannedTaskDDL(task *storage.Task, replannedDDL string) error {
 // prepareRetryableTasksForResume queues only the task work that previously
 // stopped on a retryable engine failure. Completed tasks remain completed, and
 // pending tasks remain queued behind the retried work.
-func (c *LocalClient) prepareRetryableTasksForResume(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) {
+func (c *LocalClient) prepareRetryableTasksForResume(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) error {
 	if !state.IsState(apply.State, state.Apply.FailedRetryable) {
-		return
+		return nil
 	}
 	apply.ErrorMessage = ""
 	for _, task := range tasks {
@@ -525,27 +533,33 @@ func (c *LocalClient) prepareRetryableTasksForResume(ctx context.Context, apply 
 		task.Attempt++
 		task.ErrorMessage = ""
 		task.CompletedAt = nil
-		c.transitionTaskState(ctx, task, apply.ID, state.Task.Pending,
-			fmt.Sprintf("Task %s queued for retry", task.TaskIdentifier))
+		if err := c.transitionTaskState(ctx, task, apply.ID, state.Task.Pending,
+			fmt.Sprintf("Task %s queued for retry", task.TaskIdentifier)); err != nil {
+			return fmt.Errorf("queue retryable task for resume: %w", err)
+		}
 	}
+	return nil
 }
 
 // prepareStoppedTasksForResume turns an operator-claimed start request back into
 // runnable task work. The start intent stays pending until stopped task rows are
 // requeued and the apply is ready for execution, so a driver crash can still be
 // recovered by another operator driver.
-func (c *LocalClient) prepareStoppedTasksForResume(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, startRequested bool) {
+func (c *LocalClient) prepareStoppedTasksForResume(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, startRequested bool) error {
 	if !startRequested {
-		return
+		return nil
 	}
 	for _, task := range tasks {
 		if !state.IsState(task.State, state.Task.Stopped) {
 			continue
 		}
 		task.CompletedAt = nil
-		c.transitionTaskState(ctx, task, apply.ID, state.Task.Pending,
-			fmt.Sprintf("Task %s queued for start", task.TaskIdentifier))
+		if err := c.transitionTaskState(ctx, task, apply.ID, state.Task.Pending,
+			fmt.Sprintf("Task %s queued for start", task.TaskIdentifier)); err != nil {
+			return fmt.Errorf("queue stopped task for start: %w", err)
+		}
 	}
+	return nil
 }
 
 func shouldInspectDeferredCutoverSignal(apply *storage.Apply) bool {
@@ -603,8 +617,10 @@ func (c *LocalClient) markApplyRecovering(ctx context.Context, apply *storage.Ap
 				"task_state", task.State)
 			continue
 		}
-		c.transitionTaskState(ctx, task, apply.ID, state.Task.Recovering,
-			fmt.Sprintf("Task %s is recovering after restart", task.TaskIdentifier))
+		if err := c.transitionTaskState(ctx, task, apply.ID, state.Task.Recovering,
+			fmt.Sprintf("Task %s is recovering after restart", task.TaskIdentifier)); err != nil {
+			return fmt.Errorf("mark task recovering after restart: %w", err)
+		}
 	}
 	apply.State = state.Apply.Recovering
 	apply.CompletedAt = nil
@@ -759,7 +775,9 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 		if recovering {
 			taskState = state.Task.Recovering
 		}
-		c.transitionTaskState(ctx, task, 0, taskState, "")
+		if err := c.transitionTaskState(ctx, task, 0, taskState, ""); err != nil {
+			return fmt.Errorf("mark resumed task %s for apply %s: %w", taskState, apply.ApplyIdentifier, err)
+		}
 	}
 
 	apply.State = state.Apply.Running
@@ -1437,8 +1455,12 @@ func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.A
 		return nil
 	}
 
-	c.prepareRetryableTasksForResume(ctx, apply, activeTasks)
-	c.prepareStoppedTasksForResume(ctx, apply, activeTasks, startRequested)
+	if err := c.prepareRetryableTasksForResume(ctx, apply, activeTasks); err != nil {
+		return fmt.Errorf("prepare retryable tasks for resume of apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	if err := c.prepareStoppedTasksForResume(ctx, apply, activeTasks, startRequested); err != nil {
+		return fmt.Errorf("prepare stopped tasks for resume of apply %s: %w", apply.ApplyIdentifier, err)
+	}
 
 	if c.usesGroupedApply(apply, options) {
 		resumeCtx, cancelResume := context.WithCancel(ctx)

--- a/pkg/tern/local_control_test.go
+++ b/pkg/tern/local_control_test.go
@@ -1124,3 +1124,77 @@ func TestLocalClient_RunEngineTaskAbortsWhenTaskWriteFails(t *testing.T) {
 
 	assert.Equal(t, taskAbort, action, "the drive must exit for operator retry when the running task state cannot be persisted")
 }
+
+// A failed task-state write must leave the in-memory task reflecting the
+// stored state. Callers log and branch on task.State after a failed write
+// (conflict checks, finalization loops), so a struct claiming a transition
+// storage never accepted would mislead both the code and the operator reading
+// its logs.
+func TestLocalClient_TransitionTaskStateRestoresTaskOnWriteFailure(t *testing.T) {
+	apply := &storage.Apply{
+		ID:              42,
+		ApplyIdentifier: "apply-mysql-transition-task-write",
+		State:           state.Apply.Running,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+	}
+	updatedAt := time.Now().Add(-time.Minute)
+	task := &storage.Task{
+		ID:             7,
+		ApplyID:        apply.ID,
+		TaskIdentifier: "task-mysql-transition-task-write",
+		Database:       "testdb",
+		Namespace:      "testdb",
+		State:          state.Task.Running,
+		UpdatedAt:      updatedAt,
+	}
+	updateErr := errors.New("storage write refused")
+	client := newFailingTaskWriteClient(apply, []*storage.Task{task}, &controlCaptureEngine{}, updateErr)
+
+	err := client.transitionTaskState(t.Context(), task, 0, state.Task.Stopped, "")
+
+	require.ErrorIs(t, err, updateErr)
+	assert.Equal(t, state.Task.Running, task.State, "in-memory task state must match the stored state after a refused write")
+	assert.Equal(t, updatedAt, task.UpdatedAt, "in-memory update time must match the stored row after a refused write")
+}
+
+// Once the engine has accepted a grouped apply, its schema change is in
+// flight, so a failed running task-state write must not record a failed
+// outcome — the engine may still complete the change on the target. The
+// current apply owner exits and the apply stays non-terminal so recovery
+// re-drives it from stored state.
+func TestLocalClient_GroupedApplyExitsWithoutTerminalizingWhenTaskWriteFails(t *testing.T) {
+	apply := &storage.Apply{
+		ID:              42,
+		ApplyIdentifier: "apply-mysql-grouped-task-write",
+		State:           state.Apply.Pending,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+	}
+	task := &storage.Task{
+		ID:             7,
+		ApplyID:        apply.ID,
+		TaskIdentifier: "task-mysql-grouped-task-write",
+		Database:       "testdb",
+		Namespace:      "testdb",
+		TableName:      "t1",
+		DDL:            "ALTER TABLE `t1` ADD COLUMN `c` INT",
+		State:          state.Task.Pending,
+	}
+	plan := &storage.Plan{
+		PlanIdentifier: "plan-mysql-grouped-task-write",
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Namespaces:     map[string]*storage.NamespacePlanData{"testdb": {}},
+	}
+	updateErr := errors.New("storage write refused")
+	client := newFailingTaskWriteClient(apply, []*storage.Task{task}, &applyAcceptingEngine{}, updateErr)
+	client.heartbeatInterval = time.Hour
+
+	client.executeGroupedApply(t.Context(), apply, []*storage.Task{task}, plan, nil, false)
+
+	assert.Equal(t, state.Apply.Running, apply.State, "apply must stay non-terminal so recovery re-drives the in-flight engine work")
+	assert.Nil(t, apply.CompletedAt, "an apply that could not persist task state has no final outcome to stamp")
+}

--- a/pkg/tern/local_control_test.go
+++ b/pkg/tern/local_control_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -813,6 +814,108 @@ func TestLocalClient_CancelFailedRetryableCancelsDeployRequest(t *testing.T) {
 	assert.Equal(t, state.Apply.Cancelled, apply.State)
 }
 
+// Cancel must preserve an apply's recorded final outcome. Completed, failed,
+// and reverted describe engine work that already happened on the target, so a
+// late cancel must not rewrite them — a fully-applied change recorded as
+// cancelled would mislead the merge gate and operators. Cancelled is
+// re-writable (repeated cancel is idempotent) and stopped is terminal but
+// still cancellable, so neither is preserved.
+func TestCancelPreservesApplyOutcome(t *testing.T) {
+	assert.True(t, cancelPreservesApplyOutcome(state.Apply.Completed))
+	assert.True(t, cancelPreservesApplyOutcome(state.Apply.Failed))
+	assert.True(t, cancelPreservesApplyOutcome(state.Apply.Reverted))
+	assert.False(t, cancelPreservesApplyOutcome(state.Apply.Cancelled))
+	assert.False(t, cancelPreservesApplyOutcome(state.Apply.Stopped))
+	assert.False(t, cancelPreservesApplyOutcome(state.Apply.Running))
+	assert.False(t, cancelPreservesApplyOutcome(state.Apply.FailedRetryable))
+}
+
+// A cancel that arrives after the apply already reached a final outcome must
+// not rewrite the stored apply record. The schema change already ran (or
+// failed) on the target, so flipping the record to cancelled would tell the
+// merge gate and operators that a deployed change never happened. The cancel
+// is acknowledged with nothing left to cancel, the engine is not touched, and
+// the apply keeps its recorded state and completion time.
+func TestLocalClient_CancelAfterFinalOutcomePreservesApplyState(t *testing.T) {
+	testCases := []struct {
+		name       string
+		applyState string
+		taskState  string
+	}{
+		{name: "completed apply stays completed", applyState: state.Apply.Completed, taskState: state.Task.Completed},
+		{name: "failed apply stays failed", applyState: state.Apply.Failed, taskState: state.Task.Failed},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			completedAt := time.Now().Add(-time.Hour)
+			apply := &storage.Apply{
+				ID:              42,
+				ApplyIdentifier: "apply-vitess-cancel-final",
+				State:           tc.applyState,
+				Database:        "testdb",
+				DatabaseType:    storage.DatabaseTypeVitess,
+				Environment:     "staging",
+				CompletedAt:     &completedAt,
+			}
+			task := &storage.Task{
+				ID:             7,
+				ApplyID:        apply.ID,
+				TaskIdentifier: "task-vitess-cancel-final",
+				Database:       "testdb",
+				Namespace:      "testdb",
+				State:          tc.taskState,
+			}
+			eng := &controlCaptureEngine{}
+			client := newVitessControlTestClient(apply, []*storage.Task{task}, nil, eng)
+
+			resp, err := client.cancelOwnedApply(t.Context(), &ternv1.CancelRequest{ApplyId: apply.ApplyIdentifier}, "")
+
+			require.NoError(t, err)
+			assert.True(t, resp.Accepted)
+			assert.Equal(t, int64(0), resp.CancelledCount)
+			assert.Equal(t, int64(1), resp.SkippedCount)
+			assert.Nil(t, eng.cancelReq, "cancel of a finished apply must not touch the engine")
+			assert.Equal(t, tc.applyState, apply.State, "cancel must not rewrite the recorded final outcome")
+			assert.Equal(t, tc.taskState, task.State)
+			require.NotNil(t, apply.CompletedAt)
+			assert.Equal(t, completedAt, *apply.CompletedAt, "cancel must not restamp the completion time")
+		})
+	}
+}
+
+// Stopped is terminal but explicitly cancellable: an operator can cancel a
+// stopped apply to abandon its checkpoint permanently. Cancel must still move
+// the stopped apply and its stopped tasks to cancelled.
+func TestLocalClient_CancelStoppedApplyMarksCancelled(t *testing.T) {
+	apply := &storage.Apply{
+		ID:              42,
+		ApplyIdentifier: "apply-mysql-cancel-stopped",
+		State:           state.Apply.Stopped,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+	}
+	task := &storage.Task{
+		ID:             7,
+		ApplyID:        apply.ID,
+		TaskIdentifier: "task-mysql-cancel-stopped",
+		Database:       "testdb",
+		Namespace:      "testdb",
+		State:          state.Task.Stopped,
+	}
+	client := newMySQLControlTestClient(apply, []*storage.Task{task}, &controlCaptureEngine{})
+
+	resp, err := client.cancelOwnedApply(t.Context(), &ternv1.CancelRequest{ApplyId: apply.ApplyIdentifier}, "")
+
+	require.NoError(t, err)
+	assert.True(t, resp.Accepted)
+	assert.Equal(t, int64(1), resp.CancelledCount)
+	assert.Equal(t, state.Task.Cancelled, task.State)
+	assert.Equal(t, state.Apply.Cancelled, apply.State)
+	require.NotNil(t, apply.CompletedAt)
+}
+
 // A task in the revert window has already cut over: the new schema is live.
 // Stop must reject rather than record it as cancelled, so an operator chooses
 // explicitly between reverting (undo) and skip-revert (finalize). The engine is
@@ -878,4 +981,146 @@ func TestSuppressParentApplyWrites(t *testing.T) {
 		ctx := storage.WithOperationLease(t.Context(), storage.OperationLease{})
 		assert.False(t, suppressParentApplyWrites(ctx))
 	})
+}
+
+// controlTestFailingTaskStore serves tasks like controlTestTaskStore but
+// refuses every task write, simulating storage unavailability at the moment a
+// task state transition must be persisted.
+type controlTestFailingTaskStore struct {
+	controlTestTaskStore
+	updateErr error
+}
+
+func (s *controlTestFailingTaskStore) Update(context.Context, *storage.Task) error {
+	return s.updateErr
+}
+
+// applyAcceptingEngine accepts any apply request, standing in for an engine
+// that has already started the schema change when a later storage write fails.
+type applyAcceptingEngine struct {
+	controlCaptureEngine
+}
+
+func (e *applyAcceptingEngine) Apply(context.Context, *engine.ApplyRequest) (*engine.ApplyResult, error) {
+	return &engine.ApplyResult{Accepted: true}, nil
+}
+
+func newFailingTaskWriteClient(apply *storage.Apply, tasks []*storage.Task, eng engine.Engine, updateErr error) *LocalClient {
+	client := &LocalClient{
+		config: LocalConfig{
+			Database:  "testdb",
+			Type:      apply.DatabaseType,
+			TargetDSN: "root@tcp(localhost:3306)/",
+		},
+		storage: &controlTestStorage{
+			applies: &controlTestApplyStore{apply: apply},
+			tasks: &controlTestFailingTaskStore{
+				controlTestTaskStore: controlTestTaskStore{tasks: tasks},
+				updateErr:            updateErr,
+			},
+			applyLogs:       &controlTestApplyLogStore{},
+			controlRequests: &testControlRequestStore{},
+		},
+		logger: slog.Default(),
+	}
+	if apply.DatabaseType == storage.DatabaseTypeVitess {
+		client.planetscaleEngine = eng
+	} else {
+		client.spiritEngine = eng
+	}
+	return client
+}
+
+// Stop reports success to the operator only once storage reflects it. When the
+// stopped task state cannot be persisted, the stop must fail so the operator
+// retries, rather than report a stop that left task rows active in storage.
+func TestLocalClient_StopFailsClosedWhenTaskWriteFails(t *testing.T) {
+	apply := &storage.Apply{
+		ID:              42,
+		ApplyIdentifier: "apply-mysql-stop-task-write",
+		State:           state.Apply.Running,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+	}
+	task := &storage.Task{
+		ID:             7,
+		ApplyID:        apply.ID,
+		TaskIdentifier: "task-mysql-stop-task-write",
+		Database:       "testdb",
+		Namespace:      "testdb",
+		State:          state.Task.Running,
+	}
+	updateErr := errors.New("storage write refused")
+	client := newFailingTaskWriteClient(apply, []*storage.Task{task}, &controlCaptureEngine{}, updateErr)
+
+	_, err := client.stopOwnedApply(t.Context(), &ternv1.StopRequest{ApplyId: apply.ApplyIdentifier}, "")
+
+	require.ErrorIs(t, err, updateErr)
+	assert.ErrorContains(t, err, "persist stopped task state during stop")
+	assert.Equal(t, state.Apply.Running, apply.State, "stored apply must stay running when the stop could not be persisted")
+	assert.Nil(t, apply.CompletedAt)
+}
+
+// Cancel reports success to the operator only once storage reflects it. When
+// the cancelled task state cannot be persisted, the cancel must fail so the
+// operator retries, rather than report a cancel that left task rows active in
+// storage.
+func TestLocalClient_CancelFailsClosedWhenTaskWriteFails(t *testing.T) {
+	apply := &storage.Apply{
+		ID:              42,
+		ApplyIdentifier: "apply-mysql-cancel-task-write",
+		State:           state.Apply.Stopped,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+	}
+	task := &storage.Task{
+		ID:             7,
+		ApplyID:        apply.ID,
+		TaskIdentifier: "task-mysql-cancel-task-write",
+		Database:       "testdb",
+		Namespace:      "testdb",
+		State:          state.Task.Stopped,
+	}
+	updateErr := errors.New("storage write refused")
+	client := newFailingTaskWriteClient(apply, []*storage.Task{task}, &controlCaptureEngine{}, updateErr)
+
+	_, err := client.cancelOwnedApply(t.Context(), &ternv1.CancelRequest{ApplyId: apply.ApplyIdentifier}, "")
+
+	require.ErrorIs(t, err, updateErr)
+	assert.ErrorContains(t, err, "persist cancelled task state during cancel")
+	assert.Equal(t, state.Apply.Stopped, apply.State, "stored apply must stay stopped when the cancel could not be persisted")
+}
+
+// A sequential drive must not keep polling engine work against task rows that
+// storage never accepted. When the engine accepts a task but the running-state
+// write fails, the current apply owner exits (taskAbort) so operator recovery
+// re-drives from the authoritative stored state instead of in-memory state a
+// crash would lose.
+func TestLocalClient_RunEngineTaskAbortsWhenTaskWriteFails(t *testing.T) {
+	apply := &storage.Apply{
+		ID:              42,
+		ApplyIdentifier: "apply-mysql-run-task-write",
+		State:           state.Apply.Running,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+	}
+	task := &storage.Task{
+		ID:             7,
+		ApplyID:        apply.ID,
+		TaskIdentifier: "task-mysql-run-task-write",
+		Database:       "testdb",
+		Namespace:      "testdb",
+		TableName:      "t1",
+		DDL:            "ALTER TABLE `t1` ADD COLUMN `c` INT",
+		State:          state.Task.Pending,
+	}
+	updateErr := errors.New("storage write refused")
+	client := newFailingTaskWriteClient(apply, []*storage.Task{task}, &applyAcceptingEngine{}, updateErr)
+
+	action := client.runEngineTask(t.Context(), apply, task, nil, nil)
+
+	assert.Equal(t, taskAbort, action, "the drive must exit for operator retry when the running task state cannot be persisted")
 }


### PR DESCRIPTION
## Why this matters

A cancel racing an apply's completion could rewrite a fully-applied schema change as cancelled — restamping `completed_at` and telling the merge gate and operators that a deployed change never ran. Separately, task-state writes that failed were logged and swallowed, letting the drive proceed with in-memory state diverging from the stored rows that crash recovery re-drives from.

## What it does

- `markApplyCancelled` refuses to overwrite an apply that already recorded a final outcome (completed, failed, reverted). The policy is a named predicate, `cancelPreservesApplyOutcome`.
- Cancel-of-stopped remains supported: stopped is terminal but explicitly cancellable (a driver may cancel a stopped apply to abandon its checkpoint), and a repeated cancel stays idempotent.
- `transitionTaskState` and `markTasksRunning` now return write errors instead of logging and continuing; every caller handles the failure explicitly.
- Stop/Cancel control paths fail closed: the operator is only told the stop or cancel succeeded once storage reflects it.
- Drive paths (engine task launch, terminal poll transitions, grouped progress sync, resume preparation) exit for operator retry (`taskAbort` / propagated error) instead of finalizing from task rows storage never accepted.
- Best-effort finalizers (`failApplyWithTasks`, pending-task cancellation) and per-tick progress writes log a definitive message and continue — each iteration is independent or rewritten by the next poll.

## Before / after

```
apply completes ──▶ state=completed, completed_at stamped
late cancel     ──▶ overwrites: state=cancelled, completed_at restamped ❌
                    (merge gate told a deployed change never ran)
task write fails ──▶ log + swallow ──▶ drive keeps going ⛔
                    (memory ≠ storage; a crash re-drives stale task rows)
```

```
apply completes ──▶ state=completed, completed_at stamped
late cancel     ──▶ refused, final outcome preserved ✅
cancel of stopped ─▶ still cancels (abandon checkpoint) ✅
task write fails ──▶ control path: RPC fails, operator retries ✅
                 └─▶ drive path: owner exits, recovery re-drives from stored state ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
