### PR TITLE
feat(github): list authorized teams and users on command rejection

### DIFF
--- a/pkg/api/actor_authorization.go
+++ b/pkg/api/actor_authorization.go
@@ -139,3 +139,32 @@ func validateGitHubUsers(field string, users []string) error {
 	}
 	return nil
 }
+
+// PRCommandAuthorizedPrincipals returns the GitHub principals (teams as
+// "org/team", plain user logins) allowed to run mutating PR commands for
+// database: the deployment-wide admin teams/users plus the database's operator
+// teams/users. Rejection comments surface this list so a blocked user knows
+// who to ask instead of guessing.
+func (c *ServerConfig) PRCommandAuthorizedPrincipals(database string) []string {
+	if c == nil {
+		return nil
+	}
+	var principals []string
+	seen := map[string]bool{}
+	add := func(items []string) {
+		for _, item := range items {
+			if item == "" || seen[item] {
+				continue
+			}
+			seen[item] = true
+			principals = append(principals, item)
+		}
+	}
+	add(c.PRCommandAuthorization.AdminTeams)
+	add(c.PRCommandAuthorization.AdminUsers)
+	if db, ok := c.Databases[database]; ok {
+		add(db.OperatorTeams)
+		add(db.OperatorUsers)
+	}
+	return principals
+}

