### PR TITLE
test(github): participant deployments stay silent on leader-owned fan-out applies

### DIFF
--- a/pkg/webhook/aggregate_fanout_silent_skip_test.go
+++ b/pkg/webhook/aggregate_fanout_silent_skip_test.go
@@ -101,6 +101,22 @@ func TestUnscopedApplyOnUnregisteredDatabaseStaysSilent(t *testing.T) {
 		assert.Empty(t, comments, "non-owning deployment must not post a comment for an unscoped fan-out apply")
 	})
 
+	// A tenant deployment receives the same fan-out for a PR touching only a
+	// database the leader owns; it must stay just as silent as the leader does
+	// for a participant-owned database.
+	t.Run("unscoped apply on participant deployment stays silent", func(t *testing.T) {
+		cfg := aggregateLeaderConfig()
+		repoCfg := cfg.Repos["octocat/hello-world"]
+		repoCfg.Aggregate = &api.AggregateConfig{Role: api.AggregateRoleParticipant}
+		cfg.Repos["octocat/hello-world"] = repoCfg
+		h, mux, comments := newFanOutSkipHandler(t, cfg)
+		serveSchemaConfigForDatabase(t, mux, "orders")
+
+		h.handleApplyCommand("octocat/hello-world", 1, "staging", "", 12345, "hubot", CommandResult{Action: action.Apply})
+
+		assert.Empty(t, comments, "a participant must not post Apply Failed for a database another deployment owns")
+	})
+
 	t.Run("tenant-scoped apply still reports the error", func(t *testing.T) {
 		h, mux, comments := newFanOutSkipHandler(t, aggregateLeaderConfig())
 		serveSchemaConfigForDatabase(t, mux, "orders")

--- a/pkg/webhook/aggregate_fanout_silent_skip_test.go
+++ b/pkg/webhook/aggregate_fanout_silent_skip_test.go
@@ -101,9 +101,9 @@ func TestUnscopedApplyOnUnregisteredDatabaseStaysSilent(t *testing.T) {
 		assert.Empty(t, comments, "non-owning deployment must not post a comment for an unscoped fan-out apply")
 	})
 
-	// A tenant deployment receives the same fan-out for a PR touching only a
-	// database the leader owns; it must stay just as silent as the leader does
-	// for a participant-owned database.
+	// A participant deployment receives the same fan-out for a PR touching
+	// only a database another deployment owns; the skip is role-agnostic, so
+	// it stays just as silent as a leader would.
 	t.Run("unscoped apply on participant deployment stays silent", func(t *testing.T) {
 		cfg := aggregateLeaderConfig()
 		repoCfg := cfg.Repos["octocat/hello-world"]


### PR DESCRIPTION
Test-only. Pins the mirror case of the unowned-database silent skip: a **participant** deployment receiving an unscoped fan-out apply for a PR that touches only a **leader-owned** database must stay silent (the existing coverage exercised the leader-side direction; the guard is role-agnostic and this asserts it). Observed live before the silent-skip fix merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)