### PR TITLE
fix(github): rollback command hints carry the tenant flag in tenant mode

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -726,8 +726,8 @@ schemabot apply -e staging --allow-unsafe
 | `schemabot start <apply-id> -e <env>` | Resume a stopped deployment |
 | `schemabot release <apply-id> -e <env>` | Release a paused rollout to proceed |
 | `schemabot cutover <apply-id> -e <env>` | Complete a deferred cutover |
-| `schemabot rollback <apply-id> -e <env>` | Generate a rollback plan |
-| `schemabot rollback-confirm -e <env>` | Execute a rollback |
+| `schemabot rollback <apply-id> -e <env> [-t <tenant>]` | Generate a rollback plan |
+| `schemabot rollback-confirm -e <env> [-t <tenant>]` | Execute a rollback |
 
 **Options**: `-e <env>` environment, `-d <db>` database, `-t, --tenant <name>` deployment routing, `--defer-cutover`, `--allow-unsafe`, `--skip-revert` (Vitess)
 
@@ -756,8 +756,8 @@ That command wasn't recognized. Available commands:
 | `schemabot start <apply-id> -e <env>` | Resume a stopped deployment |
 | `schemabot release <apply-id> -e <env>` | Release a paused rollout to proceed |
 | `schemabot cutover <apply-id> -e <env>` | Complete a deferred cutover |
-| `schemabot rollback <apply-id> -e <env>` | Generate a rollback plan |
-| `schemabot rollback-confirm -e <env>` | Execute a rollback |
+| `schemabot rollback <apply-id> -e <env> [-t <tenant>]` | Generate a rollback plan |
+| `schemabot rollback-confirm -e <env> [-t <tenant>]` | Execute a rollback |
 
 **Options**: `-e <env>` environment, `-d <db>` database, `-t, --tenant <name>` deployment routing, `--defer-cutover`, `--allow-unsafe`, `--skip-revert` (Vitess)
 
@@ -950,8 +950,8 @@ That command wasn't recognized. Available commands:
 | `schemabot start <apply-id> -e <env>` | Resume a stopped deployment |
 | `schemabot release <apply-id> -e <env>` | Release a paused rollout to proceed |
 | `schemabot cutover <apply-id> -e <env>` | Complete a deferred cutover |
-| `schemabot rollback <apply-id> -e <env>` | Generate a rollback plan |
-| `schemabot rollback-confirm -e <env>` | Execute a rollback |
+| `schemabot rollback <apply-id> -e <env> [-t <tenant>]` | Generate a rollback plan |
+| `schemabot rollback-confirm -e <env> [-t <tenant>]` | Execute a rollback |
 
 **Options**: `-e <env>` environment, `-d <db>` database, `-t, --tenant <name>` deployment routing, `--defer-cutover`, `--allow-unsafe`, `--skip-revert` (Vitess)
 

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -342,6 +342,18 @@ func (h *Handler) config() *api.ServerConfig {
 	return h.service.Config()
 }
 
+// deploymentTenant returns this deployment's own tenant, or "" when the
+// deployment is untenanted or the service is not wired. Command hints posted
+// back to the PR carry it so pasted commands address this deployment: in
+// tenant mode, commands without an explicit tenant target are ignored.
+func (h *Handler) deploymentTenant() string {
+	cfg := h.config()
+	if cfg == nil {
+		return ""
+	}
+	return cfg.Tenant
+}
+
 // clientForRepo returns an installation-scoped GitHub client for the App
 // that owns the given repository. Callers that already have a factory in
 // scope should use it directly; this is the convenience for the common

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -216,7 +216,7 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 	}
 
 	if result.Found && result.Action == action.Rollback && result.ApplyID == "" {
-		h.postComment(repo, pr, installationID, templates.RenderRollbackMissingApplyID())
+		h.postComment(repo, pr, installationID, templates.RenderRollbackMissingApplyID(h.deploymentTenant()))
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "missing apply ID"})
 		return
 	}

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -29,7 +29,7 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 
 	applyID := result.ApplyID
 	if applyID == "" {
-		h.postComment(repo, pr, installationID, templates.RenderRollbackMissingApplyID())
+		h.postComment(repo, pr, installationID, templates.RenderRollbackMissingApplyID(h.deploymentTenant()))
 		return
 	}
 
@@ -128,7 +128,8 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 	if existingLock != nil && existingLock.Owner != lockOwner {
 		h.postComment(repo, pr, installationID, templates.RenderRollbackBlockedByLock(
 			database, environment,
-			existingLock.Owner, existingLock.Repository, existingLock.PullRequest))
+			existingLock.Owner, existingLock.Repository, existingLock.PullRequest,
+			h.deploymentTenant()))
 		return
 	}
 
@@ -213,6 +214,7 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 		DatabaseType: dbType,
 		IsMySQL:      dbType == "mysql",
 		ApplyID:      apply.ApplyIdentifier,
