### PR TITLE
feat(github): publish the aggregate check on default-branch pushes

### DIFF
--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -80,6 +80,7 @@ Under **Organization permissions**, grant:
 |-------|---------|
 | **Issue comment** | Receive `schemabot plan`, `schemabot help`, etc. from PR comments |
 | **Merge group** | Publish a passing SchemaBot check on a merge-queue commit so a required SchemaBot check does not block the merge queue (only needed if a repo uses a merge queue) |
+| **Push** | Publish a passing SchemaBot check on default-branch commits so branch rulesets can select the App as a pinned required-check source (rulesets only index Apps whose check suites ran against the target branch) |
 
 Subscribe to **Merge group**, not **Merge queue entry** — the two are distinct events, and SchemaBot handles only `merge_group`. The **Merge group** event requires the **Merge queues: Read** repository permission above. Because that is a new permission, adding it to an existing App marks the App as requesting new permissions, which an org or repository admin must approve on each installation before it takes effect.
 

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -84,6 +84,8 @@ Under **Organization permissions**, grant:
 
 Subscribe to **Merge group**, not **Merge queue entry** — the two are distinct events, and SchemaBot handles only `merge_group`. The **Merge group** event requires the **Merge queues: Read** repository permission above. Because that is a new permission, adding it to an existing App marks the App as requesting new permissions, which an org or repository admin must approve on each installation before it takes effect.
 
