### PR TITLE
fix(tern): recover ambiguous remote dispatch instead of failing a live apply

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -570,6 +570,51 @@ func RecordRemoteApplyDedup(ctx context.Context, database, environment, outcome 
 	)
 }
 
+// RecordRemoteApplyDispatchRecovery increments the counter for control-plane
+// re-dispatches of a remote apply whose prior dispatch outcome was lost (the
+// stored row is active with no remote apply id). The re-dispatch reuses the
+// generation's idempotency key, so the data plane returns the already-accepted
+// apply or starts fresh. A spike means dispatch RPCs are being cut off before
+// their response is durably recorded — investigate control-plane to data-plane
+// connectivity, dispatch deadlines, and driver churn.
+func RecordRemoteApplyDispatchRecovery(ctx context.Context, database, environment string) {
+	addCounter(ctx, "schemabot.remote_apply_dispatch_recovery_total",
+		"Total re-dispatches of remote applies whose prior dispatch outcome was lost", "{dispatch}",
+		attribute.String("database", database),
+		EnvironmentAttribute(environment),
+	)
+}
+
+// knownRemoteApplyOrphanStopOutcomes limits metric cardinality to the expected
+// best-effort stop outcomes recorded when a remote apply is orphaned.
+var knownRemoteApplyOrphanStopOutcomes = map[string]bool{
+	"stop_requested": true,
+	"stop_failed":    true,
+	"no_remote_id":   true,
+}
+
+// RecordRemoteApplyOrphaned increments the counter for applies the control
+// plane terminally failed while the data plane may still be executing the
+// schema change. Every increment requires operator action: reconcile the target
+// database against the stored failure. stopOutcome records the best-effort
+// remote stop paired with the verdict:
+//   - "stop_requested": the data plane accepted a stop for the known remote apply.
+//   - "stop_failed": a stop was attempted for the known remote apply and was
+//     refused or errored — the remote schema change can run to cutover.
+//   - "no_remote_id": no remote apply id is known, so no stop could be sent —
+//     check the data plane for an active schema change on the target database.
+func RecordRemoteApplyOrphaned(ctx context.Context, database, environment, stopOutcome string) {
+	if !knownRemoteApplyOrphanStopOutcomes[stopOutcome] {
+		stopOutcome = "unknown"
+	}
+	addCounter(ctx, "schemabot.remote_apply_orphaned_total",
+		"Total remote applies terminally failed by the control plane while the data plane may still be executing the schema change", "{apply}",
+		attribute.String("database", database),
+		EnvironmentAttribute(environment),
+		attribute.String("stop", stopOutcome),
+	)
+}
+
 // operatorMetricNames returns the canonical operator metric name alongside its
 // deprecated schemabot.scheduler.* alias. Both are emitted for one release so
 // dashboards and alerts can migrate before the legacy series is removed.

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -124,6 +124,13 @@ import (
 const (
 	grpcProgressPollInterval       = 500 * time.Millisecond
 	maxGRPCProgressPollErrorStreak = 10
+
+	// orphanedRemoteStopTimeout bounds the best-effort Stop RPC sent before an
+	// orphaned remote apply is recorded as failed. The stop must not inherit
+	// the drive context — the same cancellation or deadline that made the
+	// dispatch ambiguous would otherwise skip the stop attempt entirely — but
+	// it also must not block the terminal failure write indefinitely.
+	orphanedRemoteStopTimeout = 30 * time.Second
 )
 
 var grpcStoppedAfterStartGracePeriod = 30 * time.Second
@@ -2170,7 +2177,12 @@ func (c *GRPCClient) failOrphanedRemoteDispatch(ctx context.Context, apply *stor
 		slog.Error("failing remote apply with no known remote apply id; the control plane cannot stop a schema change the data plane may still be executing — check the data plane and reconcile the target database",
 			append(apply.LogAttrs(), "reason", message)...)
 	} else {
-		stopResp, stopErr := c.client.Stop(ctx, &ternv1.StopRequest{
+		// The drive context may already be canceled or past its deadline —
+		// often the very condition that made the dispatch ambiguous — so the
+		// stop gets its own bounded context to still reach the data plane.
+		stopCtx, cancelStop := context.WithTimeout(context.WithoutCancel(ctx), orphanedRemoteStopTimeout)
+		defer cancelStop()
+		stopResp, stopErr := c.client.Stop(stopCtx, &ternv1.StopRequest{
 			ApplyId:     remoteID,
 			Environment: apply.Environment,
 		})

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -1284,6 +1284,13 @@ func remoteApplyIdempotencyKey(apply *storage.Apply, scope applyTaskScope) strin
 	return "schemabot:v1:" + hex.EncodeToString(sum[:])
 }
 
+// errRemoteApplyIdentityConflict marks a refusal to adopt a remote apply id
+// because the stored operation row already carries a different remote identity
+// or belongs to another apply. It distinguishes an identity invariant violation
+// from a transient storage failure, so callers can decide whether the dispatch
+// stays claimable or must be resolved as unrecoverable.
+var errRemoteApplyIdentityConflict = errors.New("remote apply identity conflict")
+
 // persistRemoteApplyID stores the remote Tern apply id returned by dispatch.
 // Single-operation drives keep it on the parent applies.external_id (mutated in
 // place so the caller's Applies().Update persists it). Multi-operation drives
@@ -1304,17 +1311,17 @@ func (c *GRPCClient) persistRemoteApplyID(ctx context.Context, apply *storage.Ap
 		return fmt.Errorf("reload apply_operation %d before storing remote apply id: %w", op.ID, err)
 	}
 	if current.ApplyID != apply.ID {
-		return fmt.Errorf("apply_operation %d belongs to apply %d, not %s (%d)", op.ID, current.ApplyID, apply.ApplyIdentifier, apply.ID)
+		return fmt.Errorf("%w: apply_operation %d belongs to apply %d, not %s (%d)", errRemoteApplyIdentityConflict, op.ID, current.ApplyID, apply.ApplyIdentifier, apply.ID)
 	}
 	currentRemoteID := current.ExternalID
 	if currentRemoteID == "" {
 		currentRemoteID = current.EngineResumeContext
 	}
 	if currentRemoteID != "" && currentRemoteID != remoteID {
-		return fmt.Errorf("apply_operation %d already has remote apply id %q; refusing to overwrite with %q", op.ID, currentRemoteID, remoteID)
+		return fmt.Errorf("%w: apply_operation %d already has remote apply id %q; refusing to overwrite with %q", errRemoteApplyIdentityConflict, op.ID, currentRemoteID, remoteID)
 	}
 	if remoteOperationID != "" && current.ExternalOperationID != "" && current.ExternalOperationID != remoteOperationID {
-		return fmt.Errorf("apply_operation %d already has remote apply_operation id %q; refusing to overwrite with %q", op.ID, current.ExternalOperationID, remoteOperationID)
+		return fmt.Errorf("%w: apply_operation %d already has remote apply_operation id %q; refusing to overwrite with %q", errRemoteApplyIdentityConflict, op.ID, current.ExternalOperationID, remoteOperationID)
 	}
 	if err := c.storage.ApplyOperations().SaveExternalID(ctx, op.ID, remoteID); err != nil {
 		return fmt.Errorf("store remote apply id for apply_operation %d: %w", op.ID, err)
@@ -1463,7 +1470,7 @@ func (c *GRPCClient) ResumeApplyOperation(ctx context.Context, apply *storage.Ap
 	}
 	// Fail closed before any dispatch or state mutation: a work operation that
 	// resolves to no tasks is an invalid or stale claim. The shared resume path
-	// would otherwise mark the whole parent apply failed (dispatchPendingApply
+	// would otherwise mark the whole parent apply failed (dispatchRemoteApply
 	// and the remote-failure sites set applies.state regardless of scope), which
 	// is wrong when only this operation's lookup came back empty. Mirrors
 	// LocalClient.ResumeApplyOperation.
@@ -1720,14 +1727,10 @@ func (c *GRPCClient) resumeApply(ctx context.Context, apply *storage.Apply, scop
 	}
 
 	if shouldDispatchQueuedRemoteApply(apply, scope) {
-		return c.dispatchPendingApply(ctx, apply, scope)
+		return c.dispatchRemoteApply(ctx, apply, scope, dispatchModeQueued)
 	}
 	if hasAmbiguousRemoteDispatchState(apply, scope) {
-		errMsg := fmt.Sprintf("gRPC apply %s is %s without a remote apply id; remote dispatch state is ambiguous", apply.ApplyIdentifier, scope.dispatchState(apply))
-		if err := c.markRemoteApplyFailed(ctx, apply, nil, errMsg, false, scope); err != nil {
-			return fmt.Errorf("%s; persist failure state: %w", errMsg, err)
-		}
-		return errors.New(errMsg)
+		return c.recoverAmbiguousRemoteDispatch(ctx, apply, scope)
 	}
 
 	startControlReq, err := pendingControlRequest(ctx, c.storage, apply, storage.ControlOperationStart)
@@ -2121,9 +2124,91 @@ func hasAmbiguousRemoteDispatchState(apply *storage.Apply, scope applyTaskScope)
 		!shouldDispatchQueuedRemoteApply(apply, scope)
 }
 
-func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Apply, scope applyTaskScope) error {
+// remoteDispatchMode selects the failure policy for a remote Apply dispatch.
+type remoteDispatchMode int
+
+const (
+	// dispatchModeQueued is the first dispatch of a queued apply. Nothing has
+	// been sent to the data plane for this generation yet, so a definite
+	// rejection can be recorded as a terminal or retryable failure directly.
+	dispatchModeQueued remoteDispatchMode = iota
+	// dispatchModeAmbiguousRecovery re-sends a dispatch whose earlier outcome
+	// was lost, so the data plane may already be executing the schema change
+	// under this generation's idempotency key. Failures must either keep the
+	// apply claimable (the next claim re-dispatches with the same key) or go
+	// through the orphan verdict — never a silent terminal failure, and never a
+	// failed_retryable transition, whose claim-time attempt rotation would
+	// rotate the idempotency key and let a re-dispatch duplicate a remote apply
+	// the data plane already accepted.
+	dispatchModeAmbiguousRecovery
+)
+
+// recoverAmbiguousRemoteDispatch re-drives a claimed apply whose remote
+// dispatch outcome was lost: the stored row is active with no remote apply id,
+// which happens when the dispatch RPC was cut off before the response arrived
+// (deadline, cancellation) or the prior driver died between remote acceptance
+// and the durable id write. The idempotency key is deterministic for the
+// dispatch generation, so re-sending the same Apply request is safe: the data
+// plane either returns the already-accepted apply's identity (which this drive
+// adopts and resumes) or accepts the work fresh (nothing had been accepted).
+func (c *GRPCClient) recoverAmbiguousRemoteDispatch(ctx context.Context, apply *storage.Apply, scope applyTaskScope) error {
+	slog.Warn("remote dispatch state is ambiguous; re-dispatching with the generation's idempotency key so the data plane returns the existing apply or starts fresh",
+		append(apply.LogAttrs(), "dispatch_state", scope.dispatchState(apply))...)
+	metrics.RecordRemoteApplyDispatchRecovery(ctx, apply.Database, apply.Environment)
+	return c.dispatchRemoteApply(ctx, apply, scope, dispatchModeAmbiguousRecovery)
+}
+
+// failOrphanedRemoteDispatch terminally fails an apply whose ambiguous remote
+// dispatch could not be recovered. The data plane may still be executing the
+// schema change, so the verdict is never silent: when the remote apply id is
+// known a best-effort remote Stop is sent first, and the orphan counter fires
+// either way so an operator knows to reconcile the target database against the
+// stored failure.
+func (c *GRPCClient) failOrphanedRemoteDispatch(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, scope applyTaskScope, remoteID, message string) error {
+	stopOutcome := "no_remote_id"
+	if remoteID == "" {
+		slog.Error("failing remote apply with no known remote apply id; the control plane cannot stop a schema change the data plane may still be executing — check the data plane and reconcile the target database",
+			append(apply.LogAttrs(), "reason", message)...)
+	} else {
+		stopResp, stopErr := c.client.Stop(ctx, &ternv1.StopRequest{
+			ApplyId:     remoteID,
+			Environment: apply.Environment,
+		})
+		switch {
+		case stopErr != nil:
+			stopOutcome = "stop_failed"
+			slog.Error("best-effort stop of orphaned remote apply failed; the data plane will keep executing the schema change — reconcile the target database",
+				append(apply.LogAttrs(), "remote_apply_id", remoteID, "reason", message, "error", stopErr)...)
+		case stopResp == nil || !stopResp.Accepted:
+			stopOutcome = "stop_failed"
+			slog.Error("best-effort stop of orphaned remote apply was not accepted; the data plane will keep executing the schema change — reconcile the target database",
+				append(apply.LogAttrs(), "remote_apply_id", remoteID, "reason", message)...)
+		default:
+			stopOutcome = "stop_requested"
+			slog.Warn("requested stop of orphaned remote apply before recording the terminal failure",
+				append(apply.LogAttrs(), "remote_apply_id", remoteID, "reason", message)...)
+		}
+	}
+	metrics.RecordRemoteApplyOrphaned(ctx, apply.Database, apply.Environment, stopOutcome)
+	if markErr := c.markRemoteApplyFailed(ctx, apply, tasks, message, false, scope); markErr != nil {
+		return fmt.Errorf("mark orphaned gRPC apply %s failed: %w", apply.ApplyIdentifier, markErr)
+	}
+	return fmt.Errorf("gRPC apply %s: %s", apply.ApplyIdentifier, message)
+}
+
+// dispatchRemoteApply sends the idempotency-keyed Apply RPC for a claimed apply
+// and drives the accepted remote apply to completion. mode selects the failure
+// policy: see remoteDispatchMode.
+func (c *GRPCClient) dispatchRemoteApply(ctx context.Context, apply *storage.Apply, scope applyTaskScope, mode remoteDispatchMode) error {
+	recovering := mode == dispatchModeAmbiguousRecovery
 	plan, err := c.storage.Plans().GetByID(ctx, apply.PlanID)
 	if err != nil {
+		if recovering {
+			// Storage uncertainty must keep the apply claimable: the data plane
+			// may be executing this generation, and the next claim re-resolves
+			// the dispatch with the same idempotency key.
+			return fmt.Errorf("load plan %d for ambiguous gRPC apply %s: %w", apply.PlanID, apply.ApplyIdentifier, err)
+		}
 		if markErr := c.markRemoteApplyFailed(ctx, apply, nil, fmt.Sprintf("queued gRPC apply failed: load plan %d: %v", apply.PlanID, err), false, scope); markErr != nil {
 			return fmt.Errorf("mark queued gRPC apply %s failed after plan load error: %w", apply.ApplyIdentifier, markErr)
 		}
@@ -2131,6 +2216,9 @@ func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Ap
 	}
 	if plan == nil {
 		errMsg := fmt.Sprintf("queued gRPC apply failed: plan %d not found", apply.PlanID)
+		if recovering {
+			return c.failOrphanedRemoteDispatch(ctx, apply, nil, scope, "", fmt.Sprintf("cannot re-dispatch ambiguous remote apply: plan %d not found", apply.PlanID))
+		}
 		if markErr := c.markRemoteApplyFailed(ctx, apply, nil, errMsg, false, scope); markErr != nil {
 			return fmt.Errorf("mark queued gRPC apply %s failed after missing plan: %w", apply.ApplyIdentifier, markErr)
 		}
@@ -2139,6 +2227,10 @@ func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Ap
 
 	tasks, err := c.loadApplyTasks(ctx, apply, scope)
 	if err != nil {
+		if recovering {
+			// Storage uncertainty: stay claimable, same reasoning as the plan load.
+			return fmt.Errorf("load tasks for ambiguous gRPC apply %s: %w", apply.ApplyIdentifier, err)
+		}
 		if markErr := c.markRemoteApplyFailed(ctx, apply, nil, fmt.Sprintf("queued gRPC apply failed: load tasks: %v", err), false, scope); markErr != nil {
 			return fmt.Errorf("mark queued gRPC apply %s failed after task load error: %w", apply.ApplyIdentifier, markErr)
 		}
@@ -2146,6 +2238,9 @@ func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Ap
 	}
 	if len(tasks) == 0 {
 		errMsg := "queued gRPC apply failed: no tasks found"
+		if recovering {
+			return c.failOrphanedRemoteDispatch(ctx, apply, tasks, scope, "", "cannot re-dispatch ambiguous remote apply: no tasks found")
+		}
 		if markErr := c.markRemoteApplyFailed(ctx, apply, nil, errMsg, false, scope); markErr != nil {
 			return fmt.Errorf("mark queued gRPC apply %s failed after missing tasks: %w", apply.ApplyIdentifier, markErr)
 		}
@@ -2165,6 +2260,10 @@ func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Ap
 	targetShards := taskTargetShards(tasks)
 	if scope.operation != nil && isShardWorkOperationKey(scope.operation.OperationKey) && len(targetShards) != 1 {
 		errMsg := fmt.Sprintf("queued gRPC apply failed: shard operation %q resolved %d target shards, expected exactly 1 — its tasks carry no shard, so refusing to dispatch (the data plane would reject with \"expected exactly one target shard, got 0\"); this indicates a version or data skew", scope.operation.OperationKey, len(targetShards))
+		if recovering {
+			return c.failOrphanedRemoteDispatch(ctx, apply, tasks, scope, "",
+				fmt.Sprintf("cannot re-dispatch ambiguous remote apply: shard operation %q resolved %d target shards, expected exactly 1", scope.operation.OperationKey, len(targetShards)))
+		}
 		if markErr := c.markRemoteApplyFailed(ctx, apply, nil, errMsg, false, scope); markErr != nil {
 			return fmt.Errorf("mark queued gRPC apply %s failed after shard-scope guard: %w", apply.ApplyIdentifier, markErr)
 		}
@@ -2202,7 +2301,21 @@ func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Ap
 	})
 	if err != nil {
 		if isAmbiguousRemoteApplyDispatchError(err) {
+			if recovering {
+				// Still unresolved: the apply stays claimable and the next claim
+				// re-dispatches with the same idempotency key.
+				return fmt.Errorf("re-dispatch of ambiguous gRPC apply %s has ambiguous remote dispatch outcome: %w", apply.ApplyIdentifier, err)
+			}
 			return fmt.Errorf("apply queued gRPC apply %s has ambiguous remote dispatch outcome: %w", apply.ApplyIdentifier, err)
+		}
+		if recovering {
+			if isRetryableRemoteApplyError(err) {
+				slog.Warn("re-dispatch of ambiguous remote dispatch failed with a retryable error; apply stays claimable and the next claim re-dispatches with the same idempotency key",
+					append(apply.LogAttrs(), "error", err)...)
+				return fmt.Errorf("re-dispatch ambiguous gRPC apply %s: %w", apply.ApplyIdentifier, err)
+			}
+			return c.failOrphanedRemoteDispatch(ctx, apply, tasks, scope, "",
+				fmt.Sprintf("re-dispatch of ambiguous remote dispatch was rejected: %v", err))
 		}
 		if markErr := c.markRemoteApplyFailed(ctx, apply, tasks, err.Error(), isRetryableRemoteApplyError(err), scope); markErr != nil {
 			return fmt.Errorf("mark queued gRPC apply %s failed after remote apply error: %w", apply.ApplyIdentifier, markErr)
@@ -2211,6 +2324,10 @@ func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Ap
 	}
 	if resp == nil {
 		errMsg := "remote apply returned nil response"
+		if recovering {
+			return c.failOrphanedRemoteDispatch(ctx, apply, tasks, scope, "",
+				"re-dispatch of ambiguous remote dispatch returned nil response")
+		}
 		if markErr := c.markRemoteApplyFailed(ctx, apply, tasks, errMsg, false, scope); markErr != nil {
 			return fmt.Errorf("mark queued gRPC apply %s failed after nil response: %w", apply.ApplyIdentifier, markErr)
 		}
@@ -2221,6 +2338,10 @@ func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Ap
 		if errMsg == "" {
 			errMsg = "remote apply was not accepted"
 		}
+		if recovering {
+			return c.failOrphanedRemoteDispatch(ctx, apply, tasks, scope, "",
+				fmt.Sprintf("re-dispatch of ambiguous remote dispatch was not accepted: %s", errMsg))
+		}
 		if markErr := c.markRemoteApplyFailed(ctx, apply, tasks, errMsg, false, scope); markErr != nil {
 			return fmt.Errorf("mark queued gRPC apply %s failed after rejection: %w", apply.ApplyIdentifier, markErr)
 		}
@@ -2228,6 +2349,10 @@ func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Ap
 	}
 	if resp.ApplyId == "" {
 		errMsg := "remote apply accepted without apply_id"
+		if recovering {
+			return c.failOrphanedRemoteDispatch(ctx, apply, tasks, scope, "",
+				"re-dispatch of ambiguous remote dispatch was accepted without apply_id")
+		}
 		if markErr := c.markRemoteApplyFailed(ctx, apply, tasks, errMsg, false, scope); markErr != nil {
 			return fmt.Errorf("mark queued gRPC apply %s failed after missing remote apply id: %w", apply.ApplyIdentifier, markErr)
 		}
@@ -2241,6 +2366,13 @@ func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Ap
 	// dispatching a duplicate. Multi-operation drives store it on the claimed
 	// operation row; single-operation drives mutate apply.ExternalID in place.
 	if err := c.persistRemoteApplyID(ctx, apply, scope, resp.ApplyId, resp.ApplyOperationId); err != nil {
+		if recovering && errors.Is(err, errRemoteApplyIdentityConflict) {
+			// The stored operation adopted a different remote identity while this
+			// drive resolved its own. The drive's remote apply id is known, so it
+			// must not be left running silently behind a failure verdict.
+			return c.failOrphanedRemoteDispatch(ctx, apply, tasks, scope, resp.ApplyId,
+				fmt.Sprintf("cannot adopt remote apply %s resolved for the ambiguous dispatch: %v", resp.ApplyId, err))
+		}
 		return fmt.Errorf("store remote apply id for %s: %w", apply.ApplyIdentifier, err)
 	}
 	apply.State = state.InitialActiveApplyState(apply.Engine)
@@ -2255,9 +2387,11 @@ func (c *GRPCClient) dispatchPendingApply(ctx context.Context, apply *storage.Ap
 		return fmt.Errorf("update dispatched gRPC apply %s after storing remote apply id %s: %w", apply.ApplyIdentifier, resp.ApplyId, err)
 	}
 	if persisted {
-		c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo,
-			fmt.Sprintf("Apply dispatched to remote Tern: target=%s deployment=%s remote_apply_id=%s", target, apply.Deployment, resp.ApplyId),
-			oldApplyState)
+		message := fmt.Sprintf("Apply dispatched to remote Tern: target=%s deployment=%s remote_apply_id=%s", target, apply.Deployment, resp.ApplyId)
+		if recovering {
+			message = fmt.Sprintf("Apply re-dispatched to remote Tern after ambiguous dispatch: target=%s deployment=%s remote_apply_id=%s", target, apply.Deployment, resp.ApplyId)
+		}
+		c.logApplyStateTransition(ctx, apply, storage.LogLevelInfo, message, oldApplyState)
 	}
 
 	return c.pollForCompletion(ctx, apply, false, scope,

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/block/spirit/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -460,27 +464,32 @@ type capturingTernServer struct {
 	mu                sync.Mutex
 	applyReq          *ternv1.ApplyRequest
 	applyErr          error
+	applyRejectionMsg string // non-empty: Apply responds Accepted=false with this message
 	remoteApplyID     string
 	remoteOperationID string
-	cancelApplyID     string
-	stopApplyID       string
-	startApplyID      string
-	cutoverApplyID    string
-	skipRevertApplyID string
-	revertApplyID     string
-	progressApplyID   string
-	progressReq       *ternv1.ProgressRequest
-	progressState     ternv1.State // state returned by Progress; 0 = STATE_COMPLETED
-	progressStateSet  bool
-	progressStates    []ternv1.State
-	progressTables    []*ternv1.TableProgress
-	progressError     string
-	progressErr       error
-	startErr          error
-	cutoverErr        error
-	cutoverAccepted   bool
-	cutoverMessage    string
-	startCalled       bool // tracks whether Start was actually invoked
+	// applyIDsByIdempotencyKey simulates the data plane's idempotency dedupe: a
+	// request whose key is present returns that already-accepted apply's
+	// identity instead of creating (and returning) a fresh one.
+	applyIDsByIdempotencyKey map[string]string
+	cancelApplyID            string
+	stopApplyID              string
+	startApplyID             string
+	cutoverApplyID           string
+	skipRevertApplyID        string
+	revertApplyID            string
+	progressApplyID          string
+	progressReq              *ternv1.ProgressRequest
+	progressState            ternv1.State // state returned by Progress; 0 = STATE_COMPLETED
+	progressStateSet         bool
+	progressStates           []ternv1.State
+	progressTables           []*ternv1.TableProgress
+	progressError            string
+	progressErr              error
+	startErr                 error
+	cutoverErr               error
+	cutoverAccepted          bool
+	cutoverMessage           string
+	startCalled              bool // tracks whether Start was actually invoked
 }
 
 func (s *capturingTernServer) Apply(_ context.Context, req *ternv1.ApplyRequest) (*ternv1.ApplyResponse, error) {
@@ -490,11 +499,18 @@ func (s *capturingTernServer) Apply(_ context.Context, req *ternv1.ApplyRequest)
 	if applyID == "" {
 		applyID = "remote-apply-123"
 	}
+	if existingID, ok := s.applyIDsByIdempotencyKey[req.IdempotencyKey]; ok && req.IdempotencyKey != "" {
+		applyID = existingID
+	}
 	operationID := s.remoteOperationID
 	err := s.applyErr
+	rejectionMsg := s.applyRejectionMsg
 	s.mu.Unlock()
 	if err != nil {
 		return nil, err
+	}
+	if rejectionMsg != "" {
+		return &ternv1.ApplyResponse{Accepted: false, ErrorMessage: rejectionMsg}, nil
 	}
 	return &ternv1.ApplyResponse{Accepted: true, ApplyId: applyID, ApplyOperationId: operationID}, nil
 }
@@ -3741,15 +3757,60 @@ func TestGRPCClient_MarkRemoteApplyFailedReturnsTaskLoadError(t *testing.T) {
 	assert.Equal(t, state.Apply.Running, applyStore.apply.State)
 }
 
-func TestGRPCClient_ResumeApplyRejectsAmbiguousRemoteDispatchState(t *testing.T) {
-	// A stale active gRPC apply without an external_id is ambiguous: the prior
-	// driver may have sent the remote Apply RPC and crashed before persisting the
-	// returned data-plane ID. Fail closed instead of dispatching a duplicate
-	// remote schema change.
-	server := &capturingTernServer{remoteApplyID: "remote-duplicate"}
-	client, cleanup := testCapturingGRPCClient(t, server)
-	defer cleanup()
+// installTestMeterReader routes the global OTel meter provider to a manual
+// reader for the duration of the test so counters emitted by the code under
+// test can be collected and asserted.
+func installTestMeterReader(t *testing.T) *sdkmetric.ManualReader {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	previous := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	t.Cleanup(func() {
+		otel.SetMeterProvider(previous)
+		require.NoError(t, mp.Shutdown(t.Context()))
+	})
+	return reader
+}
 
+// counterValue sums the data points of the named Int64 counter whose
+// attributes include every wantAttrs entry.
+func counterValue(t *testing.T, reader *sdkmetric.ManualReader, name string, wantAttrs map[string]string) int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	var total int64
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "metric %s must be an Int64 sum", name)
+			for _, dp := range sum.DataPoints {
+				matches := true
+				for k, v := range wantAttrs {
+					got, ok := dp.Attributes.Value(attribute.Key(k))
+					if !ok || got.AsString() != v {
+						matches = false
+						break
+					}
+				}
+				if matches {
+					total += dp.Value
+				}
+			}
+		}
+	}
+	return total
+}
+
+// ambiguousDispatchTestApply builds the stored state of a drive whose prior
+// remote dispatch outcome was lost: the claim moved the applies row to running
+// (with a lease) but no remote apply id was durably written before the prior
+// driver died. Returns the apply, its still-running task, and the backing
+// storage to install on the client under test.
+func ambiguousDispatchTestApply() (*storage.Apply, *storage.Task, *mockStorage) {
 	apply := &storage.Apply{
 		ID:              8,
 		ApplyIdentifier: "apply-ambiguous-dispatch",
@@ -3764,9 +3825,12 @@ func TestGRPCClient_ResumeApplyRejectsAmbiguousRemoteDispatchState(t *testing.T)
 		TaskIdentifier: "task-ambiguous-dispatch",
 		ApplyID:        apply.ID,
 		TableName:      "users",
+		DDL:            "ALTER TABLE users ADD COLUMN email varchar(255)",
+		DDLAction:      "alter",
+		Namespace:      "default",
 		State:          state.Task.Running,
 	}
-	client.storage = &mockStorage{
+	st := &mockStorage{
 		applies: &mockApplyStore{apply: apply},
 		tasks:   &mockTaskStore{tasks: []*storage.Task{task}},
 		plans: &mockPlanStore{plan: &storage.Plan{
@@ -3774,18 +3838,173 @@ func TestGRPCClient_ResumeApplyRejectsAmbiguousRemoteDispatchState(t *testing.T)
 			PlanIdentifier: "plan-ambiguous-dispatch",
 		}},
 	}
+	return apply, task, st
+}
+
+func TestGRPCClient_ResumeApplyRecoversAmbiguousDispatchByAdoptingExistingRemoteApply(t *testing.T) {
+	// A driver can die between the data plane accepting a dispatch and the
+	// durable remote-apply-id write, leaving a running apply with no remote
+	// apply id. The next claim re-sends the same dispatch under the
+	// generation's deterministic idempotency key; the data plane returns the
+	// already-accepted apply's identity instead of executing the schema change
+	// a second time, and the drive adopts that identity and resumes polling it
+	// to terminal. The apply is never failed while the data plane executes it.
+	apply, task, st := ambiguousDispatchTestApply()
+	expectedKey := remoteApplyIdempotencyKey(apply, wholeApplyTaskScope())
+	server := &capturingTernServer{
+		remoteApplyID:            "remote-fresh-should-not-win",
+		applyIDsByIdempotencyKey: map[string]string{expectedKey: "remote-original-999"},
+		progressTables: []*ternv1.TableProgress{{
+			Namespace:       "default",
+			TableName:       "users",
+			Status:          state.Task.Completed,
+			PercentComplete: 100,
+		}},
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+	client.storage = st
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	err := client.ResumeApply(ctx, apply)
+	require.NoError(t, err)
+
+	req := server.getApplyRequest()
+	require.NotNil(t, req, "expected the ambiguous apply to be re-dispatched to remote Tern")
+	assert.Equal(t, expectedKey, req.IdempotencyKey, "re-dispatch must reuse the generation's deterministic idempotency key")
+	assert.Equal(t, "remote-original-999", apply.ExternalID, "the drive must adopt the already-accepted remote apply's identity")
+	assert.Equal(t, state.Apply.Completed, apply.State)
+	assert.Equal(t, state.Task.Completed, task.State)
+	assert.Equal(t, "remote-original-999", server.getProgressApplyID(), "polling must target the adopted remote apply")
+}
+
+func TestGRPCClient_ResumeApplyRecoversAmbiguousDispatchByStartingFresh(t *testing.T) {
+	// The prior dispatch RPC can also be cut off before the data plane accepts
+	// anything (deadline before acceptance). The recovery re-dispatch finds no
+	// apply under the idempotency key, so the data plane accepts the work fresh
+	// and the drive proceeds exactly like a first dispatch.
+	apply, task, st := ambiguousDispatchTestApply()
+	server := &capturingTernServer{
+		remoteApplyID: "remote-fresh-456",
+		progressTables: []*ternv1.TableProgress{{
+			Namespace:       "default",
+			TableName:       "users",
+			Status:          state.Task.Completed,
+			PercentComplete: 100,
+		}},
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+	client.storage = st
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	err := client.ResumeApply(ctx, apply)
+	require.NoError(t, err)
+
+	req := server.getApplyRequest()
+	require.NotNil(t, req, "expected the ambiguous apply to be re-dispatched to remote Tern")
+	assert.Equal(t, remoteApplyIdempotencyKey(apply, wholeApplyTaskScope()), req.IdempotencyKey)
+	assert.Equal(t, "remote-fresh-456", apply.ExternalID)
+	assert.Equal(t, state.Apply.Completed, apply.State)
+	assert.Equal(t, state.Task.Completed, task.State)
+}
+
+func TestGRPCClient_ResumeApplyKeepsAmbiguousApplyClaimableOnRetryableRedispatchError(t *testing.T) {
+	// A retryable data-plane error during the recovery re-dispatch proves
+	// nothing about the original dispatch, so stored state must stay unchanged:
+	// no terminal failure while the remote may be executing, and no
+	// failed_retryable transition whose claim-time attempt rotation would
+	// rotate the idempotency key. The apply stays claimable and the next claim
+	// re-dispatches with the same key.
+	apply, task, st := ambiguousDispatchTestApply()
+	server := &capturingTernServer{
+		applyErr: status.Error(codes.Unavailable, "data plane restarting"),
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+	client.storage = st
 
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 	defer cancel()
 	err := client.ResumeApply(ctx, apply)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "remote dispatch state is ambiguous")
+	assert.Contains(t, err.Error(), "re-dispatch ambiguous gRPC apply")
 
-	assert.Nil(t, server.getApplyRequest(), "ambiguous apply should not be dispatched to remote Tern")
+	require.NotNil(t, server.getApplyRequest(), "expected the re-dispatch to be attempted")
+	assert.Equal(t, state.Apply.Running, apply.State)
+	assert.Empty(t, apply.ErrorMessage)
+	assert.Nil(t, apply.CompletedAt)
+	assert.Equal(t, state.Task.Running, task.State)
+	assert.Empty(t, task.ErrorMessage)
+}
+
+func TestGRPCClient_ResumeApplyOrphansAmbiguousApplyOnDefinitiveRedispatchRejection(t *testing.T) {
+	// A definitive data-plane rejection of the recovery re-dispatch means the
+	// dispatch cannot be resolved by key, so the apply is terminally failed —
+	// but never silently: no remote apply id is known (so no remote stop can be
+	// sent) and the orphan counter fires so an operator checks the data plane
+	// for an active schema change on the target database.
+	reader := installTestMeterReader(t)
+	apply, task, st := ambiguousDispatchTestApply()
+	server := &capturingTernServer{
+		applyRejectionMsg: "plan validation failed",
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+	client.storage = st
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	err := client.ResumeApply(ctx, apply)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "was not accepted")
+	assert.Contains(t, err.Error(), "plan validation failed")
+
 	assert.Equal(t, state.Apply.Failed, apply.State)
-	assert.Contains(t, apply.ErrorMessage, "remote dispatch state is ambiguous")
+	assert.Contains(t, apply.ErrorMessage, "plan validation failed")
 	assert.Equal(t, state.Task.Failed, task.State)
-	assert.Contains(t, task.ErrorMessage, "remote dispatch state is ambiguous")
+	assert.Empty(t, server.getStopApplyID(), "no remote apply id is known, so no stop can be sent")
+	assert.Equal(t, int64(1), counterValue(t, reader, "schemabot.remote_apply_orphaned_total", map[string]string{
+		"database":    "testdb",
+		"environment": "staging",
+		"stop":        "no_remote_id",
+	}))
+	assert.Equal(t, int64(1), counterValue(t, reader, "schemabot.remote_apply_dispatch_recovery_total", map[string]string{
+		"database":    "testdb",
+		"environment": "staging",
+	}))
+}
+
+func TestGRPCClient_FailOrphanedRemoteDispatchStopsKnownRemoteApply(t *testing.T) {
+	// When an ambiguous dispatch must be resolved as a terminal failure while
+	// the remote apply's identity is known, the verdict is paired with a
+	// best-effort remote Stop and the orphan counter, so the data plane halts
+	// the schema change and an operator can reconcile the target database.
+	// The failure is never silent while the remote runs.
+	reader := installTestMeterReader(t)
+	apply, task, st := ambiguousDispatchTestApply()
+	server := &capturingTernServer{}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+	client.storage = st
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	err := client.failOrphanedRemoteDispatch(ctx, apply, []*storage.Task{task}, wholeApplyTaskScope(),
+		"remote-orphan-1", "cannot adopt remote apply remote-orphan-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot adopt remote apply remote-orphan-1")
+
+	assert.Equal(t, "remote-orphan-1", server.getStopApplyID(), "the known remote apply must receive a best-effort stop")
+	assert.Equal(t, state.Apply.Failed, apply.State)
+	assert.Equal(t, state.Task.Failed, task.State)
+	assert.Equal(t, int64(1), counterValue(t, reader, "schemabot.remote_apply_orphaned_total", map[string]string{
+		"database":    "testdb",
+		"environment": "staging",
+		"stop":        "stop_requested",
+	}))
 }
 
 func TestGRPCClient_ResumeApplyDoesNotFailStateWhenRemoteDispatchOutcomeIsAmbiguous(t *testing.T) {

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -3766,9 +3766,12 @@ func installTestMeterReader(t *testing.T) *sdkmetric.ManualReader {
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	previous := otel.GetMeterProvider()
 	otel.SetMeterProvider(mp)
+	// Shutdown runs after the test finishes, when t.Context() is already
+	// canceled, so the cleanup context must not inherit its cancellation.
+	shutdownCtx := context.WithoutCancel(t.Context())
 	t.Cleanup(func() {
 		otel.SetMeterProvider(previous)
-		require.NoError(t, mp.Shutdown(t.Context()))
+		require.NoError(t, mp.Shutdown(shutdownCtx))
 	})
 	return reader
 }
@@ -3817,6 +3820,7 @@ func ambiguousDispatchTestApply() (*storage.Apply, *storage.Task, *mockStorage) 
 		PlanID:          100,
 		Database:        "testdb",
 		DatabaseType:    storage.DatabaseTypeMySQL,
+		Engine:          storage.EngineSpirit,
 		Environment:     "staging",
 		State:           state.Apply.Running,
 	}


### PR DESCRIPTION
## Why this matters

A deadline during a remote Apply dispatch — or a driver dying between the data plane accepting the dispatch and the durable remote-apply-id write — leaves the stored apply active with no remote apply id. The next claim treated that ambiguity as a terminal failure with no remote Stop: stored state said **failed** while the data plane could still drive the schema change all the way to cutover.

## What it does

- The claim path re-sends the Apply RPC with the generation's deterministic idempotency key instead of failing. The data plane dedupes on it: if it had accepted the earlier dispatch it returns the existing apply's identity (the drive adopts it and resumes polling); if it had accepted nothing it starts fresh, exactly like a first dispatch.
- **Key invariant**: an inconclusive re-dispatch failure keeps the apply claimable — never `failed_retryable`, because a retryable claim rotates the attempt and thus the idempotency key, and a later re-dispatch could then duplicate a remote apply the data plane already accepted. Each subsequent claim retries with the same key.
- Storage uncertainty during recovery (plan/task load errors) also stays claimable rather than terminal.
- When recovery must still end in a terminal failure (definitive data-plane rejection, unrecoverable control-plane data, identity conflict on adoption), the verdict is never silent: a best-effort remote Stop is sent when the remote apply id is known, and `schemabot.remote_apply_orphaned_total` (labeled with the stop outcome) fires so an operator knows to reconcile the target database.
- `schemabot.remote_apply_dispatch_recovery_total` counts recovery attempts; all stored-state writes stay on the existing lease-held drive paths.

## Before / after

```
dispatch Apply ──▶ deadline / driver dies before the id write
next claim: active apply, no remote apply id
    └──▶ marked failed (terminal), no remote Stop ❌
         stored state: failed ⛔  data plane: still driving to cutover
```

```
next claim: active apply, no remote apply id
    └──▶ re-send Apply with the SAME idempotency key
           ├─ data plane had accepted it ──▶ returns existing id ──▶ adopt + resume polling ✅
           ├─ nothing was accepted       ──▶ fresh dispatch, drive proceeds ✅
           ├─ inconclusive               ──▶ stays claimable; next claim retries, same key ✅
           └─ must fail terminally       ──▶ best-effort remote Stop + orphan counter ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