+		Tenant:       h.deploymentTenant(),
 	}
 
 	for _, sc := range planResp.Changes {
@@ -312,7 +314,7 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment 
 				"repo", repo, "pr", pr, "environment", environment)
 			return
 		}
-		h.postComment(repo, pr, installationID, templates.RenderRollbackConfirmNoLock("", environment))
+		h.postComment(repo, pr, installationID, templates.RenderRollbackConfirmNoLock("", environment, h.deploymentTenant()))
 		return
 	}
 
@@ -341,7 +343,7 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment 
 				"database_type", dbType, "environment", environment,
 				"lock_owner", lockOwner, "error", err)
 			h.postComment(repo, pr, installationID,
-				templates.RenderRollbackAlreadyRolledBackLockHeld(database, environment, lockOwner))
+				templates.RenderRollbackAlreadyRolledBackLockHeld(database, environment, lockOwner, h.deploymentTenant()))
 			return
 		}
 		h.postComment(repo, pr, installationID,

--- a/pkg/webhook/schema_reconciliation.go
+++ b/pkg/webhook/schema_reconciliation.go
@@ -39,6 +39,7 @@ func (h *Handler) handleNoManagedSchemaChangesForCommand(ctx context.Context, cl
 			"database", databaseName, "action", commandName,
 			"record_count", len(records))
 		h.postComment(repo, pr, installationID, templates.RenderSchemaChangeReconciliationRequired(templates.SchemaChangeReconciliationData{
+			Tenant:      h.deploymentTenant(),
 			RequestedBy: requestedBy,
 			Timestamp:   templates.NowFunc().UTC().Format("2006-01-02 15:04:05"),
 			Items:       schemaChangeReconciliationItems(records),

--- a/pkg/webhook/templates/help.go
+++ b/pkg/webhook/templates/help.go
@@ -14,8 +14,8 @@ func commandReference() string {
 | ` + "`schemabot start <apply-id> -e <env>`" + ` | Resume a stopped deployment |
 | ` + "`schemabot release <apply-id> -e <env>`" + ` | Release a paused rollout to proceed |
 | ` + "`schemabot cutover <apply-id> -e <env>`" + ` | Complete a deferred cutover |
-| ` + "`schemabot rollback <apply-id> -e <env>`" + ` | Generate a rollback plan |
-| ` + "`schemabot rollback-confirm -e <env>`" + ` | Execute a rollback |
+| ` + "`schemabot rollback <apply-id> -e <env> [-t <tenant>]`" + ` | Generate a rollback plan |
+| ` + "`schemabot rollback-confirm -e <env> [-t <tenant>]`" + ` | Execute a rollback |
 
 **Options**: ` + "`-e <env>`" + ` environment, ` + "`-d <db>`" + ` database, ` + "`-t, --tenant <name>`" + ` deployment routing, ` + "`--defer-cutover`" + `, ` + "`--allow-unsafe`" + `, ` + "`--skip-revert`" + ` (Vitess)
 

--- a/pkg/webhook/templates/issue_comment.go
+++ b/pkg/webhook/templates/issue_comment.go
@@ -7,19 +7,23 @@ import (
 )
 
 // RenderRollbackMissingArguments renders the message posted when `schemabot rollback`
-// is invoked without an apply ID and without an `-e` flag.
+// is invoked without an apply ID and without an `-e` flag. The usage line keeps
+// the tenant flag in optional form because this message also renders on
+// untenanted deployments.
 func RenderRollbackMissingArguments() string {
 	return "## Missing Arguments\n\n" +
-		"Usage: `schemabot rollback <apply-id> -e <environment>`\n\n" +
+		"Usage: `schemabot rollback <apply-id> -e <environment> [-t <tenant>]`\n\n" +
 		"Rollback requires both an apply ID and the `-e` flag to select the target environment."
 }
 
 // RenderRollbackMissingEnv renders the message posted when `schemabot rollback`
 // is invoked with an apply ID but no `-e` flag. Distinct from RenderMissingEnv —
-// the rollback variant tailors the example usage to rollback semantics.
+// the rollback variant tailors the example usage to rollback semantics. The
+// usage line keeps the tenant flag in optional form because this message also
+// renders on untenanted deployments.
 func RenderRollbackMissingEnv() string {
 	return "## Missing Environment\n\n" +
-		"Usage: `schemabot rollback <apply-id> -e <environment>`\n\n" +
+		"Usage: `schemabot rollback <apply-id> -e <environment> [-t <tenant>]`\n\n" +
 		"The `-e` flag is required to select the target environment."
 }
 

--- a/pkg/webhook/templates/issue_comment_test.go
+++ b/pkg/webhook/templates/issue_comment_test.go
@@ -10,14 +10,14 @@ import (
 func TestRenderRollbackMissingArguments(t *testing.T) {
 	rendered := RenderRollbackMissingArguments()
 	assert.Contains(t, rendered, "## Missing Arguments")
-	assert.Contains(t, rendered, "schemabot rollback <apply-id> -e <environment>")
+	assert.Contains(t, rendered, "`schemabot rollback <apply-id> -e <environment> [-t <tenant>]`")
 	assert.Contains(t, rendered, "both an apply ID and the `-e` flag")
 }
 
 func TestRenderRollbackMissingEnv(t *testing.T) {
 	rendered := RenderRollbackMissingEnv()
 	assert.Contains(t, rendered, "## Missing Environment")
-	assert.Contains(t, rendered, "schemabot rollback <apply-id> -e <environment>")
+	assert.Contains(t, rendered, "`schemabot rollback <apply-id> -e <environment> [-t <tenant>]`")
 	assert.Contains(t, rendered, "The `-e` flag is required")
 	assert.NotContains(t, rendered, "both an apply ID",
 		"missing-env variant should not say both args are missing")

--- a/pkg/webhook/templates/plan.go
+++ b/pkg/webhook/templates/plan.go
@@ -876,11 +876,18 @@ func writeMultiEnvFooter(sb *strings.Builder, data MultiEnvPlanCommentData) {
 }
 
 func tenantCommand(baseCommand, environment, tenant string) string {
-	command := fmt.Sprintf("%s -e %s", baseCommand, environment)
-	if tenant != "" {
-		command += fmt.Sprintf(" --tenant %s", tenant)
+	return appendTenantFlag(fmt.Sprintf("%s -e %s", baseCommand, environment), tenant)
+}
+
+// appendTenantFlag appends the --tenant flag to a pasteable command hint when
+// tenant is set. In tenant mode, commands without an explicit tenant target
+// are ignored, so every command hint a user may copy-paste must carry the
+// deployment's tenant.
+func appendTenantFlag(command, tenant string) string {
+	if tenant == "" {
+		return command
 	}
-	return command
+	return fmt.Sprintf("%s --tenant %s", command, tenant)
 }
 
 // allPlansIdentical returns true if all environments have identical changes.

--- a/pkg/webhook/templates/reconciliation.go
+++ b/pkg/webhook/templates/reconciliation.go
@@ -10,7 +10,10 @@ import (
 type SchemaChangeReconciliationData struct {
 	RequestedBy string
 	Timestamp   string
-	Items       []SchemaChangeReconciliationItem
+	// Tenant is the deployment's own tenant; when set, the pasteable stop and
+	// rollback hints carry it so the command addresses this deployment.
+	Tenant string
+	Items  []SchemaChangeReconciliationItem
 }
 
 // SchemaChangeReconciliationItem describes one database/environment whose live
@@ -46,9 +49,9 @@ func RenderSchemaChangeReconciliationRequired(data SchemaChangeReconciliationDat
 	sb.WriteString("\n")
 
 	if reconciliationHasInProgressApply(data.Items) {
-		writeInProgressReconciliation(&sb, data.Items)
+		writeInProgressReconciliation(&sb, data.Tenant, data.Items)
 	} else {
-		writeCompletedReconciliation(&sb, data.Items)
+		writeCompletedReconciliation(&sb, data.Tenant, data.Items)
 	}
 
 	return sb.String()
@@ -108,23 +111,23 @@ func reconciliationHasInProgressApply(items []SchemaChangeReconciliationItem) bo
 	return false
 }
 
-func writeInProgressReconciliation(sb *strings.Builder, items []SchemaChangeReconciliationItem) {
+func writeInProgressReconciliation(sb *strings.Builder, tenant string, items []SchemaChangeReconciliationItem) {
 	sb.WriteString("SchemaBot is still applying a schema change from this PR, but the current PR no longer contains that change.\n\n")
 	sb.WriteString("The live database operation was already started and may continue independently of the current PR diff.\n\n")
 	sb.WriteString("### What to do next\n\n")
 	sb.WriteString("1. First, resolve the in-flight apply:\n")
 	sb.WriteString("   - Wait for SchemaBot to post the final apply result, or\n")
 	sb.WriteString("   - If stopping is supported for this database, comment:\n")
-	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", stopCommand(items))
+	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", stopCommand(tenant, items))
 	sb.WriteString("\n2. Then reconcile the final live schema:\n")
 	sb.WriteString("   - If the live schema change should remain, add the schema change back to the PR, then comment:\n")
 	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", planCommand(items))
 	sb.WriteString("   - If the live schema change should not remain, roll it back:\n")
-	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", rollbackCommand(items))
+	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", rollbackCommand(tenant, items))
 	sb.WriteString("     After rollback: push a no-op `schemabot.yaml` edit to trigger a fresh plan.\n")
 }
 
-func writeCompletedReconciliation(sb *strings.Builder, items []SchemaChangeReconciliationItem) {
+func writeCompletedReconciliation(sb *strings.Builder, tenant string, items []SchemaChangeReconciliationItem) {
 	sb.WriteString("SchemaBot already applied a schema change from this PR, but the current PR no longer contains that change.\n\n")
 	sb.WriteString("The live database was already updated and may no longer match the current PR schema files.\n\n")
 	sb.WriteString("### What to do next\n\n")
@@ -135,7 +138,7 @@ func writeCompletedReconciliation(sb *strings.Builder, items []SchemaChangeRecon
 	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", planCommand(items))
 	sb.WriteString("\n2. Undo the live schema change:\n")
 	sb.WriteString("   - comment:\n")
-	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", rollbackCommand(items))
+	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", rollbackCommand(tenant, items))
 	sb.WriteString("   - after rollback: push a no-op `schemabot.yaml` edit to trigger a fresh plan\n")
 }
 
@@ -151,20 +154,20 @@ func planCommand(items []SchemaChangeReconciliationItem) string {
 	return cmd
 }
 
-func stopCommand(items []SchemaChangeReconciliationItem) string {
+func stopCommand(tenant string, items []SchemaChangeReconciliationItem) string {
 	item, ok := singleCommandItem(items)
 	if !ok || item.ApplyID == "" {
-		return "schemabot stop <apply-id> -e <environment>"
+		return appendTenantFlag("schemabot stop <apply-id> -e <environment>", tenant)
 	}
-	return fmt.Sprintf("schemabot stop %s -e %s", item.ApplyID, item.Environment)
+	return appendTenantFlag(fmt.Sprintf("schemabot stop %s -e %s", item.ApplyID, item.Environment), tenant)
 }
 
-func rollbackCommand(items []SchemaChangeReconciliationItem) string {
+func rollbackCommand(tenant string, items []SchemaChangeReconciliationItem) string {
 	item, ok := singleCommandItem(items)
 	if !ok || item.ApplyID == "" {
-		return "schemabot rollback <apply-id> -e <environment>"
+		return appendTenantFlag("schemabot rollback <apply-id> -e <environment>", tenant)
 	}
-	return fmt.Sprintf("schemabot rollback %s -e %s", item.ApplyID, item.Environment)
+	return appendTenantFlag(fmt.Sprintf("schemabot rollback %s -e %s", item.ApplyID, item.Environment), tenant)
 }
 
 func singleCommandItem(items []SchemaChangeReconciliationItem) (SchemaChangeReconciliationItem, bool) {

--- a/pkg/webhook/templates/reconciliation_tenant_test.go
+++ b/pkg/webhook/templates/reconciliation_tenant_test.go
@@ -1,0 +1,16 @@
+package templates
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReconciliationHintsCarryTenant(t *testing.T) {
+	out := RenderSchemaChangeReconciliationRequired(SchemaChangeReconciliationData{
+		Tenant: "acme",
+		Items:  []SchemaChangeReconciliationItem{{Database: "orders", Environment: "staging", ApplyID: "apply_abc123", State: "completed"}},
+	})
+	if !strings.Contains(out, "schemabot rollback apply_abc123 -e staging --tenant acme") {
+		t.Fatalf("rollback hint missing tenant:\n%s", out)
+	}
+}

--- a/pkg/webhook/templates/reconciliation_tenant_test.go
+++ b/pkg/webhook/templates/reconciliation_tenant_test.go
@@ -1,16 +1,23 @@
 package templates
 
 import (
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
+// The reconciliation comment's pasteable stop/rollback hints address a
+// specific deployment, so on a tenant deployment they carry its tenant flag.
 func TestReconciliationHintsCarryTenant(t *testing.T) {
 	out := RenderSchemaChangeReconciliationRequired(SchemaChangeReconciliationData{
 		Tenant: "acme",
 		Items:  []SchemaChangeReconciliationItem{{Database: "orders", Environment: "staging", ApplyID: "apply_abc123", State: "completed"}},
 	})
-	if !strings.Contains(out, "schemabot rollback apply_abc123 -e staging --tenant acme") {
-		t.Fatalf("rollback hint missing tenant:\n%s", out)
-	}
+	require.Contains(t, out, "schemabot rollback apply_abc123 -e staging --tenant acme")
+
+	untenanted := RenderSchemaChangeReconciliationRequired(SchemaChangeReconciliationData{
+		Items: []SchemaChangeReconciliationItem{{Database: "orders", Environment: "staging", ApplyID: "apply_abc123", State: "completed"}},
+	})
+	require.Contains(t, untenanted, "schemabot rollback apply_abc123 -e staging")
+	require.NotContains(t, untenanted, "--tenant")
 }

--- a/pkg/webhook/templates/rollback.go
+++ b/pkg/webhook/templates/rollback.go
@@ -49,9 +49,9 @@ func RenderRollbackPlanComment(data PlanCommentData) string {
 	// Footer
 	sb.WriteString("---\n\n")
 	sb.WriteString("To confirm this rollback, comment:\n")
-	fmt.Fprintf(&sb, "```\nschemabot rollback-confirm -e %s\n```\n\n", data.Environment)
+	fmt.Fprintf(&sb, "```\n%s\n```\n\n", tenantCommand("schemabot rollback-confirm", data.Environment, data.Tenant))
 	sb.WriteString("To cancel, comment:\n")
-	fmt.Fprintf(&sb, "```\nschemabot unlock\n```\n")
+	fmt.Fprintf(&sb, "```\n%s\n```\n", appendTenantFlag("schemabot unlock", data.Tenant))
 
 	return sb.String()
 }
@@ -67,28 +67,32 @@ func RenderRollbackNoCompletedApply(database, environment string) string {
 }
 
 // RenderRollbackConfirmNoLock renders a message when rollback-confirm is run
-// without a held lock.
-func RenderRollbackConfirmNoLock(database, environment string) string {
+// without a held lock. Tenant is the deployment's own tenant; when set, the
+// suggested command carries it so pasting the hint addresses this deployment.
+func RenderRollbackConfirmNoLock(database, environment, tenant string) string {
+	rollbackCmd := tenantCommand("schemabot rollback <apply-id>", environment, tenant)
 	if database == "" {
 		return fmt.Sprintf("## 🔒 No Lock Found\n\n"+
 			"**Environment**: `%s`\n\n"+
-			"No rollback lock is held by this PR. Run `schemabot rollback <apply-id> -e %s` first to generate a rollback plan.",
-			environment, environment)
+			"No rollback lock is held by this PR. Run `%s` first to generate a rollback plan.",
+			environment, rollbackCmd)
 	}
 	return fmt.Sprintf("## 🔒 No Lock Found\n\n"+
 		"**Database**: `%s` | **Environment**: `%s`\n\n"+
-		"No rollback lock is held. Run `schemabot rollback <apply-id> -e %s` first to generate a rollback plan.",
-		database, environment, environment)
+		"No rollback lock is held. Run `%s` first to generate a rollback plan.",
+		database, environment, rollbackCmd)
 }
 
 // RenderRollbackMissingApplyID renders the message posted when `schemabot rollback`
-// is invoked without an apply ID argument.
-func RenderRollbackMissingApplyID() string {
+// is invoked without an apply ID argument. Tenant is the deployment's own
+// tenant; when set, the suggested commands carry it so pasting a hint
+// addresses this deployment.
+func RenderRollbackMissingApplyID(tenant string) string {
 	return "## Missing Apply ID\n\n" +
-		"Usage: `schemabot rollback <apply-id> -e <environment>`\n\n" +
-		"Confirm a generated rollback with `schemabot rollback-confirm -e <environment>`.\n\n" +
+		fmt.Sprintf("Usage: `%s`\n\n", tenantCommand("schemabot rollback <apply-id>", "<environment>", tenant)) +
+		fmt.Sprintf("Confirm a generated rollback with `%s`.\n\n", tenantCommand("schemabot rollback-confirm", "<environment>", tenant)) +
 		"You can find the apply ID in the summary comment of a completed apply, " +
-		"or by running `schemabot status`."
+		fmt.Sprintf("or by running `%s`.", appendTenantFlag("schemabot status", tenant))
 }
 
 // RenderRollbackApplyNotFound renders the message posted when the supplied apply ID
@@ -144,16 +148,19 @@ func sanitizedRollbackRejectionReason(reason string) string {
 // RenderRollbackBlockedByLock renders the message posted when a rollback cannot
 // acquire the database lock because another caller holds it. When lockRepo and
 // lockPR are populated, the holder is rendered as a PR link; otherwise the bare
-// owner string is shown.
-func RenderRollbackBlockedByLock(database, environment, lockOwner, lockRepo string, lockPR int) string {
+// owner string is shown. Tenant is the deployment's own tenant; when set, the
+// suggested unlock command carries it so pasting the hint addresses this
+// deployment.
+func RenderRollbackBlockedByLock(database, environment, lockOwner, lockRepo string, lockPR int, tenant string) string {
 	if lockPR > 0 && lockRepo != "" {
 		return fmt.Sprintf("## Rollback Blocked\n\n"+
 			"**Database**: `%s` | **Environment**: `%s`\n\n"+
 			"A lock is currently held by [%s#%d](https://github.com/%s/pull/%d).\n\n"+
-			"Wait for that operation to complete, or ask the lock owner to run `schemabot unlock`.",
+			"Wait for that operation to complete, or ask the lock owner to run `%s`.",
 			database, environment,
 			lockRepo, lockPR,
-			lockRepo, lockPR)
+			lockRepo, lockPR,
+			appendTenantFlag("schemabot unlock", tenant))
 	}
 	return fmt.Sprintf("## Rollback Blocked\n\n"+
 		"**Database**: `%s` | **Environment**: `%s`\n\n"+
@@ -193,17 +200,21 @@ func RenderRollbackAlreadyRolledBack(database, environment string) string {
 // RenderRollbackAlreadyRolledBackLockHeld renders the message posted when
 // rollback-confirm finds no changes remain but the database lock could not be
 // released. The lock continues to block applies on the database until an
-// operator releases it.
-func RenderRollbackAlreadyRolledBackLockHeld(database, environment, lockOwner string) string {
+// operator releases it. Tenant is the deployment's own tenant; when set, the
+// suggested unlock commands carry it so pasting a hint addresses this
+// deployment.
+func RenderRollbackAlreadyRolledBackLockHeld(database, environment, lockOwner, tenant string) string {
 	return fmt.Sprintf("## Already Rolled Back\n\n"+
 		"**Database**: `%s` | **Environment**: `%s`\n\n"+
 		"The database schema already matches the original state, but SchemaBot failed to release the lock held by `%s`. "+
 		"Applies on this database will be blocked until the lock is released.\n\n"+
 		"Release it by commenting:\n"+
-		"```\nschemabot unlock\n```\n"+
+		"```\n%s\n```\n"+
 		"If the lock persists, force-release it:\n"+
-		"```\nschemabot unlock -d %s --force\n```",
-		database, environment, lockOwner, database)
+		"```\n%s\n```",
+		database, environment, lockOwner,
+		appendTenantFlag("schemabot unlock", tenant),
+		appendTenantFlag(fmt.Sprintf("schemabot unlock -d %s --force", database), tenant))
 }
 
 // RenderRollbackNotAccepted renders the message posted when the apply service

--- a/pkg/webhook/templates/rollback_test.go
+++ b/pkg/webhook/templates/rollback_test.go
@@ -34,9 +34,39 @@ func TestRenderRollbackPlanComment_WithChanges(t *testing.T) {
 	assert.Contains(t, rendered, "DROP INDEX")
 	assert.Contains(t, rendered, "DROP COLUMN")
 	assert.Contains(t, rendered, "destructive changes")
-	assert.Contains(t, rendered, "schemabot rollback-confirm -e staging")
+	assert.Contains(t, rendered, "```\nschemabot rollback-confirm -e staging\n```")
 	assert.NotContains(t, rendered, "schemabot rollback-confirm -e staging -d")
-	assert.Contains(t, rendered, "schemabot unlock")
+	assert.NotContains(t, rendered, "--tenant")
+	assert.Contains(t, rendered, "```\nschemabot unlock\n```")
+}
+
+// A rollback plan posted by a tenant deployment must render confirm/cancel
+// hints that carry the deployment's tenant — in tenant mode, a pasted command
+// without an explicit tenant target is ignored.
+func TestRenderRollbackPlanComment_TenantCarriesFlagInHints(t *testing.T) {
+	data := PlanCommentData{
+		Database:    "testapp",
+		Environment: "production",
+		RequestedBy: "testuser",
+		IsMySQL:     true,
+		ApplyID:     "apply_abc123",
+		Tenant:      "acme",
+		Changes: []KeyspaceChangeData{
+			{
+				Keyspace:   "testapp",
+				Statements: []string{"ALTER TABLE `users` DROP INDEX `idx_email`"},
+			},
+		},
+	}
+
+	rendered := RenderRollbackPlanComment(data)
+	assert.Contains(t, rendered, "```\nschemabot rollback-confirm -e production --tenant acme\n```")
+	assert.Contains(t, rendered, "```\nschemabot unlock --tenant acme\n```")
+	assert.Contains(t, rendered, "**Tenant**: `acme`")
+	assert.NotContains(t, rendered, "```\nschemabot rollback-confirm -e production\n```",
+		"tenant deployments must not hint the unscoped confirm command")
+	assert.NotContains(t, rendered, "```\nschemabot unlock\n```",
+		"tenant deployments must not hint the unscoped unlock command")
 }
 
 func TestRenderRollbackPlanComment_NoChanges(t *testing.T) {
@@ -129,28 +159,48 @@ func TestRenderRollbackNoCompletedApply(t *testing.T) {
 }
 
 func TestRenderRollbackConfirmNoLock(t *testing.T) {
-	rendered := RenderRollbackConfirmNoLock("testapp", "staging")
+	rendered := RenderRollbackConfirmNoLock("testapp", "staging", "")
 	assert.Contains(t, rendered, "## 🔒 No Lock Found")
 	assert.Contains(t, rendered, "`testapp`")
 	assert.Contains(t, rendered, "`staging`")
-	assert.Contains(t, rendered, "schemabot rollback <apply-id> -e staging")
+	assert.Contains(t, rendered, "`schemabot rollback <apply-id> -e staging`")
 }
 
 func TestRenderRollbackConfirmNoLockWithoutDatabase(t *testing.T) {
-	rendered := RenderRollbackConfirmNoLock("", "staging")
+	rendered := RenderRollbackConfirmNoLock("", "staging", "")
 	assert.Contains(t, rendered, "## 🔒 No Lock Found")
 	assert.Contains(t, rendered, "`staging`")
 	assert.Contains(t, rendered, "No rollback lock is held by this PR")
-	assert.Contains(t, rendered, "schemabot rollback <apply-id> -e staging")
+	assert.Contains(t, rendered, "`schemabot rollback <apply-id> -e staging`")
 	assert.NotContains(t, rendered, "**Database**")
 }
 
+// On a tenant deployment, the no-lock hint must suggest a rollback command
+// that carries the deployment's tenant so pasting it addresses this deployment.
+func TestRenderRollbackConfirmNoLockTenant(t *testing.T) {
+	rendered := RenderRollbackConfirmNoLock("testapp", "production", "acme")
+	assert.Contains(t, rendered, "`schemabot rollback <apply-id> -e production --tenant acme`")
+
+	withoutDatabase := RenderRollbackConfirmNoLock("", "production", "acme")
+	assert.Contains(t, withoutDatabase, "`schemabot rollback <apply-id> -e production --tenant acme`")
+}
+
 func TestRenderRollbackMissingApplyID(t *testing.T) {
-	rendered := RenderRollbackMissingApplyID()
+	rendered := RenderRollbackMissingApplyID("")
 	assert.Contains(t, rendered, "## Missing Apply ID")
-	assert.Contains(t, rendered, "schemabot rollback <apply-id> -e <environment>")
-	assert.Contains(t, rendered, "schemabot rollback-confirm -e <environment>")
-	assert.Contains(t, rendered, "schemabot status")
+	assert.Contains(t, rendered, "`schemabot rollback <apply-id> -e <environment>`")
+	assert.Contains(t, rendered, "`schemabot rollback-confirm -e <environment>`")
+	assert.Contains(t, rendered, "`schemabot status`")
+	assert.NotContains(t, rendered, "--tenant")
+}
+
+// On a tenant deployment, the missing-apply-ID usage hints must carry the
+// deployment's tenant so pasting them addresses this deployment.
+func TestRenderRollbackMissingApplyIDTenant(t *testing.T) {
+	rendered := RenderRollbackMissingApplyID("acme")
+	assert.Contains(t, rendered, "`schemabot rollback <apply-id> -e <environment> --tenant acme`")
+	assert.Contains(t, rendered, "`schemabot rollback-confirm -e <environment> --tenant acme`")
+	assert.Contains(t, rendered, "`schemabot status --tenant acme`")
 }
 
 func TestRenderRollbackApplyNotFound(t *testing.T) {
@@ -186,19 +236,25 @@ func TestRenderRollbackRejectedSanitizesReason(t *testing.T) {
 
 func TestRenderRollbackBlockedByLock(t *testing.T) {
 	t.Run("PR-owned lock renders as link", func(t *testing.T) {
-		rendered := RenderRollbackBlockedByLock("testapp", "staging", "block/myapp#42", "block/myapp", 42)
+		rendered := RenderRollbackBlockedByLock("testapp", "staging", "block/myapp#42", "block/myapp", 42, "")
 
 		assert.Contains(t, rendered, "## Rollback Blocked")
 		assert.Contains(t, rendered, "`testapp`")
 		assert.Contains(t, rendered, "`staging`")
 		assert.Contains(t, rendered, "[block/myapp#42](https://github.com/block/myapp/pull/42)")
-		assert.Contains(t, rendered, "schemabot unlock")
+		assert.Contains(t, rendered, "`schemabot unlock`")
+		assert.NotContains(t, rendered, "--tenant")
 		assert.NotContains(t, rendered, "`block/myapp#42`",
 			"PR-link variant should not render the owner as a bare backticked string")
 	})
 
+	t.Run("PR-owned lock on tenant deployment hints tenant-scoped unlock", func(t *testing.T) {
+		rendered := RenderRollbackBlockedByLock("testapp", "production", "block/myapp#42", "block/myapp", 42, "acme")
+		assert.Contains(t, rendered, "`schemabot unlock --tenant acme`")
+	})
+
 	t.Run("non-PR lock renders bare owner", func(t *testing.T) {
-		rendered := RenderRollbackBlockedByLock("testapp", "staging", "cli:alice@laptop", "", 0)
+		rendered := RenderRollbackBlockedByLock("testapp", "staging", "cli:alice@laptop", "", 0, "")
 
 		assert.Contains(t, rendered, "## Rollback Blocked")
 		assert.Contains(t, rendered, "`cli:alice@laptop`")
@@ -210,7 +266,7 @@ func TestRenderRollbackBlockedByLock(t *testing.T) {
 	})
 
 	t.Run("missing repo falls back to bare owner even with PR > 0", func(t *testing.T) {
-		rendered := RenderRollbackBlockedByLock("testapp", "staging", "stale-owner", "", 99)
+		rendered := RenderRollbackBlockedByLock("testapp", "staging", "stale-owner", "", 99, "")
 		assert.Contains(t, rendered, "`stale-owner`")
 		assert.NotContains(t, rendered, "github.com")
 	})
@@ -241,16 +297,25 @@ func TestRenderRollbackAlreadyRolledBack(t *testing.T) {
 }
 
 func TestRenderRollbackAlreadyRolledBackLockHeld(t *testing.T) {
-	rendered := RenderRollbackAlreadyRolledBackLockHeld("testapp", "staging", "block/myapp#42")
+	rendered := RenderRollbackAlreadyRolledBackLockHeld("testapp", "staging", "block/myapp#42", "")
 	assert.Contains(t, rendered, "## Already Rolled Back")
 	assert.Contains(t, rendered, "`testapp`")
 	assert.Contains(t, rendered, "`staging`")
 	assert.Contains(t, rendered, "failed to release the lock held by `block/myapp#42`")
 	assert.Contains(t, rendered, "Applies on this database will be blocked until the lock is released")
-	assert.Contains(t, rendered, "schemabot unlock")
-	assert.Contains(t, rendered, "schemabot unlock -d testapp --force")
+	assert.Contains(t, rendered, "```\nschemabot unlock\n```")
+	assert.Contains(t, rendered, "```\nschemabot unlock -d testapp --force\n```")
+	assert.NotContains(t, rendered, "--tenant")
 	assert.NotContains(t, rendered, "Lock released",
 		"a failed release must not claim the lock was released")
+}
+
+// On a tenant deployment, the stuck-lock release hints must carry the
+// deployment's tenant so pasting them addresses this deployment.
+func TestRenderRollbackAlreadyRolledBackLockHeldTenant(t *testing.T) {
+	rendered := RenderRollbackAlreadyRolledBackLockHeld("testapp", "production", "block/myapp#42", "acme")
+	assert.Contains(t, rendered, "```\nschemabot unlock --tenant acme\n```")
+	assert.Contains(t, rendered, "```\nschemabot unlock -d testapp --force --tenant acme\n```")
 }
 
 func TestRenderRollbackNotAccepted(t *testing.T) {
@@ -263,15 +328,15 @@ func TestRenderRollbackNotAccepted(t *testing.T) {
 
 func TestRollbackTemplates_NoStrayWhitespace(t *testing.T) {
 	for name, body := range map[string]string{
-		"MissingApplyID":            RenderRollbackMissingApplyID(),
+		"MissingApplyID":            RenderRollbackMissingApplyID(""),
 		"ApplyNotFound":             RenderRollbackApplyNotFound("a"),
 		"Rejected":                  RenderRollbackRejected(RollbackRejectedData{ApplyID: "a", Database: "d", Environment: "e", Reason: "r"}),
-		"BlockedByLockPR":           RenderRollbackBlockedByLock("d", "e", "o", "r", 1),
-		"BlockedByLockOwner":        RenderRollbackBlockedByLock("d", "e", "o", "", 0),
+		"BlockedByLockPR":           RenderRollbackBlockedByLock("d", "e", "o", "r", 1, ""),
+		"BlockedByLockOwner":        RenderRollbackBlockedByLock("d", "e", "o", "", 0, ""),
 		"NothingToDo":               RenderRollbackNothingToDo("d", "e", "a"),
 		"LockNotOwned":              RenderRollbackLockNotOwned("d", "e", "o"),
 		"AlreadyRolledBack":         RenderRollbackAlreadyRolledBack("d", "e"),
-		"AlreadyRolledBackLockHeld": RenderRollbackAlreadyRolledBackLockHeld("d", "e", "o"),
+		"AlreadyRolledBackLockHeld": RenderRollbackAlreadyRolledBackLockHeld("d", "e", "o", ""),
 		"NotAccepted":               RenderRollbackNotAccepted("d", "e", "x"),
 	} {
 		assert.False(t, strings.HasPrefix(body, " ") || strings.HasPrefix(body, "\n"),


### PR DESCRIPTION
## Why this matters

In tenant mode, `rollback` and `rollback-confirm` require an explicit `--tenant` — but the pasteable command hints SchemaBot posts omitted it, so following the bot's own instructions produced a command every deployment ignores. Observed live: a user pasted the rollback plan's `schemabot rollback-confirm -e <env>` hint verbatim and dead-ended.

## What it does

Threads the deployment's own tenant into every pasteable rollback-flow hint — the rollback plan's confirm/unlock footer, no-lock and missing-apply-id guidance, lock-conflict and already-rolled-back messages, and the reconciliation comment's stop/rollback hints — mirroring the treatment the apply-confirm hint already had. Untenanted deployments render unchanged; generic usage strings show the optional `[-t <tenant>]` form. Tests assert full command strings both with and without a tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)