+The **Push** event needs no new permission — **Contents: Read** above already unlocks it — so subscribing an existing App takes effect immediately on every installation, with no admin re-approval. Expect webhook delivery volume to rise once subscribed: GitHub sends a `push` event for every branch and tag push on installed repositories, and SchemaBot discards everything but default-branch pushes.
+
 Future phases will also use **Check run** (action buttons) and **Pull request** (auto-plan on open/sync).
 
 ### Where Can This GitHub App Be Installed?

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1081,6 +1081,7 @@ var knownStatusCheckOperations = map[string]bool{
 	"aggregate_participant_fanout":         true,
 	"participant_comment_nudge":            true,
 	"merge_group_check":                    true,
+	"default_branch_check":                 true,
 }
 
 var knownStatusCheckStatuses = map[string]bool{

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -533,6 +533,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "merge_group":
 		h.handleMergeGroup(ctx, metricApp, w, body)
 		metrics.RecordWebhookEvent(ctx, metricApp, eventType, action, repo, "processed")
+	case "push":
+		h.handlePush(ctx, metricApp, w, body)
+		metrics.RecordWebhookEvent(ctx, metricApp, eventType, action, repo, "processed")
 	default:
 		h.logger.Info("webhook ignored",
 			"reason", "unsupported_event_type",

--- a/pkg/webhook/merge_group.go
+++ b/pkg/webhook/merge_group.go
@@ -115,7 +115,12 @@ func (h *Handler) handleMergeGroup(ctx context.Context, metricApp string, w http
 		return
 	}
 
-	if err := h.postMergeGroupChecks(postCtx, client, repo, headSHA); err != nil {
+	if err := h.postPassingAggregateChecks(postCtx, client, repo, headSHA, passingAggregateCheckContent{
+		operation: "merge_group_check",
+		title:     "Schema changes verified before merge queue",
+		summary: "Schema changes in queued pull requests are applied and verified by SchemaBot before " +
+			"they enter the merge queue, so no additional verification is required for this merge group.",
+	}); err != nil {
 		// Return 500 so GitHub redelivers. The merge queue blocks until the check
 		// is posted, so a transient failure must be retried, not dropped.
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
@@ -132,53 +137,59 @@ func (h *Handler) handleMergeGroup(ctx context.Context, metricApp string, w http
 	h.writeJSON(w, http.StatusOK, map[string]string{"message": "merge_group checks posted"})
 }
 
-// postMergeGroupChecks publishes a passing aggregate Check Run on the
-// merge-group head SHA for each environment this instance gates, reusing the
-// same check names as the PR-head aggregates so branch protection's required
-// checks always match.
-func (h *Handler) postMergeGroupChecks(ctx context.Context, client *ghclient.InstallationClient, repo, headSHA string) error {
-	const (
-		title   = "Schema changes verified before merge queue"
-		summary = "Schema changes in queued pull requests are applied and verified by SchemaBot before they enter the merge queue, so no additional verification is required for this merge group."
-	)
+// passingAggregateCheckContent carries the operation name and Check Run output
+// for a passing aggregate published outside the PR-head path (merge-queue
+// heads, default-branch pushes).
+type passingAggregateCheckContent struct {
+	operation string
+	title     string
+	summary   string
+}
 
+// postPassingAggregateChecks publishes a passing aggregate Check Run on
+// headSHA for each environment this instance gates, reusing the same check
+// names as the PR-head aggregates so branch protection's required checks
+// always match.
+func (h *Handler) postPassingAggregateChecks(ctx context.Context, client *ghclient.InstallationClient, repo, headSHA string, content passingAggregateCheckContent) error {
 	for _, target := range h.aggregateCheckTargetsForRepo(repo) {
 		opts := ghclient.CheckRunOptions{
 			Name:       target.name,
 			Status:     checkStatusCompleted,
 			Conclusion: checkConclusionSuccess,
 			Output: &ghclient.CheckRunOutput{
-				Title:   title,
-				Summary: summary,
+				Title:   content.title,
+				Summary: content.summary,
 			},
 		}
-		// Reuse an existing run for this name on the merge-group SHA so a webhook
+		// Reuse an existing run for this name on the SHA so a webhook
 		// redelivery updates it rather than creating a duplicate Check Run. The
 		// lookup fails closed when the App slug is unknown; on that error fall
 		// back to creating, which is the safe (if untidy) outcome.
 		existing, _, findErr := client.FindCheckRunByName(ctx, repo, headSHA, target.name)
 		if findErr != nil {
-			h.logger.Warn("could not look up existing merge_group check; creating a new one",
-				"repo", repo, "head_sha", headSHA, "check_name", target.name, "error", findErr)
+			h.logger.Warn("could not look up existing check; creating a new one",
+				"repo", repo, "head_sha", headSHA, "check_name", target.name,
+				"operation", content.operation, "error", findErr)
 		}
 		switch {
 		case findErr == nil && existing != nil:
 			if err := client.UpdateCheckRun(ctx, repo, existing.ID, opts); err != nil {
-				return fmt.Errorf("update merge_group check %q on %s: %w", target.name, headSHA, err)
+				return fmt.Errorf("update %s check %q on %s: %w", content.operation, target.name, headSHA, err)
 			}
 		default:
 			if _, err := client.CreateCheckRun(ctx, repo, headSHA, opts); err != nil {
-				return fmt.Errorf("create merge_group check %q on %s: %w", target.name, headSHA, err)
+				return fmt.Errorf("create %s check %q on %s: %w", content.operation, target.name, headSHA, err)
 			}
 		}
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
-			Operation:   "merge_group_check",
+			Operation:   content.operation,
 			Repository:  repo,
 			Environment: target.environment,
 			Status:      "success",
 		})
-		h.logger.Info("merge_group check posted",
-			"repo", repo, "head_sha", headSHA, "check_name", target.name, "environment", target.environment)
+		h.logger.Info("passing aggregate check posted",
+			"repo", repo, "head_sha", headSHA, "check_name", target.name,
+			"environment", target.environment, "operation", content.operation)
 	}
 	return nil
 }

--- a/pkg/webhook/merge_group.go
+++ b/pkg/webhook/merge_group.go
@@ -162,9 +162,10 @@ func (h *Handler) postPassingAggregateChecks(ctx context.Context, client *ghclie
 			},
 		}
 		// Reuse an existing run for this name on the SHA so a webhook
-		// redelivery updates it rather than creating a duplicate Check Run. The
-		// lookup fails closed when the App slug is unknown; on that error fall
-		// back to creating, which is the safe (if untidy) outcome.
+		// redelivery updates it rather than creating a duplicate Check Run.
+		// The lookup errors when the App slug is unknown; on any lookup error
+		// fall back to creating a new run — a duplicate Check Run is the safe
+		// outcome, a missing one is not.
 		existing, _, findErr := client.FindCheckRunByName(ctx, repo, headSHA, target.name)
 		if findErr != nil {
 			h.logger.Warn("could not look up existing check; creating a new one",
@@ -174,11 +175,11 @@ func (h *Handler) postPassingAggregateChecks(ctx context.Context, client *ghclie
 		switch {
 		case findErr == nil && existing != nil:
 			if err := client.UpdateCheckRun(ctx, repo, existing.ID, opts); err != nil {
-				return fmt.Errorf("update %s check %q on %s: %w", content.operation, target.name, headSHA, err)
+				return fmt.Errorf("update %s check %q on %s@%s: %w", content.operation, target.name, repo, headSHA, err)
 			}
 		default:
 			if _, err := client.CreateCheckRun(ctx, repo, headSHA, opts); err != nil {
-				return fmt.Errorf("create %s check %q on %s: %w", content.operation, target.name, headSHA, err)
+				return fmt.Errorf("create %s check %q on %s@%s: %w", content.operation, target.name, repo, headSHA, err)
 			}
 		}
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{

--- a/pkg/webhook/merge_group.go
+++ b/pkg/webhook/merge_group.go
@@ -121,8 +121,10 @@ func (h *Handler) handleMergeGroup(ctx context.Context, metricApp string, w http
 		summary: "Schema changes in queued pull requests are applied and verified by SchemaBot before " +
 			"they enter the merge queue, so no additional verification is required for this merge group.",
 	}); err != nil {
-		// Return 500 so GitHub redelivers. The merge queue blocks until the check
-		// is posted, so a transient failure must be retried, not dropped.
+		// Return 500 so the delivery is recorded as failed and shows up in the
+		// App's delivery log for redelivery. The merge queue blocks until the
+		// check is posted, so the failure must be visible for retry, not
+		// silently dropped.
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
 			Operation:  "merge_group_check",
 			Repository: repo,

--- a/pkg/webhook/push.go
+++ b/pkg/webhook/push.go
@@ -1,0 +1,130 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/block/schemabot/pkg/metrics"
+)
+
+// pushPayload is the subset of the GitHub push webhook payload SchemaBot
+// needs. GitHub fires this event for every branch or tag push on repositories
+// the App is installed on.
+type pushPayload struct {
+	Ref        string `json:"ref"`
+	After      string `json:"after"`
+	Deleted    bool   `json:"deleted"`
+	Repository struct {
+		FullName      string `json:"full_name"`
+		DefaultBranch string `json:"default_branch"`
+	} `json:"repository"`
+	Installation struct {
+		ID int64 `json:"id"`
+	} `json:"installation"`
+}
+
+// handlePush responds to push webhook events on the default branch by
+// publishing SchemaBot's passing aggregate Check Run on the pushed commit.
+//
+// Every other SchemaBot check runs against a PR head or a merge-queue head, so
+// its check suites never record the default branch as their head branch. Branch
+// rulesets index required-check sources by exactly that field: an App that has
+// never completed a check suite on the target branch cannot be selected as a
+// check source, which forces repository admins into unpinned "any source"
+// requirements that a same-named status from any writer can satisfy. Publishing
+// the aggregate on default-branch pushes keeps the App selectable as a pinned
+// check source.
+//
+// Posting a passing check is correct for the same reason as the merge-queue
+// check: SchemaBot gates schema changes on pull requests before they reach the
+// default branch, so a commit already on the default branch has nothing left to
+// verify. Rulesets evaluate required checks on PR and merge-queue commits, never
+// on commits already landed, so this check can never satisfy a merge gate.
+func (h *Handler) handlePush(ctx context.Context, metricApp string, w http.ResponseWriter, body []byte) {
+	var payload pushPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		h.writeError(w, http.StatusBadRequest, "invalid push payload")
+		return
+	}
+
+	repo := payload.Repository.FullName
+	headSHA := payload.After
+
+	// Only default-branch pushes need the check; pushes to feature branches,
+	// merge-queue branches, and tags are covered by the PR and merge-queue
+	// check paths.
+	if payload.Repository.DefaultBranch == "" || payload.Ref != "refs/heads/"+payload.Repository.DefaultBranch {
+		h.logger.Debug("push ignored: not the default branch",
+			"repo", repo, "ref", payload.Ref, "default_branch", payload.Repository.DefaultBranch)
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "push ignored: not the default branch"})
+		return
+	}
+
+	// A branch deletion has no commit to publish a check on.
+	if payload.Deleted || headSHA == "" || strings.Trim(headSHA, "0") == "" {
+		h.logger.Debug("push ignored: branch deletion",
+			"repo", repo, "ref", payload.Ref)
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "push ignored: branch deletion"})
+		return
+	}
+
+	installationID := h.effectiveInstallationID(ctx, payload.Installation.ID)
+	if installationID == 0 {
+		h.writeError(w, http.StatusBadRequest, "missing installation ID in push payload")
+		return
+	}
+
+	// A repo SchemaBot does not manage gets no check — its check is not
+	// required on that repo, so there is no check source to keep selectable.
+	if h.service != nil && !h.service.Config().IsRepoAllowed(repo) {
+		h.logger.Debug("push webhook from unregistered repository",
+			"repo", repo, "head_sha", headSHA, "installation_id", installationID)
+		metrics.RecordUnregisteredRepositoryWebhook(ctx, metricApp, "push", "", repo)
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "repository not registered"})
+		return
+	}
+
+	// When check publishing is disabled for this repo, SchemaBot's check is not
+	// required either, so there is no check source to maintain.
+	if !h.shouldPublishChecks(ctx, repo, "default_branch_check") {
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "check publishing disabled"})
+		return
+	}
+
+	postCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+
+	client, err := h.clientForRepo(repo, installationID)
+	if err != nil {
+		h.logger.Error("failed to create GitHub client for default-branch check",
+			"repo", repo, "head_sha", headSHA, "installation_id", installationID, "error", err)
+		h.writeError(w, http.StatusInternalServerError, "failed to initialize GitHub client")
+		return
+	}
+
+	if err := h.postPassingAggregateChecks(postCtx, client, repo, headSHA, passingAggregateCheckContent{
+		operation: "default_branch_check",
+		title:     "Schema changes are verified before merge",
+		summary: "SchemaBot gates schema changes on pull requests before they reach the default branch, " +
+			"so commits on the default branch require no additional verification. " +
+			"This check also keeps SchemaBot selectable as a required-check source in branch rulesets.",
+	}); err != nil {
+		// Return 500 so GitHub redelivers. A missed post only ages the
+		// ruleset source index, but redelivery is idempotent and keeps the
+		// index fresh without operator involvement.
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:  "default_branch_check",
+			Repository: repo,
+			Status:     "error",
+		})
+		h.logger.Error("failed to post default-branch checks",
+			"repo", repo, "head_sha", headSHA, "error", err)
+		h.writeError(w, http.StatusInternalServerError, "failed to post default-branch checks")
+		return
+	}
+
+	h.writeJSON(w, http.StatusOK, map[string]string{"message": "default-branch checks posted"})
+}

