### PR TITLE
fix(github): acknowledge a command only when a deployment acts on it

### DIFF
--- a/pkg/webhook/aggregate_fanout_silent_skip_test.go
+++ b/pkg/webhook/aggregate_fanout_silent_skip_test.go
@@ -309,6 +309,24 @@ func TestCommandAcknowledgmentFollowsOwnership(t *testing.T) {
 		}
 	})
 
+	// A bare multi-env plan on a repo without a schema-dir allowlist resolves
+	// config discovery successfully even on a deployment that does not own the
+	// database — ownership is only decided at the registry lookup. A fan-out
+	// participant in that position silently skips, so it must not acknowledge.
+	t.Run("multi-env plan on unowned database does not react", func(t *testing.T) {
+		h, mux, _ := newFanOutSkipHandler(t, aggregateLeaderConfig())
+		serveSchemaConfigForDatabase(t, mux, "orders")
+		reactions := registerReactionRecorder(t, mux)
+
+		h.handleMultiEnvPlan("octocat/hello-world", 1, "", "", 12345, "hubot", false, true, 42)
+
+		select {
+		case <-reactions:
+			t.Fatal("a deployment that cannot resolve the database in its registry must not acknowledge")
+		case <-time.After(100 * time.Millisecond):
+		}
+	})
+
 	t.Run("silently skipping deployment does not react", func(t *testing.T) {
 		h, mux, comments := newFanOutSkipHandler(t, aggregateLeaderConfig())
 		serveSchemaConfigForDatabase(t, mux, "orders")

--- a/pkg/webhook/aggregate_fanout_silent_skip_test.go
+++ b/pkg/webhook/aggregate_fanout_silent_skip_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -210,5 +211,88 @@ func TestUnscopedRollbackConfirmNoLockStaysSilentOnAggregateRepo(t *testing.T) {
 		body := requireComment(t, comments, "no-lock rollback-confirm comment")
 		assert.Contains(t, body, "No Lock Found")
 		assert.Contains(t, body, "`staging`")
+	})
+}
+
+// registerReactionRecorder captures acknowledgment reactions posted to the
+// command comment.
+func registerReactionRecorder(t *testing.T, mux *http.ServeMux) chan string {
+	t.Helper()
+	reactions := make(chan string, 4)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/comments/42/reactions", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Content string `json:"content"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		reactions <- body.Content
+		w.WriteHeader(http.StatusCreated)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 1}))
+	})
+	return reactions
+}
+
+// The acknowledgment reaction means "this deployment is acting on your
+// command": a deployment that owns the discovered database reacts with eyes,
+// while a fan-out deployment that silently skips unowned work leaves only its
+// log — so the reaction count on a shared repo reflects the deployments doing
+// work, not everyone who heard the command.
+func TestCommandAcknowledgmentFollowsOwnership(t *testing.T) {
+	t.Run("owning deployment reacts", func(t *testing.T) {
+		cfg := aggregateLeaderConfig()
+		cfg.Databases = map[string]api.DatabaseConfig{
+			"orders": {Environments: map[string]api.EnvironmentConfig{
+				"staging": {Deployment: "default", Target: "orders"},
+			}},
+		}
+		h, mux, _ := newFanOutSkipHandler(t, cfg)
+		serveSchemaConfigForDatabase(t, mux, "orders")
+		// Discovery loads the schema files next to schemabot.yaml: serve the
+		// root directory listing and one table file so the command proceeds
+		// past discovery to the acknowledgment point.
+		mux.HandleFunc("GET /repos/octocat/hello-world/contents/", func(w http.ResponseWriter, _ *http.Request) {
+			require.NoError(t, json.NewEncoder(w).Encode([]map[string]any{
+				{"type": "file", "name": "schemabot.yaml", "path": "schemabot.yaml"},
+				{"type": "dir", "name": "staging", "path": "staging"},
+			}))
+		})
+		mux.HandleFunc("GET /repos/octocat/hello-world/contents/staging", func(w http.ResponseWriter, _ *http.Request) {
+			require.NoError(t, json.NewEncoder(w).Encode([]map[string]any{
+				{"type": "file", "name": "users.sql", "path": "staging/users.sql"},
+			}))
+		})
+		mux.HandleFunc("GET /repos/octocat/hello-world/contents/staging/users.sql", func(w http.ResponseWriter, _ *http.Request) {
+			ddl := "CREATE TABLE `users` (`id` bigint unsigned NOT NULL AUTO_INCREMENT, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;"
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]string{
+				"type": "file", "encoding": "base64",
+				"content": base64.StdEncoding.EncodeToString([]byte(ddl)),
+			}))
+		})
+		reactions := registerReactionRecorder(t, mux)
+
+		h.handleApplyCommand("octocat/hello-world", 1, "staging", "", 12345, "hubot",
+			CommandResult{Action: action.Apply, CommentID: 42})
+
+		select {
+		case content := <-reactions:
+			assert.Equal(t, "eyes", content)
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for the acknowledgment reaction")
+		}
+	})
+
+	t.Run("silently skipping deployment does not react", func(t *testing.T) {
+		h, mux, comments := newFanOutSkipHandler(t, aggregateLeaderConfig())
+		serveSchemaConfigForDatabase(t, mux, "orders")
+		reactions := registerReactionRecorder(t, mux)
+
+		h.handleApplyCommand("octocat/hello-world", 1, "staging", "", 12345, "hubot",
+			CommandResult{Action: action.Apply, CommentID: 42})
+
+		assert.Empty(t, comments, "the silent skip posts nothing")
+		select {
+		case <-reactions:
+			t.Fatal("a silently skipping deployment must not acknowledge the command")
+		case <-time.After(100 * time.Millisecond):
+		}
 	})
 }

