### PR TITLE
chore(deps): bump block/vitess to pick up mysqltopo correctness fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -264,7 +264,7 @@ require (
 )
 
 // needed for Strata and vtcombo OnlineDDL suppport
-replace vitess.io/vitess => github.com/block/vitess v0.0.0-20260626202504-ceae63376aaa
+replace vitess.io/vitess => github.com/block/vitess v0.0.0-20260702135400-add994347c62
 
 // needed for SPATIAL index support in Spirit v0.13.0
 replace github.com/pingcap/tidb/pkg/parser => github.com/block/tidb/pkg/parser v0.0.0-20260506200501-e528fd979fc8

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/block/spirit v0.15.2-0.20260629112820-8f451ff83766 h1:zMEF7E4k886bl2u
 github.com/block/spirit v0.15.2-0.20260629112820-8f451ff83766/go.mod h1:ku7mCCKx7Wk4QrMa/mHnsqQhZkoUD2vdBkpjJEDk4lY=
 github.com/block/tidb/pkg/parser v0.0.0-20260506200501-e528fd979fc8 h1:+OfdTacrEyjlqcRUpBFX9uJ6ROBq6cUjwY4DClhnsdU=
 github.com/block/tidb/pkg/parser v0.0.0-20260506200501-e528fd979fc8/go.mod h1:zDLDsfNBU5+L6T4J9/OgWAHc/WZvMUjbpgHqQ/t3yKo=
-github.com/block/vitess v0.0.0-20260626202504-ceae63376aaa h1:TcxuMn8uWNfflF775gh65Tm5wdEQY15DvvmaKYKtl5U=
-github.com/block/vitess v0.0.0-20260626202504-ceae63376aaa/go.mod h1:tOLnFt2ryuSGSYZ9NxLjsRhYrWxGBxz/z0zxrvuWYwE=
+github.com/block/vitess v0.0.0-20260702135400-add994347c62 h1:mIWQ8KeqzsJ6xLQfYs6Vp9zmi47ermvOL1RCFW0dE3U=
+github.com/block/vitess v0.0.0-20260702135400-add994347c62/go.mod h1:tOLnFt2ryuSGSYZ9NxLjsRhYrWxGBxz/z0zxrvuWYwE=
 github.com/bndr/gotabulate v1.1.2 h1:yC9izuZEphojb9r+KYL4W9IJKO/ceIO8HDwxMA24U4c=
 github.com/bndr/gotabulate v1.1.2/go.mod h1:0+8yUgaPTtLRTjf49E8oju7ojpU11YmXyvq1LbPAb3U=
 github.com/bradleyfalzon/ghinstallation/v2 v2.18.0 h1:WPqnN6NS9XvYlOgZQAIseN7Z1uAiE+UxgDKlW7FvFuU=


### PR DESCRIPTION
Bumps the `vitess.io/vitess` replace to block/vitess `release-24.0` head (`add994347c62`), picking up [block/vitess#18](https://github.com/block/vitess/pull/18) — the mysqltopo lock/watch correctness fixes. Same bump as [strata#126](https://github.com/squareup/strata/pull/126) and [gap#11929](https://github.com/squareup/gap/pull/11929):

- Topo lock mutual exclusion: per-attempt expiry and ownership-token matching (a stalled holder can no longer validate/extend/delete the next holder's lock)
- Unconditional topo updates use an atomic `version = version + 1` upsert — concurrent SrvVSchema/RoutingRules writes can no longer produce duplicate versions that made changes invisible to watchers
- Watches register before the initial read (no silently-missed gap changes)
- A dead notification system cancels its watchers (`topo.Interrupted`) and is replaced on next acquisition instead of starving all watches

Verification: `make test-unit` fully green (`-race`, all packages). I ran `make test-integration` locally twice on this branch and once on unbumped `main`: all three runs show overlapping, infra-flavored flakes (testcontainers teardown `context canceled`, state-machine timeouts the Makefile itself warns about under CPU contention) — `main` fails the same way, so the bump is not implicated; CI should arbitrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)