--- a/pkg/api/actor_authorization.go
+++ b/pkg/api/actor_authorization.go
@@ -142,10 +142,11 @@ func validateGitHubUsers(field string, users []string) error {
 
 // PRCommandAuthorizedPrincipals returns the GitHub principals (teams as
 // "org/team", plain user logins) allowed to run mutating PR commands for
-// database: the deployment-wide admin teams/users plus the database's operator
-// teams/users. Rejection comments surface this list so a blocked user knows
-// who to ask instead of guessing.
-func (c *ServerConfig) PRCommandAuthorizedPrincipals(database string) []string {
+// database via repo, in the order the authorizer consults them: the
+// deployment-wide admin teams/users, the repository's admin teams/users, then
+// the database's operator teams/users. Rejection comments surface this list so
+// a blocked user knows who to ask instead of guessing.
+func (c *ServerConfig) PRCommandAuthorizedPrincipals(repo, database string) []string {
 	if c == nil {
 		return nil
 	}
@@ -162,6 +163,9 @@ func (c *ServerConfig) PRCommandAuthorizedPrincipals(database string) []string {
 	}
 	add(c.PRCommandAuthorization.AdminTeams)
 	add(c.PRCommandAuthorization.AdminUsers)
+	repoAdminTeams, repoAdminUsers := c.RepoAdmins(repo)
+	add(repoAdminTeams)
+	add(repoAdminUsers)
 	if db, ok := c.Databases[database]; ok {
 		add(db.OperatorTeams)
 		add(db.OperatorUsers)

--- a/pkg/api/actor_authorization.go
+++ b/pkg/api/actor_authorization.go
@@ -154,11 +154,15 @@ func (c *ServerConfig) PRCommandAuthorizedPrincipals(repo, database string) []st
 	seen := map[string]bool{}
 	add := func(items []string) {
 		for _, item := range items {
-			if item == "" || seen[item] {
+			// GitHub logins and team slugs are case-insensitive, and operators
+			// sometimes configure them with a leading "@" — normalize both so
+			// the rendered list never repeats one principal in two spellings.
+			display := strings.TrimPrefix(strings.TrimSpace(item), "@")
+			if display == "" || seen[strings.ToLower(display)] {
 				continue
 			}
-			seen[item] = true
-			principals = append(principals, item)
+			seen[strings.ToLower(display)] = true
+			principals = append(principals, display)
 		}
 	}
 	add(c.PRCommandAuthorization.AdminTeams)

--- a/pkg/api/actor_authorization_test.go
+++ b/pkg/api/actor_authorization_test.go
@@ -275,6 +275,24 @@ func TestPRCommandAuthorizedPrincipals(t *testing.T) {
 		cfg.PRCommandAuthorizedPrincipals("octocat/hello-world", "unknown"),
 		"an unknown database still lists the deployment and repo admins")
 
+	normalized := &ServerConfig{
+		PRCommandAuthorization: PRCommandAuthorizationConfig{
+			Enabled:    true,
+			AdminTeams: []string{"@octocat/db-admins"},
+			AdminUsers: []string{"Kara"},
+		},
+		Databases: map[string]DatabaseConfig{
+			"orders": {
+				OperatorTeams: []string{"octocat/DB-Admins"},
+				OperatorUsers: []string{"kara", " lee "},
+			},
+		},
+	}
+	assert.Equal(t,
+		[]string{"octocat/db-admins", "Kara", "lee"},
+		normalized.PRCommandAuthorizedPrincipals("octocat/hello-world", "orders"),
+		"leading @, surrounding whitespace, and case variants collapse to one entry per principal")
+
 	var nilCfg *ServerConfig
 	assert.Nil(t, nilCfg.PRCommandAuthorizedPrincipals("octocat/hello-world", "orders"))
 }

--- a/pkg/api/actor_authorization_test.go
+++ b/pkg/api/actor_authorization_test.go
@@ -235,3 +235,35 @@ func TestServerConfigValidatePRCommandAuthorization(t *testing.T) {
 		})
 	}
 }
+
+// The authorized-principal list for a database is the deployment-wide admin
+// teams and users plus the database's own operators, deduplicated in that
+// order — the set surfaced on command-rejection comments.
+func TestPRCommandAuthorizedPrincipals(t *testing.T) {
+	cfg := &ServerConfig{
+		PRCommandAuthorization: PRCommandAuthorizationConfig{
+			Enabled:    true,
+			AdminTeams: []string{"octocat/db-admins"},
+			AdminUsers: []string{"kara"},
+		},
+		Databases: map[string]DatabaseConfig{
+			"orders": {
+				OperatorTeams: []string{"octocat/orders-operators", "octocat/db-admins"},
+				OperatorUsers: []string{"kara", "lee"},
+			},
+		},
+	}
+
+	assert.Equal(t,
+		[]string{"octocat/db-admins", "kara", "octocat/orders-operators", "lee"},
+		cfg.PRCommandAuthorizedPrincipals("orders"),
+		"admins first, then the database's operators, deduplicated")
+
+	assert.Equal(t,
+		[]string{"octocat/db-admins", "kara"},
+		cfg.PRCommandAuthorizedPrincipals("unknown"),
+		"an unknown database still lists the deployment-wide admins")
+
+	var nilCfg *ServerConfig
+	assert.Nil(t, nilCfg.PRCommandAuthorizedPrincipals("orders"))
+}

--- a/pkg/api/actor_authorization_test.go
+++ b/pkg/api/actor_authorization_test.go
@@ -246,6 +246,12 @@ func TestPRCommandAuthorizedPrincipals(t *testing.T) {
 			AdminTeams: []string{"octocat/db-admins"},
 			AdminUsers: []string{"kara"},
 		},
+		Repos: map[string]RepoConfig{
+			"octocat/hello-world": {
+				AdminTeams: []string{"octocat/repo-admins", "octocat/db-admins"},
+				AdminUsers: []string{"mona"},
+			},
+		},
 		Databases: map[string]DatabaseConfig{
 			"orders": {
 				OperatorTeams: []string{"octocat/orders-operators", "octocat/db-admins"},
@@ -255,15 +261,20 @@ func TestPRCommandAuthorizedPrincipals(t *testing.T) {
 	}
 
 	assert.Equal(t,
-		[]string{"octocat/db-admins", "kara", "octocat/orders-operators", "lee"},
-		cfg.PRCommandAuthorizedPrincipals("orders"),
-		"admins first, then the database's operators, deduplicated")
+		[]string{"octocat/db-admins", "kara", "octocat/repo-admins", "mona", "octocat/orders-operators", "lee"},
+		cfg.PRCommandAuthorizedPrincipals("octocat/hello-world", "orders"),
+		"deployment admins, then repo admins, then the database's operators, deduplicated across all three")
 
 	assert.Equal(t,
-		[]string{"octocat/db-admins", "kara"},
-		cfg.PRCommandAuthorizedPrincipals("unknown"),
-		"an unknown database still lists the deployment-wide admins")
+		[]string{"octocat/db-admins", "kara", "octocat/orders-operators", "lee"},
+		cfg.PRCommandAuthorizedPrincipals("octocat/other-repo", "orders"),
+		"a repo with no config entry contributes no repo admins")
+
+	assert.Equal(t,
+		[]string{"octocat/db-admins", "kara", "octocat/repo-admins", "mona"},
+		cfg.PRCommandAuthorizedPrincipals("octocat/hello-world", "unknown"),
+		"an unknown database still lists the deployment and repo admins")
 
 	var nilCfg *ServerConfig
-	assert.Nil(t, nilCfg.PRCommandAuthorizedPrincipals("orders"))
+	assert.Nil(t, nilCfg.PRCommandAuthorizedPrincipals("octocat/hello-world", "orders"))
 }

