### PR TITLE
feat(observability): count per-deployment review diffs and guard shard survival

### DIFF
--- a/pkg/api/plan_deployment_diffs.go
+++ b/pkg/api/plan_deployment_diffs.go
@@ -6,6 +6,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	"github.com/block/schemabot/pkg/metrics"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/routing"
 )
@@ -65,9 +66,12 @@ func (s *Service) PlanDeploymentDiffs(ctx context.Context, req PlanRequest, prim
 			Target:       target.Target,
 		}
 
-		// Rollout index 0 is the primary. When its reviewed plan is provided,
-		// reuse it so the rollup's primary member is exactly what was reviewed and
-		// no redundant live-schema read runs.
+		// Rollout index 0 is the primary. ResolveDatabaseTargets returns targets
+		// in rollout order, primary first, so the primary is positionally index 0;
+		// a future change to that ordering would misattribute the primary here and
+		// must keep primary-first. When its reviewed plan is provided, reuse it so
+		// the rollup's primary member is exactly what was reviewed and no redundant
+		// live-schema read runs.
 		if i == 0 && primaryPlan != nil {
 			results[i].Engine = primaryPlan.Engine
 			results[i].Changes = primaryPlan.Changes
@@ -82,7 +86,6 @@ func (s *Service) PlanDeploymentDiffs(ctx context.Context, req PlanRequest, prim
 			continue
 		}
 
-		i, target := i, target
 		g.Go(func() error {
 			resp, err := s.planDeploymentDiff(gctx, req, target)
 			if err != nil {
@@ -92,6 +95,7 @@ func (s *Service) PlanDeploymentDiffs(ctx context.Context, req PlanRequest, prim
 					"deployment", target.Deployment,
 					"target", target.Target,
 					"error", err)
+				metrics.RecordDeploymentDiff(gctx, req.Database, target.Deployment, req.Environment, "errored")
 				results[i].Err = err
 				return nil
 			}
@@ -110,8 +114,11 @@ func (s *Service) PlanDeploymentDiffs(ctx context.Context, req PlanRequest, prim
 					"deployment", target.Deployment,
 					"target", target.Target,
 					"error", diffErr)
+				metrics.RecordDeploymentDiff(gctx, req.Database, target.Deployment, req.Environment, "errored")
 				results[i].Err = diffErr
+				return nil
 			}
+			metrics.RecordDeploymentDiff(gctx, req.Database, target.Deployment, req.Environment, "ok")
 			return nil
 		})
 	}

--- a/pkg/api/plan_deployment_diffs_test.go
+++ b/pkg/api/plan_deployment_diffs_test.go
@@ -145,6 +145,73 @@ func TestPlanDeploymentDiffs_PerDeploymentErrorIsCaptured(t *testing.T) {
 	assert.Nil(t, results[1].Changes)
 }
 
