### PR TITLE
fix(github): stay silent on unscoped fan-out commands for work another deployment owns

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -1300,15 +1300,29 @@ func (c *ServerConfig) OnFailure(database, environment string) string {
 	return env.OnFailure
 }
 
+// DatabaseNotConfiguredError reports that a database has no entry in this
+// server's databases registry. Callers use it to distinguish "this server does
+// not own the database" from other configuration failures — on repos where
+// deployments share PR commands, a database missing from the registry means
+// another deployment owns the work.
+type DatabaseNotConfiguredError struct {
+	Database string
+}
+
+func (e *DatabaseNotConfiguredError) Error() string {
+	return fmt.Sprintf("database %q is not configured on this server", e.Database)
+}
+
 // DatabaseEnvironments returns the environments configured server-side for a
-// database, ordered by the server-owned promotion order.
+// database, ordered by the server-owned promotion order. Returns
+// *DatabaseNotConfiguredError when the database has no registry entry.
 func (c *ServerConfig) DatabaseEnvironments(database string) ([]string, error) {
 	if c == nil {
 		return nil, fmt.Errorf("server config is nil")
 	}
 	db := c.Database(database)
 	if db == nil {
-		return nil, fmt.Errorf("database %q is not configured on this server", database)
+		return nil, &DatabaseNotConfiguredError{Database: database}
 	}
 	environments := make([]string, 0, len(db.Environments))
 	for environment := range db.Environments {

--- a/pkg/webhook/aggregate_fanout_silent_skip_test.go
+++ b/pkg/webhook/aggregate_fanout_silent_skip_test.go
@@ -1,0 +1,198 @@
+package webhook
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/api"
+	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/webhook/action"
+)
+
+// aggregateLeaderConfig returns a server config where the test repo has the
+// aggregate leader role and the databases registry has no entry for the
+// participant-owned database "orders" — the shape of an untenanted leader
+// receiving unscoped fan-out commands for work another deployment owns.
+func aggregateLeaderConfig() *api.ServerConfig {
+	return &api.ServerConfig{
+		Repos: map[string]api.RepoConfig{
+			"octocat/hello-world": {Aggregate: &api.AggregateConfig{
+				Role:            api.AggregateRoleLeader,
+				ExpectedTenants: []api.ExpectedTenant{{Tenant: "tenant-b", Paths: []string{"tenant-b/schema"}, CheckName: "SchemaBot Tenant B"}},
+			}},
+		},
+	}
+}
+
+// nonAggregateConfig returns a server config where the test repo has no
+// aggregate role, so every "nothing to do" answer stays a visible PR comment.
+func nonAggregateConfig() *api.ServerConfig {
+	return &api.ServerConfig{
+		Repos: map[string]api.RepoConfig{"octocat/hello-world": {}},
+	}
+}
+
+// newFanOutSkipHandler builds a handler backed by a fake GitHub server and
+// empty storage, returning the handler, the GitHub mux for extra routes, and a
+// channel capturing posted PR comments. The handlers under test post comments
+// synchronously, so after a direct handler call the channel holds every
+// comment the command produced.
+func newFanOutSkipHandler(t *testing.T, cfg *api.ServerConfig) (*Handler, *http.ServeMux, chan string) {
+	t.Helper()
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 10)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", commentRecorder(t, comments))
+
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+	h := &Handler{
+		service:   api.New(&emptyStorage{}, cfg, nil, testLogger()),
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: installClient}),
+		logger:    testLogger(),
+	}
+	return h, mux, comments
+}
+
+// serveSchemaConfigForDatabase registers the GitHub content routes config
+// discovery needs so the PR resolves to a schemabot.yaml for the given
+// database.
+func serveSchemaConfigForDatabase(t *testing.T, mux *http.ServeMux, database string) {
+	t.Helper()
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"head": map[string]any{"sha": "abc123", "ref": "feature-branch"},
+			"base": map[string]any{"sha": "def456", "ref": "main"},
+			"user": map[string]any{"login": "testuser"},
+		}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode([]map[string]string{{
+			"filename": "schemabot.yaml",
+			"status":   "modified",
+		}}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/contents/schemabot.yaml", func(w http.ResponseWriter, _ *http.Request) {
+		content := "database: " + database + "\ntype: mysql\n"
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]string{
+			"type":     "file",
+			"encoding": "base64",
+			"content":  base64.StdEncoding.EncodeToString([]byte(content)),
+		}))
+	})
+}
+
+// On an aggregate repo, an unscoped `apply -e <env>` fans out to every
+// installed deployment. A deployment whose databases registry has no entry for
+// the database discovered from the PR's schemabot.yaml is not the owner under
+// the aggregate contract, so it stays silent instead of posting a "database is
+// not configured on this server" failure comment. A -t-scoped command and a
+// non-aggregate repo still surface the error.
+func TestUnscopedApplyOnUnregisteredDatabaseStaysSilent(t *testing.T) {
+	t.Run("unscoped apply on aggregate repo stays silent", func(t *testing.T) {
+		h, mux, comments := newFanOutSkipHandler(t, aggregateLeaderConfig())
+		serveSchemaConfigForDatabase(t, mux, "orders")
+
+		h.handleApplyCommand("octocat/hello-world", 1, "staging", "", 12345, "hubot", CommandResult{Action: action.Apply})
+
+		assert.Empty(t, comments, "non-owning deployment must not post a comment for an unscoped fan-out apply")
+	})
+
+	t.Run("tenant-scoped apply still reports the error", func(t *testing.T) {
+		h, mux, comments := newFanOutSkipHandler(t, aggregateLeaderConfig())
+		serveSchemaConfigForDatabase(t, mux, "orders")
+
+		h.handleApplyCommand("octocat/hello-world", 1, "staging", "", 12345, "hubot", CommandResult{Action: action.Apply, Tenant: "tenant-b"})
+
+		body := requireComment(t, comments, "database-not-configured apply error")
+		assert.Contains(t, body, `database "orders" is not configured on this server`)
+	})
+
+	t.Run("non-aggregate repo still reports the error", func(t *testing.T) {
+		h, mux, comments := newFanOutSkipHandler(t, nonAggregateConfig())
+		serveSchemaConfigForDatabase(t, mux, "orders")
+
+		h.handleApplyCommand("octocat/hello-world", 1, "staging", "", 12345, "hubot", CommandResult{Action: action.Apply})
+
+		body := requireComment(t, comments, "database-not-configured apply error")
+		assert.Contains(t, body, `database "orders" is not configured on this server`)
+	})
+}
+
+// On an aggregate repo, an unscoped `rollback <apply-id> -e <env>` fans out to
+// every deployment, but the apply lives in exactly one tenant's storage. A
+// deployment whose storage has no such apply stays silent so only the owning
+// deployment answers — it must not post "Apply Not Found" for another tenant's
+// apply. A -t-scoped rollback and a non-aggregate repo still get the comment.
+func TestUnscopedRollbackUnknownApplyStaysSilentOnAggregateRepo(t *testing.T) {
+	rollbackResult := func(tenant string) CommandResult {
+		return CommandResult{Action: action.Rollback, ApplyID: "apply_a1b2c3", Environment: "staging", Tenant: tenant}
+	}
+
+	t.Run("unscoped rollback on aggregate repo stays silent", func(t *testing.T) {
+		h, _, comments := newFanOutSkipHandler(t, aggregateLeaderConfig())
+
+		h.handleRollbackCommand("octocat/hello-world", 1, 12345, "hubot", rollbackResult(""))
+
+		assert.Empty(t, comments, "deployment without the apply must not post Apply Not Found on an unscoped fan-out rollback")
+	})
+
+	t.Run("tenant-scoped rollback still posts apply not found", func(t *testing.T) {
+		h, _, comments := newFanOutSkipHandler(t, aggregateLeaderConfig())
+
+		h.handleRollbackCommand("octocat/hello-world", 1, 12345, "hubot", rollbackResult("tenant-b"))
+
+		body := requireComment(t, comments, "apply-not-found rollback comment")
+		assert.Contains(t, body, "Apply Not Found")
+		assert.Contains(t, body, "`apply_a1b2c3`")
+	})
+
+	t.Run("non-aggregate repo still posts apply not found", func(t *testing.T) {
+		h, _, comments := newFanOutSkipHandler(t, nonAggregateConfig())
+
+		h.handleRollbackCommand("octocat/hello-world", 1, 12345, "hubot", rollbackResult(""))
+
+		body := requireComment(t, comments, "apply-not-found rollback comment")
+		assert.Contains(t, body, "Apply Not Found")
+		assert.Contains(t, body, "`apply_a1b2c3`")
+	})
+}
+
+// On an aggregate repo, an unscoped `rollback-confirm -e <env>` fans out to
+// every deployment, but only the deployment holding the pinned rollback lock
+// has anything to confirm. A deployment with no pending rollback stays silent
+// so only the owning deployment answers — it must not post "No Lock Found" for
+// another tenant's rollback. A -t-scoped rollback-confirm and a non-aggregate
+// repo still get the comment.
+func TestUnscopedRollbackConfirmNoLockStaysSilentOnAggregateRepo(t *testing.T) {
+	t.Run("unscoped rollback-confirm on aggregate repo stays silent", func(t *testing.T) {
+		h, _, comments := newFanOutSkipHandler(t, aggregateLeaderConfig())
+
+		h.handleRollbackConfirmCommand("octocat/hello-world", 1, "staging", 12345, "hubot", CommandResult{Action: action.RollbackConfirm})
+
+		assert.Empty(t, comments, "deployment without a pending rollback must not post No Lock Found on an unscoped fan-out rollback-confirm")
+	})
+
+	t.Run("tenant-scoped rollback-confirm still posts no lock found", func(t *testing.T) {
+		h, _, comments := newFanOutSkipHandler(t, aggregateLeaderConfig())
+
+		h.handleRollbackConfirmCommand("octocat/hello-world", 1, "staging", 12345, "hubot", CommandResult{Action: action.RollbackConfirm, Tenant: "tenant-b"})
+
+		body := requireComment(t, comments, "no-lock rollback-confirm comment")
+		assert.Contains(t, body, "No Lock Found")
+		assert.Contains(t, body, "`staging`")
+	})
+
+	t.Run("non-aggregate repo still posts no lock found", func(t *testing.T) {
+		h, _, comments := newFanOutSkipHandler(t, nonAggregateConfig())
+
+		h.handleRollbackConfirmCommand("octocat/hello-world", 1, "staging", 12345, "hubot", CommandResult{Action: action.RollbackConfirm})
+
+		body := requireComment(t, comments, "no-lock rollback-confirm comment")
+		assert.Contains(t, body, "No Lock Found")
+		assert.Contains(t, body, "`staging`")
+	})
+}

