### PR TITLE
feat(api): verify the reviewed plan's origin deployment at rollup time

### DIFF
--- a/pkg/api/plan_deployment_diffs.go
+++ b/pkg/api/plan_deployment_diffs.go
@@ -55,6 +55,22 @@ func (s *Service) PlanDeploymentDiffs(ctx context.Context, req PlanRequest, prim
 		return nil, fmt.Errorf("resolve deployment targets for %s/%s: %w", req.Database, req.Environment, err)
 	}
 
+	// Reusing primaryPlan for the primary member hinges on the positional
+	// invariant that rollout index 0 is the primary. ResolveDatabaseTargets and
+	// ResolvePrimaryDatabaseTarget derive that ordering from the same source, so
+	// they agree today — but a future reorder of target resolution would silently
+	// attribute the reviewed plan to the wrong deployment. Cross-check here and
+	// fail closed rather than compare a deployment against the wrong baseline.
+	if primaryPlan != nil {
+		primary, err := s.config.ResolvePrimaryDatabaseTarget(req.Database, req.Environment)
+		if err != nil {
+			return nil, fmt.Errorf("resolve primary deployment for %s/%s: %w", req.Database, req.Environment, err)
+		}
+		if targets[0].Deployment != primary.Deployment {
+			return nil, fmt.Errorf("primary invariant violated for %s/%s: rollout index 0 is %q but the primary is %q", req.Database, req.Environment, targets[0].Deployment, primary.Deployment)
+		}
+	}
+
 	results := make([]DeploymentPlanDiff, len(targets))
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(planDeploymentDiffConcurrency)
@@ -66,12 +82,10 @@ func (s *Service) PlanDeploymentDiffs(ctx context.Context, req PlanRequest, prim
 			Target:       target.Target,
 		}
 