+// A deployment's PlanDiff can carry per-shard plans, and the deployment and
+// shard axes are orthogonal: the producer iterates deployments while each
+// deployment's single diff retains its full per-shard set. This guards that the
+// producer copies resp.Shards through, so per-shard drift within a deployment
+// stays visible to the rollup rather than being flattened away.
+func TestPlanDeploymentDiffs_PreservesShards(t *testing.T) {
+	usShards := &ternv1.PlanDiffResponse{
+		Engine: ternv1.Engine_ENGINE_SPIRIT,
+		Shards: []*ternv1.ShardPlan{
+			{
+				Shard:     "-80",
+				Namespace: "testapp",
+				Changes: []*ternv1.TableChange{{
+					TableName:  "users",
+					ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER,
+					Ddl:        "ALTER TABLE `users` ADD COLUMN `email` varchar(255)",
+					Namespace:  "testapp",
+				}},
+			},
+			{
+				Shard:     "80-",
+				Namespace: "testapp",
+				Changes: []*ternv1.TableChange{{
+					TableName:  "users",
+					ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER,
+					Ddl:        "ALTER TABLE `users` ADD COLUMN `phone` varchar(32)",
+					Namespace:  "testapp",
+				}},
+			},
+		},
+	}
+	eu := &mockTernClient{}
+	us := &mockTernClient{planDiffResp: usShards}
+	svc := twoDeploymentService(t, eu, us)
+
+	primaryPlan := &ternv1.PlanResponse{
+		PlanId: "plan_eu",
+		Engine: ternv1.Engine_ENGINE_SPIRIT,
+		Shards: []*ternv1.ShardPlan{{
+			Shard:     "0",
+			Namespace: "testapp",
+			Changes: []*ternv1.TableChange{{
+				TableName:  "users",
+				ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER,
+				Ddl:        "ALTER TABLE `users` ADD COLUMN `email` varchar(255)",
+				Namespace:  "testapp",
+			}},
+		}},
+	}
+
+	results, err := svc.PlanDeploymentDiffs(t.Context(), planDiffReq(t), primaryPlan)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	// The primary reuses the reviewed plan's shard set verbatim.
+	require.NoError(t, results[0].Err)
+	assert.Equal(t, primaryPlan.Shards, results[0].Shards)
+
+	// The non-primary deployment's full two-shard set survives the producer.
+	require.NoError(t, results[1].Err)
+	require.Len(t, results[1].Shards, 2)
+	assert.Equal(t, "-80", results[1].Shards[0].Shard)
+	assert.Equal(t, "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", results[1].Shards[0].Changes[0].Ddl)
+	assert.Equal(t, "80-", results[1].Shards[1].Shard)
+	assert.Equal(t, "ALTER TABLE `users` ADD COLUMN `phone` varchar(32)", results[1].Shards[1].Changes[0].Ddl)
+}
+
 // A request-level failure (the database/environment resolves no deployments)
 // returns an error rather than a per-deployment result.
 func TestPlanDeploymentDiffs_UnresolvedTargetsError(t *testing.T) {

--- a/pkg/metrics/README.md
+++ b/pkg/metrics/README.md
@@ -15,6 +15,7 @@ available, such as `repository`, `github_app`, and `installation_id`.
 | `schemabot.plan.duration_seconds` | Histogram | repository, database, environment, status | Plan execution time |
 | `schemabot.applies.total` | Counter | repository, database, environment, status | Total apply operations |
 | `schemabot.apply.duration_seconds` | Histogram | repository, database, environment, status | Apply API call time |
+| `schemabot.deployment_diff.total` | Counter | database, deployment, environment, status | Review-time per-deployment plan diffs by outcome (the fan-out that feeds the drift rollup) |
 | `schemabot.schema_freshness.rejected.total` | Counter | action, environment | Plan/apply/apply-confirm rejected because PR HEAD advanced after discovery loaded schema files |
 | `schemabot.command.rejected_stale_plan.total` | Counter | action, environment | Apply-confirm rejected because PR HEAD advanced after the confirmation plan was posted |
 | `schemabot.source_policy.blocks_total` | Counter | operation, database, environment, reason | Trusted-source plan/apply requests blocked by source policy |
@@ -49,6 +50,8 @@ available, such as `repository`, `github_app`, and `installation_id`.
 **status** (plans): `success`, `error`
 
 **status** (applies): `success`, `error`, `rejected`, `conflict`
+
+**status** (deployment diff): `ok`, `errored`
 
 **action** (schema freshness): `plan`, `apply`, `apply_confirm`, `unknown`
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -130,6 +130,22 @@ func RecordPlanDuration(ctx context.Context, duration time.Duration, repo, datab
 	)
 }
 
+// RecordDeploymentDiff counts one deployment's review-time desired-vs-live diff
+// outcome. status is "ok" when the diff was computed and reported no planning
+// errors, or "errored" when the PlanDiff RPC failed or the diff itself reported
+// errors — the branch that makes a deployment block the review-time drift rollup
+// closed. Alert on the errored count so an unreachable or un-diffable deployment
+// gating merges is investigable without waiting on the rollup layer.
+func RecordDeploymentDiff(ctx context.Context, database, deployment, environment, status string) {
+	addCounter(ctx, "schemabot.deployment_diff.total",
+		"Total number of review-time per-deployment plan diffs by outcome", "{diff}",
+		attribute.String("database", database),
+		DeploymentAttribute(deployment),
+		EnvironmentAttribute(environment),
+		attribute.String("status", status),
+	)
+}
+
 // RecordApply increments the applies counter with database, deployment, environment, and status attributes.
 // Status should be "success", "error", "rejected", or "conflict".
 func RecordApply(ctx context.Context, repo, database, deployment, environment, status string) {


### PR DESCRIPTION
## Summary
Non-blocking follow-ups from the review of the per-deployment plan-diff producer. Adds an actionable counter on the producer's error branch, closes a producer-layer test gap for per-shard survival, hardens the positional-primary invariant, and drops a redundant loop-variable capture.

## What
- **Metric:** `schemabot.deployment_diff.total` (`status=ok|errored`) on the per-deployment diff fan-out — `errored` fires when the `PlanDiff` RPC fails or the diff reports planning errors, the branch that makes a deployment block the review rollup closed. The primary-reuse path runs no diff and emits no counter.
- **Test:** `TestPlanDeploymentDiffs_PreservesShards` feeds a non-primary `PlanDiffResponse` with two `ShardPlan`s and asserts the producer copies the full per-shard set through, so per-shard drift within a deployment stays visible rather than being flattened.
- **Primary invariant:** a comment ties "rollout index 0 is the primary" to the primary-first target resolution order, so a future reorder that would misattribute the primary is called out.
- **Nit:** removed the redundant `i, target := i, target` capture (per-iteration loop vars on Go 1.22+).

## Why
The per-deployment error branch was Warn-logged but had no counter, so a deployment repeatedly failing its diff and gating merges was not directly alertable. The producer is the layer that preserves the per-shard dimension a drift rollup needs, but no producer test fed a sharded response — a regression dropping the shard copy would have gone undetected here.