--- a/pkg/webhook/aggregate_participant_fanout_test.go
+++ b/pkg/webhook/aggregate_participant_fanout_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/block/schemabot/pkg/api"
 	"github.com/block/schemabot/pkg/webhook/action"
@@ -13,20 +14,27 @@ import (
 // On an aggregate repo, an unscoped fan-out command that resolves to schema this
 // deployment doesn't own is a silent no-op — the deployment that does own it
 // handles the command, so no "config not authorized" comment is posted. This is
-// the leader's behavior on a PR that touches only a participant's database
-// (e.g. kgoose): it gates on the participant's check but applies nothing itself.
-// A -t-scoped command, a non-aggregate repo, or a real error still surfaces.
+// the leader's behavior on a PR that touches only a participant's database: it
+// gates on the participant's check but applies nothing itself. The same applies
+// when the discovered database has no entry in this deployment's registry at
+// all — under the aggregate contract another deployment owns it. A -t-scoped
+// command, a non-aggregate repo, or a real error still surfaces.
 func TestSkipUnownedUnscopedCommand(t *testing.T) {
-	cfg := &api.ServerConfig{Repos: map[string]api.RepoConfig{
-		"octocat/participant-repo": {Aggregate: &api.AggregateConfig{Role: api.AggregateRoleParticipant}},
-		"octocat/leader-repo": {Aggregate: &api.AggregateConfig{
-			Role:            api.AggregateRoleLeader,
-			ExpectedTenants: []api.ExpectedTenant{{Tenant: "tenant-b", Paths: []string{"tenant-b/schema"}, CheckName: "SchemaBot Tenant B"}},
-		}},
-		"octocat/plain-repo": {},
-	}}
+	cfg := &api.ServerConfig{
+		Repos: map[string]api.RepoConfig{
+			"octocat/participant-repo": {Aggregate: &api.AggregateConfig{Role: api.AggregateRoleParticipant}},
+			"octocat/leader-repo": {Aggregate: &api.AggregateConfig{
+				Role:            api.AggregateRoleLeader,
+				ExpectedTenants: []api.ExpectedTenant{{Tenant: "tenant-b", Paths: []string{"tenant-b/schema"}, CheckName: "SchemaBot Tenant B"}},
+			}},
+			"octocat/plain-repo": {},
+		},
+		Databases: map[string]api.DatabaseConfig{
+			"inventory": {Type: "mysql", Environments: map[string]api.EnvironmentConfig{"staging": {}}},
+		},
+	}
 	h := &Handler{service: api.New(nil, cfg, nil, testLogger())}
-	notOwned := &schemaConfigOutsideAllowedDirsError{Database: "kgoose", SchemaPath: "kgoose/schema"}
+	notOwned := &schemaConfigOutsideAllowedDirsError{Database: "orders", SchemaPath: "tenant-b/schema"}
 
 	assert.True(t, h.skipUnownedUnscopedCommand("octocat/participant-repo", "", notOwned),
 		"a participant silently skips an unowned unscoped command")
@@ -40,6 +48,27 @@ func TestSkipUnownedUnscopedCommand(t *testing.T) {
 		"an unconfigured repo has no aggregate role — keep the error")
 	assert.False(t, h.skipUnownedUnscopedCommand("octocat/participant-repo", "", errors.New("github unavailable")),
 		"a real error is not the not-owned case and must still surface")
+
+	// The exact error the environment validator produces when a fan-out command
+	// discovers a database absent from this deployment's registry: skipped on
+	// aggregate repos, still surfaced for -t-scoped commands and plain repos.
+	notConfigured := h.validateRequestedDatabaseEnvironment("orders", "staging")
+	require.Error(t, notConfigured)
+	assert.True(t, h.skipUnownedUnscopedCommand("octocat/participant-repo", "", notConfigured),
+		"a participant silently skips a database missing from its registry")
+	assert.True(t, h.skipUnownedUnscopedCommand("octocat/leader-repo", "", notConfigured),
+		"a leader silently skips a participant-owned database missing from its registry")
+	assert.False(t, h.skipUnownedUnscopedCommand("octocat/participant-repo", "tenant-b", notConfigured),
+		"a -t-scoped command named a deployment, so the error still surfaces")
+	assert.False(t, h.skipUnownedUnscopedCommand("octocat/plain-repo", "", notConfigured),
+		"a non-aggregate repo is a single deployment — the error is useful, keep it")
+
+	// A registered database with an unconfigured environment is a real user
+	// error on this deployment, not an ownership signal — never skipped.
+	envNotConfigured := h.validateRequestedDatabaseEnvironment("inventory", "production")
+	require.Error(t, envNotConfigured)
+	assert.False(t, h.skipUnownedUnscopedCommand("octocat/leader-repo", "", envNotConfigured),
+		"an unconfigured environment for an owned database must still surface")
 }
 
 // On an aggregate repo an unscoped command fans out to every deployment, so a

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -39,7 +39,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	if err != nil {
 		if h.skipUnownedUnscopedCommand(repo, result.Tenant, err) {
 			h.logger.Debug("unscoped fan-out apply touches no schema this deployment owns; staying silent",
-				"repo", repo, "pr", pr, "environment", environment)
+				"repo", repo, "pr", pr, "environment", environment, "error", err)
 			return
 		}
 		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.Apply, err)