--- a/pkg/webhook/aggregate_fanout_silent_skip_test.go
+++ b/pkg/webhook/aggregate_fanout_silent_skip_test.go
@@ -280,6 +280,35 @@ func TestCommandAcknowledgmentFollowsOwnership(t *testing.T) {
 		}
 	})
 
+	// The acknowledgment must not wait for schema files to load: ownership is
+	// decidable from config discovery alone, so on databases with large schema
+	// directories the user still sees the reaction promptly. Failing the file
+	// fetch proves the reaction fired before it.
+	t.Run("owning deployment acknowledges before schema files load", func(t *testing.T) {
+		cfg := aggregateLeaderConfig()
+		cfg.Databases = map[string]api.DatabaseConfig{
+			"orders": {Environments: map[string]api.EnvironmentConfig{
+				"staging": {Deployment: "default", Target: "orders"},
+			}},
+		}
+		h, mux, _ := newFanOutSkipHandler(t, cfg)
+		serveSchemaConfigForDatabase(t, mux, "orders")
+		mux.HandleFunc("GET /repos/octocat/hello-world/contents/staging", func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "schema listing unavailable", http.StatusInternalServerError)
+		})
+		reactions := registerReactionRecorder(t, mux)
+
+		h.handleApplyCommand("octocat/hello-world", 1, "staging", "", 12345, "hubot",
+			CommandResult{Action: action.Apply, CommentID: 42})
+
+		select {
+		case content := <-reactions:
+			assert.Equal(t, "eyes", content)
+		case <-time.After(2 * time.Second):
+			t.Fatal("the acknowledgment must fire from config discovery, before schema files load")
+		}
+	})
+
 	t.Run("silently skipping deployment does not react", func(t *testing.T) {
 		h, mux, comments := newFanOutSkipHandler(t, aggregateLeaderConfig())
 		serveSchemaConfigForDatabase(t, mux, "orders")

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -49,7 +49,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.Apply, err)
 		return
 	}
-	h.acknowledgeCommandActPoint(repo, pr, installationID, result.CommentID)
+	h.acknowledgeCommandActPoint(repo, pr, installationID, result)
 
 	if blocked := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, schemaResult.Database, schemaResult.Type, environment, action.Apply); blocked {
 		return
@@ -418,7 +418,7 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 			"This lock belongs to a rollback plan. Use `schemabot rollback-confirm` to execute it, or `schemabot unlock` to cancel it.")
 		return
 	}
-	h.acknowledgeCommandActPoint(repo, pr, installationID, result.CommentID)
+	h.acknowledgeCommandActPoint(repo, pr, installationID, result)
 
 	// Cross-delivery freshness check: reject if the confirmation plan (the one
 	// the user reviewed) was rendered against a commit that is no longer the
@@ -491,7 +491,7 @@ func (h *Handler) handleUnlockCommand(repo string, pr int, installationID int64,
 		h.postComment(repo, pr, installationID, templates.RenderNoLocksFound())
 		return
 	}
-	h.acknowledgeCommandActPoint(repo, pr, installationID, result.CommentID)
+	h.acknowledgeCommandActPoint(repo, pr, installationID, result)
 
 	// Unlock mutates lock state for every matched database, including
 	// force-releasing CLI-owned locks, so the actor must be an authorized

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -34,6 +34,8 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		return
 	}
 
+	ackedEarly := h.acknowledgeCommandEarlyIfOwned(ctx, client, repo, pr, databaseName, result.Tenant, installationID, result.CommentID)
+
 	// Discover config and fetch schema files from PR
 	schemaResult, err := h.createManagedSchemaRequestFromPR(ctx, client, repo, pr, environment, databaseName, action.Apply)
 	if err != nil {
@@ -49,7 +51,9 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.Apply, err)
 		return
 	}
-	h.acknowledgeCommandActPoint(repo, pr, installationID, result)
+	if !ackedEarly {
+		h.acknowledgeCommandActPoint(repo, pr, installationID, result)
+	}
 
 	if blocked := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, schemaResult.Database, schemaResult.Type, environment, action.Apply); blocked {
 		return

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -49,6 +49,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.Apply, err)
 		return
 	}
+	h.acknowledgeCommand(repo, pr, installationID, result.CommentID)
 
 	if blocked := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, schemaResult.Database, schemaResult.Type, environment, action.Apply); blocked {
 		return
@@ -417,6 +418,7 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 			"This lock belongs to a rollback plan. Use `schemabot rollback-confirm` to execute it, or `schemabot unlock` to cancel it.")
 		return
 	}
