### PR TITLE
fix(tern): fail closed on drives outside the client's database scope

### DIFF
--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -1643,13 +1643,19 @@ func TestLocalClient_ResumeApplyOperationCutoverFailsClosedOnApplyMismatch(t *te
 
 	ownerApplyID, operationID := seedCutoverOperationWithTask(ctx, t, stor, state.ApplyOperation.WaitingForCutover)
 
-	// A different apply that does not own the operation.
+	// A different apply that does not own the operation. It targets this
+	// client's database ("testdb") so it passes the drive's database-scope
+	// guard and actually reaches the operation-ownership check under test,
+	// but on a sibling deployment so it doesn't collide with the owner's
+	// active apply on the "testdb" deployment. The foreign-scope path (an
+	// apply outside this client's database entirely) is covered by
+	// TestLocalClient_ResumeRefusesApplyOutsideDatabaseScope.
 	now := time.Now()
 	otherApply := &storage.Apply{
 		ApplyIdentifier: fmt.Sprintf("apply-cutover-other-%d", time.Now().UnixNano()),
-		Database:        "otherdb",
+		Database:        "testdb",
 		DatabaseType:    storage.DatabaseTypeMySQL,
-		Deployment:      "otherdb",
+		Deployment:      "testdb-sibling",
 		Engine:          storage.EngineSpirit,
 		State:           state.Apply.WaitingForCutover,
 		Options:         storage.MarshalApplyOptions(storage.ApplyOptions{}),

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -930,10 +930,37 @@ func (c *LocalClient) notifyTerminalObserver(apply *storage.Apply, tasks []*stor
 	}
 }
 
+// guardDriveScope fails closed when a claimed apply does not belong to the
+// database this client is bound to. Operators claim from whatever Tern storage
+// they poll and resolve the drive client afterwards, and that resolution can
+// fall back to a database-bound default client (RegisterGRPC wires the gRPC
+// transport's client as the service-wide fallback) — so in a storage database
+// shared by more than one tern, a claim of another tern's apply would
+// otherwise run that apply's DDL against this client's target. Every
+// legitimate drive reaches a client whose database matches the apply's
+// deployment (Apply stamps Deployment from the creating client's database;
+// routing resolves operation drives by their deployment) or the apply's
+// database (the target router builds per-target clients keyed by it), so a
+// claim matching neither is foreign work. The refused apply stays claimable
+// by an operator whose client matches once its lease goes stale.
+func (c *LocalClient) guardDriveScope(apply *storage.Apply) error {
+	if apply == nil {
+		return fmt.Errorf("stored apply is required")
+	}
+	if apply.Deployment == c.config.Database || apply.Database == c.config.Database {
+		return nil
+	}
+	return fmt.Errorf("apply %s (database %q, deployment %q) is outside this client's database scope (%q); refusing to drive it against the wrong target",
+		apply.ApplyIdentifier, apply.Database, apply.Deployment, c.config.Database)
+}
+
 // ResumeApply starts or resumes an apply claimed by an operator driver.
 // Pending applies are dispatched for the first time; stale applies use the
 // engine's resume metadata to continue after a missed heartbeat.
 func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) error {
+	if err := c.guardDriveScope(apply); err != nil {
+		return err
+	}
 	tasks, err := c.storage.Tasks().GetByApplyID(ctx, apply.ID)
 	if err != nil {
 		return fmt.Errorf("get tasks for apply %s: %w", apply.ApplyIdentifier, err)
@@ -952,6 +979,9 @@ func (c *LocalClient) ResumeApply(ctx context.Context, apply *storage.Apply) err
 // are loaded scoped to the operation rather than the whole apply, so a driver
 // can advance one deployment independently of its siblings.
 func (c *LocalClient) ResumeApplyOperation(ctx context.Context, apply *storage.Apply, applyOperationID int64) error {
+	if err := c.guardDriveScope(apply); err != nil {
+		return err
+	}
 	op, err := c.storage.ApplyOperations().Get(ctx, applyOperationID)
 	if err != nil {
 		return fmt.Errorf("get apply_operation %d (apply %s): %w", applyOperationID, apply.ApplyIdentifier, err)
@@ -1011,6 +1041,9 @@ func (c *LocalClient) ResumeApplyOperation(ctx context.Context, apply *storage.A
 func (c *LocalClient) ResumeApplyOperationCutover(ctx context.Context, apply *storage.Apply, applyOperationID int64) error {
 	if apply == nil {
 		return fmt.Errorf("stored apply is required to drive apply_operation %d cutover", applyOperationID)
+	}
+	if err := c.guardDriveScope(apply); err != nil {
+		return err
 	}
 	op, err := c.storage.ApplyOperations().Get(ctx, applyOperationID)
 	if err != nil {

--- a/pkg/tern/local_resume_scope_integration_test.go
+++ b/pkg/tern/local_resume_scope_integration_test.go
@@ -1,0 +1,116 @@
+//go:build integration
+
+package tern
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// Operators claim from whatever Tern storage they poll and resolve the drive
+// client afterwards, so in a storage database shared by more than one tern a
+// claim can hand another tern's apply to a client bound to the wrong target
+// (the in-process harness routes around exactly this — see
+// integration/grpc_server_test.go). The drive must fail closed on that shape:
+// refuse the claim, never touch the engine, and leave the apply for an
+// operator whose client matches.
+func TestLocalClient_ResumeRefusesApplyOutsideDatabaseScope(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+	cleanupTestTables(t, dsn)
+
+	ctx := t.Context()
+	stor := createStorage(t, dsn)
+	defer utils.CloseAndLog(stor)
+	// The client under test is bound to "testdb"; the apply below belongs to a
+	// different tern's database sharing this storage.
+	client, eng := newTasklessControlClient(t, dsn, stor)
+
+	plan := &storage.Plan{
+		PlanIdentifier: fmt.Sprintf("plan-foreign-%d", time.Now().UnixNano()),
+		Database:       "otherdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Deployment:     "otherdb",
+		Environment:    localClientTestEnvironment,
+		CreatedAt:      time.Now(),
+		Namespaces: map[string]*storage.NamespacePlanData{
+			"otherdb": {
+				Tables: []storage.TableChange{
+					{Namespace: "otherdb", Table: "users", DDL: "ALTER TABLE `users` ADD COLUMN x INT", Operation: "alter"},
+				},
+			},
+		},
+	}
+	planID, err := stor.Plans().Create(ctx, plan)
+	require.NoError(t, err)
+
+	now := time.Now()
+	apply := &storage.Apply{
+		ApplyIdentifier: "apply-foreign-scope",
+		PlanID:          planID,
+		Database:        "otherdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Deployment:      "otherdb",
+		Environment:     localClientTestEnvironment,
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Pending,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	applyID, err := stor.Applies().CreateWithTasksAndOperations(ctx, apply, nil, []*storage.ApplyOperation{{
+		Deployment: apply.Deployment,
+		State:      state.ApplyOperation.Pending,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}})
+	require.NoError(t, err)
+	apply.ID = applyID
+
+	// The claim itself succeeds — FindNextApply has no deployment filter, which
+	// is exactly why the drive has to be the fail-closed layer.
+	claimed, err := stor.Applies().FindNextApply(ctx, "test-operator-"+t.Name())
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	require.Equal(t, apply.ApplyIdentifier, claimed.ApplyIdentifier)
+
+	driveCtx := storage.WithApplyLease(ctx, claimed.Lease())
+	err = client.ResumeApply(driveCtx, claimed)
+	require.Error(t, err, "driving a foreign database's apply must fail closed")
+	assert.Contains(t, err.Error(), "outside this client's database scope")
+
+	ops, err := stor.ApplyOperations().ListByApply(ctx, apply.ID)
+	require.NoError(t, err)
+	require.Len(t, ops, 1)
+	err = client.ResumeApplyOperation(driveCtx, claimed, ops[0].ID)
+	require.Error(t, err, "the operation drive must refuse a foreign apply the same way")
+	assert.Contains(t, err.Error(), "outside this client's database scope")
+
+	err = client.ResumeApplyOperationCutover(driveCtx, claimed, ops[0].ID)
+	require.Error(t, err, "the cutover drive must refuse a foreign apply the same way")
+	assert.Contains(t, err.Error(), "outside this client's database scope")
+
+	assert.Empty(t, eng.recorded(), "a refused foreign apply must never reach the engine")
+
+	// The claim itself moved the apply to running; the refused drive must not
+	// advance it further — it stays active work, re-claimable by an operator
+	// whose client matches once this claim's heartbeat goes stale.
+	persisted, err := stor.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.False(t, state.IsTerminalApplyState(persisted.State),
+		"a refused foreign apply must not be settled by the wrong client (state %q)", persisted.State)
+	assert.Nil(t, persisted.CompletedAt, "a refused foreign apply must not be stamped completed")
+}


### PR DESCRIPTION
## Summary
Follow-up on correctness check for #635. 

It queues the dispatched applies in Tern storage and lets operators claim them, resolving the
drive client *after* the claim — including a database-bound default-client fallback
(`RegisterGRPC` wires the gRPC transport's client as the service-wide default).
`FindNextApply` has no deployment filter, so in a storage database shared by more than one
tern, one tern's operator can claim another tern's apply and the fallback hands the drive to
a client bound to the wrong target — running foreign DDL against this tern's database.

The in-process harness acknowledges exactly this hazard and routes around it, but only in
tests (`integration/grpc_server_test.go`: *"driving it through the wrong database-bound
client would run DDL against the wrong target"*). Production had no equivalent guard.

## What changed

- `LocalClient.guardDriveScope`: a claimed apply whose deployment **and** database both
differ from the client's bound database is refused, at all three operator entry points
(`ResumeApply`, `ResumeApplyOperation`, `ResumeApplyOperationCutover`).
- The predicate is safe for every legitimate routing shape: `Apply` stamps `Deployment` from
the creating client's database, routing resolves operation drives by their deployment, and
the target router builds per-target clients keyed by `apply.Database` — so a claim matching
neither is foreign work.
- A refused apply keeps its claim-time state and stays re-claimable by an operator whose
client matches once the lease goes stale.

## Behaviour — foreign claim in shared storage (before → after)

BEFORE
```
operator poll ─▶ FindNextApply (no deployment filter) ─▶ claims foreign apply
│
▼
TernClient(deployment, env): unconfigured ─▶ default client (bound to THIS tern's target)
│
▼
ResumeApply loads tasks by apply ID ─▶ runs the foreign apply's DDL on the wrong target ✗
```
AFTER
```
operator poll ─▶ FindNextApply ─▶ claims foreign apply
│
▼
TernClient(deployment, env): unconfigured ─▶ default client (bound to THIS tern's target)
│
▼
guardDriveScope: apply.Deployment or apply.Database == client's database?
│ no                                        │ yes
▼                                           ▼
refuse: error, engine never invoked;        drive proceeds unchanged
apply stays re-claimable by a matching
operator once the lease goes stale ✓
```

## Testing / validation

New integration test (`local_resume_scope_integration_test.go`): the claim succeeds, all
three drive entry points refuse with the scope error, the engine records zero invocations,
and the apply stays non-terminal. 