@@ -317,7 +317,7 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 	if err != nil {
 		if h.skipUnownedUnscopedCommand(repo, result.Tenant, err) {
 			h.logger.Debug("unscoped fan-out apply-confirm touches no schema this deployment owns; staying silent",
-				"repo", repo, "pr", pr, "environment", environment)
+				"repo", repo, "pr", pr, "environment", environment, "error", err)
 			return
 		}
 		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.ApplyConfirm, err)

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -48,7 +48,7 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 	if err != nil {
 		if h.skipUnownedUnscopedCommand(repo, tenant, err) {
 			h.logger.Debug("unscoped fan-out plan touches no schema this deployment owns; staying silent",
-				"repo", repo, "pr", pr, "environment", environment)
+				"repo", repo, "pr", pr, "environment", environment, "error", err)
 			h.writeJSON(w, http.StatusOK, map[string]string{"message": "unowned unscoped command skipped"})
 			return
 		}

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -57,6 +57,15 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 		return
 	}
 	if apply == nil {
+		// On an aggregate repo an unscoped rollback fans out to every
+		// deployment, but the apply lives in exactly one tenant's storage. A
+		// deployment that doesn't have it is not the owner and stays silent so
+		// only the owning deployment answers.
+		if h.silentOnUnscopedFanOut(repo, result.Tenant) {
+			h.logger.Info("unscoped fan-out rollback targets an apply not stored on this deployment; staying silent so the owning deployment responds",
+				"repo", repo, "pr", pr, "apply_id", applyID, "environment", result.Environment)
+			return
+		}
 		h.postComment(repo, pr, installationID, templates.RenderRollbackApplyNotFound(applyID))
 		return
 	}
