### PR TITLE
fix(github): converge stored check state when an apply finishes before its claim

### DIFF
--- a/pkg/webhook/apply_check_records.go
+++ b/pkg/webhook/apply_check_records.go
@@ -142,6 +142,12 @@ func (h *Handler) updateCheckRecordForApplyStart(ctx context.Context, client *gh
 		h.logger.Info("apply finished before its check claim; refreshing stored check state to the terminal outcome",
 			apply.LogAttrs()...)
 		h.refreshChecksForTerminalApply(ctx, apply, "apply finished before check claim")
+		// The refresh resolves its own GitHub client from the durable apply; if
+		// that resolution fails, the stored check state has still converged but
+		// the visible aggregate Check Run has not. Refresh it with the request's
+		// client too — recomputing the aggregate is idempotent, and this path
+		// only runs when an apply outraces its own claim.
+		h.updateAggregateCheck(ctx, client, repo, pr, check.HeadSHA)
 		return nil
 	}
 

--- a/pkg/webhook/apply_check_records.go
+++ b/pkg/webhook/apply_check_records.go
@@ -7,6 +7,7 @@ import (
 	"github.com/block/schemabot/pkg/apitypes"
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/metrics"
+	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 )
 
@@ -19,7 +20,9 @@ func (h *Handler) storeApplyPlanCheckRecord(ctx context.Context, client *ghclien
 }
 
 // updateCheckRecordForApplyStart updates the stored check state to "in_progress"
-// when an apply begins execution. The aggregate check is updated to reflect the state.
+// when an apply begins execution. The aggregate check is updated to reflect the
+// state. If the apply is already terminal by the time the claim lands, the
+// stored check state is immediately refreshed to the apply's terminal outcome.
 func (h *Handler) updateCheckRecordForApplyStart(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, environment string, applyID int64) error {
 	check, err := h.service.Storage().Checks().Get(ctx, repo, pr, environment, schema.Type, schema.Database)
 	if err != nil {
@@ -118,6 +121,30 @@ func (h *Handler) updateCheckRecordForApplyStart(ctx context.Context, client *gh
 		Environment:  environment,
 		Status:       "success",
 	})
+
+	// The claim above races the driver: a fast apply can reach a terminal state
+	// before the claim lands, and the driver's terminal check update skips
+	// fail-closed when the stored row is not yet owned by the apply. Reload the
+	// apply now that the claim is durable; if the apply already finished, run
+	// the terminal refresh here so the stored check state converges to the
+	// apply's outcome instead of staying in_progress with no writer left to
+	// complete it.
+	apply, err := h.service.Storage().Applies().Get(ctx, applyID)
+	if err != nil {
+		return fmt.Errorf("reload apply after check claim repo %s pr %d environment %s database_type %s database %s apply_id %d: %w",
+			repo, pr, environment, schema.Type, schema.Database, applyID, err)
+	}
+	if apply == nil {
+		return fmt.Errorf("apply missing after check claim repo %s pr %d environment %s database_type %s database %s apply_id %d",
+			repo, pr, environment, schema.Type, schema.Database, applyID)
+	}
+	if state.IsTerminalApplyState(apply.State) {
+		h.logger.Info("apply finished before its check claim; refreshing stored check state to the terminal outcome",
+			apply.LogAttrs()...)
+		h.refreshChecksForTerminalApply(ctx, apply, "apply finished before check claim")
+		return nil
+	}
+
 	h.updateAggregateCheck(ctx, client, repo, pr, check.HeadSHA)
 	return nil
 }

