### PR TITLE
fix(github): leader re-folds on its own schedule when participants have not reported

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -342,6 +342,13 @@ type InstallationClient struct {
 	checkStatusSingleflight *CheckStatusSingleflight
 }
 
+// InstallationID returns the GitHub App installation this client is scoped
+// to, so callers can schedule follow-up work (e.g. a delayed aggregate
+// re-fold) that must resolve a client for the same installation later.
+func (ic *InstallationClient) InstallationID() int64 {
+	return ic.installationID
+}
+
 // loadAppSlug returns the current app slug, or empty if not yet set.
 func (ic *InstallationClient) loadAppSlug() string {
 	if p := ic.appSlug.Load(); p != nil {

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -525,6 +525,16 @@ type PullRequestInfo struct {
 	BaseRef string
 	BaseSHA string
 	User    string
+	// State is the PR's lifecycle state as GitHub reports it: "open" or
+	// "closed" (a merged PR reads as closed).
+	State string
+}
+
+// IsClosed reports whether the PR is closed (merged or unmerged). Callers that
+// act on a PR asynchronously — timers, reconciliation — use this to stop work
+// that only makes sense on an open PR.
+func (pri *PullRequestInfo) IsClosed() bool {
+	return pri.State == "closed"
 }
 
 // FetchPullRequest is the dedupe-friendly variant. It honours the
@@ -597,6 +607,7 @@ func (ic *InstallationClient) fetchPullRequest(ctx context.Context, repo string,
 		BaseRef: ghPR.GetBase().GetRef(),
 		BaseSHA: ghPR.GetBase().GetSHA(),
 		User:    ghPR.GetUser().GetLogin(),
+		State:   ghPR.GetState(),
 	}, nil
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -483,8 +483,12 @@ const (
 	// completed, and successful — it does not block the aggregate.
 	LeaderParticipantGateSuccess = "success"
 	// LeaderParticipantGateFailure: the participant's Check Run completed with a
-	// non-success conclusion — the aggregate fails.
+	// failing conclusion — the aggregate fails.
 	LeaderParticipantGateFailure = "failure"
+	// LeaderParticipantGatePending: the participant's Check Run completed with
+	// action_required — the participant has pending work (typically an apply
+	// awaiting an operator) and the aggregate blocks as pending.
+	LeaderParticipantGatePending = "pending"
 	// LeaderParticipantGateInProgress: the participant's Check Run is not yet
 	// terminal — the aggregate stays in progress.
 	LeaderParticipantGateInProgress = "in_progress"
@@ -1125,17 +1129,20 @@ var knownStatusCheckOperations = map[string]bool{
 	"aggregate_participant_skip":           true,
 	"aggregate_participant_fanout":         true,
 	"participant_comment_nudge":            true,
+	"participant_refold":                   true,
 	"merge_group_check":                    true,
 	"default_branch_check":                 true,
 }
 
 var knownStatusCheckStatuses = map[string]bool{
-	"success": true,
-	"error":   true,
-	"skipped": true,
-	"stale":   true,
-	"noop":    true,
-	"blocked": true,
+	"success":   true,
+	"error":     true,
+	"skipped":   true,
+	"stale":     true,
+	"noop":      true,
+	"blocked":   true,
+	"scheduled": true,
+	"exhausted": true,
 }
 
 // StatusCheckOperation describes one status-check storage or GitHub operation.

--- a/pkg/webhook/check_aggregate.go
+++ b/pkg/webhook/check_aggregate.go
@@ -236,23 +236,66 @@ func aggregateSummary(checks []*storage.Check, conclusion string) (title, summar
 		summary = buildAggregateTable(checks)
 	case checkConclusionActionRequired:
 		pending := 0
+		unresolved := 0
 		for _, c := range checks {
-			if c.Conclusion == checkConclusionActionRequired {
-				pending++
+			if c.Conclusion != checkConclusionActionRequired {
+				continue
+			}
+			pending++
+			if isUnresolvedParticipantCheck(c) {
+				unresolved++
 			}
 		}
-		if pending == 1 {
+		switch {
+		case pending > 0 && unresolved == pending:
+			// Every blocking row is a participant whose Check Run could not be
+			// read; no apply is actually pending, the participants are silent.
+			if pending == 1 {
+				title = "1 participant deployment has not reported"
+			} else {
+				title = fmt.Sprintf("%d participant deployments have not reported", pending)
+			}
+		case pending == 1:
 			title = "1 apply pending"
-		} else {
+		default:
 			title = fmt.Sprintf("%d applies pending", pending)
 		}
 		summary = buildAggregateTable(checks)
 	default:
 		// in_progress — conclusion is empty
-		title = "Apply in progress"
+		inProgress := 0
+		waiting := 0
+		for _, c := range checks {
+			if c.Status != checkStatusInProgress {
+				continue
+			}
+			inProgress++
+			if isUnresolvedParticipantCheck(c) {
+				waiting++
+			}
+		}
+		if inProgress > 0 && waiting == inProgress {
+			// Nothing is applying; the fold is waiting for participant Check
+			// Runs a scheduled re-fold will re-read shortly.
+			if waiting == 1 {
+				title = "Waiting for 1 participant deployment to report"
+			} else {
+				title = fmt.Sprintf("Waiting for %d participant deployments to report", waiting)
+			}
+		} else {
+			title = "Apply in progress"
+		}
 		summary = buildAggregateTable(checks)
 	}
 	return title, summary
+}
+
+// isUnresolvedParticipantCheck reports whether a synthesized participant row
+// blocks only because the participant's Check Run could not be read (not
+// reported yet, or a failed Checks API read) — the aggregate should present it
+// as a reporting gap, never as a pending or failed apply.
+func isUnresolvedParticipantCheck(c *storage.Check) bool {
+	return c.BlockingReason == participantUnresolvedBlockingReason
 }
 
 // isParticipantCheck reports whether a check is a participant deployment's
@@ -392,6 +435,12 @@ func allChecksAreUpToDate(checks []*storage.Check) bool {
 func checkStatusLabel(c *storage.Check) string {
 	if c.Status == checkStatusCompleted && c.Conclusion == checkConclusionSuccess && !c.HasChanges {
 		return "Up to date"
+	}
+	if isUnresolvedParticipantCheck(c) {
+		if c.Status == checkStatusInProgress {
+			return "Waiting to report"
+		}
+		return "Not reported"
 	}
 	return conclusionEmoji(c.Status, c.Conclusion)
 }

--- a/pkg/webhook/check_publisher.go
+++ b/pkg/webhook/check_publisher.go
@@ -149,13 +149,21 @@ func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.Ins
 
 	checkNameBase := h.aggregateCheckNameForRepo(repo)
 
+	// A retriable participant outcome (not reported yet, or a failed Checks
+	// API read) can newly resolve on a later re-read. Participants with no
+	// schema work publish their check but never comment, so no nudge will
+	// arrive — the leader must re-fold on its own schedule or the aggregate
+	// stays blocked on a participant that already reported green.
+	participantsRetriable := false
+
 	if len(config.AllowedEnvironments) > 0 {
 		// Per-environment aggregates: create one aggregate per allowed environment.
 		// Each uses the real environment name in the storage key to avoid collisions
 		// between environments (e.g., staging vs production aggregates).
 		for _, env := range config.AllowedEnvironments {
 			envChecks := filterChecksByEnvironment(dbChecks, env)
-			participantChecks := h.participantCheckOutcomes(ctx, client, repo, pr, env, headSHA, expectedParticipants)
+			participantChecks, retriable := h.participantCheckOutcomes(ctx, client, repo, pr, env, headSHA, expectedParticipants)
+			participantsRetriable = participantsRetriable || retriable
 			envChecks = append(envChecks, participantChecks...)
 			if len(envChecks) == 0 {
 				h.logger.Debug("no checks or expected participants for aggregate environment",
@@ -168,11 +176,18 @@ func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.Ins
 	} else {
 		// Single aggregate. Uses aggregateSentinel for the environment field
 		// since there is no per-environment scoping.
-		participantChecks := h.participantCheckOutcomes(ctx, client, repo, pr, aggregateSentinel, headSHA, expectedParticipants)
+		participantChecks, retriable := h.participantCheckOutcomes(ctx, client, repo, pr, aggregateSentinel, headSHA, expectedParticipants)
+		participantsRetriable = retriable
 		aggChecks := make([]*storage.Check, 0, len(dbChecks)+len(participantChecks))
 		aggChecks = append(aggChecks, dbChecks...)
 		aggChecks = append(aggChecks, participantChecks...)
 		h.upsertAggregateCheckRun(ctx, client, repo, pr, headSHA, aggChecks, checkNameBase, aggregateSentinel)
+	}
+
+	if participantsRetriable {
+		h.scheduleParticipantRefold(ctx, repo, pr, client.InstallationID())
+	} else {
+		h.clearParticipantRefoldBudget(repo, pr)
 	}
 }
 

--- a/pkg/webhook/check_publisher.go
+++ b/pkg/webhook/check_publisher.go
@@ -121,7 +121,10 @@ func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.Ins
 			// The leader cannot determine which participants a PR requires without
 			// the changed files. Fail closed: do not publish an aggregate at all,
 			// which leaves any existing (still-blocking) aggregate in place rather
-			// than downgrading it to a passing success we cannot justify.
+			// than downgrading it to a passing success we cannot justify. The read
+			// failure is as transient as a failed participant Checks read, so arm
+			// a bounded re-fold — otherwise one API blip strands the aggregate
+			// until an external event re-folds it.
 			metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
 				Operation:  "aggregate_check_sync",
 				Repository: repo,
@@ -129,6 +132,7 @@ func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.Ins
 			})
 			h.logger.Error("aggregate leader cannot fetch PR files, not publishing aggregate",
 				"repo", repo, "pr", pr, "head_sha", headSHA, "error", err)
+			h.scheduleParticipantRefold(ctx, repo, pr, client.InstallationID())
 			return
 		}
 		expectedParticipants = config.ExpectedParticipantChecksForPR(repo, prFilePaths(files))
@@ -153,8 +157,12 @@ func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.Ins
 	// API read) can newly resolve on a later re-read. Participants with no
 	// schema work publish their check but never comment, so no nudge will
 	// arrive — the leader must re-fold on its own schedule or the aggregate
-	// stays blocked on a participant that already reported green.
+	// stays blocked on a participant that already reported green. While the
+	// re-fold budget lasts, unresolved participants render as in_progress
+	// (equally merge-blocking) so the wait is not mislabeled as pending
+	// applies.
 	participantsRetriable := false
+	retryPending := h.participantRefoldBudgetRemaining(repo, pr)
 
 	if len(config.AllowedEnvironments) > 0 {
 		// Per-environment aggregates: create one aggregate per allowed environment.
@@ -162,7 +170,7 @@ func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.Ins
 		// between environments (e.g., staging vs production aggregates).
 		for _, env := range config.AllowedEnvironments {
 			envChecks := filterChecksByEnvironment(dbChecks, env)
-			participantChecks, retriable := h.participantCheckOutcomes(ctx, client, repo, pr, env, headSHA, expectedParticipants)
+			participantChecks, retriable := h.participantCheckOutcomes(ctx, client, repo, pr, env, headSHA, expectedParticipants, retryPending)
 			participantsRetriable = participantsRetriable || retriable
 			envChecks = append(envChecks, participantChecks...)
 			if len(envChecks) == 0 {
@@ -176,7 +184,7 @@ func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.Ins
 	} else {
 		// Single aggregate. Uses aggregateSentinel for the environment field
 		// since there is no per-environment scoping.
-		participantChecks, retriable := h.participantCheckOutcomes(ctx, client, repo, pr, aggregateSentinel, headSHA, expectedParticipants)
+		participantChecks, retriable := h.participantCheckOutcomes(ctx, client, repo, pr, aggregateSentinel, headSHA, expectedParticipants, retryPending)
 		participantsRetriable = retriable
 		aggChecks := make([]*storage.Check, 0, len(dbChecks)+len(participantChecks))
 		aggChecks = append(aggChecks, dbChecks...)

--- a/pkg/webhook/check_publisher.go
+++ b/pkg/webhook/check_publisher.go
@@ -85,6 +85,12 @@ func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.Ins
 	}
 
 	if !h.verifyHeadSHAStillCurrentForPR(ctx, client, repo, pr, headSHA, "aggregate_check_sync") {
+		// False covers a transient PR-fetch failure as well as a genuinely
+		// newer head; either way a leader's next re-fold fetches the
+		// then-current head, so arming a bounded re-fold converges the
+		// aggregate instead of stranding one waiting on a participant re-read.
+		// verifyHeadSHAStillCurrentForPR already logged the reason.
+		h.scheduleLeaderRefoldIfConfigured(ctx, repo, pr, client.InstallationID())
 		return
 	}
 
@@ -96,6 +102,10 @@ func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.Ins
 			Status:     "error",
 		})
 		h.logger.Error("failed to fetch checks for aggregate", "repo", repo, "pr", pr, "error", err)
+		// A storage blip must not end a leader's retry chain while its
+		// aggregate renders unresolved participants as in_progress; the
+		// bounded re-fold retries the read.
+		h.scheduleLeaderRefoldIfConfigured(ctx, repo, pr, client.InstallationID())
 		return
 	}
 

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -86,6 +86,12 @@ type Handler struct {
 	// package default.
 	participantNudgeRefoldDelay time.Duration
 
+	// participantRefoldDelayOverride overrides the backoff before each
+	// self-scheduled aggregate re-fold armed while expected participants
+	// remain unresolved. Test-only: when set it applies to every attempt.
+	// Zero means the package backoff schedule.
+	participantRefoldDelayOverride time.Duration
+
 	// participantRefoldAttempts tracks, per repo#pr, how many self-scheduled
 	// aggregate re-folds have been armed while expected participants remain
 	// unresolved. Bounded by maxParticipantRefoldAttempts and cleared when a

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -18,6 +18,7 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -84,6 +85,13 @@ type Handler struct {
 	// aggregate re-fold after a participant-comment nudge. Zero means the
 	// package default.
 	participantNudgeRefoldDelay time.Duration
+
+	// participantRefoldAttempts tracks, per repo#pr, how many self-scheduled
+	// aggregate re-folds have been armed while expected participants remain
+	// unresolved. Bounded by maxParticipantRefoldAttempts and cleared when a
+	// fold resolves every participant. Guarded by participantRefoldMu.
+	participantRefoldMu       sync.Mutex
+	participantRefoldAttempts map[string]int
 
 	// webhookSecretsByApp maps each configured App's logical name to its
 	// HMAC webhook secret. In legacy single-App mode there is exactly one

--- a/pkg/webhook/leader_gate_integration_test.go
+++ b/pkg/webhook/leader_gate_integration_test.go
@@ -226,8 +226,9 @@ func TestE2ELeaderPassesOnTrustedSuccessfulParticipant(t *testing.T) {
 
 // When an expected participant has not reported its Check Run on the head
 // commit, the leader has no evidence the participant's schema is safe. It fails
-// closed: the aggregate blocks (action_required) rather than passing on the
-// participant's silence.
+// closed: the aggregate blocks as in_progress (a self-scheduled re-fold will
+// re-read the participant shortly) rather than passing on the participant's
+// silence.
 func TestE2ELeaderBlocksOnMissingParticipantCheck(t *testing.T) {
 	svc := setupE2EServiceWithConfig(t, leaderRepoConfig())
 
@@ -256,8 +257,8 @@ func TestE2ELeaderBlocksOnMissingParticipantCheck(t *testing.T) {
 	cr := collectAggregate(t, checkRuns, aggregateCheckNameForEnv("SchemaBot", "production"))
 	assert.Equal(t, headSHA, cr.HeadSHA)
 	assert.NotEqual(t, checkConclusionSuccess, cr.Conclusion, "missing participant must not pass the aggregate")
-	assert.Equal(t, checkStatusCompleted, cr.Status)
-	assert.Equal(t, checkConclusionActionRequired, cr.Conclusion)
+	assert.Equal(t, checkStatusInProgress, cr.Status)
+	assert.Empty(t, cr.Conclusion, "the wait for a participant re-read blocks without a conclusion")
 }
 
 // While the participant's Check Run is still in progress, the leader's
@@ -464,9 +465,9 @@ func TestE2ELeaderNonSchemaPRTouchingParticipantPathBlocks(t *testing.T) {
 	for _, env := range []string{"staging", "production"} {
 		cr := collectAggregate(t, checkRuns, aggregateCheckNameForEnv("SchemaBot", env))
 		assert.Equal(t, headSHA, cr.HeadSHA)
-		assert.Equal(t, checkStatusCompleted, cr.Status)
-		assert.Equal(t, checkConclusionActionRequired, cr.Conclusion,
-			"aggregate for %s must fail closed while the expected participant is silent", env)
+		assert.Equal(t, checkStatusInProgress, cr.Status,
+			"aggregate for %s must block while the expected participant is silent", env)
+		assert.Empty(t, cr.Conclusion)
 	}
 }
 
@@ -551,11 +552,12 @@ func TestE2ELeaderRefoldsWhenParticipantReportsAfterFirstFold(t *testing.T) {
 		if cr.Name != aggregateCheckNameForEnv("SchemaBot", "production") {
 			continue
 		}
-		if cr.Conclusion == checkConclusionActionRequired {
+		if cr.Status == checkStatusInProgress {
 			// The blocked aggregate is created fresh on the head commit; the
 			// converged pass below updates that run in place, so head_sha only
 			// appears on this create.
 			assert.Equal(t, headSHA, cr.HeadSHA)
+			assert.Empty(t, cr.Conclusion, "the wait for the participant re-read blocks without a conclusion")
 			sawBlocked = true
 			continue
 		}

--- a/pkg/webhook/leader_gate_integration_test.go
+++ b/pkg/webhook/leader_gate_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -467,6 +468,110 @@ func TestE2ELeaderNonSchemaPRTouchingParticipantPathBlocks(t *testing.T) {
 		assert.Equal(t, checkConclusionActionRequired, cr.Conclusion,
 			"aggregate for %s must fail closed while the expected participant is silent", env)
 	}
+}
+
+// A participant with no schema work publishes its Check Run moments after the
+// leader's first fold and never comments, so no nudge will ever arrive. The
+// leader must converge on its own: the first fold blocks fail-closed on the
+// unreported participant and arms a delayed re-fold, and the re-fold reads the
+// now-present successful participant check and publishes a passing aggregate.
+func TestE2ELeaderRefoldsWhenParticipantReportsAfterFirstFold(t *testing.T) {
+	svc := setupE2EServiceWithConfig(t, leaderRepoConfig())
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	const headSHA = "abc123"
+	mockLeaderPRHead(mux, headSHA)
+	mockLeaderPRFilesTouchTenantB(mux)
+	mockLeaderEmptyTree(mux, headSHA)
+
+	// The first fold reads one participant check per environment and sees
+	// nothing — the participant has not published yet. Every later read finds
+	// the completed, successful, trusted run, exactly like a participant that
+	// publishes its check just after the leader's first fold.
+	prodCheckName := aggregateCheckNameForEnv(tenantBCheckName, "production")
+	stagingCheckName := aggregateCheckNameForEnv(tenantBCheckName, "staging")
+	runsByName := map[string]map[string]any{
+		prodCheckName: {
+			"id": 7001, "name": prodCheckName, "status": "completed", "conclusion": "success",
+			"app": map[string]any{"slug": trustedTenantAppSlug},
+		},
+		stagingCheckName: {
+			"id": 7002, "name": stagingCheckName, "status": "completed", "conclusion": "success",
+			"app": map[string]any{"slug": trustedTenantAppSlug},
+		},
+	}
+	var checkRunReads atomic.Int64
+	firstFoldReads := int64(len(leaderRepoConfig().AllowedEnvironments))
+	mux.HandleFunc("GET /repos/octocat/hello-world/commits/", func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/check-runs") {
+			http.NotFound(w, r)
+			return
+		}
+		if checkRunReads.Add(1) <= firstFoldReads {
+			_ = json.NewEncoder(w).Encode(map[string]any{"total_count": 0, "check_runs": []any{}})
+			return
+		}
+		run, ok := runsByName[r.URL.Query().Get("check_name")]
+		if !ok {
+			_ = json.NewEncoder(w).Encode(map[string]any{"total_count": 0, "check_runs": []any{}})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"total_count": 1, "check_runs": []map[string]any{run}})
+	})
+	checkRuns := captureLeaderCheckRuns(mux)
+
+	h := newLeaderHandler(t, svc, client)
+	h.participantNudgeRefoldDelay = 10 * time.Millisecond
+	req := buildPRWebhookRequest(t, prWebhookPayloadOpts{
+		action:  "opened",
+		headSHA: headSHA,
+		headRef: "feature-branch",
+	}, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// The first fold blocks fail-closed, then the self-scheduled re-fold
+	// converges to success without any comment, commit, or webhook.
+	sawBlocked := false
+	deadline := time.After(webhookIntegrationCheckRunDeadline)
+	for {
+		var cr checkRunCapture
+		select {
+		case cr = <-checkRuns:
+		case <-deadline:
+			t.Fatalf("timed out waiting for the production aggregate to converge (saw blocked first: %v)", sawBlocked)
+		}
+		if cr.Name != aggregateCheckNameForEnv("SchemaBot", "production") {
+			continue
+		}
+		if cr.Conclusion == checkConclusionActionRequired {
+			// The blocked aggregate is created fresh on the head commit; the
+			// converged pass below updates that run in place, so head_sha only
+			// appears on this create.
+			assert.Equal(t, headSHA, cr.HeadSHA)
+			sawBlocked = true
+			continue
+		}
+		assert.True(t, sawBlocked, "the first fold must block before the re-fold converges")
+		assert.Equal(t, checkStatusCompleted, cr.Status)
+		assert.Equal(t, checkConclusionSuccess, cr.Conclusion)
+		break
+	}
+
+	// The converged fold resets the re-fold budget for the PR.
+	require.Eventually(t, func() bool {
+		h.participantRefoldMu.Lock()
+		defer h.participantRefoldMu.Unlock()
+		_, pending := h.participantRefoldAttempts[participantRefoldKey("octocat/hello-world", 1)]
+		return !pending
+	}, webhookIntegrationCheckRunDeadline, 10*time.Millisecond, "a fold that resolves every participant must clear the re-fold budget")
 }
 
 // The expected-tenant set is path-filtered: a leader's non-schema PR touching

--- a/pkg/webhook/leader_gate_integration_test.go
+++ b/pkg/webhook/leader_gate_integration_test.go
@@ -69,17 +69,30 @@ func newLeaderHandler(t *testing.T, svc *api.Service, client *gh.Client) *Handle
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	installClient := ghclient.NewInstallationClientWithSlug(client, logger, leaderOwnAppSlug, trustedTenantAppSlug)
 	factory := &fakeClientFactory{client: installClient}
-	return NewHandler(svc, factory, nil, logger)
+	h := NewHandler(svc, factory, nil, logger)
+	// A fold that leaves participants unresolved arms a self-scheduled re-fold;
+	// keep those timers from firing inside the test process (pending timers at
+	// process exit are inert). Tests that exercise re-fold convergence lower
+	// this after construction.
+	h.participantRefoldDelayOverride = time.Hour
+	return h
 }
 
-// mockLeaderPRHead serves the PR head SHA so the leader's head-SHA freshness
-// check passes for headSHA.
+// mockLeaderPRHead serves an open PR with the given head SHA so the leader's
+// head-SHA freshness check passes for headSHA.
 func mockLeaderPRHead(mux *http.ServeMux, headSHA string) {
+	mockLeaderPRHeadWithState(mux, headSHA, "open")
+}
+
+// mockLeaderPRHeadWithState serves the PR with the given head SHA and
+// lifecycle state ("open" or "closed").
+func mockLeaderPRHeadWithState(mux *http.ServeMux, headSHA, state string) {
 	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(gh.PullRequest{
-			Head: &gh.PullRequestBranch{Ref: new("feature-branch"), SHA: &headSHA},
-			Base: &gh.PullRequestBranch{Ref: new("main"), SHA: new("def456")},
-			User: &gh.User{Login: new("testuser")},
+			State: &state,
+			Head:  &gh.PullRequestBranch{Ref: new("feature-branch"), SHA: &headSHA},
+			Base:  &gh.PullRequestBranch{Ref: new("main"), SHA: new("def456")},
+			User:  &gh.User{Login: new("testuser")},
 		})
 	})
 }
@@ -528,7 +541,7 @@ func TestE2ELeaderRefoldsWhenParticipantReportsAfterFirstFold(t *testing.T) {
 	checkRuns := captureLeaderCheckRuns(mux)
 
 	h := newLeaderHandler(t, svc, client)
-	h.participantNudgeRefoldDelay = 10 * time.Millisecond
+	h.participantRefoldDelayOverride = 10 * time.Millisecond
 	req := buildPRWebhookRequest(t, prWebhookPayloadOpts{
 		action:  "opened",
 		headSHA: headSHA,
@@ -617,5 +630,80 @@ func TestE2ELeaderNonSchemaPROutsideParticipantPathsPasses(t *testing.T) {
 		assert.Equal(t, checkStatusCompleted, cr.Status)
 		assert.Equal(t, checkConclusionSuccess, cr.Conclusion,
 			"aggregate for %s keeps passing on a PR outside all participant paths", env)
+	}
+}
+
+// participantRefoldAttemptCount reads the leader's re-fold budget entry for the
+// PR, reporting the consumed attempts and whether an entry exists at all.
+func participantRefoldAttemptCount(h *Handler, repo string, pr int) (int, bool) {
+	h.participantRefoldMu.Lock()
+	defer h.participantRefoldMu.Unlock()
+	n, ok := h.participantRefoldAttempts[participantRefoldKey(repo, pr)]
+	return n, ok
+}
+
+// A re-fold pass that cannot read the PR head must not end the retry chain:
+// the aggregate is rendering unresolved participants as in_progress on the
+// promise of a coming re-read, so the leader arms another bounded attempt
+// instead of stranding the wait until an external event happens to re-fold.
+func TestE2ELeaderBrokenRefoldArmsAnotherAttempt(t *testing.T) {
+	svc := setupE2EServiceWithConfig(t, leaderRepoConfig())
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	// No PR endpoint is registered, so the re-fold's head fetch fails.
+	checkRuns := captureLeaderCheckRuns(mux)
+
+	h := newLeaderHandler(t, svc, client)
+	h.refoldAggregateForPR("octocat/hello-world", 1, 12345, "unresolved participant delayed re-fold")
+
+	attempts, armed := participantRefoldAttemptCount(h, "octocat/hello-world", 1)
+	assert.True(t, armed, "a broken re-fold pass must arm another bounded attempt")
+	assert.Equal(t, 1, attempts)
+
+	select {
+	case cr := <-checkRuns:
+		t.Fatalf("a re-fold that cannot read the PR head must not publish an aggregate: %+v", cr)
+	default:
+	}
+}
+
+// An armed re-fold can fire after its PR closes. The leader publishes nothing
+// on the closed PR and arms no further attempts; it drops the PR's re-fold
+// budget entry so the in-memory map does not retain closed PRs.
+func TestE2ELeaderRefoldSkipsClosedPR(t *testing.T) {
+	svc := setupE2EServiceWithConfig(t, leaderRepoConfig())
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	mockLeaderPRHeadWithState(mux, "abc123", "closed")
+	checkRuns := captureLeaderCheckRuns(mux)
+
+	h := newLeaderHandler(t, svc, client)
+	// The chain was armed while the PR was open, so a budget entry exists when
+	// the timer fires.
+	h.scheduleParticipantRefold(t.Context(), "octocat/hello-world", 1, 12345)
+	_, armed := participantRefoldAttemptCount(h, "octocat/hello-world", 1)
+	require.True(t, armed)
+
+	h.refoldAggregateForPR("octocat/hello-world", 1, 12345, "unresolved participant delayed re-fold")
+
+	_, armed = participantRefoldAttemptCount(h, "octocat/hello-world", 1)
+	assert.False(t, armed, "a closed PR's re-fold budget entry must be dropped")
+
+	select {
+	case cr := <-checkRuns:
+		t.Fatalf("a re-fold must not publish an aggregate on a closed PR: %+v", cr)
+	default:
 	}
 }

--- a/pkg/webhook/leader_participant_gate.go
+++ b/pkg/webhook/leader_participant_gate.go
@@ -32,13 +32,28 @@ type participantCheckOutcome struct {
 	retriable bool
 }
 
+// participantUnresolvedBlockingReason marks a synthesized participant row whose
+// Check Run could not be read yet (not reported, or a failed Checks API read).
+// It drives the aggregate's title and the tenant table's status label so an
+// unresolved participant reads as "waiting to report" / "not reported" rather
+// than as a pending or failed apply. Synthesized rows are never persisted, so
+// the marker never reaches stored check state.
+const participantUnresolvedBlockingReason = "participant_unresolved"
+
 // synthesizeParticipantCheck maps a resolved participant outcome to a stored
 // Check shape so computeAggregate folds it exactly like a per-database check.
 // DatabaseType is the aggregate sentinel and DatabaseName is the tenant so the
 // synthesized row is distinguishable in the aggregate table while still
 // contributing its status/conclusion to the fold.
-func synthesizeParticipantCheck(outcome participantCheckOutcome, repo string, pr int, headSHA, env string) *storage.Check {
-	return &storage.Check{
+//
+// A retriable outcome with re-fold budget remaining renders as in_progress: a
+// scheduled re-fold will re-read the participant within seconds, and
+// in_progress blocks merge exactly as hard as action_required without
+// mislabeling the wait as pending applies. Once the budget is spent the row
+// lands action_required — the participant is genuinely not reporting and an
+// operator needs to look.
+func synthesizeParticipantCheck(outcome participantCheckOutcome, repo string, pr int, headSHA, env string, retryPending bool) *storage.Check {
+	check := &storage.Check{
 		Repository:   repo,
 		PullRequest:  pr,
 		HeadSHA:      headSHA,
@@ -49,6 +64,14 @@ func synthesizeParticipantCheck(outcome participantCheckOutcome, repo string, pr
 		Status:       outcome.status,
 		Conclusion:   outcome.conclusion,
 	}
+	if outcome.retriable {
+		check.BlockingReason = participantUnresolvedBlockingReason
+		if retryPending {
+			check.Status = checkStatusInProgress
+			check.Conclusion = ""
+		}
+	}
+	return check
 }
 
 // blockedParticipantOutcome builds a fail-closed outcome that folds to
@@ -99,14 +122,14 @@ func participantCheckName(base, env string) string {
 func (h *Handler) participantCheckOutcomes(
 	ctx context.Context, client checkRunFinder,
 	repo string, pr int, env, headSHA string,
-	expected []api.ExpectedTenant,
+	expected []api.ExpectedTenant, retryPending bool,
 ) ([]*storage.Check, bool) {
 	checks := make([]*storage.Check, 0, len(expected))
 	retriable := false
 	for _, tenant := range expected {
 		outcome := h.resolveParticipantOutcome(ctx, client, repo, pr, env, headSHA, tenant)
 		retriable = retriable || outcome.retriable
-		checks = append(checks, synthesizeParticipantCheck(outcome, repo, pr, headSHA, env))
+		checks = append(checks, synthesizeParticipantCheck(outcome, repo, pr, headSHA, env, retryPending))
 	}
 	return checks, retriable
 }

--- a/pkg/webhook/leader_participant_gate.go
+++ b/pkg/webhook/leader_participant_gate.go
@@ -25,6 +25,11 @@ type participantCheckOutcome struct {
 	checkName  string
 	status     string // checkStatus*
 	conclusion string // checkConclusion* (empty when in_progress)
+	// retriable marks an outcome that a later re-read can improve without any
+	// config change: the participant has not reported yet, or the Checks API
+	// read failed. Untrusted-only and unresolvable-name outcomes are not
+	// retriable — only a config fix can clear those.
+	retriable bool
 }
 
 // synthesizeParticipantCheck maps a resolved participant outcome to a stored
@@ -48,12 +53,16 @@ func synthesizeParticipantCheck(outcome participantCheckOutcome, repo string, pr
 
 // blockedParticipantOutcome builds a fail-closed outcome that folds to
 // action_required so any resolution uncertainty blocks the aggregate.
-func blockedParticipantOutcome(tenant, checkName string) participantCheckOutcome {
+// retriable distinguishes uncertainty a later re-read can resolve (participant
+// not reported yet, transient API failure) from uncertainty only a config
+// change can (untrusted App, unresolvable name).
+func blockedParticipantOutcome(tenant, checkName string, retriable bool) participantCheckOutcome {
 	return participantCheckOutcome{
 		tenant:     tenant,
 		checkName:  checkName,
 		status:     checkStatusCompleted,
 		conclusion: checkConclusionActionRequired,
+		retriable:  retriable,
 	}
 }
 
@@ -71,28 +80,35 @@ func participantCheckName(base, env string) string {
 
 // participantCheckOutcomes resolves every expected participant's per-environment
 // Check Run for headSHA and returns synthesized stored Check rows to fold into
-// the aggregate leader's check for env. It fails closed: anything other than a
-// trusted, completed, success participant check yields a blocking row.
+// the aggregate leader's check for env, plus whether any outcome is retriable —
+// blocked only because the participant has not reported yet (or the read
+// failed), so a scheduled re-fold can converge without any external event. It
+// fails closed: anything other than a trusted, completed, success participant
+// check yields a blocking row.
 //
 // resolveParticipantOutcome is the fail-closed truth table:
-//   - unresolvable check name        → action_required (blocks)
-//   - Checks API error               → action_required (blocks)
-//   - only untrusted same-named runs → action_required (blocks)
-//   - no trusted run on the commit   → action_required (blocks)
-//   - trusted run, non-terminal      → in_progress    (blocks)
-//   - trusted run, completed+success → success        (passes)
-//   - trusted run, completed+other   → failure        (blocks)
+//   - unresolvable check name           → action_required (blocks)
+//   - Checks API error                  → action_required (blocks, retriable)
+//   - only untrusted same-named runs    → action_required (blocks)
+//   - no trusted run on the commit      → action_required (blocks, retriable)
+//   - trusted run, non-terminal         → in_progress     (blocks)
+//   - trusted run, completed+success    → success         (passes)
+//   - trusted run, completed+
+//     action_required                   → action_required (blocks: tenant apply pending)
+//   - trusted run, completed+other      → failure         (blocks)
 func (h *Handler) participantCheckOutcomes(
 	ctx context.Context, client checkRunFinder,
 	repo string, pr int, env, headSHA string,
 	expected []api.ExpectedTenant,
-) []*storage.Check {
+) ([]*storage.Check, bool) {
 	checks := make([]*storage.Check, 0, len(expected))
+	retriable := false
 	for _, tenant := range expected {
 		outcome := h.resolveParticipantOutcome(ctx, client, repo, pr, env, headSHA, tenant)
+		retriable = retriable || outcome.retriable
 		checks = append(checks, synthesizeParticipantCheck(outcome, repo, pr, headSHA, env))
 	}
-	return checks
+	return checks, retriable
 }
 
 func (h *Handler) resolveParticipantOutcome(
@@ -107,7 +123,7 @@ func (h *Handler) resolveParticipantOutcome(
 		h.logger.Warn("aggregate leader cannot resolve participant check name, blocking aggregate",
 			"repo", repo, "pr", pr, "environment", env, "head_sha", headSHA, "tenant", tenant.Tenant)
 		metrics.RecordLeaderParticipantGate(ctx, repo, env, tenant.Tenant, metrics.LeaderParticipantGateError)
-		return blockedParticipantOutcome(tenant.Tenant, "")
+		return blockedParticipantOutcome(tenant.Tenant, "", false)
 	}
 
 	checkName := participantCheckName(tenant.CheckName, env)
@@ -118,7 +134,7 @@ func (h *Handler) resolveParticipantOutcome(
 			"repo", repo, "pr", pr, "environment", env, "head_sha", headSHA,
 			"tenant", tenant.Tenant, "check_name", checkName, "error", err)
 		metrics.RecordLeaderParticipantGate(ctx, repo, env, tenant.Tenant, metrics.LeaderParticipantGateError)
-		return blockedParticipantOutcome(tenant.Tenant, checkName)
+		return blockedParticipantOutcome(tenant.Tenant, checkName, true)
 	}
 
 	if result == nil && len(untrusted) > 0 {
@@ -132,7 +148,7 @@ func (h *Handler) resolveParticipantOutcome(
 			metrics.RecordUntrustedAggregateNamedCheck(ctx, repo, env, appSlug, metrics.CheckTrustGateLeaderFold)
 		}
 		metrics.RecordLeaderParticipantGate(ctx, repo, env, tenant.Tenant, metrics.LeaderParticipantGateUntrusted)
-		return blockedParticipantOutcome(tenant.Tenant, checkName)
+		return blockedParticipantOutcome(tenant.Tenant, checkName, false)
 	}
 
 	if result == nil {
@@ -140,7 +156,7 @@ func (h *Handler) resolveParticipantOutcome(
 			"repo", repo, "pr", pr, "environment", env, "head_sha", headSHA,
 			"tenant", tenant.Tenant, "check_name", checkName)
 		metrics.RecordLeaderParticipantGate(ctx, repo, env, tenant.Tenant, metrics.LeaderParticipantGateMissing)
-		return blockedParticipantOutcome(tenant.Tenant, checkName)
+		return blockedParticipantOutcome(tenant.Tenant, checkName, true)
 	}
 
 	if result.Status != checkStatusCompleted {
@@ -165,6 +181,22 @@ func (h *Handler) resolveParticipantOutcome(
 			checkName:  checkName,
 			status:     checkStatusCompleted,
 			conclusion: checkConclusionSuccess,
+		}
+	}
+
+	if result.Conclusion == checkConclusionActionRequired {
+		// The participant is blocking on its own pending work (typically an
+		// apply awaiting an operator), not a failure. Fold it as action_required
+		// so the leader's aggregate reads as pending rather than failed.
+		h.logger.Warn("participant check reports pending work, blocking aggregate",
+			"repo", repo, "pr", pr, "environment", env, "head_sha", headSHA,
+			"tenant", tenant.Tenant, "check_name", checkName)
+		metrics.RecordLeaderParticipantGate(ctx, repo, env, tenant.Tenant, metrics.LeaderParticipantGatePending)
+		return participantCheckOutcome{
+			tenant:     tenant.Tenant,
+			checkName:  checkName,
+			status:     checkStatusCompleted,
+			conclusion: checkConclusionActionRequired,
 		}
 	}
 

--- a/pkg/webhook/leader_participant_gate.go
+++ b/pkg/webhook/leader_participant_gate.go
@@ -26,10 +26,20 @@ type participantCheckOutcome struct {
 	status     string // checkStatus*
 	conclusion string // checkConclusion* (empty when in_progress)
 	// retriable marks an outcome that a later re-read can improve without any
-	// config change: the participant has not reported yet, or the Checks API
-	// read failed. Untrusted-only and unresolvable-name outcomes are not
-	// retriable — only a config fix can clear those.
+	// config change: the participant has not reported yet, the Checks API
+	// read failed, or the participant's run has not reached a terminal state.
+	// Untrusted-only and unresolvable-name outcomes are not retriable — only
+	// a config fix can clear those.
 	retriable bool
+}
+
+// unresolved reports whether the outcome blocks only because the participant's
+// Check Run could not be read (not reported yet, or a failed Checks API read).
+// A trusted non-terminal run is retriable too — a later re-read can observe it
+// finish — but it is not unresolved: its live in_progress status is already
+// the right thing to render, so it must not be relabeled as a reporting gap.
+func (o participantCheckOutcome) unresolved() bool {
+	return o.retriable && o.status == checkStatusCompleted
 }
 
 // participantUnresolvedBlockingReason marks a synthesized participant row whose
@@ -46,12 +56,13 @@ const participantUnresolvedBlockingReason = "participant_unresolved"
 // synthesized row is distinguishable in the aggregate table while still
 // contributing its status/conclusion to the fold.
 //
-// A retriable outcome with re-fold budget remaining renders as in_progress: a
-// scheduled re-fold will re-read the participant within seconds, and
+// An unresolved outcome with re-fold budget remaining renders as in_progress:
+// a scheduled re-fold will re-read the participant within seconds, and
 // in_progress blocks merge exactly as hard as action_required without
 // mislabeling the wait as pending applies. Once the budget is spent the row
 // lands action_required — the participant is genuinely not reporting and an
-// operator needs to look.
+// operator needs to look. A retriable outcome that did read a live run (a
+// trusted non-terminal check) keeps that run's own status.
 func synthesizeParticipantCheck(outcome participantCheckOutcome, repo string, pr int, headSHA, env string, retryPending bool) *storage.Check {
 	check := &storage.Check{
 		Repository:   repo,
@@ -64,7 +75,7 @@ func synthesizeParticipantCheck(outcome participantCheckOutcome, repo string, pr
 		Status:       outcome.status,
 		Conclusion:   outcome.conclusion,
 	}
-	if outcome.retriable {
+	if outcome.unresolved() {
 		check.BlockingReason = participantUnresolvedBlockingReason
 		if retryPending {
 			check.Status = checkStatusInProgress
@@ -104,17 +115,17 @@ func participantCheckName(base, env string) string {
 // participantCheckOutcomes resolves every expected participant's per-environment
 // Check Run for headSHA and returns synthesized stored Check rows to fold into
 // the aggregate leader's check for env, plus whether any outcome is retriable —
-// blocked only because the participant has not reported yet (or the read
-// failed), so a scheduled re-fold can converge without any external event. It
-// fails closed: anything other than a trusted, completed, success participant
-// check yields a blocking row.
+// blocked only because the participant has not reported yet, the read failed,
+// or its run is not yet terminal — so a scheduled re-fold can converge without
+// any external event. It fails closed: anything other than a trusted,
+// completed, success participant check yields a blocking row.
 //
 // resolveParticipantOutcome is the fail-closed truth table:
 //   - unresolvable check name           → action_required (blocks)
 //   - Checks API error                  → action_required (blocks, retriable)
 //   - only untrusted same-named runs    → action_required (blocks)
 //   - no trusted run on the commit      → action_required (blocks, retriable)
-//   - trusted run, non-terminal         → in_progress     (blocks)
+//   - trusted run, non-terminal         → in_progress     (blocks, retriable)
 //   - trusted run, completed+success    → success         (passes)
 //   - trusted run, completed+
 //     action_required                   → action_required (blocks: tenant apply pending)
@@ -183,6 +194,9 @@ func (h *Handler) resolveParticipantOutcome(
 	}
 
 	if result.Status != checkStatusCompleted {
+		// A run that flips terminal moments later may never comment (a
+		// participant with no schema work publishes success silently), so the
+		// leader must re-read on its own schedule to observe the finish.
 		h.logger.Debug("participant check is not yet terminal, aggregate stays in progress",
 			"repo", repo, "pr", pr, "environment", env, "head_sha", headSHA,
 			"tenant", tenant.Tenant, "check_name", checkName, "check_status", result.Status)
@@ -191,6 +205,7 @@ func (h *Handler) resolveParticipantOutcome(
 			tenant:    tenant.Tenant,
 			checkName: checkName,
 			status:    checkStatusInProgress,
+			retriable: true,
 		}
 	}
 

--- a/pkg/webhook/leader_participant_gate_test.go
+++ b/pkg/webhook/leader_participant_gate_test.go
@@ -88,10 +88,10 @@ func TestParticipantCheckOutcomesFold(t *testing.T) {
 			wantStatus:     checkStatusCompleted,
 		},
 		{
-			name:           "missing check blocks and is retriable",
+			name:           "missing check blocks as in_progress while a re-fold is coming",
 			finder:         &fakeCheckRunFinder{},
-			wantConclusion: checkConclusionActionRequired,
-			wantStatus:     checkStatusCompleted,
+			wantConclusion: "",
+			wantStatus:     checkStatusInProgress,
 			wantRetriable:  true,
 		},
 		{
@@ -103,12 +103,12 @@ func TestParticipantCheckOutcomesFold(t *testing.T) {
 			wantStatus:     checkStatusCompleted,
 		},
 		{
-			name: "lookup error blocks and is retriable",
+			name: "lookup error blocks as in_progress while a re-fold is coming",
 			finder: &fakeCheckRunFinder{errs: map[string]error{
 				checkName: fmt.Errorf("boom"),
 			}},
-			wantConclusion: checkConclusionActionRequired,
-			wantStatus:     checkStatusCompleted,
+			wantConclusion: "",
+			wantStatus:     checkStatusInProgress,
 			wantRetriable:  true,
 		},
 	}
@@ -116,7 +116,7 @@ func TestParticipantCheckOutcomesFold(t *testing.T) {
 	h := &Handler{logger: testLogger()}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			checks, retriable := h.participantCheckOutcomes(t.Context(), tc.finder, repo, pr, env, headSHA, expected)
+			checks, retriable := h.participantCheckOutcomes(t.Context(), tc.finder, repo, pr, env, headSHA, expected, true)
 			require.Len(t, checks, 1)
 
 			c := checks[0]
@@ -133,11 +133,56 @@ func TestParticipantCheckOutcomesFold(t *testing.T) {
 	}
 }
 
+// Once the re-fold budget is spent, an unresolved participant stops rendering
+// as in_progress: no re-read is coming, so the aggregate lands action_required
+// and names the reporting gap instead of pending applies.
+func TestParticipantCheckOutcomesUnresolvedAfterBudgetExhausted(t *testing.T) {
+	const (
+		repo    = "octocat/shared-repo"
+		pr      = 7
+		env     = "staging"
+		headSHA = "abc123"
+	)
+	expected := []api.ExpectedTenant{{Tenant: "tenant-a", Paths: []string{"services/a"}, CheckName: "SchemaBot Tenant A"}}
+
+	h := &Handler{logger: testLogger()}
+	checks, retriable := h.participantCheckOutcomes(t.Context(), &fakeCheckRunFinder{}, repo, pr, env, headSHA, expected, false)
+	require.Len(t, checks, 1)
+	assert.True(t, retriable)
+
+	conclusion, status := computeAggregate(checks)
+	assert.Equal(t, checkConclusionActionRequired, conclusion)
+	assert.Equal(t, checkStatusCompleted, status)
+
+	title, _ := aggregateSummary(checks, conclusion)
+	assert.Equal(t, "1 participant deployment has not reported", title,
+		"an unresolved participant must read as a reporting gap, not a pending apply")
+}
+
+// While a re-fold is pending, the aggregate's in_progress title names the wait
+// for participants instead of claiming an apply is running, and the tenant
+// table labels the row as waiting.
+func TestAggregateSummaryWaitingForParticipants(t *testing.T) {
+	expected := []api.ExpectedTenant{{Tenant: "tenant-a", Paths: []string{"services/a"}, CheckName: "SchemaBot Tenant A"}}
+	h := &Handler{logger: testLogger()}
+	checks, _ := h.participantCheckOutcomes(t.Context(), &fakeCheckRunFinder{}, "octocat/shared-repo", 7, "staging", "abc123", expected, true)
+	require.Len(t, checks, 1)
+
+	conclusion, status := computeAggregate(checks)
+	require.Empty(t, conclusion)
+	require.Equal(t, checkStatusInProgress, status)
+
+	title, summary := aggregateSummary(checks, conclusion)
+	assert.Equal(t, "Waiting for 1 participant deployment to report", title)
+	assert.Contains(t, summary, "Waiting to report")
+	assert.Contains(t, summary, "`tenant-a`")
+}
+
 // An empty expected set folds to nothing, so a non-leader or a PR touching no
 // participant paths never contributes participant rows to the aggregate.
 func TestParticipantCheckOutcomesEmptyExpected(t *testing.T) {
 	h := &Handler{logger: testLogger()}
-	checks, retriable := h.participantCheckOutcomes(t.Context(), &fakeCheckRunFinder{}, "octocat/shared-repo", 1, "staging", "sha", nil)
+	checks, retriable := h.participantCheckOutcomes(t.Context(), &fakeCheckRunFinder{}, "octocat/shared-repo", 1, "staging", "sha", nil, true)
 	assert.Empty(t, checks)
 	assert.False(t, retriable)
 }
@@ -147,7 +192,7 @@ func TestParticipantCheckOutcomesEmptyExpected(t *testing.T) {
 func TestParticipantCheckOutcomesEmptyCheckNameBlocks(t *testing.T) {
 	h := &Handler{logger: testLogger()}
 	expected := []api.ExpectedTenant{{Tenant: "tenant-a", Paths: []string{"services/a"}}}
-	checks, retriable := h.participantCheckOutcomes(t.Context(), &fakeCheckRunFinder{}, "octocat/shared-repo", 1, "staging", "sha", expected)
+	checks, retriable := h.participantCheckOutcomes(t.Context(), &fakeCheckRunFinder{}, "octocat/shared-repo", 1, "staging", "sha", expected, true)
 	require.Len(t, checks, 1)
 	assert.False(t, retriable, "a config error cannot be fixed by re-reading; no re-fold should be scheduled")
 

--- a/pkg/webhook/leader_participant_gate_test.go
+++ b/pkg/webhook/leader_participant_gate_test.go
@@ -45,6 +45,7 @@ func TestParticipantCheckOutcomesFold(t *testing.T) {
 		finder         *fakeCheckRunFinder
 		wantConclusion string
 		wantStatus     string
+		wantRetriable  bool
 	}{
 		{
 			name: "trusted completed success passes",
@@ -79,18 +80,19 @@ func TestParticipantCheckOutcomesFold(t *testing.T) {
 			wantStatus:     checkStatusCompleted,
 		},
 		{
-			name: "completed action_required blocks as failure",
+			name: "completed action_required blocks as pending",
 			finder: &fakeCheckRunFinder{results: map[string]*ghclient.CheckRunResult{
 				checkName: {Status: checkStatusCompleted, Conclusion: checkConclusionActionRequired},
 			}},
-			wantConclusion: checkConclusionFailure,
+			wantConclusion: checkConclusionActionRequired,
 			wantStatus:     checkStatusCompleted,
 		},
 		{
-			name:           "missing check blocks",
+			name:           "missing check blocks and is retriable",
 			finder:         &fakeCheckRunFinder{},
 			wantConclusion: checkConclusionActionRequired,
 			wantStatus:     checkStatusCompleted,
+			wantRetriable:  true,
 		},
 		{
 			name: "untrusted-only check blocks",
@@ -101,19 +103,20 @@ func TestParticipantCheckOutcomesFold(t *testing.T) {
 			wantStatus:     checkStatusCompleted,
 		},
 		{
-			name: "lookup error blocks",
+			name: "lookup error blocks and is retriable",
 			finder: &fakeCheckRunFinder{errs: map[string]error{
 				checkName: fmt.Errorf("boom"),
 			}},
 			wantConclusion: checkConclusionActionRequired,
 			wantStatus:     checkStatusCompleted,
+			wantRetriable:  true,
 		},
 	}
 
 	h := &Handler{logger: testLogger()}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			checks := h.participantCheckOutcomes(t.Context(), tc.finder, repo, pr, env, headSHA, expected)
+			checks, retriable := h.participantCheckOutcomes(t.Context(), tc.finder, repo, pr, env, headSHA, expected)
 			require.Len(t, checks, 1)
 
 			c := checks[0]
@@ -121,6 +124,7 @@ func TestParticipantCheckOutcomesFold(t *testing.T) {
 			assert.Equal(t, "tenant-a", c.DatabaseName, "synthesized row must be labeled by tenant")
 			assert.Equal(t, env, c.Environment)
 			assert.Equal(t, headSHA, c.HeadSHA)
+			assert.Equal(t, tc.wantRetriable, retriable, "retriable must mark exactly the outcomes a re-read can improve")
 
 			conclusion, status := computeAggregate(checks)
 			assert.Equal(t, tc.wantConclusion, conclusion)
@@ -133,8 +137,9 @@ func TestParticipantCheckOutcomesFold(t *testing.T) {
 // participant paths never contributes participant rows to the aggregate.
 func TestParticipantCheckOutcomesEmptyExpected(t *testing.T) {
 	h := &Handler{logger: testLogger()}
-	checks := h.participantCheckOutcomes(t.Context(), &fakeCheckRunFinder{}, "octocat/shared-repo", 1, "staging", "sha", nil)
+	checks, retriable := h.participantCheckOutcomes(t.Context(), &fakeCheckRunFinder{}, "octocat/shared-repo", 1, "staging", "sha", nil)
 	assert.Empty(t, checks)
+	assert.False(t, retriable)
 }
 
 // A missing participant check name is a fail-closed configuration error: the
@@ -142,8 +147,9 @@ func TestParticipantCheckOutcomesEmptyExpected(t *testing.T) {
 func TestParticipantCheckOutcomesEmptyCheckNameBlocks(t *testing.T) {
 	h := &Handler{logger: testLogger()}
 	expected := []api.ExpectedTenant{{Tenant: "tenant-a", Paths: []string{"services/a"}}}
-	checks := h.participantCheckOutcomes(t.Context(), &fakeCheckRunFinder{}, "octocat/shared-repo", 1, "staging", "sha", expected)
+	checks, retriable := h.participantCheckOutcomes(t.Context(), &fakeCheckRunFinder{}, "octocat/shared-repo", 1, "staging", "sha", expected)
 	require.Len(t, checks, 1)
+	assert.False(t, retriable, "a config error cannot be fixed by re-reading; no re-fold should be scheduled")
 
 	conclusion, status := computeAggregate(checks)
 	assert.Equal(t, checkConclusionActionRequired, conclusion)

--- a/pkg/webhook/leader_participant_gate_test.go
+++ b/pkg/webhook/leader_participant_gate_test.go
@@ -56,20 +56,22 @@ func TestParticipantCheckOutcomesFold(t *testing.T) {
 			wantStatus:     checkStatusCompleted,
 		},
 		{
-			name: "in progress blocks",
+			name: "in progress blocks and stays retriable",
 			finder: &fakeCheckRunFinder{results: map[string]*ghclient.CheckRunResult{
 				checkName: {Status: checkStatusInProgress},
 			}},
 			wantConclusion: "",
 			wantStatus:     checkStatusInProgress,
+			wantRetriable:  true,
 		},
 		{
-			name: "queued blocks as in progress",
+			name: "queued blocks as in progress and stays retriable",
 			finder: &fakeCheckRunFinder{results: map[string]*ghclient.CheckRunResult{
 				checkName: {Status: checkStatusQueued},
 			}},
 			wantConclusion: "",
 			wantStatus:     checkStatusInProgress,
+			wantRetriable:  true,
 		},
 		{
 			name: "completed failure blocks",

--- a/pkg/webhook/participant_nudge.go
+++ b/pkg/webhook/participant_nudge.go
@@ -80,12 +80,39 @@ func (h *Handler) nudgeRefoldDelay() time.Duration {
 	return defaultParticipantNudgeRefoldDelay
 }
 
-// maxParticipantRefoldAttempts bounds the self-scheduled re-folds a single
-// PR's aggregate arms while expected participants remain unresolved. The
-// budget resets whenever a fold resolves every participant, so it only caps
-// consecutive misses — a participant that never reports leaves the aggregate
-// blocked (fail-closed) until a nudge, new commit, or manual plan re-folds.
-const maxParticipantRefoldAttempts = 3
+// participantRefoldBackoff staggers the self-scheduled re-folds a single PR's
+// aggregate arms while expected participants remain unresolved. Participants
+// publish their Check Runs within seconds of the leader's first fold, so the
+// first retry comes quickly and later ones back off. One entry per attempt;
+// the budget resets whenever a fold resolves every participant, so it only
+// caps consecutive misses — a participant that never reports leaves the
+// aggregate blocked (fail-closed) until a nudge, new commit, or manual plan
+// re-folds.
+var participantRefoldBackoff = []time.Duration{5 * time.Second, 15 * time.Second, 45 * time.Second}
+
+var maxParticipantRefoldAttempts = len(participantRefoldBackoff)
+
+// participantRefoldDelay resolves the delay before the attempt-th re-fold
+// (zero-based). The test override, when set, applies to every attempt.
+func (h *Handler) participantRefoldDelay(attempt int) time.Duration {
+	if h.participantNudgeRefoldDelay > 0 {
+		return h.participantNudgeRefoldDelay
+	}
+	if attempt >= len(participantRefoldBackoff) {
+		return participantRefoldBackoff[len(participantRefoldBackoff)-1]
+	}
+	return participantRefoldBackoff[attempt]
+}
+
+// participantRefoldBudgetRemaining reports whether the PR can still arm a
+// self-scheduled re-fold. The fold uses this to render unresolved participants
+// as in_progress (a re-read is coming) versus action_required (the budget is
+// spent and an operator needs to look at the participant deployment).
+func (h *Handler) participantRefoldBudgetRemaining(repo string, pr int) bool {
+	h.participantRefoldMu.Lock()
+	defer h.participantRefoldMu.Unlock()
+	return h.participantRefoldAttempts[participantRefoldKey(repo, pr)] < maxParticipantRefoldAttempts
+}
 
 // scheduleParticipantRefold arms a delayed aggregate re-fold because at least
 // one expected participant resolved as retriable (not reported yet, or a
@@ -116,15 +143,16 @@ func (h *Handler) scheduleParticipantRefold(ctx context.Context, repo string, pr
 	h.participantRefoldAttempts[key] = attempts + 1
 	h.participantRefoldMu.Unlock()
 
+	delay := h.participantRefoldDelay(attempts)
 	h.logger.Info("expected participants have not resolved; scheduling aggregate re-fold",
-		"repo", repo, "pr", pr, "delay", h.nudgeRefoldDelay(), "attempt", attempts+1)
+		"repo", repo, "pr", pr, "delay", delay, "attempt", attempts+1)
 	metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
 		Operation:  "participant_refold",
 		Repository: repo,
 		Status:     "scheduled",
 	})
 
-	time.AfterFunc(h.nudgeRefoldDelay(), func() {
+	time.AfterFunc(delay, func() {
 		h.goSafe(repo, pr, installationID, func() {
 			h.refoldAggregateForPR(repo, pr, installationID, "unresolved participant delayed re-fold")
 		})

--- a/pkg/webhook/participant_nudge.go
+++ b/pkg/webhook/participant_nudge.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"strings"
 	"time"
@@ -77,6 +78,71 @@ func (h *Handler) nudgeRefoldDelay() time.Duration {
 		return h.participantNudgeRefoldDelay
 	}
 	return defaultParticipantNudgeRefoldDelay
+}
+
+// maxParticipantRefoldAttempts bounds the self-scheduled re-folds a single
+// PR's aggregate arms while expected participants remain unresolved. The
+// budget resets whenever a fold resolves every participant, so it only caps
+// consecutive misses — a participant that never reports leaves the aggregate
+// blocked (fail-closed) until a nudge, new commit, or manual plan re-folds.
+const maxParticipantRefoldAttempts = 3
+
+// scheduleParticipantRefold arms a delayed aggregate re-fold because at least
+// one expected participant resolved as retriable (not reported yet, or a
+// failed Checks API read). Participants publish their Check Runs moments after
+// the leader's first fold, and a participant with no schema work never
+// comments, so without this the leader's aggregate would stay blocked on a
+// participant that already reported green. Attempts are bounded per PR so a
+// participant that is genuinely down cannot keep a timer chain alive forever.
+func (h *Handler) scheduleParticipantRefold(ctx context.Context, repo string, pr int, installationID int64) {
+	key := participantRefoldKey(repo, pr)
+
+	h.participantRefoldMu.Lock()
+	attempts := h.participantRefoldAttempts[key]
+	if attempts >= maxParticipantRefoldAttempts {
+		h.participantRefoldMu.Unlock()
+		h.logger.Warn("expected participants still unresolved after scheduled re-folds; aggregate stays blocked until a participant comment, new commit, or manual plan re-folds it",
+			"repo", repo, "pr", pr, "refold_attempts", attempts)
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:  "participant_refold",
+			Repository: repo,
+			Status:     "exhausted",
+		})
+		return
+	}
+	if h.participantRefoldAttempts == nil {
+		h.participantRefoldAttempts = make(map[string]int)
+	}
+	h.participantRefoldAttempts[key] = attempts + 1
+	h.participantRefoldMu.Unlock()
+
+	h.logger.Info("expected participants have not resolved; scheduling aggregate re-fold",
+		"repo", repo, "pr", pr, "delay", h.nudgeRefoldDelay(), "attempt", attempts+1)
+	metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+		Operation:  "participant_refold",
+		Repository: repo,
+		Status:     "scheduled",
+	})
+
+	time.AfterFunc(h.nudgeRefoldDelay(), func() {
+		h.goSafe(repo, pr, installationID, func() {
+			h.refoldAggregateForPR(repo, pr, installationID, "unresolved participant delayed re-fold")
+		})
+	})
+}
+
+// clearParticipantRefoldBudget resets the re-fold budget once a fold resolves
+// every expected participant, so a later commit on the same PR gets a fresh
+// budget.
+func (h *Handler) clearParticipantRefoldBudget(repo string, pr int) {
+	key := participantRefoldKey(repo, pr)
+	h.participantRefoldMu.Lock()
+	delete(h.participantRefoldAttempts, key)
+	h.participantRefoldMu.Unlock()
+}
+
+func participantRefoldKey(repo string, pr int) string {
+	return fmt.Sprintf("%s#%d", repo, pr)
 }
 
 // refoldAggregateForPR re-reads the PR's current head and re-runs the

--- a/pkg/webhook/participant_nudge.go
+++ b/pkg/webhook/participant_nudge.go
@@ -95,8 +95,8 @@ var maxParticipantRefoldAttempts = len(participantRefoldBackoff)
 // participantRefoldDelay resolves the delay before the attempt-th re-fold
 // (zero-based). The test override, when set, applies to every attempt.
 func (h *Handler) participantRefoldDelay(attempt int) time.Duration {
-	if h.participantNudgeRefoldDelay > 0 {
-		return h.participantNudgeRefoldDelay
+	if h.participantRefoldDelayOverride > 0 {
+		return h.participantRefoldDelayOverride
 	}
 	if attempt >= len(participantRefoldBackoff) {
 		return participantRefoldBackoff[len(participantRefoldBackoff)-1]
@@ -176,10 +176,27 @@ func participantRefoldKey(repo string, pr int) string {
 	return fmt.Sprintf("%s#%d", repo, pr)
 }
 
+// scheduleLeaderRefoldIfConfigured arms a bounded aggregate re-fold when this
+// deployment leads the repo's aggregate. Fold passes that break before they
+// can read participant state call this so a transient failure cannot strand
+// an aggregate whose unresolved participants render as in_progress on the
+// promise of a coming re-read — the next attempt fetches the then-current
+// head and folds it, and the per-PR budget still bounds the chain. Non-leader
+// repos never fold participants, so there is nothing to re-arm.
+func (h *Handler) scheduleLeaderRefoldIfConfigured(ctx context.Context, repo string, pr int, installationID int64) {
+	if h.service == nil || !h.service.Config().IsAggregateLeaderForRepo(repo) {
+		h.logger.Debug("repo is not an aggregate leader; no re-fold to arm", "repo", repo, "pr", pr)
+		return
+	}
+	h.scheduleParticipantRefold(ctx, repo, pr, installationID)
+}
+
 // refoldAggregateForPR re-reads the PR's current head and re-runs the
 // aggregate fold against it. The head is fetched fresh on every pass so a
 // nudge raced by a new commit folds the commit that is actually current;
 // updateAggregateCheck independently verifies head freshness before writing.
+// A pass that breaks before it can fold re-arms (leader-gated, bounded) so
+// the retry chain survives transient client and PR-fetch failures.
 func (h *Handler) refoldAggregateForPR(repo string, pr int, installationID int64, trigger string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -188,12 +205,23 @@ func (h *Handler) refoldAggregateForPR(repo string, pr int, installationID int64
 	if err != nil {
 		h.logger.Error("failed to create GitHub client for aggregate re-fold",
 			"repo", repo, "pr", pr, "trigger", trigger, "error", err)
+		h.scheduleLeaderRefoldIfConfigured(ctx, repo, pr, installationID)
 		return
 	}
 	prInfo, err := client.FetchPullRequestNoCache(ctx, repo, pr)
 	if err != nil {
 		h.logger.Error("failed to fetch PR head for aggregate re-fold",
 			"repo", repo, "pr", pr, "trigger", trigger, "error", err)
+		h.scheduleLeaderRefoldIfConfigured(ctx, repo, pr, client.InstallationID())
+		return
+	}
+	if prInfo.IsClosed() {
+		// An armed re-fold can fire after its PR closes; folding would publish
+		// a check on the closed PR and re-arm a chain whose budget entry
+		// nothing would clear again (PR-close cleanup already ran).
+		h.logger.Debug("skipping aggregate re-fold for closed PR",
+			"repo", repo, "pr", pr, "trigger", trigger)
+		h.clearParticipantRefoldBudget(repo, pr)
 		return
 	}
 	h.updateAggregateCheck(ctx, client, repo, pr, prInfo.HeadSHA)

--- a/pkg/webhook/participant_nudge.go
+++ b/pkg/webhook/participant_nudge.go
@@ -159,9 +159,12 @@ func (h *Handler) scheduleParticipantRefold(ctx context.Context, repo string, pr
 	})
 }
 
-// clearParticipantRefoldBudget resets the re-fold budget once a fold resolves
-// every expected participant, so a later commit on the same PR gets a fresh
-// budget.
+// clearParticipantRefoldBudget resets the re-fold budget once a fold ends with
+// no retriable participant outcomes: every participant either resolved or
+// blocks for a reason no re-read can improve (an untrusted App, an
+// unresolvable check name, or its own pending work). PR close also clears the
+// entry so the in-memory map does not retain abandoned PRs. A later fold that
+// turns retriable again gets a fresh budget.
 func (h *Handler) clearParticipantRefoldBudget(repo string, pr int) {
 	key := participantRefoldKey(repo, pr)
 	h.participantRefoldMu.Lock()

--- a/pkg/webhook/participant_nudge_integration_test.go
+++ b/pkg/webhook/participant_nudge_integration_test.go
@@ -227,9 +227,10 @@ func TestE2EParticipantCommentNudgeFailClosedThroughRollback(t *testing.T) {
 	h.ServeHTTP(rr, req)
 	require.Equal(t, http.StatusOK, rr.Code)
 
-	// A completed-but-not-successful participant check (action_required after a
-	// rollback) folds as failure — the strongest blocking conclusion.
-	blocked := collectAggregateConclusion(t, checkRuns, aggregateCheckNameForEnv("SchemaBot", "production"), checkConclusionFailure)
+	// The participant's post-rollback check reads action_required — its change
+	// was reverted and a re-apply is pending — so the aggregate blocks as
+	// action_required.
+	blocked := collectAggregateConclusion(t, checkRuns, aggregateCheckNameForEnv("SchemaBot", "production"), checkConclusionActionRequired)
 	assert.Equal(t, headSHA, blocked.HeadSHA)
 	assert.Equal(t, checkStatusCompleted, blocked.Status,
 		"a rolled-back participant blocks the aggregate")

--- a/pkg/webhook/participant_refold_test.go
+++ b/pkg/webhook/participant_refold_test.go
@@ -1,0 +1,53 @@
+package webhook
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The self-scheduled re-fold budget caps consecutive arms per PR so a
+// participant that never reports cannot keep a timer chain alive forever, and
+// a fold that resolves every participant resets the budget so a later commit
+// on the same PR converges again.
+func TestParticipantRefoldBudget(t *testing.T) {
+	const (
+		repo = "octocat/shared-repo"
+		pr   = 7
+	)
+	h := &Handler{logger: testLogger()}
+	// Keep armed timers from firing inside the test process; pending timers at
+	// process exit are inert.
+	h.participantNudgeRefoldDelay = time.Hour
+
+	attempts := func() (int, bool) {
+		h.participantRefoldMu.Lock()
+		defer h.participantRefoldMu.Unlock()
+		n, ok := h.participantRefoldAttempts[participantRefoldKey(repo, pr)]
+		return n, ok
+	}
+
+	for i := range maxParticipantRefoldAttempts {
+		h.scheduleParticipantRefold(t.Context(), repo, pr, 42)
+		n, ok := attempts()
+		assert.True(t, ok)
+		assert.Equal(t, i+1, n)
+	}
+
+	// The budget is spent: further schedules arm nothing and do not grow the
+	// counter.
+	h.scheduleParticipantRefold(t.Context(), repo, pr, 42)
+	n, _ := attempts()
+	assert.Equal(t, maxParticipantRefoldAttempts, n)
+
+	// A fold that resolves every participant clears the budget, so a later
+	// commit gets fresh attempts.
+	h.clearParticipantRefoldBudget(repo, pr)
+	_, ok := attempts()
+	assert.False(t, ok)
+
+	h.scheduleParticipantRefold(t.Context(), repo, pr, 42)
+	n, _ = attempts()
+	assert.Equal(t, 1, n)
+}

--- a/pkg/webhook/participant_refold_test.go
+++ b/pkg/webhook/participant_refold_test.go
@@ -19,7 +19,7 @@ func TestParticipantRefoldBudget(t *testing.T) {
 	h := &Handler{logger: testLogger()}
 	// Keep armed timers from firing inside the test process; pending timers at
 	// process exit are inert.
-	h.participantNudgeRefoldDelay = time.Hour
+	h.participantRefoldDelayOverride = time.Hour
 
 	attempts := func() (int, bool) {
 		h.participantRefoldMu.Lock()

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -327,6 +327,11 @@ func (h *Handler) handlePRClosed(repo string, pr int, _ int64) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	// A closed PR gets no more scheduled re-folds; drop its budget entry so the
+	// in-memory map does not accumulate one entry per closed PR. A reopen folds
+	// fresh and re-arms with a full budget.
+	h.clearParticipantRefoldBudget(repo, pr)
+
 	applies, err := h.service.Storage().Applies().GetByPR(ctx, repo, pr)
 	if err != nil {
 		// Fail closed: with apply state unknown, releasing a lock or deleting


### PR DESCRIPTION
## Why this matters

When a PR touches a participant tenant's paths but that tenant has no actual schema work, the tenant publishes its green check and never comments. GitHub only delivers check events to the App that created them, so the leader never hears about that green check. If the leader's first fold ran before the check appeared — they usually land within a second or two of each other — the aggregate blocked and **nothing would ever unblock it**:

```
t+0s   leader folds: participant check not found → aggregate blocks (fail-closed)
t+1s   participant publishes its green check — no comment, no event to the leader
t+∞    nothing re-folds → PR stays red forever ⛔
```

The PR stayed red until someone happened to comment, push, or run a manual plan.

## What it does

The leader now retries on its own. When a fold blocks only because a participant hasn't reported yet (or a Checks API read failed), it schedules a re-read: after 5 seconds, then 15, then 45. The first retry catches the common case — the participant's check was just a moment behind.

While retries are pending, the aggregate shows **in progress** ("waiting for the participant to report") — still merge-blocking, but honest about why. If all three retries come up empty, it flips to **action required**: the participant genuinely isn't reporting and someone should look at that deployment. A definitive log line and a `participant_refold` metric mark both the scheduling and the giving-up.

Things a retry can't fix — an untrusted App or a misconfigured check name — never schedule one; those need a config change and block immediately.

## Known limitation (follow-up tracked)

The retry state lives in process memory: a pod restart mid-window drops a pending retry, and a participant slower than the full retry window still needs a comment, commit, or manual plan to converge. The durable fix is a periodic reconciler that sweeps blocked aggregates and re-folds them; the `participant_unresolved` marker this PR introduces is the hook it will use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
