### PR TITLE
fix(tern): bound every outbound call on the drive path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/google/go-github/v86 v86.0.0
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0
+	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hmarr/codeowners v1.2.1
 	github.com/pingcap/tidb/pkg/parser v0.0.0-20260504140133-511dba1dbe17
 	github.com/planetscale/planetscale-go v0.155.0
@@ -150,7 +151,6 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/hashicorp/consul/api v1.34.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-metrics v0.5.4 // indirect

--- a/pkg/mysqlconn/mysqlconn.go
+++ b/pkg/mysqlconn/mysqlconn.go
@@ -3,9 +3,38 @@ package mysqlconn
 import (
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/block/spirit/pkg/dbconn"
 	"github.com/go-sql-driver/mysql"
+)
+
+// Transport timeouts applied to every SchemaBot-managed MySQL connection.
+// These exist so a black-holed connection (dropped packets, dead NAT entry,
+// half-open TCP) cannot block a goroutine forever — the invariant is that
+// every wire operation is bounded, not that it is fast. A DSN that sets its
+// own value keeps it.
+//
+// Spirit's runner connections are unaffected: Spirit opens its own
+// connections via its dbconn package, so long copy phases never traverse a
+// connection opened here.
+const (
+	// connectTimeout bounds establishing a new connection (TCP + handshake).
+	connectTimeout = 30 * time.Second
+
+	// connReadTimeout bounds each network read. It applies per read, so a
+	// streamed result set only needs the server to keep sending; only a
+	// statement that is silent on the wire for the whole duration hits it.
+	// It must comfortably exceed the longest legitimate silent wait on a
+	// SchemaBot-managed connection — the EnsureSchema advisory-lock wait and
+	// DDL statements (stale-table drops, pending-drop cleanup) — so it is
+	// deliberately long.
+	connReadTimeout = 30 * time.Minute
+
+	// connWriteTimeout bounds each network write. Writes are query payloads
+	// (statements, schema files), so they complete quickly on a healthy
+	// connection.
+	connWriteTimeout = 1 * time.Minute
 )
 
 var openSQL = sql.Open
@@ -23,26 +52,43 @@ func Open(dsn string) (*sql.DB, error) {
 	return db, nil
 }
 
