### PR TITLE
feat(auth): repository-scoped admin teams and users

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -444,6 +444,8 @@ When enabled, SchemaBot checks PR approval before proceeding. A satisfying revie
 
 Repo admins sit between the global admin policy and per-database operators: they hold authority over every database whose schema changes flow through their repository — useful for monorepo maintainers — without gaining authority over databases managed through other repositories. The same principals may also run mutating PR comment commands when `pr_command_authorization` is enabled.
 
+> **Note:** a populated `repos:` map doubles as a repository allowlist — once any repository is listed, only listed repositories may use SchemaBot. If you add a repo entry solely to configure its admins, make sure every other repository this deployment serves is also listed, or they will be rejected as unregistered.
+
 The PR author's own approval never counts, even if they match one of the configured principals. If the GitHub API fails while checking reviews or team membership, SchemaBot blocks the apply and posts an error comment.
 
 CODEOWNERS support is opt-in because CODEOWNERS is repo-controlled while review policy is server-controlled. When `include_codeowners` is true, SchemaBot looks for CODEOWNERS in the standard GitHub locations on the base branch:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -418,6 +418,13 @@ review_policy:
   include_database_operators: true   # default: true
   include_codeowners: false          # default: false
 
+repos:
+  myorg/monorepo:
+    admin_teams:
+      - myorg/monorepo-maintainers
+    admin_users:
+      - some-maintainer
+
 databases:
   payments:
     type: mysql
@@ -431,8 +438,11 @@ databases:
 When enabled, SchemaBot checks PR approval before proceeding. A satisfying review can come from:
 
 1. `review_policy.admin_teams` or `review_policy.admin_users`, which apply to every configured database.
-2. The target database's `operator_teams` or `operator_users` when `include_database_operators` is true.
-3. Matching CODEOWNERS when `include_codeowners` is true.
+2. The PR repository's `admin_teams` or `admin_users` (under `repos:`), which apply to every database managed through that repository.
+3. The target database's `operator_teams` or `operator_users` when `include_database_operators` is true.
+4. Matching CODEOWNERS when `include_codeowners` is true.
+
+Repo admins sit between the global admin policy and per-database operators: they hold authority over every database whose schema changes flow through their repository — useful for monorepo maintainers — without gaining authority over databases managed through other repositories. The same principals may also run mutating PR comment commands when `pr_command_authorization` is enabled.
 
 The PR author's own approval never counts, even if they match one of the configured principals. If the GitHub API fails while checking reviews or team membership, SchemaBot blocks the apply and posts an error comment.
 