--- a/pkg/webhook/actor_authorization.go
+++ b/pkg/webhook/actor_authorization.go
@@ -103,7 +103,7 @@ func (h *Handler) enforcePRCommandActorAuthorization(
 			CommandName:          commandName,
 			Database:             database,
 			Environment:          environment,
-			AuthorizedPrincipals: h.service.Config().PRCommandAuthorizedPrincipals(database),
+			AuthorizedPrincipals: h.service.Config().PRCommandAuthorizedPrincipals(repo, database),
 		}))
 		return true
 	}

--- a/pkg/webhook/actor_authorization.go
+++ b/pkg/webhook/actor_authorization.go
@@ -99,10 +99,11 @@ func (h *Handler) enforcePRCommandActorAuthorization(
 			"command", commandName, "requested_by", requestedBy,
 			"reason", result.Reason)
 		h.postComment(repo, pr, installationID, templates.RenderPRCommandNotAuthorized(templates.ActorAuthorizationCommentData{
-			RequestedBy: requestedBy,
-			CommandName: commandName,
-			Database:    database,
-			Environment: environment,
+			RequestedBy:          requestedBy,
+			CommandName:          commandName,
+			Database:             database,
+			Environment:          environment,
+			AuthorizedPrincipals: h.service.Config().PRCommandAuthorizedPrincipals(database),
 		}))
 		return true
 	}

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -53,9 +53,12 @@ func RenderPRCommandNotAuthorized(data ActorAuthorizationCommentData) string {
 		fmt.Fprintf(&sb, "The requester is not authorized to run `schemabot %s` for this database.\n\n", data.CommandName)
 	}
 	if len(data.AuthorizedPrincipals) > 0 {
+		// Principals render as inline code, never @-mentions: the list is
+		// guidance for the blocked user, and mentions would notify every
+		// admin team and operator on every rejected command.
 		sb.WriteString("**Who can run this command** — members of these teams, or these users:\n")
 		for _, principal := range data.AuthorizedPrincipals {
-			fmt.Fprintf(&sb, "- @%s\n", principal)
+			fmt.Fprintf(&sb, "- `%s`\n", principal)
 		}
 		sb.WriteString("\nAsk one of them to run it, or request membership in one of the teams above.\n")
 	} else {

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -33,6 +33,10 @@ type ActorAuthorizationCommentData struct {
 	CommandName string
 	Database    string
 	Environment string
+	// AuthorizedPrincipals are the GitHub teams (org/team) and users allowed
+	// to run mutating commands for the database, listed on rejection so the
+	// blocked user knows who to ask.
+	AuthorizedPrincipals []string
 }
 
 // RenderPRCommandNotAuthorized renders a comment when a GitHub PR command
@@ -48,7 +52,15 @@ func RenderPRCommandNotAuthorized(data ActorAuthorizationCommentData) string {
 	} else {
 		fmt.Fprintf(&sb, "The requester is not authorized to run `schemabot %s` for this database.\n\n", data.CommandName)
 	}
-	sb.WriteString("A configured SchemaBot admin/database operator must run this command.\n")
+	if len(data.AuthorizedPrincipals) > 0 {
+		sb.WriteString("**Who can run this command** — members of these teams, or these users:\n")
+		for _, principal := range data.AuthorizedPrincipals {
+			fmt.Fprintf(&sb, "- @%s\n", principal)
+		}
+		sb.WriteString("\nAsk one of them to run it, or request membership in one of the teams above.\n")
+	} else {
+		sb.WriteString("A configured SchemaBot admin/database operator must run this command.\n")
+	}
 
 	return sb.String()
 }