@@ -294,6 +303,15 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment 
 		return
 	}
 	if existingLock == nil || rollbackPlan == nil {
+		// On an aggregate repo an unscoped rollback-confirm fans out to every
+		// deployment, but only the deployment holding the pinned rollback lock
+		// has anything to confirm. One with no pending rollback stays silent so
+		// only the owning deployment answers.
+		if h.silentOnUnscopedFanOut(repo, result.Tenant) {
+			h.logger.Info("unscoped fan-out rollback-confirm found no pending rollback on this deployment; staying silent so the owning deployment responds",
+				"repo", repo, "pr", pr, "environment", environment)
+			return
+		}
 		h.postComment(repo, pr, installationID, templates.RenderRollbackConfirmNoLock("", environment))
 		return
 	}

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -40,19 +40,19 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 
 	stor := h.service.Storage()
 	if stor == nil {
-		h.logger.Error("storage not configured for rollback", "repo", repo, "pr", pr, "applyID", applyID)
+		h.logger.Error("storage not configured for rollback", "repo", repo, "pr", pr, "apply_id", applyID)
 		h.postCommandError(repo, pr, installationID, action.Rollback, result.Environment, requestedBy, "Storage is not available")
 		return
 	}
 	applyStore := stor.Applies()
 	if applyStore == nil {
-		h.logger.Error("apply store not configured for rollback", "repo", repo, "pr", pr, "applyID", applyID)
+		h.logger.Error("apply store not configured for rollback", "repo", repo, "pr", pr, "apply_id", applyID)
 		h.postCommandError(repo, pr, installationID, action.Rollback, result.Environment, requestedBy, "Apply store is not available")
 		return
 	}
 	apply, err := applyStore.GetByApplyIdentifier(ctx, applyID)
 	if err != nil {
-		h.logger.Error("failed to look up rollback apply", "repo", repo, "pr", pr, "applyID", applyID, "error", err)
+		h.logger.Error("failed to look up rollback apply", "repo", repo, "pr", pr, "apply_id", applyID, "error", err)
 		h.postCommandError(repo, pr, installationID, action.Rollback, result.Environment, requestedBy, "Failed to look up apply: "+err.Error())
 		return
 	}
