### PR TITLE
fix(github): aggregate participants stay silent on merge-group commits

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1080,6 +1080,7 @@ var knownStatusCheckOperations = map[string]bool{
 	"aggregate_participant_skip":           true,
 	"aggregate_participant_fanout":         true,
 	"participant_comment_nudge":            true,
+	"merge_group_check":                    true,
 }
 
 var knownStatusCheckStatuses = map[string]bool{

--- a/pkg/webhook/merge_group.go
+++ b/pkg/webhook/merge_group.go
@@ -87,7 +87,7 @@ func (h *Handler) handleMergeGroup(ctx context.Context, metricApp string, w http
 	// required checks gate a merge-group entry.
 	if h.isAggregateParticipant(repo) {
 		h.logger.Info("aggregate participant staying silent on merge_group; the leader posts the required checks",
-			"repo", repo, "head_sha", headSHA)
+			"repo", repo, "head_sha", headSHA, "installation_id", installationID)
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
 			Operation:  "merge_group_check",
 			Repository: repo,

--- a/pkg/webhook/merge_group.go
+++ b/pkg/webhook/merge_group.go
@@ -80,6 +80,23 @@ func (h *Handler) handleMergeGroup(ctx context.Context, metricApp string, w http
 		return
 	}
 
+	// An aggregate participant's checks are never required — the leader owns
+	// the required aggregate and posts it on the merge-group commit — so a
+	// participant posting here would only re-add the per-tenant rows the
+	// aggregate removes. A silent participant cannot wedge the queue: only
+	// required checks gate a merge-group entry.
+	if h.isAggregateParticipant(repo) {
+		h.logger.Info("aggregate participant staying silent on merge_group; the leader posts the required checks",
+			"repo", repo, "head_sha", headSHA)
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:  "merge_group_check",
+			Repository: repo,
+			Status:     "skipped",
+		})
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "merge_group ignored (aggregate participant, staying silent)"})
+		return
+	}
+
 	// When check publishing is disabled for this repo, SchemaBot's check is not
 	// required either, so skipping the merge-group check is correct.
 	if !h.shouldPublishChecks(ctx, repo, "merge_group_check") {

--- a/pkg/webhook/merge_group_test.go
+++ b/pkg/webhook/merge_group_test.go
@@ -267,7 +267,7 @@ func TestWebhookMergeGroupParticipantStaysSilent(t *testing.T) {
 	select {
 	case c := <-created:
 		t.Fatalf("participant posted a merge_group check run: %q", c.Name)
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(100 * time.Millisecond):
 	}
 }
 

--- a/pkg/webhook/merge_group_test.go
+++ b/pkg/webhook/merge_group_test.go
@@ -245,3 +245,56 @@ func TestWebhookMergeGroupSingleAggregateWhenNoEnvScoping(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 	}
 }
+
+// An aggregate participant's checks are never required, so it posts nothing on
+// a merge-group commit — the leader publishes the required aggregate there.
+// Without this silence, every queue entry would re-grow the per-tenant check
+// rows the aggregate removes from PR heads.
+func TestWebhookMergeGroupParticipantStaysSilent(t *testing.T) {
+	h, created := mergeGroupTestHandler(t,
+		[]string{"production"},
+		map[string]api.RepoConfig{"octocat/hello-world": {
+			Aggregate: &api.AggregateConfig{Role: api.AggregateRoleParticipant},
+		}},
+	)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, buildMergeGroupWebhookRequest(t, "checks_requested", "mergesha123", nil))
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "aggregate participant, staying silent")
+
+	select {
+	case c := <-created:
+		t.Fatalf("participant posted a merge_group check run: %q", c.Name)
+	case <-time.After(500 * time.Millisecond):
+	}
+}
+
+// The aggregate leader keeps posting its required checks on merge-group
+// commits — silence is participant-only, so the queue never wedges.
+func TestWebhookMergeGroupLeaderStillPosts(t *testing.T) {
+	h, created := mergeGroupTestHandler(t,
+		[]string{"production"},
+		map[string]api.RepoConfig{"octocat/hello-world": {
+			Aggregate: &api.AggregateConfig{
+				Role:            api.AggregateRoleLeader,
+				ExpectedTenants: []api.ExpectedTenant{{Tenant: "tenant-b", Paths: []string{"tenant-b/schema"}, CheckName: "SchemaBot Tenant B"}},
+			},
+		}},
+	)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, buildMergeGroupWebhookRequest(t, "checks_requested", "mergesha123", nil))
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "merge_group checks posted")
+
+	select {
+	case c := <-created:
+		assert.Equal(t, "SchemaBot (production)", c.Name)
+		assert.Equal(t, "success", c.Conclusion)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the leader's merge_group check run")
+	}
+}


### PR DESCRIPTION
## Why this matters

The participant-silence rule covered PR-head events but not the `merge_group` handler: when a PR enters the merge queue, GitHub fires `checks_requested` to every installed App, and each participant posted its own passing `SchemaBot <tenant> (<env>)` check on the merge-group commit — re-growing, on every queue entry, exactly the per-tenant check rows the aggregate removes from PR heads. Observed live on a merge-queue commit's checks popup.

## What it does

In `handleMergeGroup`, a deployment with the `participant` role for the repo logs, counts a skipped `merge_group_check`, and posts nothing. The leader keeps posting its required aggregate checks on the merge-group commit, so the queue can never wedge — only required checks gate a merge-group entry, and those are the leader's. Tests cover both directions: participant silent, leader still posting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)