+	h.acknowledgeCommand(repo, pr, installationID, result.CommentID)
 
 	// Cross-delivery freshness check: reject if the confirmation plan (the one
 	// the user reviewed) was rendered against a commit that is no longer the
@@ -489,6 +491,7 @@ func (h *Handler) handleUnlockCommand(repo string, pr int, installationID int64,
 		h.postComment(repo, pr, installationID, templates.RenderNoLocksFound())
 		return
 	}
+	h.acknowledgeCommand(repo, pr, installationID, result.CommentID)
 
 	// Unlock mutates lock state for every matched database, including
 	// force-releasing CLI-owned locks, so the actor must be an authorized

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -49,7 +49,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.Apply, err)
 		return
 	}
-	h.acknowledgeCommand(repo, pr, installationID, result.CommentID)
+	h.acknowledgeCommandActPoint(repo, pr, installationID, result.CommentID)
 
 	if blocked := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, schemaResult.Database, schemaResult.Type, environment, action.Apply); blocked {
 		return
@@ -418,7 +418,7 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 			"This lock belongs to a rollback plan. Use `schemabot rollback-confirm` to execute it, or `schemabot unlock` to cancel it.")
 		return
 	}
-	h.acknowledgeCommand(repo, pr, installationID, result.CommentID)
+	h.acknowledgeCommandActPoint(repo, pr, installationID, result.CommentID)
 
 	// Cross-delivery freshness check: reject if the confirmation plan (the one
 	// the user reviewed) was rendered against a commit that is no longer the
@@ -491,7 +491,7 @@ func (h *Handler) handleUnlockCommand(repo string, pr int, installationID int64,
 		h.postComment(repo, pr, installationID, templates.RenderNoLocksFound())
 		return
 	}
-	h.acknowledgeCommand(repo, pr, installationID, result.CommentID)
+	h.acknowledgeCommandActPoint(repo, pr, installationID, result.CommentID)
 
 	// Unlock mutates lock state for every matched database, including
 	// force-releasing CLI-owned locks, so the actor must be an authorized

--- a/pkg/webhook/commands.go
+++ b/pkg/webhook/commands.go
@@ -139,7 +139,11 @@ func NewCommandParser() *CommandParser {
 
 // CommandResult represents the result of parsing a command.
 type CommandResult struct {
-	Action       string
+	Action string
+	// CommentID is the PR comment that carried this command. Handlers
+	// acknowledge it with a reaction once they commit to acting, so on a
+	// fan-out only the deployments actually doing work acknowledge.
+	CommentID    int64
 	ApplyID      string // Positional apply identifier for apply-scoped commands.
 	Environment  string
 	Database     string // Optional -d flag value

--- a/pkg/webhook/control.go
+++ b/pkg/webhook/control.go
@@ -123,7 +123,7 @@ func (h *Handler) loadApplyForPRControl(ctx context.Context, repo string, pr int
 			fmt.Sprintf("Apply %s belongs to environment %q, not %q", result.ApplyID, apply.Environment, result.Environment))
 		return nil, false
 	}
-	h.acknowledgeCommandActPoint(repo, pr, installationID, result.CommentID)
+	h.acknowledgeCommandActPoint(repo, pr, installationID, result)
 	return apply, true
 }
 

--- a/pkg/webhook/control.go
+++ b/pkg/webhook/control.go
@@ -123,6 +123,7 @@ func (h *Handler) loadApplyForPRControl(ctx context.Context, repo string, pr int
 			fmt.Sprintf("Apply %s belongs to environment %q, not %q", result.ApplyID, apply.Environment, result.Environment))
 		return nil, false
 	}
+	h.acknowledgeCommand(repo, pr, installationID, result.CommentID)
 	return apply, true
 }
 

--- a/pkg/webhook/control.go
+++ b/pkg/webhook/control.go
@@ -123,7 +123,7 @@ func (h *Handler) loadApplyForPRControl(ctx context.Context, repo string, pr int
 			fmt.Sprintf("Apply %s belongs to environment %q, not %q", result.ApplyID, apply.Environment, result.Environment))
 		return nil, false
 	}
-	h.acknowledgeCommand(repo, pr, installationID, result.CommentID)
+	h.acknowledgeCommandActPoint(repo, pr, installationID, result.CommentID)
 	return apply, true
 }
 

--- a/pkg/webhook/handler_test.go
+++ b/pkg/webhook/handler_test.go
@@ -605,6 +605,38 @@ func TestWebhookEyesReactionAtDispatchForSingleDeploymentRepo(t *testing.T) {
 	}
 }
 