--- a/pkg/webhook/push.go
+++ b/pkg/webhook/push.go
@@ -87,6 +87,22 @@ func (h *Handler) handlePush(ctx context.Context, metricApp string, w http.Respo
 		return
 	}
 
+	// An aggregate participant's checks are never required — the leader owns
+	// the required aggregate, so only the leader needs to stay selectable as a
+	// ruleset check source. A participant seeding its informational check on
+	// every landed commit would only add noise.
+	if h.isAggregateParticipant(repo) {
+		h.logger.Info("aggregate participant staying silent on default-branch push; the leader maintains the check source",
+			"repo", repo, "head_sha", headSHA, "installation_id", installationID)
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:  "default_branch_check",
+			Repository: repo,
+			Status:     "skipped",
+		})
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "push ignored (aggregate participant, staying silent)"})
+		return
+	}
+
 	// When check publishing is disabled for this repo, SchemaBot's check is not
 	// required either, so there is no check source to maintain.
 	if !h.shouldPublishChecks(ctx, repo, "default_branch_check") {

--- a/pkg/webhook/push.go
+++ b/pkg/webhook/push.go
@@ -112,9 +112,10 @@ func (h *Handler) handlePush(ctx context.Context, metricApp string, w http.Respo
 			"so commits on the default branch require no additional verification. " +
 			"This check also keeps SchemaBot selectable as a required-check source in branch rulesets.",
 	}); err != nil {
-		// Return 500 so GitHub redelivers. A missed post only ages the
-		// ruleset source index, but redelivery is idempotent and keeps the
-		// index fresh without operator involvement.
+		// Return 500 so the delivery is recorded as failed and shows up in the
+		// App's delivery log for redelivery. A missed post only ages the
+		// ruleset source index — the next default-branch push refreshes it —
+		// and reposting is idempotent.
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
 			Operation:  "default_branch_check",
 			Repository: repo,

--- a/pkg/webhook/push_test.go
+++ b/pkg/webhook/push_test.go
@@ -119,6 +119,59 @@ func TestWebhookPushIgnoresBranchDeletion(t *testing.T) {
 	}
 }
 