@@ -79,7 +79,7 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 	// the comment delivery and can react to the same rollback request.
 	if h.service != nil && !h.service.Config().IsEnvironmentAllowed(environment) {
 		h.logger.Info("ignoring rollback for non-allowed environment",
-			"repo", repo, "pr", pr, "applyID", applyID, "environment", environment)
+			"repo", repo, "pr", pr, "apply_id", applyID, "environment", environment)
 		return
 	}
 
@@ -112,7 +112,7 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 	// Check for existing lock
 	lockStore := stor.Locks()
 	if lockStore == nil {
-		h.logger.Error("lock store not configured for rollback", "repo", repo, "pr", pr, "applyID", applyID, "database", database, "database_type", dbType)
+		h.logger.Error("lock store not configured for rollback", "repo", repo, "pr", pr, "apply_id", applyID, "database", database, "database_type", dbType)
 		h.postCommandError(repo, pr, installationID, action.Rollback, environment, requestedBy, "Lock store is not available")
 		return
 	}
@@ -157,7 +157,7 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 	}); err != nil {
 		h.releaseRollbackLockAfterRejectedPlan(ctx, database, dbType, lockOwner, lockAcquiredByCommand)
 		h.logger.Warn("rollback rejected by source apply guardrails after lock acquisition",
-			"repo", repo, "pr", pr, "applyID", applyID,
+			"repo", repo, "pr", pr, "apply_id", applyID,
 			"environment", result.Environment, "database", database, "error", err)
 		h.postRollbackRejected(repo, pr, installationID, apply, applyID, environment, database, err.Error())
 		return
@@ -174,7 +174,7 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 			h.postComment(repo, pr, installationID, templates.RenderRollbackNoCompletedApply(database, environment))
 			return
 		}
-		h.logger.Error("rollback plan failed", "repo", repo, "pr", pr, "applyID", applyID, "error", err)
+		h.logger.Error("rollback plan failed", "repo", repo, "pr", pr, "apply_id", applyID, "error", err)
 		h.postCommandError(repo, pr, installationID, action.Rollback, environment, requestedBy, errMsg)
 		return
 	}