+// A -t-scoped command names its actor, so the addressed tenant acknowledges
+// at dispatch — instantly, before any schema discovery — even on an
+// aggregate-role repo.
+func TestWebhookEyesReactionAtDispatchForTenantScopedCommand(t *testing.T) {
+	h, _, reactions := newTestHandler(t)
+	cfg := h.service.Config()
+	cfg.Tenant = "tenant-b"
+	repoCfg := cfg.Repos["octocat/hello-world"]
+	repoCfg.Aggregate = &api.AggregateConfig{Role: api.AggregateRoleParticipant}
+	if cfg.Repos == nil {
+		cfg.Repos = map[string]api.RepoConfig{}
+	}
+	cfg.Repos["octocat/hello-world"] = repoCfg
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot apply -e staging -t tenant-b",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case reaction := <-reactions:
+		assert.Equal(t, "eyes", reaction)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the scoped-command dispatch acknowledgment")
+	}
+}
+
 func TestWebhookSignatureValidation(t *testing.T) {
 	h, comments, _ := newTestHandler(t)
 	secret := []byte("webhook-secret")

--- a/pkg/webhook/handler_test.go
+++ b/pkg/webhook/handler_test.go
@@ -581,6 +581,30 @@ func TestWebhookIgnoresSchemaBotProse(t *testing.T) {
 	}
 }
 
+// On a repo with no aggregate role this deployment is the only SchemaBot, so
+// the acknowledgment fires at dispatch — the user sees the eyes reaction
+// immediately, before schema discovery runs.
+func TestWebhookEyesReactionAtDispatchForSingleDeploymentRepo(t *testing.T) {
+	h, _, reactions := newTestHandler(t)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot plan -e staging",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case reaction := <-reactions:
+		assert.Equal(t, "eyes", reaction)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the dispatch acknowledgment reaction")
+	}
+}
+
 func TestWebhookSignatureValidation(t *testing.T) {
 	h, comments, _ := newTestHandler(t)
 	secret := []byte("webhook-secret")

--- a/pkg/webhook/handler_test.go
+++ b/pkg/webhook/handler_test.go
@@ -605,6 +605,31 @@ func TestWebhookEyesReactionAtDispatchForSingleDeploymentRepo(t *testing.T) {
 	}
 }
 
+// A bare "schemabot plan" (no -e) fans out to every configured environment,
+// but the acknowledgment contract is the same as its scoped siblings: on a
+// repo with no aggregate role this deployment is the only SchemaBot, so the
+// eyes reaction fires at dispatch, before any discovery runs.
+func TestWebhookEyesReactionAtDispatchForBareMultiEnvPlan(t *testing.T) {
+	h, _, reactions := newTestHandler(t)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot plan",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case reaction := <-reactions:
+		assert.Equal(t, "eyes", reaction)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the bare-plan dispatch acknowledgment")
+	}
+}
+
 // A -t-scoped command names its actor, so the addressed tenant acknowledges
 // at dispatch — instantly, before any schema discovery — even on an
 // aggregate-role repo.

--- a/pkg/webhook/handler_test.go
+++ b/pkg/webhook/handler_test.go
@@ -581,29 +581,6 @@ func TestWebhookIgnoresSchemaBotProse(t *testing.T) {
 	}
 }
 
-func TestWebhookEyesReaction(t *testing.T) {
-	h, _, reactions := newTestHandler(t)
-
-	// Use an env-scoped command that reaches the reaction point (after all
-	// skip/filter checks). Help returns before the reaction fires.
-	req := buildWebhookRequest(t, webhookPayloadOpts{
-		comment: "schemabot plan -e staging",
-		isPR:    true,
-	}, nil)
-
-	rr := httptest.NewRecorder()
-	h.ServeHTTP(rr, req)
-
-	require.Equal(t, http.StatusOK, rr.Code)
-
-	select {
-	case reaction := <-reactions:
-		assert.Equal(t, "eyes", reaction)
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for eyes reaction")
-	}
-}
-
 func TestWebhookSignatureValidation(t *testing.T) {
 	h, comments, _ := newTestHandler(t)
 	secret := []byte("webhook-secret")

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -258,11 +258,14 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 		return
 	}
 
