### PR TITLE
feat(github): summarize unsafe changes with a count

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -663,7 +663,7 @@ ALTER TABLE `customers` DROP COLUMN `nickname`;
 
 ---
 
-**⛔ Unsafe Changes Detected:**
+**⛔ 1 Unsafe Change Detected:**
 - `customers`: Unsafe operation detected: DROP COLUMN `nickname`
 
 **Destructive drop guidance:**
@@ -695,7 +695,7 @@ ALTER TABLE `customers` DROP INDEX `idx_customers_email`;
 
 ---
 
-**⛔ Unsafe Changes Detected:**
+**⛔ 1 Unsafe Change Detected:**
 - `customers`: Unsafe operation detected: DROP INDEX `idx_customers_email`
 
 **Destructive drop guidance:**
@@ -6110,7 +6110,7 @@ ALTER TABLE `mutes`
     DROP COLUMN `legacy_reason`;
 ```
 
-**⛔ Unsafe Changes Detected:**
+⚠️ **Issues**: **1** unsafe change detected
 - `mutes` (shard `40-80`): DROP COLUMN removes data and is irreversible
 
 **Destructive drop guidance:**

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -661,5 +661,6 @@ func shouldShowSupportChannel(body string) bool {
 			return true
 		}
 	}
-	return strings.Contains(body, "⛔ Unsafe Changes Detected")
+	lower := strings.ToLower(body)
+	return strings.Contains(lower, "unsafe changes detected") || strings.Contains(lower, "unsafe change detected")
 }

--- a/pkg/webhook/issue_comment_test.go
+++ b/pkg/webhook/issue_comment_test.go
@@ -1,0 +1,51 @@
+package webhook
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The support-channel footer is offered on comments that report a problem the
+// operator may need help with. Unsafe-change comments qualify, whether they use
+// the plan warning's "Issues" summary line or the apply-blocked header, and in
+// both singular and plural forms. A clean plan does not trigger the footer.
+func TestShouldShowSupportChannel_UnsafeChanges(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "plan warning summary plural",
+			body: "## MySQL Schema Change Plan\n\n⚠️ **Issues**: **3** unsafe changes detected\n- `orders`: DROP INDEX\n",
+			want: true,
+		},
+		{
+			name: "plan warning summary singular",
+			body: "## MySQL Schema Change Plan\n\n⚠️ **Issues**: **1** unsafe change detected\n- `orders`: DROP INDEX\n",
+			want: true,
+		},
+		{
+			name: "apply-blocked header plural",
+			body: "## MySQL Schema Change Plan\n\n**⛔ 3 Unsafe Changes Detected:**\n- `orders`: DROP INDEX\n",
+			want: true,
+		},
+		{
+			name: "apply-blocked header singular",
+			body: "## MySQL Schema Change Plan\n\n**⛔ 1 Unsafe Change Detected:**\n- `orders`: DROP INDEX\n",
+			want: true,
+		},
+		{
+			name: "clean plan with no issues",
+			body: "## MySQL Schema Change Plan\n\n📋 **Plan**: **2** tables to create\n",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, shouldShowSupportChannel(tt.body))
+		})
+	}
+}

--- a/pkg/webhook/plan_test.go
+++ b/pkg/webhook/plan_test.go
@@ -266,9 +266,38 @@ func TestRenderPlanComment_ShowsUnsafeWarning(t *testing.T) {
 
 	rendered := templates.RenderPlanComment(data)
 
-	assert.Contains(t, rendered, "⛔ Unsafe Changes Detected")
+	assert.Contains(t, rendered, "**Issues**: **1** unsafe change detected")
 	assert.Contains(t, rendered, "`orders`")
 	assert.Contains(t, rendered, "DROP INDEX without making invisible first")
+}
+
+// The unsafe warning is rendered as an "Issues" summary line — parallel to the
+// "Plan" summary — with the total pluralized count, followed by a bullet per
+// affected table so the reviewer sees both the headline and the detail.
+func TestRenderPlanComment_UnsafeWarningSummaryCountsChanges(t *testing.T) {
+	data := templates.PlanCommentData{
+		Database:    "testdb",
+		Environment: "staging",
+		IsMySQL:     true,
+		Changes: []templates.KeyspaceChangeData{{
+			Keyspace: "testdb",
+			Statements: []string{
+				"ALTER TABLE `orders` DROP INDEX `idx_status`",
+				"ALTER TABLE `customers` DROP COLUMN `email`",
+			},
+		}},
+		HasUnsafeChanges: true,
+		UnsafeChanges: []templates.UnsafeChangeData{
+			{Table: "orders", Reason: "DROP INDEX without making invisible first"},
+			{Table: "customers", Reason: "DROP COLUMN is destructive"},
+		},
+	}
+
+	rendered := templates.RenderPlanComment(data)
+
+	assert.Contains(t, rendered, "⚠️ **Issues**: **2** unsafe changes detected")
+	assert.Contains(t, rendered, "- `orders`: DROP INDEX without making invisible first")
+	assert.Contains(t, rendered, "- `customers`: DROP COLUMN is destructive")
 }
 
 func TestRenderPlanComment_TenantScopedHints(t *testing.T) {
@@ -716,7 +745,7 @@ func TestRenderUnsafeChangesBlocked_UsedByApplyFlow(t *testing.T) {
 
 	rendered := templates.RenderUnsafeChangesBlocked(data)
 
-	assert.Contains(t, rendered, "⛔ Unsafe Changes Detected")
+	assert.Contains(t, rendered, "⛔ 1 Unsafe Change Detected")
 	assert.Contains(t, rendered, "`users`")
 	assert.Contains(t, rendered, "DROP TABLE removes all data")
 	assert.Contains(t, rendered, "--allow-unsafe")

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -128,7 +128,7 @@ func RenderUnsafeChangesBlocked(data PlanCommentData) string {
 
 	// Unsafe changes blocked section
 	sb.WriteString("---\n\n")
-	sb.WriteString("**⛔ Unsafe Changes Detected:**\n")
+	fmt.Fprintf(&sb, "**⛔ %d Unsafe %s Detected:**\n", len(data.UnsafeChanges), pluralize("Change", len(data.UnsafeChanges)))
 	for _, c := range data.UnsafeChanges {
 		reason := ui.CleanLintReason(c.Reason)
 		if reason != "" {

--- a/pkg/webhook/templates/plan.go
+++ b/pkg/webhook/templates/plan.go
@@ -525,7 +525,8 @@ func planShardList(shards []string) string {
 }
 
 func writeUnsafeWarning(sb *strings.Builder, changes []UnsafeChangeData, isMySQL bool) {
-	sb.WriteString("**⛔ Unsafe Changes Detected:**\n")
+	n := len(changes)
+	fmt.Fprintf(sb, "⚠️ **Issues**: **%d** unsafe %s detected\n", n, pluralize("change", n))
 	for _, c := range changes {
 		table := "`" + c.Table + "`"
 		if len(c.Shards) > 0 {

--- a/pkg/webhook/templates/sharded_plan_test.go
+++ b/pkg/webhook/templates/sharded_plan_test.go
@@ -51,12 +51,12 @@ func TestRenderPlanComment_UnsafeShownOnPlanNotOnApply(t *testing.T) {
 	}
 
 	plan := RenderPlanComment(data)
-	assert.Contains(t, plan, "⛔ Unsafe Changes Detected", "the plan comment surfaces unsafe changes for review")
+	assert.Contains(t, plan, "**Issues**: **1** unsafe change detected", "the plan comment surfaces unsafe changes for review")
 	assert.Contains(t, plan, "DROP COLUMN is destructive")
 
 	data.IsLocked = true
 	apply := RenderPlanComment(data)
-	assert.NotContains(t, apply, "⛔ Unsafe Changes Detected", "the locked apply comment omits the unsafe warning as noise")
+	assert.NotContains(t, apply, "**Issues**: **1** unsafe change detected", "the locked apply comment omits the unsafe warning as noise")
 	assert.NotContains(t, apply, "DROP COLUMN is destructive")
 	assert.NotContains(t, apply, "Destructive drop guidance", "the drop guidance rides inside the unsafe block and is omitted with it")
 	assert.Contains(t, apply, "DROP COLUMN `email`", "the DDL itself stays visible on the apply comment")
@@ -172,7 +172,7 @@ func TestRenderPlanComment_UnsafeShardChangeShowsShard(t *testing.T) {
 		}},
 	})
 
-	assert.Contains(t, out, "Unsafe Changes")
+	assert.Contains(t, out, "**Issues**: **1** unsafe change detected")
 	assert.Contains(t, out, "`mutes` (shard `40-80`)", "the unsafe change names the shard it applies to")
 	assert.Contains(t, out, "DROP COLUMN `x`", "the drop is shown in that shard's combined ALTER")
 }


### PR DESCRIPTION
## Summary
The unsafe-changes warning in a plan comment was a bare bold header with no count, unlike the `Plan: N tables to create` summary. This makes it a parallel summary line that leads with the number of unsafe changes.

## What
- Render the plan-comment unsafe warning as `⚠️ Issues: N unsafe changes detected`, followed by the per-table bullets as before.
- Show the count on the apply-blocked header too (`⛔ N Unsafe Change(s) Detected`).
- Make the support-channel detector match the new phrasing case-insensitively.

## Why
The count gives reviewers an immediate sense of blast radius, and matching the `Plan:` summary style keeps the comment consistent and scannable.

## Before / after
```
Before                                 After
──────────────────────────────────    ─────────────────────────────────────────
⛔ Unsafe Changes Detected:        ⚠️ Issues: 3 unsafe changes detected
- orders: DROP INDEX ...             - orders: DROP INDEX ...
- customers: DROP COLUMN ...         - customers: DROP COLUMN ...
```