--- a/pkg/api/actor_authorization.go
+++ b/pkg/api/actor_authorization.go
@@ -9,6 +9,8 @@ const (
 	ActorAuthReasonDisabled              = "disabled"
 	ActorAuthReasonAllowedAdminTeam      = "allowed_admin_team"
 	ActorAuthReasonAllowedAdminUser      = "allowed_admin_user"
+	ActorAuthReasonAllowedRepoAdminTeam  = "allowed_repo_admin_team"
+	ActorAuthReasonAllowedRepoAdminUser  = "allowed_repo_admin_user"
 	ActorAuthReasonAllowedOperatorTeam   = "allowed_operator_team"
 	ActorAuthReasonAllowedOperatorUser   = "allowed_operator_user"
 	ActorAuthReasonMissingActor          = "missing_actor"
@@ -86,6 +88,16 @@ func validateDatabaseActorAuthorization(database string, dbConfig DatabaseConfig
 		return err
 	}
 	if err := validateGitHubUsers("databases."+database+".operator_users", dbConfig.OperatorUsers); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateRepoActorAuthorization(repo string, repoConfig RepoConfig) error {
+	if err := validateGitHubTeamPrincipals("repos."+repo+".admin_teams", repoConfig.AdminTeams); err != nil {
+		return err
+	}
+	if err := validateGitHubUsers("repos."+repo+".admin_users", repoConfig.AdminUsers); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/api/actor_authorization_test.go
+++ b/pkg/api/actor_authorization_test.go
@@ -151,6 +151,35 @@ func TestServerConfigValidatePRCommandAuthorization(t *testing.T) {
 			wantErr: "duplicate",
 		},
 		{
+			name: "valid repo admins",
+			mutate: func(cfg *ServerConfig) {
+				cfg.Repos = map[string]RepoConfig{
+					"octocat/hello-world": {
+						AdminTeams: []string{"octocat/repo-admins"},
+						AdminUsers: []string{"kara"},
+					},
+				}
+			},
+		},
+		{
+			name: "invalid repo admin team",
+			mutate: func(cfg *ServerConfig) {
+				cfg.Repos = map[string]RepoConfig{
+					"octocat/hello-world": {AdminTeams: []string{"repo-admins"}},
+				}
+			},
+			wantErr: "repos.octocat/hello-world.admin_teams",
+		},
+		{
+			name: "invalid repo admin user",
+			mutate: func(cfg *ServerConfig) {
+				cfg.Repos = map[string]RepoConfig{
+					"octocat/hello-world": {AdminUsers: []string{"octocat/kara"}},
+				}
+			},
+			wantErr: "repos.octocat/hello-world.admin_users",
+		},
+		{
 			name: "username cannot contain a slash",
 			mutate: func(cfg *ServerConfig) {
 				cfg.PRCommandAuthorization = PRCommandAuthorizationConfig{

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -715,6 +715,26 @@ type RepoConfig struct {
 	// set of tenants expected to report). Nil means the repository uses the
 	// standard single-deployment check behavior.
 	Aggregate *AggregateConfig `yaml:"aggregate,omitempty"`
+
+	// AdminTeams are GitHub teams whose members may run mutating PR comment
+	// commands and whose PR approvals satisfy the review gate for every
+	// database managed through this repository. Scoped between the global
+	// admin policy (every database) and per-database operators (one database).
+	AdminTeams []string `yaml:"admin_teams,omitempty"`
+
+	// AdminUsers are GitHub users with the same repository-scoped authority
+	// as AdminTeams.
+	AdminUsers []string `yaml:"admin_users,omitempty"`
+}
+
+// RepoAdmins returns the repository-scoped admin principals configured for
+// repo. A repository with no config entry has no repo admins.
+func (c *ServerConfig) RepoAdmins(repo string) (teams, users []string) {
+	repoConfig, ok := c.Repos[repo]
+	if !ok {
+		return nil, nil
+	}
+	return repoConfig.AdminTeams, repoConfig.AdminUsers
 }
 
 // DeploymentTarget is one entry in EnvironmentConfig.Deployments. It carries
@@ -903,6 +923,9 @@ func (c *ServerConfig) Validate() error {
 
 	for repo, repoConfig := range c.Repos {
 		if err := validateAggregateConfig(repo, repoConfig.Aggregate); err != nil {
+			return err
+		}
+		if err := validateRepoActorAuthorization(repo, repoConfig); err != nil {
 			return err
 		}
 	}

--- a/pkg/webhook/actor_authorization.go
+++ b/pkg/webhook/actor_authorization.go
@@ -57,7 +57,7 @@ func (h *Handler) enforcePRCommandActorAuthorization(
 	environment string,
 	commandName string,
 ) bool {
-	result, err := h.authorizePRCommandActor(ctx, client, requestedBy, database)
+	result, err := h.authorizePRCommandActor(ctx, client, requestedBy, repo, database)
 	status := actorAuthorizationMetricStatus(result, err)
 	metrics.RecordPRCommandActorAuthorization(ctx, metricActionKey(commandName), database, environment, repo, status, result.Reason)
 
@@ -129,6 +129,7 @@ func (h *Handler) authorizePRCommandActor(
 	ctx context.Context,
 	client *ghclient.InstallationClient,
 	actor string,
+	repo string,
 	database string,
 ) (api.ActorAuthorizationResult, error) {
 	// Without server config, SchemaBot cannot know the trusted actor policy.
@@ -147,13 +148,14 @@ func (h *Handler) authorizePRCommandActor(
 		return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonMissingActor}, nil
 	}
 
-	return h.authorizeConfiguredDatabaseActor(ctx, client, actor, database)
+	return h.authorizeConfiguredDatabaseActor(ctx, client, actor, repo, database)
 }
 
 func (h *Handler) authorizeConfiguredDatabaseActor(
 	ctx context.Context,
 	client *ghclient.InstallationClient,
 	actor string,
+	repo string,
 	database string,
 ) (api.ActorAuthorizationResult, error) {
 	// Without server config, SchemaBot cannot know the trusted actor policy.
@@ -175,8 +177,9 @@ func (h *Handler) authorizeConfiguredDatabaseActor(
 	}
 
 	authConfig := config.PRCommandAuthorization
-	teamCount := len(authConfig.AdminTeams) + len(dbConfig.OperatorTeams)
-	principalCount := teamCount + len(authConfig.AdminUsers) + len(dbConfig.OperatorUsers)
+	repoAdminTeams, repoAdminUsers := config.RepoAdmins(repo)
+	teamCount := len(authConfig.AdminTeams) + len(repoAdminTeams) + len(dbConfig.OperatorTeams)
+	principalCount := teamCount + len(authConfig.AdminUsers) + len(repoAdminUsers) + len(dbConfig.OperatorUsers)
 	// Actor auth is enabled but no admin/operator principals exist for this
 	// database. Fail closed instead of treating an empty policy as "allow all".
 	if principalCount == 0 {
@@ -203,11 +206,40 @@ func (h *Handler) authorizeConfiguredDatabaseActor(
 	}
 
 	// Global admin users are checked after admin teams and before any
-	// database-scoped operator policy.
+	// repository- or database-scoped policy.
 	if matched, principal := matchedUserPrincipal(authConfig.AdminUsers, actor); matched {
 		return api.ActorAuthorizationResult{
 			Allowed:          true,
 			Reason:           api.ActorAuthReasonAllowedAdminUser,
+			MatchedPrincipal: principal,
+		}, nil
+	}
+
+	// Repository admin teams authorize every database managed through the PR's
+	// repository.
+	if len(repoAdminTeams) > 0 {
+		if client == nil {
+			return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonGitHubError}, fmt.Errorf("github client is nil")
+		}
+		matched, principal, err := actorInAnyTeam(ctx, client, repoAdminTeams, actor)
+		if err != nil {
+			return api.ActorAuthorizationResult{Reason: api.ActorAuthReasonGitHubError}, err
+		}
+		if matched {
+			return api.ActorAuthorizationResult{
+				Allowed:          true,
+				Reason:           api.ActorAuthReasonAllowedRepoAdminTeam,
+				MatchedPrincipal: principal,
+			}, nil
+		}
+	}
+
+	// Repository admin users are checked after repo admin teams and before any
+	// database-scoped operator policy.
+	if matched, principal := matchedUserPrincipal(repoAdminUsers, actor); matched {
+		return api.ActorAuthorizationResult{
+			Allowed:          true,
+			Reason:           api.ActorAuthReasonAllowedRepoAdminUser,
 			MatchedPrincipal: principal,
 		}, nil
 	}

--- a/pkg/webhook/actor_authorization_test.go
+++ b/pkg/webhook/actor_authorization_test.go
@@ -26,6 +26,7 @@ func TestAuthorizePRCommandActor(t *testing.T) {
 		name       string
 		config     *api.ServerConfig
 		actor      string
+		repo       string
 		database   string
 		wantAllow  bool
 		wantReason string
@@ -64,6 +65,58 @@ func TestAuthorizePRCommandActor(t *testing.T) {
 			wantMatch:  "mona",
 		},
 		{
+			name: "repo admin user allows databases managed through that repository",
+			config: actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
+				cfg.Repos = map[string]api.RepoConfig{
+					"octocat/hello-world": {AdminUsers: []string{"mona"}},
+				}
+			}),
+			actor:      "Mona",
+			database:   "orders",
+			wantAllow:  true,
+			wantReason: api.ActorAuthReasonAllowedRepoAdminUser,
+			wantMatch:  "mona",
+		},
+		{
+			name: "global admin user takes precedence over repo admin user",
+			config: actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
+				cfg.PRCommandAuthorization.AdminUsers = []string{"mona"}
+				cfg.Repos = map[string]api.RepoConfig{
+					"octocat/hello-world": {AdminUsers: []string{"mona"}},
+				}
+			}),
+			actor:      "mona",
+			database:   "orders",
+			wantAllow:  true,
+			wantReason: api.ActorAuthReasonAllowedAdminUser,
+			wantMatch:  "mona",
+		},
+		{
+			name: "repo admin of a different repository is not authorized",
+			config: actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
+				cfg.Repos = map[string]api.RepoConfig{
+					"octocat/other-repo": {AdminUsers: []string{"mona"}},
+				}
+				db := cfg.Databases["orders"]
+				db.OperatorUsers = []string{"hubot"}
+				cfg.Databases["orders"] = db
+			}),
+			actor:      "mona",
+			database:   "orders",
+			wantReason: api.ActorAuthReasonNotAuthorized,
+		},
+		{
+			name: "repo admins on a different repository alone leave no principals and fail closed",
+			config: actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
+				cfg.Repos = map[string]api.RepoConfig{
+					"octocat/other-repo": {AdminUsers: []string{"mona"}},
+				}
+			}),
+			actor:      "mona",
+			database:   "orders",
+			wantReason: api.ActorAuthReasonNoConfiguredPrincipal,
+		},
+		{
 			name: "missing actor denies",
 			config: actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
 				cfg.PRCommandAuthorization.AdminUsers = []string{"mona"}
@@ -100,8 +153,12 @@ func TestAuthorizePRCommandActor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			repo := tt.repo
+			if repo == "" {
+				repo = "octocat/hello-world"
+			}
 			h := actorAuthTestHandler(tt.config, nil)
-			result, err := h.authorizePRCommandActor(t.Context(), nil, tt.actor, tt.database)
+			result, err := h.authorizePRCommandActor(t.Context(), nil, tt.actor, repo, tt.database)
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantAllow, result.Allowed)
 			assert.Equal(t, tt.wantReason, result.Reason)