-	// On a repo with no aggregate role this deployment is the only SchemaBot,
-	// so it acknowledges immediately — there is no ownership question to
-	// answer. Aggregate-role repos defer the acknowledgment to each handler's
-	// act-point, after the fan-out silent-skip gates.
-	if h.service == nil || h.service.Config().AggregateRoleForRepo(repo) == "" {
+	// Two cases are decidable at dispatch and acknowledge immediately: a repo
+	// with no aggregate role has exactly one SchemaBot (no ownership question),
+	// and a -t-scoped command names its actor (every non-addressed deployment
+	// was already filtered by the tenant gate above, so reaching this point
+	// scoped means this deployment is the addressee). Unscoped commands on
+	// aggregate-role repos defer to each handler's act-point, after the
+	// fan-out silent-skip gates, where ownership is actually known.
+	if h.service == nil || h.service.Config().AggregateRoleForRepo(repo) == "" || result.Tenant != "" {
 		h.acknowledgeCommand(repo, pr, installationID, result.CommentID)
 	}
 
@@ -523,16 +526,19 @@ func (h *Handler) postInitialProgressComment(ctx context.Context, repo string, p
 }
 
 // acknowledgeCommandActPoint adds the eyes reaction once a handler commits to
-// acting on a command, on repos where this deployment has an aggregate role —
-// there, a fan-out means "heard" and "acting" differ, so only the deployments
-// actually doing work acknowledge and an ignoring deployment leaves only its
-// skip log. Repos without an aggregate role acknowledged at dispatch already,
-// so this is a no-op for them.
-func (h *Handler) acknowledgeCommandActPoint(repo string, pr int, installationID, commentID int64) {
+// acting on an unscoped command on an aggregate-role repo — there, a fan-out
+// means "heard" and "acting" differ, so only the deployments actually doing
+// work acknowledge and an ignoring deployment leaves only its skip log. Repos
+// without an aggregate role and -t-scoped commands acknowledged at dispatch
+// already, so this is a no-op for them.
+func (h *Handler) acknowledgeCommandActPoint(repo string, pr int, installationID int64, result CommandResult) {
+	if result.Tenant != "" {
+		return
+	}
 	if h.service != nil && h.service.Config().AggregateRoleForRepo(repo) == "" {
 		return
 	}
-	h.acknowledgeCommand(repo, pr, installationID, commentID)
+	h.acknowledgeCommand(repo, pr, installationID, result.CommentID)
 }
 
 // acknowledgeCommand adds the eyes reaction to the command comment,

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/block/schemabot/pkg/api"
+	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/metrics"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
@@ -546,6 +547,48 @@ func (h *Handler) acknowledgeCommandActPoint(repo string, pr int, installationID
 		return
 	}
 	h.acknowledgeCommand(repo, pr, installationID, result.CommentID)
+}
+
+// acknowledgeCommandEarlyIfOwned acknowledges an unscoped command on an
+// aggregate-role repo as soon as ownership is decidable from config discovery
+// alone — the config file resolves to a database this deployment's registry
+// knows, under an allowed schema directory — without waiting for the schema
+// files to load, which on large schema directories dominates the latency
+// between the command and its acknowledgment. The probe is advisory: it mirrors
+// the source-policy predicates without their logs and metrics, the authoritative
+// checks still run in discovery immediately after, and any probe miss defers to
+// the handler's act-point acknowledgment. Returns whether it acknowledged.
+func (h *Handler) acknowledgeCommandEarlyIfOwned(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, databaseName, tenant string, installationID, commentID int64) bool {
+	if tenant != "" {
+		return false
+	}
+	config, ok := h.serverConfig()
+	if !ok || config.AggregateRoleForRepo(repo) == "" {
+		return false
+	}
+	var (
+		sbConfig  *ghclient.SchemabotConfig
+		configDir string
+		err       error
+	)
+	if databaseName != "" {
+		sbConfig, configDir, err = client.FindConfigByDatabaseName(ctx, repo, pr, databaseName)
+	} else {
+		sbConfig, configDir, err = client.FindConfigForPR(ctx, repo, pr)
+	}
+	if err != nil || sbConfig == nil {
+		h.logger.Debug("early ownership probe could not resolve a schema config; acknowledgment defers to the act-point",
+			"repo", repo, "pr", pr, "database", databaseName, "error", err)
+		return false
+	}
+	if config.RepoHasSchemaDirAllowlist(repo) && !config.SchemaPathAllowedForRepo(repo, configDir) {
+		return false
+	}
+	if config.Database(sbConfig.Database) == nil {
+		return false
+	}
+	h.acknowledgeCommand(repo, pr, installationID, commentID)
+	return true
 }
 
 // acknowledgeCommand adds the eyes reaction to the command comment,

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -258,6 +258,14 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 		return
 	}
 
+	// On a repo with no aggregate role this deployment is the only SchemaBot,
+	// so it acknowledges immediately — there is no ownership question to
+	// answer. Aggregate-role repos defer the acknowledgment to each handler's
+	// act-point, after the fan-out silent-skip gates.
+	if h.service == nil || h.service.Config().AggregateRoleForRepo(repo) == "" {
+		h.acknowledgeCommand(repo, pr, installationID, result.CommentID)
+	}
+
 	h.logger.Info("processing command",
 		"action", result.Action,
 		"environment", result.Environment,
@@ -514,10 +522,21 @@ func (h *Handler) postInitialProgressComment(ctx context.Context, repo string, p
 	}
 }
 