-// ConnectionDSN returns a MySQL DSN with required transport settings applied.
+// ConnectionDSN returns a MySQL DSN with required transport settings applied:
+// connect/read/write timeouts (when the DSN does not set its own) and TLS for
+// hosts that require it.
 func ConnectionDSN(dsn string) (string, error) {
 	cfg, err := mysql.ParseDSN(dsn)
 	if err != nil {
 		return "", fmt.Errorf("parse DSN: %w", err)
 	}
+	applyTimeouts(cfg)
 	if cfg.TLSConfig != "" {
-		return dsn, nil
+		return cfg.FormatDSN(), nil
 	}
 	tlsMode, ok := tlsModeForHost(cfg.Addr)
 	if !ok {
-		return dsn, nil
+		return cfg.FormatDSN(), nil
 	}
 	dbConfig := dbconn.NewDBConfig()
 	dbConfig.TLSMode = tlsMode
-	connectionDSN, err := dbconn.EnhanceDSNWithTLS(dsn, dbConfig)
+	connectionDSN, err := dbconn.EnhanceDSNWithTLS(cfg.FormatDSN(), dbConfig)
 	if err != nil {
 		return "", fmt.Errorf("enhance RDS DSN with TLS: %w", err)
 	}
 	return connectionDSN, nil
+}
+
+// applyTimeouts fills in the transport timeouts, keeping any value the DSN
+// already carries.
+func applyTimeouts(cfg *mysql.Config) {
+	if cfg.Timeout == 0 {
+		cfg.Timeout = connectTimeout
+	}
+	if cfg.ReadTimeout == 0 {
+		cfg.ReadTimeout = connReadTimeout
+	}
+	if cfg.WriteTimeout == 0 {
+		cfg.WriteTimeout = connWriteTimeout
+	}
 }
 
 func tlsModeForHost(addr string) (string, bool) {

--- a/pkg/mysqlconn/mysqlconn_test.go
+++ b/pkg/mysqlconn/mysqlconn_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
@@ -15,7 +16,6 @@ func TestConnectionDSN(t *testing.T) {
 		name       string
 		dsn        string
 		wantTLS    string
-		wantSame   bool
 		wantErrSub string
 	}{
 		{
@@ -24,26 +24,24 @@ func TestConnectionDSN(t *testing.T) {
 			wantTLS: "rds",
 		},
 		{
-			name:     "non-RDS host is unchanged",
-			dsn:      "root:secret@tcp(localhost:3306)/app?parseTime=true",
-			wantSame: true,
+			name:    "non-RDS host gets no TLS",
+			dsn:     "root:secret@tcp(localhost:3306)/app?parseTime=true",
+			wantTLS: "",
 		},
 		{
-			name:     "database alias is unchanged",
-			dsn:      "spirit:secret@tcp(database.example.com:3306)/app?parseTime=true",
-			wantSame: true,
+			name:    "database alias gets no TLS",
+			dsn:     "spirit:secret@tcp(database.example.com:3306)/app?parseTime=true",
+			wantTLS: "",
 		},
 		{
-			name:     "explicit TLS is preserved",
-			dsn:      "spirit:secret@tcp(database.cluster-abc123.us-west-2.rds.amazonaws.com:3306)/app?tls=skip-verify",
-			wantTLS:  "skip-verify",
-			wantSame: true,
+			name:    "explicit TLS is preserved",
+			dsn:     "spirit:secret@tcp(database.cluster-abc123.us-west-2.rds.amazonaws.com:3306)/app?tls=skip-verify",
+			wantTLS: "skip-verify",
 		},
 		{
-			name:     "explicit disabled TLS is preserved",
-			dsn:      "spirit:secret@tcp(database.cluster-abc123.us-west-2.rds.amazonaws.com:3306)/app?tls=false",
-			wantTLS:  "false",
-			wantSame: true,
+			name:    "explicit disabled TLS is preserved",
+			dsn:     "spirit:secret@tcp(database.cluster-abc123.us-west-2.rds.amazonaws.com:3306)/app?tls=false",
+			wantTLS: "false",
 		},
 		{
 			name:       "invalid DSN returns context",
@@ -62,17 +60,43 @@ func TestConnectionDSN(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			if tt.wantSame {
-				assert.Equal(t, tt.dsn, got)
-			}
-
 			cfg, err := mysql.ParseDSN(got)
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantTLS, cfg.TLSConfig)
+
+			// Every normalized DSN carries transport timeouts so a
+			// black-holed connection cannot block a goroutine forever.
+			assert.Equal(t, connectTimeout, cfg.Timeout)
+			assert.Equal(t, connReadTimeout, cfg.ReadTimeout)
+			assert.Equal(t, connWriteTimeout, cfg.WriteTimeout)
+
+			// Normalization must not alter the connection identity or
+			// existing params.
+			want, err := mysql.ParseDSN(tt.dsn)
+			require.NoError(t, err)
+			assert.Equal(t, want.Addr, cfg.Addr)
+			assert.Equal(t, want.User, cfg.User)
+			assert.Equal(t, want.Passwd, cfg.Passwd)
+			assert.Equal(t, want.DBName, cfg.DBName)
+			assert.Equal(t, want.ParseTime, cfg.ParseTime)
+
 			_, err = mysql.NewConnector(cfg)
 			require.NoError(t, err)
 		})
 	}
+}
+
+// A DSN that sets its own transport timeouts keeps them — the defaults only
+// fill in missing values.
+func TestConnectionDSNKeepsExplicitTimeouts(t *testing.T) {
+	got, err := ConnectionDSN("root:secret@tcp(localhost:3306)/app?timeout=5s&readTimeout=10s&writeTimeout=15s")
+	require.NoError(t, err)
+
+	cfg, err := mysql.ParseDSN(got)
+	require.NoError(t, err)
+	assert.Equal(t, 5*time.Second, cfg.Timeout)
+	assert.Equal(t, 10*time.Second, cfg.ReadTimeout)
+	assert.Equal(t, 15*time.Second, cfg.WriteTimeout)
 }
 
 func TestOpenNormalizesRDSDSNBeforeOpening(t *testing.T) {
@@ -95,4 +119,6 @@ func TestOpenNormalizesRDSDSNBeforeOpening(t *testing.T) {
 	cfg, parseErr := mysql.ParseDSN(gotDSN)
 	require.NoError(t, parseErr)
 	assert.Equal(t, "rds", cfg.TLSConfig)
+	assert.Equal(t, connReadTimeout, cfg.ReadTimeout)
+	assert.Equal(t, connWriteTimeout, cfg.WriteTimeout)
 }

--- a/pkg/psclient/client.go
+++ b/pkg/psclient/client.go
@@ -6,9 +6,28 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
+	"github.com/hashicorp/go-cleanhttp"
 	ps "github.com/planetscale/planetscale-go/planetscale"
 )