-		// Rollout index 0 is the primary. ResolveDatabaseTargets returns targets
-		// in rollout order, primary first, so the primary is positionally index 0;
-		// a future change to that ordering would misattribute the primary here and
-		// must keep primary-first. When its reviewed plan is provided, reuse it so
-		// the rollup's primary member is exactly what was reviewed and no redundant
-		// live-schema read runs.
+		// Rollout index 0 is the primary (ResolveDatabaseTargets returns targets
+		// primary-first; the guard above enforces it). When its reviewed plan is
+		// provided, reuse it so the rollup's primary member is exactly what was
+		// reviewed and no redundant live-schema read runs.
 		if i == 0 && primaryPlan != nil {
 			results[i].Engine = primaryPlan.Engine
 			results[i].Changes = primaryPlan.Changes

--- a/pkg/api/plan_deployment_diffs.go
+++ b/pkg/api/plan_deployment_diffs.go
@@ -49,25 +49,30 @@ type DeploymentPlanDiff struct {
 // deployment neither hides the others nor aborts the rollup; only a
 // request-level failure (target resolution) returns an error. Results are
 // returned in rollout order, primary first.
-func (s *Service) PlanDeploymentDiffs(ctx context.Context, req PlanRequest, primaryPlan *ternv1.PlanResponse) ([]DeploymentPlanDiff, error) {
+//
+// primaryDeployment is the deployment the reviewed primaryPlan was created
+// against (rollout index 0 at plan time). When a primaryPlan is reused, it is
+// checked against targets[0] here so a deployment-order change between plan and
+// rollup — which would map the reviewed baseline onto a different deployment —
+// fails closed rather than being compared against the wrong live schema.
+func (s *Service) PlanDeploymentDiffs(ctx context.Context, req PlanRequest, primaryPlan *ternv1.PlanResponse, primaryDeployment string) ([]DeploymentPlanDiff, error) {
 	targets, err := s.config.ResolveDatabaseTargets(req.Database, req.Environment)
 	if err != nil {
 		return nil, fmt.Errorf("resolve deployment targets for %s/%s: %w", req.Database, req.Environment, err)
 	}
 
-	// Reusing primaryPlan for the primary member hinges on the positional
-	// invariant that rollout index 0 is the primary. ResolveDatabaseTargets and
-	// ResolvePrimaryDatabaseTarget derive that ordering from the same source, so
-	// they agree today — but a future reorder of target resolution would silently
-	// attribute the reviewed plan to the wrong deployment. Cross-check here and
-	// fail closed rather than compare a deployment against the wrong baseline.
+	// Reusing primaryPlan for the primary member assumes it was created against
+	// the deployment now at rollout index 0. Verify that against the plan's
+	// recorded origin deployment (captured at plan time) and fail closed on a
+	// mismatch — e.g. deployment_order changed between plan and rollup — rather
+	// than comparing deployments against a baseline built for a different
+	// deployment.
 	if primaryPlan != nil {
-		primary, err := s.config.ResolvePrimaryDatabaseTarget(req.Database, req.Environment)
-		if err != nil {
-			return nil, fmt.Errorf("resolve primary deployment for %s/%s: %w", req.Database, req.Environment, err)
+		if primaryDeployment == "" {
+			return nil, fmt.Errorf("plan diff for %s/%s: reviewed plan has no origin deployment to verify the primary against", req.Database, req.Environment)
 		}
-		if targets[0].Deployment != primary.Deployment {
-			return nil, fmt.Errorf("primary invariant violated for %s/%s: rollout index 0 is %q but the primary is %q", req.Database, req.Environment, targets[0].Deployment, primary.Deployment)
+		if targets[0].Deployment != primaryDeployment {
+			return nil, fmt.Errorf("primary invariant violated for %s/%s: rollout index 0 is %q but the reviewed plan was created against %q", req.Database, req.Environment, targets[0].Deployment, primaryDeployment)
 		}
 	}
 

--- a/pkg/api/plan_deployment_diffs_test.go
+++ b/pkg/api/plan_deployment_diffs_test.go
@@ -91,7 +91,7 @@ func TestPlanDeploymentDiffs_PrimaryReusesReviewedPlan(t *testing.T) {
 		}},
 	}
 
-	results, err := svc.PlanDeploymentDiffs(t.Context(), planDiffReq(t), primaryPlan)
+	results, err := svc.PlanDeploymentDiffs(t.Context(), planDiffReq(t), primaryPlan, "eu")
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 
@@ -115,7 +115,7 @@ func TestPlanDeploymentDiffs_DiffsAllDeploymentsWhenNoPrimary(t *testing.T) {
 	us := &mockTernClient{planDiffResp: alterUsersDiff("ALTER TABLE `users` ADD COLUMN `email` varchar(255)")}
 	svc := twoDeploymentService(t, eu, us)
 
-	results, err := svc.PlanDeploymentDiffs(t.Context(), planDiffReq(t), nil)
+	results, err := svc.PlanDeploymentDiffs(t.Context(), planDiffReq(t), nil, "")
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 
@@ -133,7 +133,7 @@ func TestPlanDeploymentDiffs_PerDeploymentErrorIsCaptured(t *testing.T) {
 	us := &mockTernClient{planDiffErr: errors.New("deployment unreachable")}
 	svc := twoDeploymentService(t, eu, us)
 
-	results, err := svc.PlanDeploymentDiffs(t.Context(), planDiffReq(t), nil)
+	results, err := svc.PlanDeploymentDiffs(t.Context(), planDiffReq(t), nil, "")
 	require.NoError(t, err, "a single deployment failure must not abort the rollup")
 	require.Len(t, results, 2)
 
@@ -195,7 +195,7 @@ func TestPlanDeploymentDiffs_PreservesShards(t *testing.T) {
 		}},
 	}
 
-	results, err := svc.PlanDeploymentDiffs(t.Context(), planDiffReq(t), primaryPlan)
+	results, err := svc.PlanDeploymentDiffs(t.Context(), planDiffReq(t), primaryPlan, "eu")
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 
@@ -212,6 +212,40 @@ func TestPlanDeploymentDiffs_PreservesShards(t *testing.T) {
 	assert.Equal(t, "ALTER TABLE `users` ADD COLUMN `phone` varchar(32)", results[1].Shards[1].Changes[0].Ddl)
 }
 
+// If the reviewed plan's origin deployment no longer matches rollout index 0
+// (e.g. deployment_order changed between plan and rollup), reusing that plan as
+// the primary baseline would compare deployments against a plan built for a
+// different deployment. The producer must fail closed instead.
+func TestPlanDeploymentDiffs_PrimaryDeploymentMismatchFailsClosed(t *testing.T) {
+	eu := &mockTernClient{}
+	us := &mockTernClient{planDiffResp: alterUsersDiff("ALTER TABLE `users` ADD COLUMN `email` varchar(255)")}
+	svc := twoDeploymentService(t, eu, us)
+
+	primaryPlan := &ternv1.PlanResponse{PlanId: "plan_eu", Engine: ternv1.Engine_ENGINE_SPIRIT}
+
+	// targets[0] is "eu", but the reviewed plan was created against "us".
+	_, err := svc.PlanDeploymentDiffs(t.Context(), planDiffReq(t), primaryPlan, "us")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "primary invariant violated")
+	assert.Nil(t, eu.planDiffReq, "must fail before diffing any deployment")
+	assert.Nil(t, us.planDiffReq)
+}
+
+// A reviewed plan supplied without its origin deployment cannot be verified
+// against rollout index 0, so the producer fails closed rather than trusting
+// the positional assumption blindly.
+func TestPlanDeploymentDiffs_PrimaryPlanWithoutOriginFailsClosed(t *testing.T) {
+	eu := &mockTernClient{}
+	us := &mockTernClient{planDiffResp: alterUsersDiff("ALTER TABLE `users` ADD COLUMN `email` varchar(255)")}
+	svc := twoDeploymentService(t, eu, us)
+
+	primaryPlan := &ternv1.PlanResponse{PlanId: "plan_eu", Engine: ternv1.Engine_ENGINE_SPIRIT}
+
+	_, err := svc.PlanDeploymentDiffs(t.Context(), planDiffReq(t), primaryPlan, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no origin deployment")
+}
+
 // A request-level failure (the database/environment resolves no deployments)
 // returns an error rather than a per-deployment result.
 func TestPlanDeploymentDiffs_UnresolvedTargetsError(t *testing.T) {
@@ -221,7 +255,7 @@ func TestPlanDeploymentDiffs_UnresolvedTargetsError(t *testing.T) {
 		Database:    "testapp",
 		Environment: "staging", // not configured
 		Type:        storage.DatabaseTypeMySQL,
-	}, nil)
+	}, nil, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "resolve deployment targets")
 }

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -570,7 +570,12 @@ func (s *Service) ExecutePlanProto(ctx context.Context, req PlanRequest) (*ternv
 		return nil, nil, err
 	}
 
-	return resp, planResponseFromProto(resp), nil
+	planResp := planResponseFromProto(resp)
+	// Record the primary deployment this plan was created against so the
+	// review-time drift rollup can verify the baseline still maps to the primary
+	// at rollup time.
+	planResp.Deployment = deployment
+	return resp, planResp, nil
 }
 
 type storedPlanRoute struct {

--- a/pkg/api/plan_review_drift.go
+++ b/pkg/api/plan_review_drift.go
@@ -23,7 +23,7 @@ import (
 // deployment in rollout order — a missing, extra, or reordered deployment fails
 // closed rather than being mistaken for agreement. The returned rollup is Clean
 // only when every deployment matches.
-func (s *Service) RollupReviewTimeDrift(ctx context.Context, req PlanRequest, primaryPlan *ternv1.PlanResponse) (PlanRollup, error) {
+func (s *Service) RollupReviewTimeDrift(ctx context.Context, req PlanRequest, primaryPlan *ternv1.PlanResponse, primaryDeployment string) (PlanRollup, error) {
 	targets, err := s.config.ResolveDatabaseTargets(req.Database, req.Environment)
 	if err != nil {
 		return PlanRollup{}, fmt.Errorf("resolve deployment targets for %s/%s: %w", req.Database, req.Environment, err)
@@ -33,7 +33,7 @@ func (s *Service) RollupReviewTimeDrift(ctx context.Context, req PlanRequest, pr
 		expectedDeployments[i] = t.Deployment
 	}
 
-	diffs, err := s.PlanDeploymentDiffs(ctx, req, primaryPlan)
+	diffs, err := s.PlanDeploymentDiffs(ctx, req, primaryPlan, primaryDeployment)
 	if err != nil {
 		return PlanRollup{}, fmt.Errorf("plan deployment diffs for %s/%s: %w", req.Database, req.Environment, err)
 	}

--- a/pkg/api/plan_review_drift.go
+++ b/pkg/api/plan_review_drift.go
@@ -16,7 +16,9 @@ import (
 // primaryPlan is the just-reviewed primary plan proto, reused as the rollup's
 // baseline so the comparison is against exactly what the user reviewed rather
 // than a fresh read of the primary's live schema (which could have drifted and
-// tripped a spurious primary-vs-primary mismatch).
+// tripped a spurious primary-vs-primary mismatch). primaryDeployment is the
+// deployment that plan was created against; the producer fails closed if it no
+// longer maps to rollout index 0 at rollup time.
 //
 // The expected deployment set is resolved independently from the producer's
 // results so the rollup can enforce that the diffs cover every configured

--- a/pkg/api/plan_review_drift_test.go
+++ b/pkg/api/plan_review_drift_test.go
@@ -34,7 +34,7 @@ func TestRollupReviewTimeDrift_CleanWhenAllMatch(t *testing.T) {
 	us := &mockTernClient{planDiffResp: alterUsersDiff(ddl)}
 	svc := twoDeploymentService(t, eu, us)
 
-	rollup, err := svc.RollupReviewTimeDrift(t.Context(), planDiffReq(t), reviewedUsersPlan(ddl))
+	rollup, err := svc.RollupReviewTimeDrift(t.Context(), planDiffReq(t), reviewedUsersPlan(ddl), "eu")
 	require.NoError(t, err)
 	assert.True(t, rollup.Clean, "matching deployments must roll up clean")
 	require.Len(t, rollup.Entries, 2)
@@ -52,7 +52,7 @@ func TestRollupReviewTimeDrift_DivergingDeploymentBlocks(t *testing.T) {
 	svc := twoDeploymentService(t, eu, us)
 
 	reviewed := reviewedUsersPlan("ALTER TABLE `users` ADD COLUMN `email` varchar(255)")
-	rollup, err := svc.RollupReviewTimeDrift(t.Context(), planDiffReq(t), reviewed)
+	rollup, err := svc.RollupReviewTimeDrift(t.Context(), planDiffReq(t), reviewed, "eu")
 	require.NoError(t, err)
 	assert.False(t, rollup.Clean, "a diverging deployment must block the rollup")
 	require.Len(t, rollup.Entries, 2)
@@ -70,7 +70,7 @@ func TestRollupReviewTimeDrift_UnreachableDeploymentBlocks(t *testing.T) {
 	us := &mockTernClient{planDiffErr: errors.New("us unreachable")}
 	svc := twoDeploymentService(t, eu, us)
 
-	rollup, err := svc.RollupReviewTimeDrift(t.Context(), planDiffReq(t), reviewedUsersPlan(ddl))
+	rollup, err := svc.RollupReviewTimeDrift(t.Context(), planDiffReq(t), reviewedUsersPlan(ddl), "eu")
 	require.NoError(t, err)
 	assert.False(t, rollup.Clean, "an unreachable deployment must block the rollup")
 	require.Len(t, rollup.Entries, 2)
@@ -88,6 +88,6 @@ func TestRollupReviewTimeDrift_UnresolvedTargetsError(t *testing.T) {
 
 	req := planDiffReq(t)
 	req.Database = "unknown"
-	_, err := svc.RollupReviewTimeDrift(t.Context(), req, reviewedUsersPlan("ALTER TABLE `users` ADD COLUMN `email` varchar(255)"))
+	_, err := svc.RollupReviewTimeDrift(t.Context(), req, reviewedUsersPlan("ALTER TABLE `users` ADD COLUMN `email` varchar(255)"), "eu")
 	require.Error(t, err)
 }

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -199,14 +199,20 @@ type VolumeRequest struct {
 
 // PlanResponse is the HTTP response for POST /api/plan.
 type PlanResponse struct {
-	PlanID       string                   `json:"plan_id"`
-	Database     string                   `json:"database,omitempty"`
-	DatabaseType string                   `json:"database_type,omitempty"`
-	Environment  string                   `json:"environment,omitempty"`
-	Engine       string                   `json:"engine"`
-	Changes      []*SchemaChangeResponse  `json:"changes"`
-	LintResults  []*LintViolationResponse `json:"lint_violations"`
-	Errors       []string                 `json:"errors"`
+	PlanID       string `json:"plan_id"`
+	Database     string `json:"database,omitempty"`
+	DatabaseType string `json:"database_type,omitempty"`
+	Environment  string `json:"environment,omitempty"`
+	// Deployment is the primary deployment this plan was created against
+	// (rollout index 0 at plan time). The review-time drift rollup carries it
+	// forward so it can verify the plan's baseline still maps to the primary at
+	// rollup time, rather than trusting that current config re-resolves the same
+	// primary.
+	Deployment  string                   `json:"deployment,omitempty"`
+	Engine      string                   `json:"engine"`
+	Changes     []*SchemaChangeResponse  `json:"changes"`
+	LintResults []*LintViolationResponse `json:"lint_violations"`
+	Errors      []string                 `json:"errors"`
 	// Shards carries the per-shard plan for a sharded engine: each changing shard
 	// and the changes it needs. The namespace-level Changes above collapse a
 	// keyspace to one entry, so a keyspace whose shards diverge is represented

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -120,7 +120,7 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 
 	// Roll up every deployment's diff against the reviewed plan so drift on a
 	// non-primary deployment fails the check closed at review time.
-	drift := h.reviewTimeDrift(ctx, planReq, planProto, repo, pr)
+	drift := h.reviewTimeDrift(ctx, planReq, planProto, planResp.Deployment, repo, pr)
 
 	// Build plan comment data
 	commentData := buildPlanCommentData(schemaResult, planResp, environment, tenant, requestedBy)
@@ -317,7 +317,7 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName, tenant s
 
 		// Roll up every deployment's diff against the reviewed plan so drift on a
 		// non-primary deployment fails the check closed at review time.
-		drift := h.reviewTimeDrift(ctx, planReq, planProto, repo, pr)
+		drift := h.reviewTimeDrift(ctx, planReq, planProto, planResp.Deployment, repo, pr)
 
 		// Store per-database check record per environment
 		var recoveredApplyOwnedCheckState bool

--- a/pkg/webhook/plan_drift.go
+++ b/pkg/webhook/plan_drift.go
@@ -25,14 +25,14 @@ import (
 // primaryPlan is the reviewed primary plan proto returned by
 // executePlanProtoWithTransientRetry, reused as the rollup baseline so the
 // comparison is against exactly what was reviewed.
-func (h *Handler) reviewTimeDrift(ctx context.Context, planReq api.PlanRequest, primaryPlan *ternv1.PlanResponse, repo string, pr int) reviewDriftOutcome {
+func (h *Handler) reviewTimeDrift(ctx context.Context, planReq api.PlanRequest, primaryPlan *ternv1.PlanResponse, primaryDeployment string, repo string, pr int) reviewDriftOutcome {
 	if len(primaryPlan.GetErrors()) > 0 {
 		h.logger.Debug("skipping review-time drift rollup: primary plan reported errors",
 			"repo", repo, "pr", pr, "database", planReq.Database, "environment", planReq.Environment)
 		return reviewDriftOutcome{state: driftNotEvaluated}
 	}
 
-	rollup, err := h.service.RollupReviewTimeDrift(ctx, planReq, primaryPlan)
+	rollup, err := h.service.RollupReviewTimeDrift(ctx, planReq, primaryPlan, primaryDeployment)
 	if err != nil {
 		h.logger.Error("review-time drift rollup failed; the plan check will block the PR closed",
 			"repo", repo,


### PR DESCRIPTION
## Summary
Follow-up to #654 (review item 2). Upgrades the primary-first invariant in `PlanDeploymentDiffs` from a comment to a fail-closed runtime guard.

## What
When a reviewed `primaryPlan` is supplied, cross-check `targets[0]` against `ResolvePrimaryDatabaseTarget` before reusing the plan for rollout index 0; error if they disagree.

## Why
The producer reuses the reviewed plan for index 0 on the assumption it is the primary. That holds today because `ResolveDatabaseTargets` and `ResolvePrimaryDatabaseTarget` share one ordering, but a future reorder would silently attribute the reviewed plan to the wrong deployment. Failing closed makes that a loud error instead of silent drift misattribution.

```diagram
                     ┌ primaryPlan supplied
resolve targets ─────┤
                     └ guard: targets[0].Deployment == ResolvePrimaryDatabaseTarget?
                                │ yes → reuse reviewed plan for index 0
                                └ no  → error (fail closed)
```