-// acknowledgeCommand adds the eyes reaction to the command comment. Handlers
-// call it once they commit to acting on the command — after their silent-skip
-// gates — so on a fan-out only the deployments actually doing work
-// acknowledge, and an ignoring deployment leaves only its skip log.
+// acknowledgeCommandActPoint adds the eyes reaction once a handler commits to
+// acting on a command, on repos where this deployment has an aggregate role —
+// there, a fan-out means "heard" and "acting" differ, so only the deployments
+// actually doing work acknowledge and an ignoring deployment leaves only its
+// skip log. Repos without an aggregate role acknowledged at dispatch already,
+// so this is a no-op for them.
+func (h *Handler) acknowledgeCommandActPoint(repo string, pr int, installationID, commentID int64) {
+	if h.service != nil && h.service.Config().AggregateRoleForRepo(repo) == "" {
+		return
+	}
+	h.acknowledgeCommand(repo, pr, installationID, commentID)
+}
+
+// acknowledgeCommand adds the eyes reaction to the command comment,
+// signalling "this deployment is acting on your command".
 func (h *Handler) acknowledgeCommand(repo string, pr int, installationID, commentID int64) {
 	if commentID <= 0 || h.ghClients.Len() == 0 {
 		return

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -97,6 +97,7 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 	// Parse command
 	parser := NewCommandParser()
 	result := parser.ParseCommand(payload.Comment.Body)
+	result.CommentID = payload.Comment.ID
 
 	if !result.IsMention {
 		h.writeJSON(w, http.StatusOK, map[string]string{
@@ -238,24 +239,6 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 		return
 	}
 
-	// Add acknowledgment reaction now that we know this instance will handle
-	// the command. Placed after all skip/filter checks so only the owning
-	// instance reacts — avoids duplicate reactions in multi-instance setups.
-	if payload.Comment.ID > 0 && h.ghClients.Len() > 0 {
-		h.goSafe(repo, pr, installationID, func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
-			client, err := h.clientForRepo(repo, installationID)
-			if err != nil {
-				h.logger.Error("failed to create GitHub client for reaction", "error", err)
-				return
-			}
-			if err := client.AddReactionToComment(ctx, repo, payload.Comment.ID, "eyes"); err != nil {
-				h.logger.Error("failed to add acknowledgment reaction", "error", err)
-			}
-		})
-	}
-
 	// Reject -y/--yes on commands that don't support it
 	if result.Action != action.Apply && parser.HasAutoConfirmFlag(payload.Comment.Body) {
 		h.postComment(repo, pr, installationID, templates.RenderUnsupportedAutoConfirm(result.Action))
@@ -284,7 +267,7 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 
 	switch result.Action {
 	case action.Plan:
-		h.handlePlanCommand(w, repo, pr, result.Environment, result.Database, result.Tenant, installationID, requestedBy)
+		h.handlePlanCommand(w, repo, pr, result.Environment, result.Database, result.Tenant, installationID, requestedBy, result.CommentID)
 	case action.Help:
 		h.postComment(repo, pr, installationID, templates.RenderHelpComment())
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "help posted"})
@@ -529,6 +512,30 @@ func (h *Handler) postInitialProgressComment(ctx context.Context, repo string, p
 		h.logger.Error("failed to increment edit count after finalizing progress comment",
 			append(apply.LogAttrs(), "error", err)...)
 	}
+}
+
+// acknowledgeCommand adds the eyes reaction to the command comment. Handlers
+// call it once they commit to acting on the command — after their silent-skip
+// gates — so on a fan-out only the deployments actually doing work
+// acknowledge, and an ignoring deployment leaves only its skip log.
+func (h *Handler) acknowledgeCommand(repo string, pr int, installationID, commentID int64) {
+	if commentID <= 0 || h.ghClients.Len() == 0 {
+		return
+	}
+	h.goSafe(repo, pr, installationID, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		client, err := h.clientForRepo(repo, installationID)
+		if err != nil {
+			h.logger.Error("failed to create GitHub client for command acknowledgment",
+				"repo", repo, "pr", pr, "error", err)
+			return
+		}
+		if err := client.AddReactionToComment(ctx, repo, commentID, "eyes"); err != nil {
+			h.logger.Error("failed to add command acknowledgment reaction",
+				"repo", repo, "pr", pr, "error", err)
+		}
+	})
 }
 
 func (h *Handler) renderPRComment(body string) string {

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -543,7 +543,7 @@ func (h *Handler) acknowledgeCommandActPoint(repo string, pr int, installationID
 	if result.Tenant != "" {
 		return
 	}
-	if h.service != nil && h.service.Config().AggregateRoleForRepo(repo) == "" {
+	if h.service == nil || h.service.Config().AggregateRoleForRepo(repo) == "" {
 		return
 	}
 	h.acknowledgeCommand(repo, pr, installationID, result.CommentID)

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -176,10 +176,17 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 	// Handle missing -e flag
 	if result.MissingEnv {
 		if result.Action == action.Plan {
-			// Plan without -e: run for all configured environments
+			// Plan without -e: run for all configured environments. The same
+			// acknowledgment split as scoped commands applies: repos without an
+			// aggregate role and -t-scoped plans acknowledge at dispatch, while
+			// an unscoped plan on an aggregate-role repo acknowledges at the
+			// handler's act-point once discovery resolves owned schema.
 			h.logger.Info("plan without -e flag", "repo", repo, "pr", pr)
+			if h.service == nil || h.service.Config().AggregateRoleForRepo(repo) == "" || result.Tenant != "" {
+				h.acknowledgeCommand(repo, pr, installationID, result.CommentID)
+			}
 			h.goSafe(repo, pr, installationID, func() {
-				h.handleMultiEnvPlan(repo, pr, result.Database, result.Tenant, installationID, requestedBy, false, true)
+				h.handleMultiEnvPlan(repo, pr, result.Database, result.Tenant, installationID, requestedBy, false, true, result.CommentID)
 			})
 			h.writeJSON(w, http.StatusOK, map[string]string{"message": "multi-env plan started"})
 			return

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -61,7 +61,7 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "schema request error handled"})
 		return
 	}
-	h.acknowledgeCommand(repo, pr, installationID, commentID)
+	h.acknowledgeCommandActPoint(repo, pr, installationID, commentID)
 
 	// Reject if the PR HEAD advanced after discovery loaded schema files.
 	// Rendering a plan comment against stale files would mislead the user

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -43,6 +43,8 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 		return
 	}
 
+	ackedEarly := h.acknowledgeCommandEarlyIfOwned(ctx, client, repo, pr, databaseName, tenant, installationID, commentID)
+
 	// Discover config and fetch schema files from PR
 	schemaResult, err := h.createManagedSchemaRequestFromPR(ctx, client, repo, pr, environment, databaseName, action.Plan)
 	if err != nil {
@@ -61,7 +63,9 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "schema request error handled"})
 		return
 	}