+
+// planetScaleHTTPTimeout bounds every PlanetScale API request, including the
+// raw-HTTP throttle endpoint. Some operations (deploy request creation,
+// branch schema diffs) can legitimately take minutes on large keyspaces, so
+// the bound is generous. The invariant is that a drive goroutine can never
+// block forever on a hung PlanetScale API call — bounded, not tuned.
+const planetScaleHTTPTimeout = 5 * time.Minute
+
+// newPlanetScaleHTTPClient returns the HTTP client used for all PlanetScale
+// API requests. The Transport must be non-nil: ps.WithServiceToken wraps the
+// client's transport in an auth RoundTripper that delegates to it directly.
+func newPlanetScaleHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout:   planetScaleHTTPTimeout,
+		Transport: cleanhttp.DefaultPooledTransport(),
+	}
+}
 
 // PSClient defines the interface for PlanetScale API operations.
 // The engine flow is: create branch → get credentials → MySQL-connect to
@@ -63,7 +82,8 @@ type ThrottleDeployRequestRequest struct {
 // psClientWrapper wraps the real PlanetScale client to implement PSClient.
 type psClientWrapper struct {
 	client     *ps.Client
-	baseURL    string // for endpoints not in the SDK (throttle)
+	httpClient *http.Client // for endpoints not in the SDK (throttle)
+	baseURL    string       // for endpoints not in the SDK (throttle)
 	tokenName  string
 	tokenValue string
 }
@@ -71,17 +91,7 @@ type psClientWrapper struct {
 // NewPSClient creates a new PSClient using the real PlanetScale API.
 // Use NewPSClientWithBaseURL for endpoints not yet in the SDK (throttle).
 func NewPSClient(tokenName, tokenValue string, opts ...ps.ClientOption) (PSClient, error) {
-	allOpts := append([]ps.ClientOption{ps.WithServiceToken(tokenName, tokenValue)}, opts...)
-	client, err := ps.NewClient(allOpts...)
-	if err != nil {
-		return nil, err
-	}
-	return &psClientWrapper{
-		client:     client,
-		baseURL:    "https://api.planetscale.com",
-		tokenName:  tokenName,
-		tokenValue: tokenValue,
-	}, nil
+	return newPSClient(tokenName, tokenValue, "https://api.planetscale.com", opts...)
 }
 
 // NewPSClientWithBaseURL creates a new PSClient with a custom base URL.
@@ -91,13 +101,26 @@ func NewPSClientWithBaseURL(tokenName, tokenValue, baseURL string) (PSClient, er
 	if baseURL != "" {
 		opts = append(opts, ps.WithBaseURL(baseURL))
 	}
-	allOpts := append([]ps.ClientOption{ps.WithServiceToken(tokenName, tokenValue)}, opts...)
+	return newPSClient(tokenName, tokenValue, baseURL, opts...)
+}
+
+func newPSClient(tokenName, tokenValue, baseURL string, opts ...ps.ClientOption) (PSClient, error) {
+	// WithHTTPClient must precede WithServiceToken: the service-token option
+	// wraps the transport of whatever client is installed at that point.
+	allOpts := append([]ps.ClientOption{
+		ps.WithHTTPClient(newPlanetScaleHTTPClient()),
+		ps.WithServiceToken(tokenName, tokenValue),
+	}, opts...)
 	client, err := ps.NewClient(allOpts...)
 	if err != nil {
 		return nil, err
 	}
 	return &psClientWrapper{
-		client:     client,
+		client: client,
+		// The throttle endpoint sets its Authorization header per request, so
+		// it needs its own client — the SDK client's transport was wrapped by
+		// the service-token option and would add a duplicate header.
+		httpClient: newPlanetScaleHTTPClient(),
 		baseURL:    baseURL,
 		tokenName:  tokenName,
 		tokenValue: tokenValue,
@@ -200,7 +223,7 @@ func (w *psClientWrapper) ThrottleDeployRequest(ctx context.Context, req *Thrott
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Authorization", w.tokenName+":"+w.tokenValue)
-	resp, err := http.DefaultClient.Do(httpReq)
+	resp, err := w.httpClient.Do(httpReq)
 	if err != nil {
 		return fmt.Errorf("throttle deploy request: %w", err)
 	}

--- a/pkg/psclient/client.go
+++ b/pkg/psclient/client.go
@@ -105,12 +105,15 @@ func NewPSClientWithBaseURL(tokenName, tokenValue, baseURL string) (PSClient, er
 }
 
 func newPSClient(tokenName, tokenValue, baseURL string, opts ...ps.ClientOption) (PSClient, error) {
-	// WithHTTPClient must precede WithServiceToken: the service-token option
-	// wraps the transport of whatever client is installed at that point.
-	allOpts := append([]ps.ClientOption{
+	// Caller options apply first; the bounded HTTP client and the service
+	// token install last so no caller option can displace them. Within that
+	// pair, WithHTTPClient must precede WithServiceToken: the service-token
+	// option wraps the transport of whatever client is installed at that
+	// point.
+	allOpts := append(append([]ps.ClientOption{}, opts...),
 		ps.WithHTTPClient(newPlanetScaleHTTPClient()),
 		ps.WithServiceToken(tokenName, tokenValue),
-	}, opts...)
+	)
 	client, err := ps.NewClient(allOpts...)
 	if err != nil {
 		return nil, err

--- a/pkg/psclient/client_test.go
+++ b/pkg/psclient/client_test.go
@@ -1,0 +1,112 @@
+package psclient
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Every PlanetScale API call runs through an HTTP client with a bounded
+// response timeout so a hung PlanetScale endpoint cannot block a drive
+// goroutine forever.
+func TestNewPSClientBoundsHTTPRequests(t *testing.T) {
+	client, err := NewPSClient("token-name", "token-value")
+	require.NoError(t, err)
+
+	wrapper, ok := client.(*psClientWrapper)
+	require.True(t, ok, "NewPSClient must return the wrapper around the SDK client")
+
+	require.NotNil(t, wrapper.httpClient)
+	assert.Equal(t, planetScaleHTTPTimeout, wrapper.httpClient.Timeout)
+	assert.Equal(t, "https://api.planetscale.com", wrapper.baseURL)
+}
+
+func TestNewPSClientWithBaseURLBoundsHTTPRequests(t *testing.T) {
+	client, err := NewPSClientWithBaseURL("token-name", "token-value", "https://ps.example.com")
+	require.NoError(t, err)
+
+	wrapper, ok := client.(*psClientWrapper)
+	require.True(t, ok, "NewPSClientWithBaseURL must return the wrapper around the SDK client")
+
+	require.NotNil(t, wrapper.httpClient)
+	assert.Equal(t, planetScaleHTTPTimeout, wrapper.httpClient.Timeout)
+	assert.Equal(t, "https://ps.example.com", wrapper.baseURL)
+}
+
+// The SDK's service-token option wraps the transport of the client installed
+// before it. The wrapper's HTTP client must be non-nil-transport and distinct
+// from the SDK's, so the throttle endpoint's per-request Authorization header
+// is the only one sent.
+func TestThrottleClientHasOwnTransport(t *testing.T) {
+	httpClient := newPlanetScaleHTTPClient()
+	require.NotNil(t, httpClient.Transport)
+	assert.Equal(t, planetScaleHTTPTimeout, httpClient.Timeout)
+}
+
+// A throttle call against an endpoint that accepts the request but never
+// responds must return once the HTTP client's timeout fires instead of
+// blocking the drive goroutine indefinitely.
+func TestThrottleDeployRequestReturnsWhenServerHangs(t *testing.T) {
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release
+	}))
+	// Cleanups run last-registered-first: the handler must be released before
+	// server.Close waits for active connections to finish.
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { close(release) })
+
+	wrapper := &psClientWrapper{
+		httpClient: &http.Client{Timeout: 100 * time.Millisecond},
+		baseURL:    server.URL,
+		tokenName:  "token-name",
+		tokenValue: "token-value",
+	}
+
+	start := time.Now()
+	err := wrapper.ThrottleDeployRequest(t.Context(), &ThrottleDeployRequestRequest{
+		Organization:  "org",
+		Database:      "db",
+		Number:        1,
+		ThrottleRatio: 0.5,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "throttle deploy request")
+	assert.Less(t, time.Since(start), 10*time.Second, "call must return by the client timeout, not hang")
+}
+
+// The throttle endpoint authenticates with a service-token Authorization
+// header and reports non-200 responses as errors.
+func TestThrottleDeployRequestSendsAuthAndBody(t *testing.T) {
+	var gotAuth []string
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Values("Authorization")
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	wrapper := &psClientWrapper{
+		httpClient: newPlanetScaleHTTPClient(),
+		baseURL:    server.URL,
+		tokenName:  "token-name",
+		tokenValue: "token-value",
+	}
+
+	err := wrapper.ThrottleDeployRequest(t.Context(), &ThrottleDeployRequestRequest{
+		Organization:  "org",
+		Database:      "db",
+		Number:        42,
+		ThrottleRatio: 0.5,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"token-name:token-value"}, gotAuth)
+	assert.Equal(t, "/v1/organizations/org/databases/db/deploy-requests/42/throttle", gotPath)
+}

--- a/pkg/psclient/client_test.go
+++ b/pkg/psclient/client_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	ps "github.com/planetscale/planetscale-go/planetscale"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -35,6 +36,36 @@ func TestNewPSClientWithBaseURLBoundsHTTPRequests(t *testing.T) {
 	require.NotNil(t, wrapper.httpClient)
 	assert.Equal(t, planetScaleHTTPTimeout, wrapper.httpClient.Timeout)
 	assert.Equal(t, "https://ps.example.com", wrapper.baseURL)
+}
+
+// Caller-supplied client options cannot displace the auth and timeout
+// invariants: the bounded HTTP client and the service token install after
+// all caller options, so SDK requests authenticate even when a caller
+// passes its own HTTP client.
+func TestNewPSClientCallerHTTPClientCannotDropAuth(t *testing.T) {
+	var gotAuth []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Values("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`{}`))
+		assert.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewPSClient("token-name", "token-value",
+		ps.WithBaseURL(server.URL),
+		ps.WithHTTPClient(&http.Client{}),
+	)
+	require.NoError(t, err)
+
+	_, err = client.GetBranch(t.Context(), &ps.GetDatabaseBranchRequest{
+		Organization: "org",
+		Database:     "db",
+		Branch:       "main",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"token-name:token-value"}, gotAuth)
 }
 
 // The SDK's service-token option wraps the transport of the client installed

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -112,6 +112,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/status"
 
 	"github.com/block/schemabot/pkg/engine"
@@ -197,6 +198,77 @@ const retryServiceConfig = `{
 	}]
 }`
 
+// Default per-RPC deadlines applied when the caller's context carries none.
+// Operator drive goroutines run on unbounded contexts while a separate
+// heartbeat goroutine keeps renewing the apply lease, so an RPC that hangs on
+// a black-holed connection would wedge the apply forever without a peer ever
+// seeing a stale heartbeat. These bounds exist so every outbound call
+// eventually returns — bounded, not tuned.
+const (
+	// grpcControlRPCDeadline bounds the polling and control RPCs (Progress,
+	// Cutover, Stop, Cancel, Start, Health). They are storage lookups or
+	// durable control-request writes on the data plane, so this is
+	// comfortably above their normal latency.
+	grpcControlRPCDeadline = 60 * time.Second
+
+	// grpcHeavyRPCDeadline bounds the RPCs that do synchronous engine or
+	// live-schema work before returning: Apply/Plan/PlanDiff/PullSchema
+	// resolve plans and inspect live schema, and Volume/Revert/SkipRevert
+	// invoke the engine control operation inline. Generous because a large
+	// database takes a while to diff and an engine restart is not instant; a
+	// DEADLINE_EXCEEDED on Apply is handled as an ambiguous dispatch outcome
+	// and recovered through the idempotency key.
+	grpcHeavyRPCDeadline = 5 * time.Minute
+)
+
+// grpcMethodDeadline returns the default deadline for a Tern unary RPC.
+func grpcMethodDeadline(fullMethod string) time.Duration {
+	switch fullMethod {
+	case ternv1.Tern_Apply_FullMethodName,
+		ternv1.Tern_Plan_FullMethodName,
+		ternv1.Tern_PlanDiff_FullMethodName,
+		ternv1.Tern_PullSchema_FullMethodName,
+		ternv1.Tern_Volume_FullMethodName,
+		ternv1.Tern_Revert_FullMethodName,
+		ternv1.Tern_SkipRevert_FullMethodName:
+		return grpcHeavyRPCDeadline
+	default:
+		return grpcControlRPCDeadline
+	}
+}
+
+// defaultRPCDeadlineInterceptor returns a unary client interceptor that
+// applies the per-method default deadline when the caller's context has none.
+// A caller that already set a deadline keeps it — the interceptor only closes
+// the unbounded-context hole. The deadlines are parameters so tests can prove
+// the bound with short durations; production dialing uses the package
+// constants via grpcMethodDeadline.
+func defaultRPCDeadlineInterceptor(deadlineFor func(fullMethod string) time.Duration) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, deadlineFor(method))
+			defer cancel()
+		}
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}
+
+// clientKeepaliveParams returns the transport keepalive settings for the Tern
+// connection so a dead peer is detected and the channel reconnects instead of
+// new RPCs queueing onto a broken connection. The values stay within gRPC's
+// default server-side keepalive enforcement (minimum ping interval, no pings
+// without active streams) because embedders attach the Tern service to their
+// own servers, which may not configure a custom enforcement policy — a more
+// aggressive client would be disconnected with ENHANCE_YOUR_CALM.
+func clientKeepaliveParams() keepalive.ClientParameters {
+	return keepalive.ClientParameters{
+		Time:                5 * time.Minute,
+		Timeout:             20 * time.Second,
+		PermitWithoutStream: false,
+	}
+}
+
 // NewGRPCClient creates a new gRPC client connected to the given address.
 //
 // The address may include a port (e.g. "tern.example.com:80"). The full
@@ -214,6 +286,8 @@ func NewGRPCClient(config Config) (*GRPCClient, error) {
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithAuthority(host),
 		grpc.WithDefaultServiceConfig(retryServiceConfig),
+		grpc.WithKeepaliveParams(clientKeepaliveParams()),
+		grpc.WithUnaryInterceptor(defaultRPCDeadlineInterceptor(grpcMethodDeadline)),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("dial %s: %w", config.Address, err)

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -5274,3 +5274,129 @@ func TestRemoteApplyIdempotencyKey_OperationAttemptRotation(t *testing.T) {
 	assert.NotEqual(t, base, remoteApplyIdempotencyKey(applyOwn, scopeOwn),
 		"this operation's own attempt advancing must rotate its key")
 }
+
+// hangingTernServer blocks every RPC until the client gives up, simulating a
+// remote deployment whose process is alive but never answers (black-holed
+// connection, wedged data plane).
+type hangingTernServer struct {
+	ternv1.UnimplementedTernServer
+}
+
+func (s *hangingTernServer) Progress(ctx context.Context, _ *ternv1.ProgressRequest) (*ternv1.ProgressResponse, error) {
+	<-ctx.Done()
+	return nil, status.FromContextError(ctx.Err()).Err()
+}
+
+func (s *hangingTernServer) Apply(ctx context.Context, _ *ternv1.ApplyRequest) (*ternv1.ApplyResponse, error) {
+	<-ctx.Done()
+	return nil, status.FromContextError(ctx.Err()).Err()
+}
+
+// newDeadlineTestClient starts an in-process Tern gRPC server and connects a
+// client that applies default per-RPC deadlines through the production
+// interceptor, with the deadline function injected so tests can use short
+// bounds.
+func newDeadlineTestClient(t *testing.T, server ternv1.TernServer, deadlineFor func(string) time.Duration) *GRPCClient {
+	t.Helper()
+
+	lis, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "localhost:0")
+	require.NoError(t, err, "failed to listen")
+
+	grpcServer := grpc.NewServer()
+	ternv1.RegisterTernServer(grpcServer, server)
+	go func() {
+		_ = grpcServer.Serve(lis)
+	}()
+
+	conn, err := grpc.NewClient(
+		lis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithUnaryInterceptor(defaultRPCDeadlineInterceptor(deadlineFor)),
+	)
+	require.NoError(t, err, "failed to dial")
+
+	client := &GRPCClient{
+		conn:   conn,
+		client: ternv1.NewTernClient(conn),
+	}
+	t.Cleanup(func() {
+		utils.CloseAndLog(client)
+		grpcServer.Stop()
+	})
+	return client
+}
+
+// A drive goroutine polls Progress on an unbounded context. When the remote
+// deployment stops answering, the call must return DEADLINE_EXCEEDED at the
+// default per-RPC deadline instead of blocking the driver forever while its
+// lease heartbeat keeps the apply claimed.
+func TestGRPCClientBoundsRPCsWithoutCallerDeadline(t *testing.T) {
+	client := newDeadlineTestClient(t, &hangingTernServer{}, func(string) time.Duration {
+		return 100 * time.Millisecond
+	})
+
+	start := time.Now()
+	_, err := client.Progress(t.Context(), &ternv1.ProgressRequest{ApplyId: "tern-1"})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
+	assert.Less(t, time.Since(start), 10*time.Second, "call must return by the default deadline, not hang")
+}
+
+// A caller that sets its own deadline keeps it — the default only fills in
+// for unbounded contexts.
+func TestGRPCClientKeepsCallerDeadline(t *testing.T) {
+	client := newDeadlineTestClient(t, &hangingTernServer{}, func(string) time.Duration {
+		return time.Hour
+	})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := client.Progress(ctx, &ternv1.ProgressRequest{ApplyId: "tern-1"})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
+	assert.Less(t, time.Since(start), 10*time.Second, "caller deadline must win over the default")
+}
+
+// RPCs that do synchronous engine or live-schema work server-side get the
+// generous bound; polling and control-request RPCs get the tight one.
+func TestGRPCMethodDeadlineRouting(t *testing.T) {
+	heavy := []string{
+		ternv1.Tern_Apply_FullMethodName,
+		ternv1.Tern_Plan_FullMethodName,
+		ternv1.Tern_PlanDiff_FullMethodName,
+		ternv1.Tern_PullSchema_FullMethodName,
+		ternv1.Tern_Volume_FullMethodName,
+		ternv1.Tern_Revert_FullMethodName,
+		ternv1.Tern_SkipRevert_FullMethodName,
+	}
+	for _, method := range heavy {
+		assert.Equal(t, grpcHeavyRPCDeadline, grpcMethodDeadline(method), method)
+	}
+
+	control := []string{
+		ternv1.Tern_Progress_FullMethodName,
+		ternv1.Tern_Cutover_FullMethodName,
+		ternv1.Tern_Stop_FullMethodName,
+		ternv1.Tern_Cancel_FullMethodName,
+		ternv1.Tern_Start_FullMethodName,
+		ternv1.Tern_Health_FullMethodName,
+	}
+	for _, method := range control {
+		assert.Equal(t, grpcControlRPCDeadline, grpcMethodDeadline(method), method)
+	}
+}
+
+// The keepalive settings must stay within gRPC's default server-side
+// enforcement policy: embedders attach the Tern service to their own servers,
+// and a client that pings faster than the server's minimum interval or
+// without active streams is disconnected with ENHANCE_YOUR_CALM.
+func TestClientKeepaliveParamsStayWithinDefaultEnforcement(t *testing.T) {
+	params := clientKeepaliveParams()
+	assert.GreaterOrEqual(t, params.Time, 5*time.Minute, "must not ping faster than the default server minimum")
+	assert.False(t, params.PermitWithoutStream, "default server enforcement rejects pings without active streams")
+	assert.Positive(t, params.Timeout)
+}


### PR DESCRIPTION
## Why this matters

A drive goroutine runs on an unbounded context while a separate heartbeat goroutine keeps renewing the apply lease. If one outbound call hangs on a black-holed connection (dropped packets, dead NAT entry, half-open TCP), the driver blocks forever — and because the heartbeat keeps the lease fresh, no peer ever sees a stale lease and reclaims the apply. One dead connection wedges the apply until a human intervenes.

## What it does

Bounds all three outbound legs of the drive path; the lease/heartbeat design is untouched.

- **Tern gRPC**: client keepalive params (kept within gRPC's default server-side enforcement so embedder-attached servers don't GOAWAY the channel) plus a unary interceptor that applies a default per-RPC deadline when the caller's context has none — 60s for polling/control RPCs, 5m for RPCs that do synchronous engine or live-schema work (`Apply`, `Plan`, `PlanDiff`, `PullSchema`, `Volume`, `Revert`, `SkipRevert`). A caller-supplied deadline always wins. A `DEADLINE_EXCEEDED` on `Apply` is handled as an ambiguous dispatch outcome and recovered via the idempotency key.
- **PlanetScale API**: the SDK client is built on a timeout-bearing HTTP client (5m — deploy request creation and branch schema diffs can legitimately take minutes), installed after caller options so no option can displace the bound or the service-token auth. The raw-HTTP throttle endpoint moves off `http.DefaultClient` onto its own bounded client.
- **MySQL connections**: DSN normalization fills in connect (30s), read (30m), and write (1m) timeouts, keeping any explicit DSN values. The read timeout applies per network read, so streamed result sets are unaffected; it is deliberately long because it must outlast legitimate silent waits (advisory-lock waits, DDL statements). Spirit opens its own connections and is unaffected.
- All bounds are generous named constants: the invariant is "no outbound call is unbounded", not "calls are fast".

## Before / after

```
driver goroutine                    heartbeat goroutine
  Progress RPC ─▶ (black hole,        renew lease ✓
                  hangs forever)      renew lease ✓ ...
  never returns ❌                    lease never stale ⛔ no peer reclaims
                                      apply wedged until a human intervenes
```

```
driver goroutine                    heartbeat goroutine
  Progress RPC ─▶ DEADLINE_EXCEEDED at the per-RPC bound ✅
  drive errors out, owner exits       heartbeat stops
                                      lease goes stale ─▶ peer reclaims and resumes ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