--- a/pkg/webhook/apply_check_records_integration_test.go
+++ b/pkg/webhook/apply_check_records_integration_test.go
@@ -1,0 +1,206 @@
+//go:build integration
+
+package webhook
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"net/url"
+	"os"
+	"testing"
+
+	gh "github.com/google/go-github/v86/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/api"
+	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/storage/mysqlstore"
+)
+
+// A fast apply can reach a terminal state before the webhook goroutine claims
+// the stored check state. The driver's terminal update then skips fail-closed
+// (the row is not yet apply-owned), so the claim is the last writer: it must
+// notice the apply already finished and immediately converge the stored check
+// state to the terminal outcome. Otherwise the check stays in_progress forever
+// and the PR's required check never reflects the successful apply.
+func TestUpdateCheckRecordForApplyStart_ConvergesWhenApplyAlreadyTerminal(t *testing.T) {
+	ctx := t.Context()
+
+	db, err := sql.Open("mysql", e2eSchemabotDSN)
+	require.NoError(t, err)
+	require.NoError(t, db.PingContext(ctx))
+	t.Cleanup(func() { _ = db.Close() })
+
+	const (
+		repo = "octocat/claim-race-check"
+		pr   = 9
+		dbn  = "claim_race_check_db"
+		env  = "staging"
+	)
+
+	clear := func(c context.Context) {
+		_, err := db.ExecContext(c, "DELETE FROM checks WHERE repository = ? AND pull_request = ?", repo, pr)
+		require.NoError(t, err)
+		_, err = db.ExecContext(c, "DELETE FROM applies WHERE repository = ? AND pull_request = ?", repo, pr)
+		require.NoError(t, err)
+	}
+	clear(ctx)
+	// Cleanup runs after t.Context() is cancelled, so derive a non-cancelled
+	// context from it for the cleanup deletes.
+	t.Cleanup(func() { clear(context.WithoutCancel(ctx)) })
+
+	st := mysqlstore.New(db)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := api.New(st, &api.ServerConfig{}, nil, logger)
+
+	// The claim and the terminal refresh both refresh the aggregate Check Run
+	// after writing stored state. Point GitHub at an unrouted test server: the
+	// stored updates (the behavior under test) land first, and the GitHub
+	// refresh fails gracefully without a real installation.
+	ghClient := gh.NewClient(nil)
+	ghClient.BaseURL, err = url.Parse("http://127.0.0.1:0/")
+	require.NoError(t, err)
+	installClient := ghclient.NewInstallationClient(ghClient, logger)
+	factory := &fakeClientFactory{client: installClient}
+	h := NewHandler(svc, factory, nil, logger)
+
+	// The driver already drove the apply to completion.
+	apply := &storage.Apply{
+		ApplyIdentifier: "apply-claim-race-terminal",
+		Database:        dbn,
+		DatabaseType:    "mysql",
+		Repository:      repo,
+		PullRequest:     pr,
+		Environment:     env,
+		Engine:          storage.EngineSpirit,
+		InstallationID:  4242,
+		State:           state.Apply.Completed,
+	}
+	applyID, err := st.Applies().Create(ctx, apply)
+	require.NoError(t, err)
+	apply.ID = applyID
+
+	// The stored check state is still what the plan wrote: pending changes,
+	// not owned by any apply.
+	require.NoError(t, st.Checks().Upsert(ctx, &storage.Check{
+		Repository:   repo,
+		PullRequest:  pr,
+		HeadSHA:      "abc123",
+		Environment:  env,
+		DatabaseType: "mysql",
+		DatabaseName: dbn,
+		CheckRunID:   1,
+		HasChanges:   true,
+		Status:       checkStatusCompleted,
+		Conclusion:   checkConclusionActionRequired,
+	}))
+
+	// The driver's terminal update runs before the claim lands: the row is not
+	// apply-owned yet, so the conditional update skips fail-closed.
+	updated, err := h.updateCheckRecordForApplyResult(ctx, repo, pr, apply)
+	require.NoError(t, err)
+	require.False(t, updated, "terminal update must not complete a check the apply does not own")
+
+	check, err := st.Checks().Get(ctx, repo, pr, env, "mysql", dbn)
+	require.NoError(t, err)
+	require.NotNil(t, check)
+	require.Equal(t, checkConclusionActionRequired, check.Conclusion, "skipped terminal update must leave the plan result in place")
+	require.Zero(t, check.ApplyID)
+
+	// The webhook claim lands after the apply finished. It must converge the
+	// stored check state to the apply's terminal outcome instead of leaving the
+	// row in_progress with no writer left to complete it.
+	schema := &ghclient.SchemaRequestResult{Type: "mysql", Database: dbn}
+	require.NoError(t, h.updateCheckRecordForApplyStart(ctx, installClient, repo, pr, schema, env, applyID))
+
+	check, err = st.Checks().Get(ctx, repo, pr, env, "mysql", dbn)
+	require.NoError(t, err)
+	require.NotNil(t, check)
+	assert.Equal(t, checkStatusCompleted, check.Status)
+	assert.Equal(t, checkConclusionSuccess, check.Conclusion, "the completed apply's success must land even when the claim raced behind it")
+	assert.Equal(t, applyID, check.ApplyID)
+	assert.False(t, check.HasChanges)
+}
+
+// While the apply is still in flight when the claim lands, the claim keeps the
+// stored check state in_progress and owned by the apply so the driver's
+// eventual terminal update can complete it.
+func TestUpdateCheckRecordForApplyStart_KeepsInProgressForRunningApply(t *testing.T) {
+	ctx := t.Context()
+
+	db, err := sql.Open("mysql", e2eSchemabotDSN)
+	require.NoError(t, err)
+	require.NoError(t, db.PingContext(ctx))
+	t.Cleanup(func() { _ = db.Close() })
+
+	const (
+		repo = "octocat/claim-running-check"
+		pr   = 10
+		dbn  = "claim_running_check_db"
+		env  = "staging"
+	)
+
+	clear := func(c context.Context) {
+		_, err := db.ExecContext(c, "DELETE FROM checks WHERE repository = ? AND pull_request = ?", repo, pr)
+		require.NoError(t, err)
+		_, err = db.ExecContext(c, "DELETE FROM applies WHERE repository = ? AND pull_request = ?", repo, pr)
+		require.NoError(t, err)
+	}
+	clear(ctx)
+	// Cleanup runs after t.Context() is cancelled, so derive a non-cancelled
+	// context from it for the cleanup deletes.
+	t.Cleanup(func() { clear(context.WithoutCancel(ctx)) })
+
+	st := mysqlstore.New(db)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := api.New(st, &api.ServerConfig{}, nil, logger)
+
+	ghClient := gh.NewClient(nil)
+	ghClient.BaseURL, err = url.Parse("http://127.0.0.1:0/")
+	require.NoError(t, err)
+	installClient := ghclient.NewInstallationClient(ghClient, logger)
+	factory := &fakeClientFactory{client: installClient}
+	h := NewHandler(svc, factory, nil, logger)
+
+	apply := &storage.Apply{
+		ApplyIdentifier: "apply-claim-running",
+		Database:        dbn,
+		DatabaseType:    "mysql",
+		Repository:      repo,
+		PullRequest:     pr,
+		Environment:     env,
+		Engine:          storage.EngineSpirit,
+		InstallationID:  4242,
+		State:           state.Apply.Running,
+	}
+	applyID, err := st.Applies().Create(ctx, apply)
+	require.NoError(t, err)
+
+	require.NoError(t, st.Checks().Upsert(ctx, &storage.Check{
+		Repository:   repo,
+		PullRequest:  pr,
+		HeadSHA:      "abc123",
+		Environment:  env,
+		DatabaseType: "mysql",
+		DatabaseName: dbn,
+		CheckRunID:   1,
+		HasChanges:   true,
+		Status:       checkStatusCompleted,
+		Conclusion:   checkConclusionActionRequired,
+	}))
+
+	schema := &ghclient.SchemaRequestResult{Type: "mysql", Database: dbn}
+	require.NoError(t, h.updateCheckRecordForApplyStart(ctx, installClient, repo, pr, schema, env, applyID))
+
+	check, err := st.Checks().Get(ctx, repo, pr, env, "mysql", dbn)
+	require.NoError(t, err)
+	require.NotNil(t, check)
+	assert.Equal(t, checkStatusInProgress, check.Status)
+	assert.Empty(t, check.Conclusion)
+	assert.Equal(t, applyID, check.ApplyID)
+	assert.True(t, check.HasChanges)
+}