-	h.acknowledgeCommandActPoint(repo, pr, installationID, CommandResult{Tenant: tenant, CommentID: commentID})
+	if !ackedEarly {
+		h.acknowledgeCommandActPoint(repo, pr, installationID, CommandResult{Tenant: tenant, CommentID: commentID})
+	}
 
 	// Reject if the PR HEAD advanced after discovery loaded schema files.
 	// Rendering a plan comment against stale files would mislead the user

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -158,7 +158,9 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 
 // handleMultiEnvPlan runs plan for all configured environments and posts a single combined comment.
 // When isAutoPlan is true and no environments have changes or errors, the comment is skipped to reduce PR noise.
-func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName, tenant string, installationID int64, requestedBy string, isAutoPlan bool, postPlanComment bool) {
+// commentID is the command comment to acknowledge once discovery commits this
+// deployment to acting; auto-plans pass zero (no comment to acknowledge).
+func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName, tenant string, installationID int64, requestedBy string, isAutoPlan bool, postPlanComment bool, commentID int64) {
 	ctx, cancel, client, err := h.commandBootstrap(repo, installationID)
 	if err != nil {
 		h.logger.Error("multi-env plan: failed to bootstrap command", "error", err)
@@ -198,6 +200,7 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName, tenant s
 		}
 		schemaDatabase = config.Database
 	}
+	h.acknowledgeCommandActPoint(repo, pr, installationID, CommandResult{Tenant: tenant, CommentID: commentID})
 	configuredEnvironments, envErr := h.configuredDatabaseEnvironments(schemaDatabase)
 	if envErr != nil {
 		if isAutoPlan {

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -16,7 +16,7 @@ import (
 )
 
 // handlePlanCommand handles the "schemabot plan -e <env>" command.
-func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, environment, databaseName, tenant string, installationID int64, requestedBy string) {
+func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, environment, databaseName, tenant string, installationID int64, requestedBy string, commentID int64) {
 	ctx, cancel, client, err := h.commandBootstrap(repo, installationID)
 	if err != nil {
 		h.logger.Error("plan: failed to bootstrap command", "error", err)
@@ -61,6 +61,7 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "schema request error handled"})
 		return
 	}
+	h.acknowledgeCommand(repo, pr, installationID, commentID)
 
 	// Reject if the PR HEAD advanced after discovery loaded schema files.
 	// Rendering a plan comment against stale files would mislead the user

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -61,7 +61,7 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "schema request error handled"})
 		return
 	}
-	h.acknowledgeCommandActPoint(repo, pr, installationID, commentID)
+	h.acknowledgeCommandActPoint(repo, pr, installationID, CommandResult{Tenant: tenant, CommentID: commentID})
 
 	// Reject if the PR HEAD advanced after discovery loaded schema files.
 	// Rendering a plan comment against stale files would mislead the user

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -204,7 +204,6 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName, tenant s
 		}
 		schemaDatabase = config.Database
 	}
-	h.acknowledgeCommandActPoint(repo, pr, installationID, CommandResult{Tenant: tenant, CommentID: commentID})
 	configuredEnvironments, envErr := h.configuredDatabaseEnvironments(schemaDatabase)
 	if envErr != nil {
 		if isAutoPlan {
@@ -221,6 +220,13 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName, tenant s
 		h.handleSchemaRequestError(repo, pr, installationID, "", databaseName, requestedBy, action.Plan, envErr)
 		return
 	}
+	// Ownership is only fully decided once the discovered database resolves in
+	// this deployment's registry: config discovery alone can pass on a repo with
+	// no schema-dir allowlist even when the database belongs to another
+	// deployment, and acknowledging there would promise work a fan-out silent
+	// skip never does. The registry lookups above are in-memory, so the
+	// acknowledgment is still immediate.
+	h.acknowledgeCommandActPoint(repo, pr, installationID, CommandResult{Tenant: tenant, CommentID: commentID})
 	configuredEnvironments = append([]string(nil), configuredEnvironments...)
 	allowedEnvironments := append([]string(nil), h.service.Config().AllowedEnvironments...)
 

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -255,7 +255,7 @@ func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.Install
 	for _, cfg := range configs {
 		database := cfg.Config.Database
 		h.goSafe(repo, pr, installationID, func() {
-			h.handleMultiEnvPlan(repo, pr, database, tenant, installationID, "", true, postPlanComment)
+			h.handleMultiEnvPlan(repo, pr, database, tenant, installationID, "", true, postPlanComment, 0)
 		})
 	}
 

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -82,6 +82,7 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 			"repo", repo, "pr", pr, "apply_id", applyID, "environment", environment)
 		return
 	}