--- a/pkg/webhook/templates/apply_commands_test.go
+++ b/pkg/webhook/templates/apply_commands_test.go
@@ -7,7 +7,9 @@ import (
 )
 
 // The rejection lists the teams and users allowed to run the command, so a
-// blocked user knows who to ask instead of guessing at the access model.
+// blocked user knows who to ask instead of guessing at the access model. The
+// principals render as inline code, never @-mentions — the list is guidance,
+// and mentions would notify every admin and operator on every rejection.
 func TestRenderPRCommandNotAuthorizedListsPrincipals(t *testing.T) {
 	out := RenderPRCommandNotAuthorized(ActorAuthorizationCommentData{
 		RequestedBy: "dave", CommandName: "apply", Database: "orders", Environment: "production",
@@ -15,9 +17,11 @@ func TestRenderPRCommandNotAuthorizedListsPrincipals(t *testing.T) {
 	})
 	require.Contains(t, out, "@dave is not authorized")
 	require.Contains(t, out, "**Who can run this command**")
-	require.Contains(t, out, "- @octocat/db-admins")
-	require.Contains(t, out, "- @octocat/orders-operators")
-	require.Contains(t, out, "- @kara")
+	require.Contains(t, out, "- `octocat/db-admins`")
+	require.Contains(t, out, "- `octocat/orders-operators`")
+	require.Contains(t, out, "- `kara`")
+	require.NotContains(t, out, "@octocat/db-admins", "team principals must never render as mentions")
+	require.NotContains(t, out, "@kara", "user principals must never render as mentions")
 
 	fallback := RenderPRCommandNotAuthorized(ActorAuthorizationCommentData{
 		RequestedBy: "dave", CommandName: "apply", Database: "orders", Environment: "production",

--- a/pkg/webhook/templates/apply_commands_test.go
+++ b/pkg/webhook/templates/apply_commands_test.go
@@ -1,0 +1,27 @@
+package templates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The rejection lists the teams and users allowed to run the command, so a
+// blocked user knows who to ask instead of guessing at the access model.
+func TestRenderPRCommandNotAuthorizedListsPrincipals(t *testing.T) {
+	out := RenderPRCommandNotAuthorized(ActorAuthorizationCommentData{
+		RequestedBy: "dave", CommandName: "apply", Database: "orders", Environment: "production",
+		AuthorizedPrincipals: []string{"octocat/db-admins", "octocat/orders-operators", "kara"},
+	})
+	require.Contains(t, out, "@dave is not authorized")
+	require.Contains(t, out, "**Who can run this command**")
+	require.Contains(t, out, "- @octocat/db-admins")
+	require.Contains(t, out, "- @octocat/orders-operators")
+	require.Contains(t, out, "- @kara")
+
+	fallback := RenderPRCommandNotAuthorized(ActorAuthorizationCommentData{
+		RequestedBy: "dave", CommandName: "apply", Database: "orders", Environment: "production",
+	})
+	require.Contains(t, fallback, "A configured SchemaBot admin/database operator must run this command.")
+	require.NotContains(t, fallback, "Who can run this command")
+}


### PR DESCRIPTION
## Why this matters

A user blocked from `schemabot apply` got only *"A configured SchemaBot admin/database operator must run this command"* — with no indication of who that actually is. Someone who clearly should have access but isn't in the configured team has no way to see which team to join, and answering "who can run this?" required an operator to go read the server config.

## What it does

The Command Not Authorized comment now lists who is allowed, in exactly the set and order the authorizer consults: the deployment's admin teams/users, the repository's admin teams/users, then the target database's operator teams/users — deduplicated, and mirroring the review gate's existing **Authorized reviewers** guidance:

> **Who can run this command** — members of these teams, or these users:
> - `org/db-admins`
> - `org/repo-admins`
> - `org/orders-operators`
>
> Ask one of them to run it, or request membership in one of the teams above.

Principals render as inline code, never `@`-mentions — the list is guidance for the blocked user, and mentions would notify every admin and operator on every rejected command. Configured spellings are normalized (leading `@`, whitespace, case) so a principal never appears twice. When nothing is configured, the comment keeps today's generic line. Authorization behavior itself is unchanged — this only improves what the rejection tells the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