--- a/pkg/webhook/apply_check_records_integration_test.go
+++ b/pkg/webhook/apply_check_records_integration_test.go
@@ -33,7 +33,7 @@ func TestUpdateCheckRecordForApplyStart_ConvergesWhenApplyAlreadyTerminal(t *tes
 	db, err := sql.Open("mysql", e2eSchemabotDSN)
 	require.NoError(t, err)
 	require.NoError(t, db.PingContext(ctx))
-	t.Cleanup(func() { _ = db.Close() })
+	t.Cleanup(func() { assert.NoError(t, db.Close()) })
 
 	const (
 		repo = "octocat/claim-race-check"
@@ -135,7 +135,7 @@ func TestUpdateCheckRecordForApplyStart_KeepsInProgressForRunningApply(t *testin
 	db, err := sql.Open("mysql", e2eSchemabotDSN)
 	require.NoError(t, err)
 	require.NoError(t, db.PingContext(ctx))
-	t.Cleanup(func() { _ = db.Close() })
+	t.Cleanup(func() { assert.NoError(t, db.Close()) })
 
 	const (
 		repo = "octocat/claim-running-check"


### PR DESCRIPTION
## Why this matters

The in-progress claim on stored check state races the driver. A fast apply (a metadata-only alter, or any apply the operator drives to terminal quickly) can finish before the webhook goroutine's claim lands. The driver's terminal check update correctly skips fail-closed — the row is not yet owned by the apply — but the claim then wrote `in_progress` with no writer left to complete it. The required check stayed "Apply in progress" forever on a PR whose apply had already succeeded.

```
webhook goroutine                     driver
────────────────────────────────────  ─────────────────────────────────────
ExecuteApply → apply queued           claims apply, drives it
post progress comment                 apply reaches terminal (fast DDL)
                                      terminal check update:
                                        row not apply-owned → skip (closed)
claim: check ← in_progress, apply_id
        ⇢ stuck: nothing completes it
```

The gate fails closed (the PR blocks, never passes wrongly), but a healthy applied PR is permanently red until an operator intervenes with a manual plan.

## What it does

After the claim upsert lands, reload the apply. If it already reached a terminal state, immediately run the terminal check refresh — now that the row is apply-owned, the conditional completion succeeds and the stored check state converges to the apply's real outcome (success, failure, or a rollback's action_required). A still-running apply keeps today's behavior: the row stays in_progress and the driver's terminal update completes it. Both the apply and rollback start paths go through this claim, so both are covered.

Integration tests pin the two orderings: a terminal apply whose driver update skipped before the claim converges to the terminal conclusion, and a running apply keeps the in-progress claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)