### PR TITLE
feat(github): trusted participant comments nudge the leader aggregate re-fold

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -1518,6 +1518,18 @@ type ResolvedGitHubApp struct {
 	Config GitHubAppConfig
 }
 
+// TrustedCheckAppSlugsForRepo returns the trusted sibling SchemaBot App slugs
+// configured for the App that owns repo, or nil when the repo resolves to no
+// App. Callers use this to recognize a sibling deployment by its bot identity
+// (login "<slug>[bot]") with the same trust set that gates Check Run reads.
+func (c *ServerConfig) TrustedCheckAppSlugsForRepo(repo string) []string {
+	app, err := c.ResolveGitHubAppForRepo(repo)
+	if err != nil {
+		return nil
+	}
+	return app.Config.TrustedCheckAppSlugs
+}
+
 // ResolveGitHubAppForRepo returns the GitHub App that owns webhooks and
 // outbound GitHub API calls for the given repository.
 //

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -1525,6 +1525,8 @@ type ResolvedGitHubApp struct {
 func (c *ServerConfig) TrustedCheckAppSlugsForRepo(repo string) []string {
 	app, err := c.ResolveGitHubAppForRepo(repo)
 	if err != nil {
+		slog.Warn("no GitHub App resolves for repo; treating its trusted check App slugs as empty",
+			"repo", repo, "error", err)
 		return nil
 	}
 	return app.Config.TrustedCheckAppSlugs

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1079,6 +1079,7 @@ var knownStatusCheckOperations = map[string]bool{
 	"managed_dir_missing_config":           true,
 	"aggregate_participant_skip":           true,
 	"aggregate_participant_fanout":         true,
+	"participant_comment_nudge":            true,
 }
 
 var knownStatusCheckStatuses = map[string]bool{

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -80,6 +80,11 @@ type Handler struct {
 	// the package default.
 	transientPlanRetryDelay time.Duration
 
+	// participantNudgeRefoldDelay overrides the pause before the second
+	// aggregate re-fold after a participant-comment nudge. Zero means the
+	// package default.
+	participantNudgeRefoldDelay time.Duration
+
 	// webhookSecretsByApp maps each configured App's logical name to its
 	// HMAC webhook secret. In legacy single-App mode there is exactly one
 	// entry under defaultAppName. In multi-App mode there is one entry per

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -60,14 +60,6 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 		return
 	}
 
-	// Ignore comments from bots to prevent infinite loops
-	if payload.Comment.User != nil && payload.Comment.User.Type == "Bot" {
-		h.writeJSON(w, http.StatusOK, map[string]string{
-			"message": "event ignored (comment from bot)",
-		})
-		return
-	}
-
 	var payloadInstallationID int64
 	if payload.Installation != nil {
 		payloadInstallationID = payload.Installation.ID
@@ -81,6 +73,25 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 	requestedBy := ""
 	if payload.Comment.User != nil {
 		requestedBy = payload.Comment.User.Login
+	}
+
+	// Ignore comments from bots to prevent infinite loops. The one exception is
+	// a trusted sibling SchemaBot deployment's comment on a repo this
+	// deployment leads: it is consumed as an aggregate re-fold nudge — never
+	// parsed as a command — because participants comment at exactly the moments
+	// their Check Runs change, and GitHub delivers check_run events only to the
+	// App that created the check.
+	if payload.Comment.User != nil && payload.Comment.User.Type == "Bot" {
+		if h.participantCommentNudge(ctx, repo, pr, installationID, requestedBy) {
+			h.writeJSON(w, http.StatusOK, map[string]string{
+				"message": "participant comment triggered aggregate re-fold",
+			})
+			return
+		}
+		h.writeJSON(w, http.StatusOK, map[string]string{
+			"message": "event ignored (comment from bot)",
+		})
+		return
 	}
 
 	// Parse command

--- a/pkg/webhook/participant_nudge.go
+++ b/pkg/webhook/participant_nudge.go
@@ -47,8 +47,11 @@ func (h *Handler) participantCommentNudge(ctx context.Context, repo string, pr i
 
 	h.goSafe(repo, pr, installationID, func() {
 		h.refoldAggregateForPR(repo, pr, installationID, "participant comment")
-		time.Sleep(h.nudgeRefoldDelay())
-		h.refoldAggregateForPR(repo, pr, installationID, "participant comment delayed pass")
+	})
+	time.AfterFunc(h.nudgeRefoldDelay(), func() {
+		h.goSafe(repo, pr, installationID, func() {
+			h.refoldAggregateForPR(repo, pr, installationID, "participant comment delayed pass")
+		})
 	})
 	return true
 }

--- a/pkg/webhook/participant_nudge.go
+++ b/pkg/webhook/participant_nudge.go
@@ -1,0 +1,100 @@
+package webhook
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/block/schemabot/pkg/metrics"
+)
+
+// defaultParticipantNudgeRefoldDelay is the pause before the second re-fold
+// after a participant-comment nudge. A participant posts its terminal summary
+// comment moments before its Check Run updates, so a single immediate fold can
+// read pre-terminal state; the delayed pass converges without a standing
+// poller.
+const defaultParticipantNudgeRefoldDelay = 45 * time.Second
+
+// participantCommentNudge treats a trusted sibling SchemaBot deployment's PR
+// comment as a re-fold trigger for this deployment's aggregate check. The
+// comment is a doorbell, not a message: its body is never parsed or trusted.
+// GitHub delivers check_run events only to the App that created the check, so
+// the leader never hears a participant's check complete directly — but
+// issue_comment events are repo-scoped, and participants comment at exactly
+// the moments their Check Runs change (plan posted, apply summary, rollback).
+// The fold re-reads every participant's authoritative Check Run via the
+// trusted API path, so a spurious nudge can cause at most wasted work, never a
+// wrongly-passing check.
+//
+// Returns false when the comment is not a nudge — not a led repo, or not a
+// trusted sibling's bot — so the caller keeps its normal bot handling.
+func (h *Handler) participantCommentNudge(ctx context.Context, repo string, pr int, installationID int64, authorLogin string) bool {
+	if h.service == nil || !h.service.Config().IsAggregateLeaderForRepo(repo) {
+		return false
+	}
+	if !h.isTrustedParticipantBotLogin(repo, authorLogin) {
+		return false
+	}
+
+	h.logger.Info("trusted participant comment triggered aggregate re-fold",
+		"repo", repo, "pr", pr, "author", authorLogin)
+	metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+		Operation:  "participant_comment_nudge",
+		Repository: repo,
+		Status:     "success",
+	})
+
+	h.goSafe(repo, pr, installationID, func() {
+		h.refoldAggregateForPR(repo, pr, installationID, "participant comment")
+		time.Sleep(h.nudgeRefoldDelay())
+		h.refoldAggregateForPR(repo, pr, installationID, "participant comment delayed pass")
+	})
+	return true
+}
+
+// isTrustedParticipantBotLogin reports whether a comment author is a trusted
+// sibling SchemaBot deployment's GitHub App bot: login "<slug>[bot]" for a
+// slug in the repo's trusted-check-app-slugs — the same trust set that gates
+// the aggregate fold's Check Run reads.
+func (h *Handler) isTrustedParticipantBotLogin(repo, login string) bool {
+	slug, ok := strings.CutSuffix(login, "[bot]")
+	if !ok {
+		return false
+	}
+	config, ok := h.serverConfig()
+	if !ok {
+		return false
+	}
+	return slices.Contains(config.TrustedCheckAppSlugsForRepo(repo), slug)
+}
+
+func (h *Handler) nudgeRefoldDelay() time.Duration {
+	if h.participantNudgeRefoldDelay > 0 {
+		return h.participantNudgeRefoldDelay
+	}
+	return defaultParticipantNudgeRefoldDelay
+}
+
+// refoldAggregateForPR re-reads the PR's current head and re-runs the
+// aggregate fold against it. The head is fetched fresh on every pass so a
+// nudge raced by a new commit folds the commit that is actually current;
+// updateAggregateCheck independently verifies head freshness before writing.
+func (h *Handler) refoldAggregateForPR(repo string, pr int, installationID int64, trigger string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client, err := h.clientForRepo(repo, installationID)
+	if err != nil {
+		h.logger.Error("failed to create GitHub client for aggregate re-fold",
+			"repo", repo, "pr", pr, "trigger", trigger, "error", err)
+		return
+	}
+	prInfo, err := client.FetchPullRequestNoCache(ctx, repo, pr)
+	if err != nil {
+		h.logger.Error("failed to fetch PR head for aggregate re-fold",
+			"repo", repo, "pr", pr, "trigger", trigger, "error", err)
+		return
+	}
+	h.updateAggregateCheck(ctx, client, repo, pr, prInfo.HeadSHA)
+}

--- a/pkg/webhook/participant_nudge_integration_test.go
+++ b/pkg/webhook/participant_nudge_integration_test.go
@@ -165,3 +165,146 @@ func TestE2EParticipantCommentNudgeLeaderOnly(t *testing.T) {
 	case <-time.After(300 * time.Millisecond):
 	}
 }