@@ -166,6 +223,33 @@ func TestAuthorizePRCommandActorTeams(t *testing.T) {
 			wantMatch:   "octocat/orders-operators",
 		},
 		{
+			name: "repo admin team allows",
+			configure: func(cfg *api.ServerConfig) {
+				cfg.Repos = map[string]api.RepoConfig{
+					"octocat/hello-world": {AdminTeams: []string{"octocat/repo-admins"}},
+				}
+			},
+			teamMembers: []string{"mona"},
+			wantAllow:   true,
+			wantReason:  api.ActorAuthReasonAllowedRepoAdminTeam,
+			wantMatch:   "octocat/repo-admins",
+		},
+		{
+			name: "repo admin team takes precedence over operator team",
+			configure: func(cfg *api.ServerConfig) {
+				cfg.Repos = map[string]api.RepoConfig{
+					"octocat/hello-world": {AdminTeams: []string{"octocat/repo-admins"}},
+				}
+				db := cfg.Databases["orders"]
+				db.OperatorTeams = []string{"octocat/orders-operators"}
+				cfg.Databases["orders"] = db
+			},
+			teamMembers: []string{"mona"},
+			wantAllow:   true,
+			wantReason:  api.ActorAuthReasonAllowedRepoAdminTeam,
+			wantMatch:   "octocat/repo-admins",
+		},
+		{
 			name: "not a member denies",
 			configure: func(cfg *api.ServerConfig) {
 				cfg.PRCommandAuthorization.AdminTeams = []string{"octocat/schema-admins"}
@@ -201,12 +285,13 @@ func TestAuthorizePRCommandActorTeams(t *testing.T) {
 				teamMembersStatusCode = http.StatusOK
 			}
 			mux.HandleFunc("GET /orgs/octocat/teams/schema-admins/members", teamMembersHandler(t, teamMembersStatusCode, tt.teamMembers...))
+			mux.HandleFunc("GET /orgs/octocat/teams/repo-admins/members", teamMembersHandler(t, teamMembersStatusCode, tt.teamMembers...))
 			mux.HandleFunc("GET /orgs/octocat/teams/orders-operators/members", teamMembersHandler(t, teamMembersStatusCode, tt.teamMembers...))
 			installClient := ghclient.NewInstallationClient(client, testLogger())
 
 			cfg := actorAuthTestConfig(true, tt.configure)
 			h := actorAuthTestHandler(cfg, installClient)
-			result, err := h.authorizePRCommandActor(t.Context(), installClient, "mona", "orders")
+			result, err := h.authorizePRCommandActor(t.Context(), installClient, "mona", "octocat/hello-world", "orders")
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -233,7 +318,7 @@ func TestAuthorizePRCommandActorUsersOnlyDoesNotCallGitHub(t *testing.T) {
 	})
 	h := actorAuthTestHandler(cfg, installClient)
 
-	result, err := h.authorizePRCommandActor(t.Context(), installClient, "mona", "orders")
+	result, err := h.authorizePRCommandActor(t.Context(), installClient, "mona", "octocat/hello-world", "orders")
 	require.NoError(t, err)
 	assert.False(t, result.Allowed)
 	assert.Equal(t, api.ActorAuthReasonNotAuthorized, result.Reason)
@@ -242,7 +327,7 @@ func TestAuthorizePRCommandActorUsersOnlyDoesNotCallGitHub(t *testing.T) {
 
 func TestAuthorizePRCommandActorMissingServiceFailsClosed(t *testing.T) {
 	h := &Handler{logger: testLogger()}
-	result, err := h.authorizePRCommandActor(t.Context(), nil, "mona", "orders")
+	result, err := h.authorizePRCommandActor(t.Context(), nil, "mona", "octocat/hello-world", "orders")
 	require.Error(t, err)
 	assert.False(t, result.Allowed)
 	assert.Equal(t, api.ActorAuthReasonMissingServerConfig, result.Reason)

--- a/pkg/webhook/review_gate.go
+++ b/pkg/webhook/review_gate.go
@@ -120,6 +120,8 @@ func (h *Handler) checkReviewGate(ctx context.Context, client *ghclient.Installa
 type reviewGatePolicy struct {
 	AdminTeams         []string
 	AdminUsers         []string
+	RepoAdminTeams     []string
+	RepoAdminUsers     []string
 	OperatorTeams      []string
 	OperatorUsers      []string
 	CodeownerReviewers map[string]struct{}
@@ -137,6 +139,18 @@ func (p reviewGatePolicy) Matches(ctx context.Context, client *ghclient.Installa
 		}
 	}
 	if matched, principal := matchedUserPrincipal(p.AdminUsers, reviewer); matched {
+		return true, principal, nil
+	}
+	if len(p.RepoAdminTeams) > 0 {
+		matched, principal, err := actorInAnyTeam(ctx, client, p.RepoAdminTeams, reviewer)
+		if err != nil {
+			return false, "", err
+		}
+		if matched {
+			return true, principal, nil
+		}
+	}
+	if matched, principal := matchedUserPrincipal(p.RepoAdminUsers, reviewer); matched {
 		return true, principal, nil
 	}
 	if len(p.OperatorTeams) > 0 {
@@ -163,9 +177,12 @@ func (h *Handler) loadReviewGatePolicy(ctx context.Context, client *ghclient.Ins
 	}
 	config := h.service.Config()
 	reviewPolicy := config.ReviewPolicy
+	repoAdminTeams, repoAdminUsers := config.RepoAdmins(repo)
 	policy := reviewGatePolicy{
 		AdminTeams:         reviewPolicy.AdminTeams,
 		AdminUsers:         reviewPolicy.AdminUsers,
+		RepoAdminTeams:     repoAdminTeams,
+		RepoAdminUsers:     repoAdminUsers,
 		CodeownerReviewers: make(map[string]struct{}),
 	}
 	appendRequiredReviewers := func(values ...[]string) {
@@ -175,7 +192,7 @@ func (h *Handler) loadReviewGatePolicy(ctx context.Context, client *ghclient.Ins
 			}
 		}
 	}
-	appendRequiredReviewers(reviewPolicy.AdminTeams, reviewPolicy.AdminUsers)
+	appendRequiredReviewers(reviewPolicy.AdminTeams, reviewPolicy.AdminUsers, repoAdminTeams, repoAdminUsers)
 
 	if config.ReviewPolicyIncludesDatabaseOperators() {
 		dbConfig := config.Database(database)

--- a/pkg/webhook/review_gate_test.go
+++ b/pkg/webhook/review_gate_test.go
@@ -232,6 +232,64 @@ func TestCheckReviewGate_RepoAdminUserApproval(t *testing.T) {
 	assert.Contains(t, result.RequiredReviewers, "kara")
 }
 
+// A repo admin team's member approval satisfies the review gate for any
+// database managed through that repository, resolved via GitHub team
+// membership, and the configured team appears among the required reviewers.
+func TestCheckReviewGate_RepoAdminTeamApproval(t *testing.T) {
+	h, mux := setupReviewGateHandler(t, reviewGateTestConfig(func(cfg *api.ServerConfig) {
+		cfg.Repos = map[string]api.RepoConfig{
+			"octocat/hello-world": {AdminTeams: []string{"octocat/repo-admins"}},
+		}
+	}))
+
+	registerPREndpoint(mux, "alice")
+	registerReviewsEndpoint(mux, []*gh.PullRequestReview{
+		{
+			User:        &gh.User{Login: new("bob")},
+			State:       new(ghclient.ReviewApproved),
+			SubmittedAt: &gh.Timestamp{Time: time.Now()},
+		},
+	})
+	mux.HandleFunc("GET /orgs/octocat/teams/repo-admins/members", teamMembersHandler(t, http.StatusOK, "bob", "carol"))
+
+	client, err := h.clientForRepo("octocat/hello-world", 12345)
+	require.NoError(t, err)
+
+	result, err := h.checkReviewGate(t.Context(), client, "octocat/hello-world", 1, "orders", "schema/testdb")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.Approved)
+	assert.Contains(t, result.RequiredReviewers, "octocat/repo-admins")
+}
+
+// An approval from someone outside the repo admin team does not satisfy the
+// review gate: team membership is resolved via GitHub, not assumed.
+func TestCheckReviewGate_RepoAdminTeamNonMemberBlocked(t *testing.T) {
+	h, mux := setupReviewGateHandler(t, reviewGateTestConfig(func(cfg *api.ServerConfig) {
+		cfg.Repos = map[string]api.RepoConfig{
+			"octocat/hello-world": {AdminTeams: []string{"octocat/repo-admins"}},
+		}
+	}))
+
+	registerPREndpoint(mux, "alice")
+	registerReviewsEndpoint(mux, []*gh.PullRequestReview{
+		{
+			User:        &gh.User{Login: new("dave")},
+			State:       new(ghclient.ReviewApproved),
+			SubmittedAt: &gh.Timestamp{Time: time.Now()},
+		},
+	})
+	mux.HandleFunc("GET /orgs/octocat/teams/repo-admins/members", teamMembersHandler(t, http.StatusOK, "bob", "carol"))
+
+	client, err := h.clientForRepo("octocat/hello-world", 12345)
+	require.NoError(t, err)
+
+	result, err := h.checkReviewGate(t.Context(), client, "octocat/hello-world", 1, "orders", "schema/testdb")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.False(t, result.Approved)
+}
+
 // An approval from a user who is only a repo admin of a different repository
 // does not satisfy the review gate for this repository's PRs.
 func TestCheckReviewGate_RepoAdminOfOtherRepoBlocked(t *testing.T) {

--- a/pkg/webhook/review_gate_test.go
+++ b/pkg/webhook/review_gate_test.go
@@ -203,6 +203,64 @@ func TestCheckReviewGate_AdminUserApproval(t *testing.T) {
 	assert.True(t, result.Approved)
 }
 
+// A repo admin's approval satisfies the review gate for any database managed
+// through that repository, without granting approval authority on databases
+// managed through other repositories.
+func TestCheckReviewGate_RepoAdminUserApproval(t *testing.T) {
+	h, mux := setupReviewGateHandler(t, reviewGateTestConfig(func(cfg *api.ServerConfig) {
+		cfg.Repos = map[string]api.RepoConfig{
+			"octocat/hello-world": {AdminUsers: []string{"kara"}},
+		}
+	}))
+
+	registerPREndpoint(mux, "alice")
+	registerReviewsEndpoint(mux, []*gh.PullRequestReview{
+		{
+			User:        &gh.User{Login: new("kara")},
+			State:       new(ghclient.ReviewApproved),
+			SubmittedAt: &gh.Timestamp{Time: time.Now()},
+		},
+	})
+
+	client, err := h.clientForRepo("octocat/hello-world", 12345)
+	require.NoError(t, err)
+
+	result, err := h.checkReviewGate(t.Context(), client, "octocat/hello-world", 1, "orders", "schema/testdb")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.Approved)
+	assert.Contains(t, result.RequiredReviewers, "kara")
+}
+
+// An approval from a user who is only a repo admin of a different repository
+// does not satisfy the review gate for this repository's PRs.
+func TestCheckReviewGate_RepoAdminOfOtherRepoBlocked(t *testing.T) {
+	h, mux := setupReviewGateHandler(t, reviewGateTestConfig(func(cfg *api.ServerConfig) {
+		cfg.ReviewPolicy.AdminUsers = []string{"mona"}
+		cfg.Repos = map[string]api.RepoConfig{
+			"octocat/other-repo": {AdminUsers: []string{"kara"}},
+		}
+	}))
+
+	registerPREndpoint(mux, "alice")
+	registerReviewsEndpoint(mux, []*gh.PullRequestReview{
+		{
+			User:        &gh.User{Login: new("kara")},
+			State:       new(ghclient.ReviewApproved),
+			SubmittedAt: &gh.Timestamp{Time: time.Now()},
+		},
+	})
+
+	client, err := h.clientForRepo("octocat/hello-world", 12345)
+	require.NoError(t, err)
+
+	result, err := h.checkReviewGate(t.Context(), client, "octocat/hello-world", 1, "orders", "schema/testdb")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.False(t, result.Approved)
+	assert.NotContains(t, result.RequiredReviewers, "kara")
+}
+
 func TestCheckReviewGate_NotApproved(t *testing.T) {
 	h, mux := setupReviewGateHandler(t, reviewGateTestConfig(func(cfg *api.ServerConfig) {
 		db := cfg.Databases["orders"]


### PR DESCRIPTION
## Why this matters

Authorization has two scopes today: global admins (`review_policy` / `pr_command_authorization` — every database on the control plane) and per-database operators (`operator_teams` / `operator_users` — one database). Monorepo maintainers fit neither: they should hold authority over every database managed through their repository. Granting that today means either control-plane-wide admin (too broad — authority over databases in unrelated repos) or re-adding them to `operator_users` on every database their repo onboards (does not scale as onboarding volume grows).

## What it does

Adds `admin_teams` / `admin_users` to the per-repository config:

```yaml
repos:
  myorg/monorepo:
    admin_teams:
      - myorg/monorepo-maintainers
    admin_users:
      - some-maintainer
```

- Repo admins may run mutating PR comment commands and their PR approvals satisfy the review gate, for any database managed through that repository — and only that repository.
- Precedence sits between global admins and database operators:

```
global admin teams → global admin users
      → repo admin teams → repo admin users
            → database operator teams → database operator users
                  → CODEOWNERS (review gate, opt-in)
```

- Repo admins count toward the fail-closed no-configured-principal check; a PR from a repository with no matching principals still denies.
- Validated at config load like the other principal tiers (org/team-slug form, no slashes in usernames, case-insensitive duplicate rejection).
- Distinct authorization reasons (`allowed_repo_admin_team`, `allowed_repo_admin_user`) keep metrics and audit logs attributable.
- Repo admins appear in the review-required PR comment's reviewer list.

Deliberately excluded from direct-API auth: repo admins are a PR-context concept, and API requests carry no repository scope — the API write tier keeps its existing admin-team policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)