+// An aggregate participant's checks are never required — the leader owns the
+// required aggregate — so a participant stays silent on default-branch pushes
+// rather than seeding an informational check on every landed commit.
+func TestWebhookPushParticipantStaysSilent(t *testing.T) {
+	h, created := mergeGroupTestHandler(t,
+		[]string{"production"},
+		map[string]api.RepoConfig{"octocat/hello-world": {
+			Aggregate: &api.AggregateConfig{Role: api.AggregateRoleParticipant},
+		}},
+	)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, buildPushWebhookRequest(t, "refs/heads/main", "pushsha123", false))
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "aggregate participant, staying silent")
+
+	select {
+	case c := <-created:
+		t.Fatalf("participant posted a default-branch check run: %q", c.Name)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// The aggregate leader keeps seeding its required check names on
+// default-branch pushes — silence is participant-only, so the leader App
+// stays selectable as a pinned required-check source.
+func TestWebhookPushLeaderStillPosts(t *testing.T) {
+	h, created := mergeGroupTestHandler(t,
+		[]string{"production"},
+		map[string]api.RepoConfig{"octocat/hello-world": {
+			Aggregate: &api.AggregateConfig{
+				Role:            api.AggregateRoleLeader,
+				ExpectedTenants: []api.ExpectedTenant{{Tenant: "tenant-b", Paths: []string{"tenant-b/schema"}, CheckName: "SchemaBot Tenant B"}},
+			},
+		}},
+	)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, buildPushWebhookRequest(t, "refs/heads/main", "pushsha123", false))
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "default-branch checks posted")
+
+	select {
+	case c := <-created:
+		assert.Equal(t, "pushsha123", c.HeadSHA)
+		assert.Equal(t, "success", c.Conclusion)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the leader's default-branch check run")
+	}
+}
+
 // A push on a repository SchemaBot does not manage gets no check: SchemaBot's
 // check is not required there, so there is no check source to maintain.
 func TestWebhookPushRejectsUnregisteredRepo(t *testing.T) {

--- a/pkg/webhook/push_test.go
+++ b/pkg/webhook/push_test.go
@@ -1,0 +1,141 @@
+package webhook
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/api"
+)
+
+// buildPushWebhookRequest constructs a push webhook POST request for
+// octocat/hello-world, whose default branch is main.
+func buildPushWebhookRequest(t *testing.T, ref, after string, deleted bool) *http.Request {
+	t.Helper()
+
+	payload := map[string]any{
+		"ref":     ref,
+		"after":   after,
+		"deleted": deleted,
+		"repository": map[string]any{
+			"full_name":      "octocat/hello-world",
+			"default_branch": "main",
+		},
+		"installation": map[string]any{
+			"id": 12345,
+		},
+	}
+
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/webhook", strings.NewReader(string(body)))
+	req.Header.Set("X-GitHub-Event", "push")
+	return req
+}
+
+// Branch rulesets index required-check sources by the branch a check suite ran
+// against, and every other SchemaBot check runs against PR or merge-queue
+// heads. Publishing the passing aggregate on default-branch pushes keeps the
+// App selectable as a pinned required-check source — one check per gated
+// environment, with the same names as the PR-head aggregates.
+func TestWebhookPushPostsPassingChecksOnDefaultBranch(t *testing.T) {
+	h, created := mergeGroupTestHandler(t,
+		[]string{"staging", "production"},
+		map[string]api.RepoConfig{"octocat/hello-world": {}},
+	)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, buildPushWebhookRequest(t, "refs/heads/main", "pushsha123", false))
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "default-branch checks posted")
+
+	got := map[string]createdCheckRun{}
+	for range []int{0, 1} {
+		select {
+		case c := <-created:
+			got[c.Name] = c
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for default-branch check run")
+		}
+	}
+
+	require.Len(t, got, 2)
+	for _, name := range []string{"SchemaBot (staging)", "SchemaBot (production)"} {
+		c, ok := got[name]
+		require.True(t, ok, "expected a check run named %q", name)
+		assert.Equal(t, "pushsha123", c.HeadSHA)
+		assert.Equal(t, "completed", c.Status)
+		assert.Equal(t, "success", c.Conclusion)
+	}
+}
+
+// Pushes to feature branches, merge-queue branches, and tags are covered by
+// the PR and merge-queue check paths; only the default branch needs the
+// check-source seed.
+func TestWebhookPushIgnoresNonDefaultBranch(t *testing.T) {
+	h, created := mergeGroupTestHandler(t,
+		[]string{"production"},
+		map[string]api.RepoConfig{"octocat/hello-world": {}},
+	)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, buildPushWebhookRequest(t, "refs/heads/feature-branch", "pushsha123", false))
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "not the default branch")
+
+	select {
+	case c := <-created:
+		t.Fatalf("unexpected check run created for non-default branch push: %q", c.Name)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// A branch deletion push has no commit to publish a check on.
+func TestWebhookPushIgnoresBranchDeletion(t *testing.T) {
+	h, created := mergeGroupTestHandler(t,
+		[]string{"production"},
+		map[string]api.RepoConfig{"octocat/hello-world": {}},
+	)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, buildPushWebhookRequest(t, "refs/heads/main", "0000000000000000000000000000000000000000", true))
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "branch deletion")
+
+	select {
+	case c := <-created:
+		t.Fatalf("unexpected check run created for branch deletion: %q", c.Name)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// A push on a repository SchemaBot does not manage gets no check: SchemaBot's
+// check is not required there, so there is no check source to maintain.
+func TestWebhookPushRejectsUnregisteredRepo(t *testing.T) {
+	h, created := mergeGroupTestHandler(t,
+		[]string{"production"},
+		map[string]api.RepoConfig{"org/allowed-repo": {}},
+	)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, buildPushWebhookRequest(t, "refs/heads/main", "pushsha123", false))
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "repository not registered")
+
+	select {
+	case c := <-created:
+		t.Fatalf("unexpected check run created for unregistered repo: %q", c.Name)
+	case <-time.After(100 * time.Millisecond):
+	}
+}


