### PR TITLE
feat(github): collapse multi-env plan DDL behind a details block

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -437,6 +437,9 @@ schemabot apply -e staging
 
 ### Staging & Production
 
+<details>
+<summary>Show SQL (3 statements)</summary>
+
 ```sql
 CREATE TABLE `users` (
     `id` bigint unsigned NOT NULL AUTO_INCREMENT,
@@ -461,6 +464,8 @@ CREATE TABLE `orders` (
 
 ALTER TABLE `products` ADD INDEX `idx_category_price`(`category`, `price`);
 ```
+
+</details>
 
 📋 **Plan**: **2** tables to create, **1** table to alter
 
@@ -494,6 +499,9 @@ schemabot apply -e production
 
 ### Production
 
+<details>
+<summary>Show SQL (3 statements)</summary>
+
 ```sql
 CREATE TABLE `users` (
     `id` bigint unsigned NOT NULL AUTO_INCREMENT,
@@ -518,6 +526,8 @@ CREATE TABLE `orders` (
 
 ALTER TABLE `products` ADD INDEX `idx_category_price`(`category`, `price`);
 ```
+
+</details>
 
 📋 **Plan**: **2** tables to create, **1** table to alter
 
@@ -542,6 +552,9 @@ schemabot apply -e production
 
 ### Staging
 
+<details>
+<summary>Show SQL (3 statements)</summary>
+
 ```sql
 CREATE TABLE `users` (
     `id` bigint unsigned NOT NULL AUTO_INCREMENT,
@@ -566,6 +579,8 @@ CREATE TABLE `orders` (
 
 ALTER TABLE `products` ADD INDEX `idx_category_price`(`category`, `price`);
 ```
+
+</details>
 
 📋 **Plan**: **2** tables to create, **1** table to alter
 
@@ -600,6 +615,9 @@ schemabot plan -e production
 
 ### Staging & Production
 
+<details>
+<summary>Show SQL (3 statements)</summary>
+
 ```sql
 CREATE TABLE `users` (
     `id` bigint unsigned NOT NULL AUTO_INCREMENT,
@@ -624,6 +642,8 @@ CREATE TABLE `orders` (
 
 ALTER TABLE `products` ADD INDEX `idx_category_price`(`category`, `price`);
 ```
+
+</details>
 
 ⚠️ **Lint Warnings**:
 - [orders] Primary key uses signed integer type (should be UNSIGNED)

--- a/pkg/webhook/plan_test.go
+++ b/pkg/webhook/plan_test.go
@@ -650,6 +650,65 @@ func TestRenderMultiEnvPlanComment_StrataHeaderWithErrors(t *testing.T) {
 	assert.Contains(t, rendered, "**Type**: `Strata`")
 }
 