+
+// collectAggregateConclusion drains published aggregates for name until one
+// carries the wanted conclusion, tolerating interleaved publishes from the
+// immediate and delayed fold passes.
+func collectAggregateConclusion(t *testing.T, checkRuns chan checkRunCapture, name, wantConclusion string) checkRunCapture {
+	t.Helper()
+	deadline := time.After(webhookIntegrationCheckRunDeadline)
+	for {
+		select {
+		case cr := <-checkRuns:
+			if cr.Name == name && cr.Conclusion == wantConclusion {
+				return cr
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for aggregate %q with conclusion %q", name, wantConclusion)
+		}
+	}
+}
+
+// A rollback on a participant must never leave the leader green. The
+// participant's check reads action_required after a completed rollback (the
+// PR's change is reverted), so a nudge-triggered fold blocks the aggregate —
+// and it stays blocked until a fold reads positive evidence again: a trusted,
+// completed, successful participant check from a fresh apply. There is no
+// timeout or default path back to green.
+func TestE2EParticipantCommentNudgeFailClosedThroughRollback(t *testing.T) {
+	svc := setupE2EServiceWithConfig(t, nudgeLeaderConfig())
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	const headSHA = "abc123"
+	mockLeaderPRHead(mux, headSHA)
+	mockLeaderPRFilesTouchTenantB(mux)
+	prodCheckName := aggregateCheckNameForEnv(tenantBCheckName, "production")
+	stagingCheckName := aggregateCheckNameForEnv(tenantBCheckName, "staging")
+	// The participant completed a rollback: its check is action_required.
+	participantRuns := map[string]map[string]any{
+		prodCheckName: {
+			"id": 6001, "name": prodCheckName, "status": "completed", "conclusion": "action_required",
+			"app": map[string]any{"slug": trustedTenantAppSlug},
+		},
+		stagingCheckName: {
+			"id": 6002, "name": stagingCheckName, "status": "completed", "conclusion": "action_required",
+			"app": map[string]any{"slug": trustedTenantAppSlug},
+		},
+	}
+	mockParticipantCheckRuns(mux, participantRuns)
+	checkRuns := captureLeaderCheckRuns(mux)
+
+	h := newLeaderHandler(t, svc, client)
+	h.participantNudgeRefoldDelay = 10 * time.Millisecond
+
+	req := buildParticipantBotCommentRequest(t, trustedTenantAppSlug+"[bot]")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// A completed-but-not-successful participant check (action_required after a
+	// rollback) folds as failure — the strongest blocking conclusion.
+	blocked := collectAggregateConclusion(t, checkRuns, aggregateCheckNameForEnv("SchemaBot", "production"), checkConclusionFailure)
+	assert.Equal(t, headSHA, blocked.HeadSHA)
+	assert.Equal(t, checkStatusCompleted, blocked.Status,
+		"a rolled-back participant blocks the aggregate")
+
+	// A fresh apply completes on the participant: its check reads success.
+	// Only now may a fold emit green.
+	participantRuns[prodCheckName]["conclusion"] = "success"
+	participantRuns[stagingCheckName]["conclusion"] = "success"
+
+	req = buildParticipantBotCommentRequest(t, trustedTenantAppSlug+"[bot]")
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// The green publish edits the existing Check Run in place (update payloads
+	// carry no head_sha); reaching this collect at all proves green returned
+	// only after the fold read a trusted, completed, successful participant
+	// check.
+	green := collectAggregateConclusion(t, checkRuns, aggregateCheckNameForEnv("SchemaBot", "production"), checkConclusionSuccess)
+	assert.Equal(t, checkStatusCompleted, green.Status)
+}
+
+// While a participant's apply or rollback is executing, its check run is
+// non-terminal; a nudge-triggered fold maps that to in_progress and the
+// aggregate blocks. The leader cannot emit green while work is visibly in
+// flight on any expected participant.
+func TestE2EParticipantCommentNudgeBlocksOnInProgressParticipant(t *testing.T) {
+	svc := setupE2EServiceWithConfig(t, nudgeLeaderConfig())
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	const headSHA = "abc123"
+	mockLeaderPRHead(mux, headSHA)
+	mockLeaderPRFilesTouchTenantB(mux)
+	prodCheckName := aggregateCheckNameForEnv(tenantBCheckName, "production")
+	stagingCheckName := aggregateCheckNameForEnv(tenantBCheckName, "staging")
+	mockParticipantCheckRuns(mux, map[string]map[string]any{
+		prodCheckName: {
+			"id": 6101, "name": prodCheckName, "status": "in_progress",
+			"app": map[string]any{"slug": trustedTenantAppSlug},
+		},
+		stagingCheckName: {
+			"id": 6102, "name": stagingCheckName, "status": "in_progress",
+			"app": map[string]any{"slug": trustedTenantAppSlug},
+		},
+	})
+	checkRuns := captureLeaderCheckRuns(mux)
+
+	h := newLeaderHandler(t, svc, client)
+	h.participantNudgeRefoldDelay = 10 * time.Millisecond
+
+	req := buildParticipantBotCommentRequest(t, trustedTenantAppSlug+"[bot]")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	deadline := time.After(webhookIntegrationCheckRunDeadline)
+	for {
+		select {
+		case cr := <-checkRuns:
+			if cr.Name != aggregateCheckNameForEnv("SchemaBot", "production") {
+				continue
+			}
+			require.NotEqual(t, checkConclusionSuccess, cr.Conclusion,
+				"an in-flight participant must never fold green")
+			assert.Equal(t, checkStatusInProgress, cr.Status,
+				"the aggregate reports the participant's in-flight work")
+			return
+		case <-deadline:
+			t.Fatal("timed out waiting for the folded aggregate")
+		}
+	}
+}

--- a/pkg/webhook/participant_nudge_integration_test.go
+++ b/pkg/webhook/participant_nudge_integration_test.go
@@ -93,6 +93,11 @@ func TestE2EParticipantCommentNudgeRefoldsAggregate(t *testing.T) {
 	assert.Equal(t, checkStatusCompleted, cr.Status)
 	assert.Equal(t, checkConclusionSuccess, cr.Conclusion,
 		"the nudge-triggered fold reads the participant's green check and passes the aggregate")
+
+	// The delayed pass publishes the aggregate a second time, so a comment that
+	// lands before the participant's Check Run update still converges.
+	second := collectAggregate(t, checkRuns, aggregateCheckNameForEnv("SchemaBot", "production"))
+	assert.Equal(t, checkConclusionSuccess, second.Conclusion, "the delayed re-fold publishes again")
 }
 
 // A bot that is not a trusted sibling deployment stays ignored — the nudge is

--- a/pkg/webhook/participant_nudge_integration_test.go
+++ b/pkg/webhook/participant_nudge_integration_test.go
@@ -1,0 +1,162 @@
+//go:build integration
+
+// Participant-comment nudge integration tests. A trusted sibling SchemaBot
+// deployment's PR comment is the leader's only timely signal that a
+// participant's Check Run changed (check_run events are delivered only to the
+// App that created the check), so the leader consumes such comments as
+// aggregate re-fold triggers — never parsing the body — and re-reads every
+// participant's authoritative Check Run before writing the aggregate.
+
+package webhook
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	gh "github.com/google/go-github/v86/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/api"
+)
+
+// nudgeLeaderConfig is leaderRepoConfig with the multi-App shape so the
+// deployment carries trusted-check-app-slugs for the led repo.
+func nudgeLeaderConfig() *api.ServerConfig {
+	cfg := leaderRepoConfig()
+	cfg.Apps = map[string]api.GitHubAppConfig{
+		"default": {TrustedCheckAppSlugs: []string{trustedTenantAppSlug}},
+	}
+	repoCfg := cfg.Repos["octocat/hello-world"]
+	repoCfg.GitHubApp = "default"
+	cfg.Repos["octocat/hello-world"] = repoCfg
+	return cfg
+}
+
+func buildParticipantBotCommentRequest(t *testing.T, login string) *http.Request {
+	t.Helper()
+	return buildWebhookRequest(t, webhookPayloadOpts{
+		comment:   "## ✅ Schema Change Applied — Production",
+		userType:  "Bot",
+		userLogin: login,
+		isPR:      true,
+	}, nil)
+}
+
+// A trusted participant's comment re-folds the aggregate: the leader fetches
+// the PR head, re-reads the participant's Check Run via the trusted API path,
+// and publishes the folded aggregate — twice (immediate and delayed pass), so
+// a comment that lands moments before the participant's Check Run update still
+// converges.
+func TestE2EParticipantCommentNudgeRefoldsAggregate(t *testing.T) {
+	svc := setupE2EServiceWithConfig(t, nudgeLeaderConfig())
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	const headSHA = "abc123"
+	mockLeaderPRHead(mux, headSHA)
+	mockLeaderPRFilesTouchTenantB(mux)
+	prodCheckName := aggregateCheckNameForEnv(tenantBCheckName, "production")
+	stagingCheckName := aggregateCheckNameForEnv(tenantBCheckName, "staging")
+	mockParticipantCheckRuns(mux, map[string]map[string]any{
+		prodCheckName: {
+			"id": 5001, "name": prodCheckName, "status": "completed", "conclusion": "success",
+			"app": map[string]any{"slug": trustedTenantAppSlug},
+		},
+		stagingCheckName: {
+			"id": 5002, "name": stagingCheckName, "status": "completed", "conclusion": "success",
+			"app": map[string]any{"slug": trustedTenantAppSlug},
+		},
+	})
+	checkRuns := captureLeaderCheckRuns(mux)
+
+	h := newLeaderHandler(t, svc, client)
+	h.participantNudgeRefoldDelay = 10 * time.Millisecond
+
+	req := buildParticipantBotCommentRequest(t, trustedTenantAppSlug+"[bot]")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "participant comment triggered aggregate re-fold")
+
+	cr := collectAggregate(t, checkRuns, aggregateCheckNameForEnv("SchemaBot", "production"))
+	assert.Equal(t, headSHA, cr.HeadSHA)
+	assert.Equal(t, checkStatusCompleted, cr.Status)
+	assert.Equal(t, checkConclusionSuccess, cr.Conclusion,
+		"the nudge-triggered fold reads the participant's green check and passes the aggregate")
+}
+
+// A bot that is not a trusted sibling deployment stays ignored — the nudge is
+// gated on the same trust set as the fold's Check Run reads, so arbitrary bot
+// traffic on a busy repo cannot trigger fold work.
+func TestE2EParticipantCommentNudgeIgnoresUntrustedBot(t *testing.T) {
+	svc := setupE2EServiceWithConfig(t, nudgeLeaderConfig())
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+	checkRuns := captureLeaderCheckRuns(mux)
+
+	h := newLeaderHandler(t, svc, client)
+	h.participantNudgeRefoldDelay = 10 * time.Millisecond
+
+	req := buildParticipantBotCommentRequest(t, "some-ci-bot[bot]")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "event ignored (comment from bot)")
+
+	select {
+	case cr := <-checkRuns:
+		t.Fatalf("untrusted bot comment must not trigger a fold, got check run %q", cr.Name)
+	case <-time.After(300 * time.Millisecond):
+	}
+}
+
+// A participant deployment receives the same sibling comments but folds
+// nothing — only the leader owns the aggregate — so the nudge is leader-only
+// and everyone else keeps the plain bot ignore.
+func TestE2EParticipantCommentNudgeLeaderOnly(t *testing.T) {
+	cfg := nudgeLeaderConfig()
+	repoCfg := cfg.Repos["octocat/hello-world"]
+	repoCfg.Aggregate = &api.AggregateConfig{Role: api.AggregateRoleParticipant}
+	cfg.Repos["octocat/hello-world"] = repoCfg
+	svc := setupE2EServiceWithConfig(t, cfg)
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+	checkRuns := captureLeaderCheckRuns(mux)
+
+	h := newLeaderHandler(t, svc, client)
+	h.participantNudgeRefoldDelay = 10 * time.Millisecond
+
+	req := buildParticipantBotCommentRequest(t, trustedTenantAppSlug+"[bot]")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "event ignored (comment from bot)")
+
+	select {
+	case cr := <-checkRuns:
+		t.Fatalf("a non-leader must not fold on sibling comments, got check run %q", cr.Name)
+	case <-time.After(300 * time.Millisecond):
+	}
+}


### PR DESCRIPTION
## Why this matters

GitHub delivers `check_run` events only to the App that created the check, so the aggregate leader never hears a participant's Check Run complete. After a participant applies, the required aggregate stays blocked until the next PR event; after a participant **rolls back**, the aggregate stays **green** — fail-open for a required check. Observed live on the first production exercise of the multi-tenant flow.

## What it does

Participants already comment at exactly the moments their Check Runs change (plan posted, apply summary, rollback), and `issue_comment` events are repo-scoped — delivered to every installed App. The leader now consumes a trusted sibling deployment's bot comment (login matching the repo's existing `trusted-check-app-slugs`) on a repo it leads as a **re-fold nudge**:

```
participant bot comment on led repo
   │  (body never parsed — the comment is a doorbell, not a message)
   ├─ fold now: re-read every participant's Check Run via the trusted API path
   └─ fold once more after a short delay (participants post their terminal
      comment moments before their Check Run updates)
```

A spurious or forged nudge can cause at most wasted work, never a wrongly-passing check — the fold reads only authoritative API state. All other bot comments keep the existing ignore path, so arbitrary bot traffic on a busy repo triggers nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)