### PR TITLE
fix(github): memoize config discovery probes across changed files

### DIFF
--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -326,6 +326,15 @@ func (ic *InstallationClient) FindAllConfigsForPR(ctx context.Context, repo stri
 // hand use this directly to avoid re-listing them; FindAllConfigsForPR is the
 // convenience wrapper that fetches the files first.
 func (ic *InstallationClient) FindConfigsForPRFiles(ctx context.Context, repo, ref string, files []PRFile) ([]DiscoveredConfig, error) {
+	// Changed schema files usually share ancestor directories (adding or
+	// deleting a schema tree touches many files under one root), so probe
+	// results are memoized per directory: each unique directory is fetched at
+	// most once per discovery pass. This bounds the GitHub call volume by the
+	// number of unique directories rather than changed files × directory
+	// depth, keeping discovery for large PRs within the webhook processing
+	// deadline.
+	probes := make(configProbeCache)
+
 	configsByPath := make(map[string]DiscoveredConfig)
 	for _, file := range files {
 		if !isConfigFile(file.Filename) {
@@ -340,6 +349,7 @@ func (ic *InstallationClient) FindConfigsForPRFiles(ctx context.Context, repo, r
 			return nil, fmt.Errorf("fetch changed config %s: %w", file.Filename, err)
 		}
 		configsByPath[configDir] = newDiscoveredConfig(config, configDir)
+		probes[configDir] = config
 	}
 
 	var filenames []string
@@ -348,7 +358,7 @@ func (ic *InstallationClient) FindConfigsForPRFiles(ctx context.Context, repo, r
 	}
 	schemaFiles := filterSchemaFiles(filenames)
 	for _, schemaFile := range schemaFiles {
-		config, configDir, err := ic.findNearestConfig(ctx, repo, ref, schemaFile)
+		config, configDir, err := ic.findNearestConfig(ctx, repo, ref, schemaFile, probes)
 		if err != nil {
 			return nil, err
 		}
@@ -433,16 +443,45 @@ func filterSchemaFiles(files []string) []string {
 	return result
 }
 
-func (ic *InstallationClient) findNearestConfig(ctx context.Context, repo, ref, filePath string) (*SchemabotConfig, string, error) {
+// configProbeCache memoizes per-directory config probe results within one
+// discovery pass. A key that maps to nil records a directory known to have no
+// schemabot.yaml, so the walk never re-fetches it for another file.
+//
+// Keys are directory paths only, so a cache is valid for exactly one
+// (repo, ref) pair — always ref a single immutable commit SHA and never reuse
+// a cache across refs. Not safe for concurrent use; probing in parallel
+// requires external synchronization.
+type configProbeCache map[string]*SchemabotConfig
+
+// probeConfigDir fetches the config for dir, consulting and populating the
+// cache. It returns (nil, nil) when the directory has no schemabot.yaml.
+// Transient errors are returned without being cached so a retry can succeed.
+func (ic *InstallationClient) probeConfigDir(ctx context.Context, repo, ref, dir string, probes configProbeCache) (*SchemabotConfig, error) {
+	if config, ok := probes[dir]; ok {
+		return config, nil
+	}
+	config, err := ic.FetchConfig(ctx, repo, configPathForDir(dir), ref)
+	if err != nil {
+		if errors.Is(err, ErrNoConfig) {
+			probes[dir] = nil
+			return nil, nil
+		}
+		return nil, err
+	}
+	probes[dir] = config
+	return config, nil
+}
+
+func (ic *InstallationClient) findNearestConfig(ctx context.Context, repo, ref, filePath string, probes configProbeCache) (*SchemabotConfig, string, error) {
 	dir := path.Dir(filePath)
 
 	for {
-		config, err := ic.FetchConfig(ctx, repo, configPathForDir(dir), ref)
-		if err == nil {
-			return config, dir, nil
-		}
-		if !errors.Is(err, ErrNoConfig) {
+		config, err := ic.probeConfigDir(ctx, repo, ref, dir, probes)
+		if err != nil {
 			return nil, "", err
+		}
+		if config != nil {
+			return config, dir, nil
 		}
 
 		if dir == "." || dir == "" {

--- a/pkg/github/config_test.go
+++ b/pkg/github/config_test.go
@@ -4,12 +4,14 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -245,6 +247,72 @@ func TestFindAllConfigsForPRDiscoversChangedConfigFile(t *testing.T) {
 	require.Len(t, configs, 1)
 	assert.Equal(t, "widgets", configs[0].Config.Database)
 	assert.Equal(t, "apps/widgets/schema", configs[0].SchemaDir)
+}
+
+// TestFindConfigsForPRFilesProbesEachDirectoryOnce exercises discovery for a
+// PR that touches many schema files under shared directory trees — the shape
+// of an onboarding PR that adds a declarative schema root while deleting a
+// legacy SQL tree. Discovery must fetch each candidate directory's
+// schemabot.yaml at most once, so the GitHub call volume is bounded by the
+// number of unique directories rather than changed files × directory depth,
+// and large PRs complete within the webhook processing deadline.
+func TestFindConfigsForPRFilesProbesEachDirectoryOnce(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerPullRequest(t, mux, "abc123")
+
+	var files []*gh.CommitFile
+	for i := range 40 {
+		files = append(files, &gh.CommitFile{
+			Filename: new(fmt.Sprintf("apps/widgets/service/resources/legacy-sql/v%04d__change.sql", i)),
+			Status:   new("removed"),
+		})
+	}
+	for i := range 10 {
+		files = append(files, &gh.CommitFile{
+			Filename: new(fmt.Sprintf("apps/widgets/service/resources/schema/widgets/table_%d.sql", i)),
+			Status:   new("added"),
+		})
+	}
+	registerPullRequestFiles(t, mux, files)
+
+	var mu sync.Mutex
+	probesByPath := make(map[string]int)
+	countProbe := func(r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		probesByPath[r.URL.Path]++
+	}
+
+	mux.HandleFunc("GET /repos/octocat/hello-world/contents/apps/widgets/service/resources/schema/schemabot.yaml", func(w http.ResponseWriter, r *http.Request) {
+		countProbe(r)
+		require.NoError(t, json.NewEncoder(w).Encode(gh.RepositoryContent{
+			Type:     new("file"),
+			Encoding: new("base64"),
+			Content:  new(base64.StdEncoding.EncodeToString([]byte("database: widgets\ntype: mysql\n"))),
+		}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/contents/", func(w http.ResponseWriter, r *http.Request) {
+		countProbe(r)
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	configs, err := ic.FindAllConfigsForPR(t.Context(), "octocat/hello-world", 1)
+
+	require.NoError(t, err)
+	require.Len(t, configs, 1)
+	assert.Equal(t, "widgets", configs[0].Config.Database)
+	assert.Equal(t, "apps/widgets/service/resources/schema", configs[0].SchemaDir)
+
+	// Every candidate directory between the changed files and the repo root,
+	// deduplicated: the two file trees share ancestors, so the probe count
+	// must not scale with the number of changed files.
+	mu.Lock()
+	defer mu.Unlock()
+	for probePath, count := range probesByPath {
+		assert.Equalf(t, 1, count, "directory probed more than once: %s", probePath)
+	}
+	assert.Len(t, probesByPath, 8)
 }
 
 func TestFindConfigForPRDiscoversChangedConfigFile(t *testing.T) {


### PR DESCRIPTION
## Why this matters

Config discovery is the intake for every PR event: when it cannot finish, the PR gets no Check Run at all — and the fail-closed "discovery failed" comment cannot post either, because the webhook processing deadline is already exhausted. Discovery walked ancestor directories independently for every changed schema file, one GitHub Contents call per file per directory level, so its call volume scaled with changed files × directory depth. Exactly the PRs that matter most — large conversions that add a declarative schema root while deleting a legacy versioned-SQL tree — deterministically blew the deadline and silently received no check.

## What it does

- Memoizes probe results per directory within a single discovery pass, negative results included: each unique directory is fetched at most once, bounding call volume by unique directories rather than changed files × directory depth.
- Never caches transient errors, so a retry within the same pass stays live.
- Leaves discovery semantics unchanged: the nearest config still wins, changed-config fetches seed the cache, and invalid configs still fail closed.
- Adds a test that drives a 50-file PR (40 deleted legacy `.sql` + 10 added declarative files) through discovery against a counting test server and asserts every candidate directory is fetched exactly once.

```
before   65 changed files × ~7 ancestor dirs ─► ~450 sequential Contents calls ─► deadline exceeded ─► no Check Run
after    8 unique dirs, each probed once     ─► ~8 calls                       ─► check posts normally
```

## How it moves toward northstar

Converting a service to the declarative workflow is the standard entry path, and those conversion PRs are inherently large. Onboarding at batch volume requires them to receive their required check as reliably as a one-line schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)