+// A multi-environment plan collapses its DDL behind a <details> block so the
+// SQL doesn't dominate the comment, while the summary line advertises the
+// statement count so a reviewer can gauge the change size without expanding it.
+func TestRenderMultiEnvPlanComment_CollapsesDDL(t *testing.T) {
+	changes := []templates.KeyspaceChangeData{{
+		Keyspace: "testdb",
+		Statements: []string{
+			"CREATE TABLE `customers` (`id` bigint NOT NULL AUTO_INCREMENT PRIMARY KEY)",
+			"CREATE TABLE `orders` (`id` bigint NOT NULL AUTO_INCREMENT PRIMARY KEY)",
+		},
+	}}
+	data := templates.MultiEnvPlanCommentData{
+		Database:     "testdb",
+		IsMySQL:      true,
+		Environments: []string{"staging", "production"},
+		Plans: map[string]*templates.PlanCommentData{
+			"staging":    {Database: "testdb", Environment: "staging", IsMySQL: true, Changes: changes},
+			"production": {Database: "testdb", Environment: "production", IsMySQL: true, Changes: changes},
+		},
+		Errors: map[string]string{},
+	}
+
+	rendered := templates.RenderMultiEnvPlanComment(data)
+
+	assert.Contains(t, rendered, "<details>\n<summary>Show SQL (2 statements)</summary>")
+	assert.Contains(t, rendered, "</details>")
+	assert.Contains(t, rendered, "```sql")
+	assert.Contains(t, rendered, "CREATE TABLE `customers`")
+	// The DDL fence lives inside the collapsed block, before it closes.
+	assert.Less(t, strings.Index(rendered, "```sql"), strings.Index(rendered, "</details>"),
+		"the SQL fence should be rendered inside the <details> block")
+	// The plan summary stays outside the collapse so it is visible at a glance.
+	assert.Contains(t, rendered, "📋 **Plan**: **2** tables to create")
+	assert.Greater(t, strings.Index(rendered, "📋 **Plan**"), strings.Index(rendered, "</details>"),
+		"the plan summary should stay outside (below) the collapsed DDL")
+}
+
+// A single statement uses the singular "statement" in the collapse summary.
+func TestRenderMultiEnvPlanComment_CollapseSummarySingular(t *testing.T) {
+	changes := []templates.KeyspaceChangeData{{
+		Keyspace:   "testdb",
+		Statements: []string{"ALTER TABLE `orders` ADD COLUMN `x` INT"},
+	}}
+	data := templates.MultiEnvPlanCommentData{
+		Database:     "testdb",
+		IsMySQL:      true,
+		Environments: []string{"staging", "production"},
+		Plans: map[string]*templates.PlanCommentData{
+			"staging":    {Database: "testdb", Environment: "staging", IsMySQL: true, Changes: changes},
+			"production": {Database: "testdb", Environment: "production", IsMySQL: true, Changes: changes},
+		},
+		Errors: map[string]string{},
+	}
+
+	rendered := templates.RenderMultiEnvPlanComment(data)
+
+	assert.Contains(t, rendered, "<summary>Show SQL (1 statement)</summary>")
+}
+
 func TestUserFacingErrorExplainsNoHealthyUpstream(t *testing.T) {
 	err := &api.RemoteDeploymentUnavailableError{
 		Deployment: "pie",

--- a/pkg/webhook/templates/plan.go
+++ b/pkg/webhook/templates/plan.go
@@ -837,18 +837,18 @@ func writeEnvironmentPlanSection(sb *strings.Builder, plan *PlanCommentData) {
 	writePlanSummary(sb, *plan, totalStatements, keyspacesWithVSchema)
 }
 
-// writeCollapsibleKeyspaceChanges renders the DDL for a plan inside a collapsed
-// <details> block. The summary line carries the statement count so reviewers can
-// gauge the size of the change without expanding the SQL.
+// writeCollapsibleKeyspaceChanges renders a plan's changes — DDL, plus VSchema
+// diffs for non-MySQL keyspaces — inside a collapsed <details> block. The
+// summary line carries the statement count so reviewers can gauge the size of
+// the change without expanding it.
 func writeCollapsibleKeyspaceChanges(sb *strings.Builder, plan PlanCommentData, totalStatements int) {
-	var ddl strings.Builder
-	writeKeyspaceChanges(&ddl, plan)
-
 	summary := "Show changes"
 	if totalStatements > 0 {
 		summary = fmt.Sprintf("Show SQL (%d %s)", totalStatements, pluralize("statement", totalStatements))
 	}
-	fmt.Fprintf(sb, "<details>\n<summary>%s</summary>\n\n%s</details>\n\n", summary, ddl.String())
+	fmt.Fprintf(sb, "<details>\n<summary>%s</summary>\n\n", summary)
+	writeKeyspaceChanges(sb, plan)
+	sb.WriteString("</details>\n\n")
 }
 
 // writeMultiEnvFooter writes the footer with apply commands and error guidance.

--- a/pkg/webhook/templates/plan.go
+++ b/pkg/webhook/templates/plan.go
@@ -814,8 +814,9 @@ func writeEnvironmentPlanSection(sb *strings.Builder, plan *PlanCommentData) {
 		return
 	}
 
-	// Detailed changes
-	writeKeyspaceChanges(sb, *plan)
+	// Detailed changes, collapsed so the DDL doesn't dominate the comment while
+	// the unsafe/lint warnings and summary below stay visible at a glance.
+	writeCollapsibleKeyspaceChanges(sb, *plan, totalStatements)
 
 	// Unsafe changes warning
 	if plan.HasUnsafeChanges && len(plan.UnsafeChanges) > 0 {
@@ -834,6 +835,20 @@ func writeEnvironmentPlanSection(sb *strings.Builder, plan *PlanCommentData) {
 
 	// Summary (after DDL, matching CLI layout)
 	writePlanSummary(sb, *plan, totalStatements, keyspacesWithVSchema)
+}
+
+// writeCollapsibleKeyspaceChanges renders the DDL for a plan inside a collapsed
+// <details> block. The summary line carries the statement count so reviewers can
+// gauge the size of the change without expanding the SQL.
+func writeCollapsibleKeyspaceChanges(sb *strings.Builder, plan PlanCommentData, totalStatements int) {
+	var ddl strings.Builder
+	writeKeyspaceChanges(&ddl, plan)
+
+	summary := "Show changes"
+	if totalStatements > 0 {
+		summary = fmt.Sprintf("Show SQL (%d %s)", totalStatements, pluralize("statement", totalStatements))
+	}
+	fmt.Fprintf(sb, "<details>\n<summary>%s</summary>\n\n%s</details>\n\n", summary, ddl.String())
 }
 
 // writeMultiEnvFooter writes the footer with apply commands and error guidance.


### PR DESCRIPTION
## Summary
The multi-environment plan comment renders the full DDL inline, so a plan with several tables becomes a wall of SQL that pushes the warnings and summary out of view. This wraps the DDL in a collapsible `<details>` block.

## What
- In the multi-environment plan section, render the DDL inside `<details>` with a summary that carries the statement count (e.g. `Show SQL (3 statements)`).
- The unsafe/lint warnings and the `Plan: N tables` summary stay outside the collapse, so the headline stays visible without expanding.

## Why
Reviewers want the at-a-glance verdict (how many changes, any issues) first, and the SQL on demand. Collapsing only the DDL keeps the comment scannable without hiding the safety signals.

## Before / after
```
Before                              After
─────────────────────────────      ─────────────────────────────
Staging & Production            ### Staging & Production
  ...30 lines of DDL...             <summary>Show SQL (3 statements)</summary>
```                                   ```sql ... ``` (collapsed)
⚠️ warnings                         </details>
📋 Plan: 3 tables to create         ⚠️ warnings
                                    📋 Plan: 3 tables to create
```