+	h.acknowledgeCommand(repo, pr, installationID, result.CommentID)
 
 	// Rollback executes DDL against the target database, so the actor must be an
 	// authorized admin/operator before SchemaBot reveals any lock or plan detail
@@ -317,6 +318,7 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment 
 		h.postComment(repo, pr, installationID, templates.RenderRollbackConfirmNoLock("", environment, h.deploymentTenant()))
 		return
 	}
+	h.acknowledgeCommand(repo, pr, installationID, result.CommentID)
 
 	database := rollbackPlan.Database
 	dbType := rollbackPlan.DatabaseType

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -82,7 +82,7 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 			"repo", repo, "pr", pr, "apply_id", applyID, "environment", environment)
 		return
 	}
-	h.acknowledgeCommandActPoint(repo, pr, installationID, result.CommentID)
+	h.acknowledgeCommandActPoint(repo, pr, installationID, result)
 
 	// Rollback executes DDL against the target database, so the actor must be an
 	// authorized admin/operator before SchemaBot reveals any lock or plan detail
@@ -318,7 +318,7 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment 
 		h.postComment(repo, pr, installationID, templates.RenderRollbackConfirmNoLock("", environment, h.deploymentTenant()))
 		return
 	}
-	h.acknowledgeCommandActPoint(repo, pr, installationID, result.CommentID)
+	h.acknowledgeCommandActPoint(repo, pr, installationID, result)
 
 	database := rollbackPlan.Database
 	dbType := rollbackPlan.DatabaseType

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -82,7 +82,7 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 			"repo", repo, "pr", pr, "apply_id", applyID, "environment", environment)
 		return
 	}
-	h.acknowledgeCommand(repo, pr, installationID, result.CommentID)
+	h.acknowledgeCommandActPoint(repo, pr, installationID, result.CommentID)
 
 	// Rollback executes DDL against the target database, so the actor must be an
 	// authorized admin/operator before SchemaBot reveals any lock or plan detail
@@ -318,7 +318,7 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment 
 		h.postComment(repo, pr, installationID, templates.RenderRollbackConfirmNoLock("", environment, h.deploymentTenant()))
 		return
 	}
-	h.acknowledgeCommand(repo, pr, installationID, result.CommentID)
+	h.acknowledgeCommandActPoint(repo, pr, installationID, result.CommentID)
 
 	database := rollbackPlan.Database
 	dbType := rollbackPlan.DatabaseType


### PR DESCRIPTION
## Why this matters

The 👀 acknowledgment fired at dispatch, before ownership was known. On a multi-tenant repo an unscoped command fans out, so every deployment that *heard* the command reacted — a single comment collected one reaction per installed deployment, reading as "N things are applying" when only one was.

## What it does

Acknowledgment timing follows what is decidable when:

```
command comment
   ├─ repo has NO aggregate role            → 👀 at dispatch (sole deployment,
   │                                          nothing to disambiguate)
   ├─ command is -t-scoped                  → 👀 at dispatch by the addressed
   │                                          tenant (the tenant gate already
   │                                          filtered everyone else)
   └─ unscoped on an aggregate-role repo    → ownership is unknowable until
         │                                    the handler's act-point:
         ├─ deployment silently skips       → skip log only, no reaction
         └─ deployment commits to acting    → 👀 (plan/apply: discovery
            resolves to owned schema · apply-confirm: lock ownership ·
            rollback: apply found + environment-routed · rollback-confirm:
            pinned rollback lock · unlock: locks matched · lifecycle
            controls: apply loaded)
```

Two deliberate consequences of "acknowledgment means acting": the dispatch acknowledgment fires after the flag-rejection checks, so a command rejected for an unsupported flag gets its error reply without a reaction; and handlers that respond with a rejection before their act-point (a lock conflict, a rollback-owned lock, no locks found) likewise reply without acknowledging — the reply itself is the feedback.

For plan and apply the act-point is config discovery plus the in-memory registry lookup — ownership is decidable before any schema files load, so even databases with large schema directories acknowledge within a couple of GitHub API calls of the command. Standard repos and every scoped command keep instant feedback (rollback and lifecycle controls require `-t` in tenant mode, so the whole scoped workflow stays instant); only unscoped discovery-bound commands on shared repos wait for ownership, and there the reaction count finally reflects the deployments doing work. Tests pin the behaviors: dispatch ack on a role-less repo (scoped and bare multi-env plan), dispatch ack for a scoped command on a participant, act-point ack for an owning deployment, and no ack for a silently-skipping one. The bare `schemabot plan` follows the same contract as its scoped siblings — dispatch ack where ownership is unambiguous, discovery act-point ack on aggregate-role repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