### PR DESCRIPTION
## Why this matters

Branch rulesets index required-check *sources* by the branch a check suite ran against: an App that has never completed a check suite on the ruleset's target branch cannot be selected as a check source in the required-checks picker. Every SchemaBot check runs against a PR head or a merge-queue head — even when the merge queue lands the exact checked SHA on the default branch, the suite keeps the queue branch as its head branch — so SchemaBot never qualifies. Repository admins are forced into unpinned "any source" requirements, which a same-named commit status from anyone with write access can satisfy. For a merge gate, the check name ends up doing the authentication.

## What it does

Handles `push` events for the default branch by publishing the passing aggregate Check Run on the pushed commit — one per gated environment, using the same names as the PR-head aggregates. That gives GitHub a check suite with the default branch as its head branch, which keeps the App selectable as a **pinned** required-check source: a ruleset pinned to the App rejects same-named checks and statuses from every other source.

```
PR head        ──► aggregate check (suite: feature branch)     ─┐
merge queue    ──► aggregate check (suite: gh-readonly-queue/…) ├─ never indexed as "ran on main"
                                                                ─┘
push to main   ──► aggregate check (suite: main)  ──► App selectable as pinned source
```

Safety properties:

- **Gates nothing.** Rulesets evaluate required checks on PR and merge-queue commits, never on commits already landed; the seeded check exists only on post-merge commits.
- **Touches no stored check state** — a fire-and-forget GitHub write outside the check-record pipeline.
- **Passing is correct** for the same reason as the merge-queue check: schema changes are gated on pull requests before they reach the default branch.
- Guards: default-branch pushes only (feature branches, tags, and deletions are ignored), registered repos only, `enable_checks` honored, idempotent on redelivery (updates the existing run).

The merge-queue and default-branch posts now share one helper, so the two off-PR publishing paths cannot drift.

Activation requires subscribing the GitHub App to **Push** events (documented in the App setup guide); an unsubscribed App never receives the event and the handler stays inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)