@@ -248,13 +248,13 @@ func (h *Handler) handleRollbackSourceError(repo string, pr int, installationID 
 	}
 	if status >= http.StatusInternalServerError {
 		h.logger.Error("rollback source validation failed",
-			"repo", repo, "pr", pr, "applyID", applyID,
+			"repo", repo, "pr", pr, "apply_id", applyID,
 			"environment", environment, "error", err)
 		h.postCommandError(repo, pr, installationID, action.Rollback, environment, requestedBy, err.Error())
 		return
 	}
 	h.logger.Warn("rollback rejected by source apply guardrails",
-		"repo", repo, "pr", pr, "applyID", applyID,
+		"repo", repo, "pr", pr, "apply_id", applyID,
 		"environment", environment, "error", err)
 	h.postRollbackRejected(repo, pr, installationID, apply, applyID, environment, "", err.Error())
 }

--- a/pkg/webhook/schema_source_policy.go
+++ b/pkg/webhook/schema_source_policy.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/block/schemabot/pkg/api"
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/metrics"
 )
@@ -15,10 +16,11 @@ import (
 // On an aggregate repo (leader or participant), an unscoped command (no -t) is a
 // fan-out broadcast every installed deployment receives; a deployment that owns
 // none of the changed schema is expected to do nothing while the deployment that
-// does own it handles the command. Posting "config not authorized" from every
-// non-owning deployment would be exactly the noise fan-out removes. Scoped to
-// the not-owned error only — real failures still surface. A -t-scoped command
-// (tenant != "") always reports, since it named a specific deployment.
+// does own it handles the command. Posting "config not authorized" or "database
+// not configured" from every non-owning deployment would be exactly the noise
+// fan-out removes. Scoped to the not-owned error classes only — real failures
+// still surface. A -t-scoped command (tenant != "") always reports, since it
+// named a specific deployment.
 func (h *Handler) skipUnownedUnscopedCommand(repo, tenant string, err error) bool {
 	if tenant != "" {
 		return false
@@ -27,8 +29,23 @@ func (h *Handler) skipUnownedUnscopedCommand(repo, tenant string, err error) boo
 	if !ok || config.AggregateRoleForRepo(repo) == "" {
 		return false
 	}
+	return isSchemaUnownedByDeploymentError(err)
+}
+
+// isSchemaUnownedByDeploymentError reports whether err means the command
+// resolved to schema another deployment owns: either the schema config lives
+// outside this server's allowed_dirs, or the discovered database has no entry
+// in this server's databases registry at all. Under the aggregate contract both
+// mean the same thing — this deployment is not the owner — so on unscoped
+// fan-out both are silently skipped rather than reported. Anything else is a
+// real failure and must still surface.
+func isSchemaUnownedByDeploymentError(err error) bool {
 	var notOwned *schemaConfigOutsideAllowedDirsError
-	return errors.As(err, &notOwned)
+	if errors.As(err, &notOwned) {
+		return true
+	}
+	var notConfigured *api.DatabaseNotConfiguredError
+	return errors.As(err, &notConfigured)
 }
 
 // silentOnUnscopedFanOut reports whether a "nothing to do on this deployment"


### PR DESCRIPTION
## Why this matters

On a multi-tenant aggregate repo, an unscoped command fans out to every deployment. Deployments that don't own the targeted work were posting error comments — observed live: the leader posted "❌ Apply Failed … database not configured on this server" for a participant-owned database, and "🔒 No Lock Found" for a participant's rollback-confirm. One real action plus N−1 error comments.

## What it does

Three silent-skip gaps closed, all scoped to **unscoped commands on aggregate-role repos** (scoped `-t` commands and non-aggregate repos keep every error comment):

- `DatabaseEnvironments` returns a typed `DatabaseNotConfiguredError`, and the unowned-schema skip predicate treats it like outside-allowed-dirs — under the aggregate contract, a database missing from this deployment's registry belongs to another deployment. A *registered* database with an unconfigured environment still surfaces.
- Unscoped `rollback` whose apply id isn't in this deployment's storage: Info log instead of "Apply not found".
- Unscoped `rollback-confirm` with no pending rollback: Info log instead of "No Lock Found".

Every skip logs with triage identifiers; handler-level tests assert silence for unscoped + aggregate-role and preserved errors for `-t` and plain repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)