### PR TITLE
fix(tern): notify late-registered observers of settled applies

### DIFF
--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -1998,6 +1998,12 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 			setter.SetApplyID(apply.ID)
 		}
 		c.SetObserver(apply.ID, obs)
+		// The apply became claimable when the create transaction committed, so a
+		// poll-tick claim can start — and even finish — the drive before the
+		// registration above. A still-running drive finds the observer on its next
+		// progress event; one that already settled will not, so deliver the missed
+		// terminal notification here in that case.
+		c.deliverTerminalIfSettled(ctx, apply.ID)
 	}
 
 	// The apply is queued, not driven here: every drive — the initial dispatch

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -924,9 +924,11 @@ func groupedResumeChanges(tasks []*storage.Task, plan *storage.Plan) []engine.Sc
 }
 
 func (c *LocalClient) notifyTerminalObserver(apply *storage.Apply, tasks []*storage.Task) {
-	if obs := c.getObserver(apply.ID); obs != nil {
+	// takeObserver (remove-then-notify, atomically) rather than get/notify/clear:
+	// the drive's terminal path can race deliverTerminalIfSettled's re-check, and
+	// OnTerminal must fire exactly once.
+	if obs := c.takeObserver(apply.ID); obs != nil {
 		obs.OnTerminal(apply, tasks)
-		c.clearObserver(apply.ID)
 	}
 }
 

--- a/pkg/tern/local_observer_settled_integration_test.go
+++ b/pkg/tern/local_observer_settled_integration_test.go
@@ -1,0 +1,130 @@
+//go:build integration
+
+package tern
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// recordingTerminalObserver counts terminal notifications so a test can prove
+// exactly-once delivery.
+type recordingTerminalObserver struct {
+	mu        sync.Mutex
+	terminals []*storage.Apply
+}
+
+func (o *recordingTerminalObserver) OnProgress(*storage.Apply, []*storage.Task) {}
+
+func (o *recordingTerminalObserver) OnTerminal(apply *storage.Apply, _ []*storage.Task) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.terminals = append(o.terminals, apply)
+}
+
+func (o *recordingTerminalObserver) terminalCount() int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return len(o.terminals)
+}
+
+func createObserverTestApply(t *testing.T, stor storage.Storage, applyState string, completedAt *time.Time) *storage.Apply {
+	t.Helper()
+	ctx := t.Context()
+	plan := &storage.Plan{
+		PlanIdentifier: fmt.Sprintf("plan-observer-%s-%d", applyState, time.Now().UnixNano()),
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Deployment:     "testdb",
+		Environment:    localClientTestEnvironment,
+		CreatedAt:      time.Now(),
+		Namespaces: map[string]*storage.NamespacePlanData{
+			"testdb": {},
+		},
+	}
+	planID, err := stor.Plans().Create(ctx, plan)
+	require.NoError(t, err)
+
+	now := time.Now()
+	apply := &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply-observer-%s-%d", applyState, now.UnixNano()),
+		PlanID:          planID,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Deployment:      "testdb",
+		Environment:     localClientTestEnvironment,
+		Engine:          storage.EngineSpirit,
+		State:           applyState,
+		CompletedAt:     completedAt,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	applyID, err := stor.Applies().CreateWithTasksAndOperations(ctx, apply, nil, []*storage.ApplyOperation{{
+		Deployment: apply.Deployment,
+		State:      state.ApplyOperation.Pending,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}})
+	require.NoError(t, err)
+	apply.ID = applyID
+	return apply
+}
+
+// An apply is claimable the moment its create transaction commits — before
+// Apply registers the dispatch's observer — so a fast drive can settle before
+// the registration and deliver its terminal notification to nobody. The
+// post-registration re-check must hand that missed notification to the late
+// observer exactly once and clear the registration; a non-terminal apply must
+// keep its observer for the drive's own progress and terminal events.
+func TestLocalClient_DeliverTerminalIfSettled(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+	cleanupTestTables(t, dsn)
+
+	ctx := t.Context()
+	stor := createStorage(t, dsn)
+	defer utils.CloseAndLog(stor)
+	client, _ := newTasklessControlClient(t, dsn, stor)
+
+	t.Run("already-terminal apply notifies the late observer exactly once", func(t *testing.T) {
+		now := time.Now()
+		apply := createObserverTestApply(t, stor, state.Apply.Completed, &now)
+
+		obs := &recordingTerminalObserver{}
+		client.SetObserver(apply.ID, obs)
+		client.deliverTerminalIfSettled(ctx, apply.ID)
+
+		require.Equal(t, 1, obs.terminalCount(), "the missed terminal notification must be delivered to the late observer")
+		assert.Nil(t, client.getObserver(apply.ID), "delivery must clear the registration")
+
+		// A second re-check (or a racing drive-side notify) finds no observer.
+		client.deliverTerminalIfSettled(ctx, apply.ID)
+		client.notifyTerminalObserver(apply, nil)
+		assert.Equal(t, 1, obs.terminalCount(), "terminal delivery must be exactly-once")
+	})
+
+	t.Run("non-terminal apply keeps its observer for the drive", func(t *testing.T) {
+		apply := createObserverTestApply(t, stor, state.Apply.Pending, nil)
+
+		obs := &recordingTerminalObserver{}
+		client.SetObserver(apply.ID, obs)
+		client.deliverTerminalIfSettled(ctx, apply.ID)
+
+		assert.Equal(t, 0, obs.terminalCount(), "a queued apply has no terminal notification to deliver")
+		assert.NotNil(t, client.getObserver(apply.ID), "the observer must stay registered for the coming drive")
+	})
+}

--- a/pkg/tern/observer.go
+++ b/pkg/tern/observer.go
@@ -1,6 +1,11 @@
 package tern
 
-import "github.com/block/schemabot/pkg/storage"
+import (
+	"context"
+
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
 
 // ProgressObserver receives notifications from the apply progress poller.
 // Implementations can post PR comments, update dashboards, send Slack
@@ -81,4 +86,47 @@ func (c *LocalClient) clearObserver(applyID int64) {
 	c.observerMu.Lock()
 	defer c.observerMu.Unlock()
 	delete(c.observers, applyID)
+}
+
+// takeObserver atomically removes and returns the observer for an apply, or
+// nil if none is set. Terminal delivery goes through it so that when the
+// drive's own terminal path races a late registration's re-check, exactly one
+// of them holds the observer and notifies.
+func (c *LocalClient) takeObserver(applyID int64) ProgressObserver {
+	c.observerMu.Lock()
+	defer c.observerMu.Unlock()
+	obs := c.observers[applyID]
+	delete(c.observers, applyID)
+	return obs
+}
+
+// deliverTerminalIfSettled re-checks a freshly registered observer's apply and
+// delivers the terminal notification if the drive has already finished. An
+// apply becomes claimable the moment its create transaction commits — before
+// Apply registers the dispatch's observer — so a poll-tick claim can start the
+// drive inside that window. Progress lookups re-read the registry per event,
+// so a still-running drive picks the late observer up on its own; a drive fast
+// enough to have already settled (e.g. a task-less no-op) delivered its
+// terminal notification to nobody, which without this re-check would strand
+// the observer unnotified and registered forever.
+func (c *LocalClient) deliverTerminalIfSettled(ctx context.Context, applyID int64) {
+	if c.getObserver(applyID) == nil {
+		return
+	}
+	apply, err := c.storage.Applies().Get(ctx, applyID)
+	if err != nil || apply == nil {
+		c.logger.Warn("could not re-check apply state after observer registration; a drive that already settled will not have notified the observer",
+			"apply_id", applyID, "error", err)
+		return
+	}
+	if !state.IsTerminalApplyState(apply.State) {
+		return
+	}
+	tasks, err := c.storage.Tasks().GetByApplyID(ctx, applyID)
+	if err != nil {
+		c.logger.Warn("could not load tasks for late terminal observer notification; notifying without them",
+			"apply_id", applyID, "error", err)
+		tasks = nil
+	}
+	c.notifyTerminalObserver(apply, tasks)
 }

--- a/pkg/tern/observer.go
+++ b/pkg/tern/observer.go
@@ -114,12 +114,27 @@ func (c *LocalClient) deliverTerminalIfSettled(ctx context.Context, applyID int6
 		return
 	}
 	apply, err := c.storage.Applies().Get(ctx, applyID)
-	if err != nil || apply == nil {
+	if err != nil {
 		c.logger.Warn("could not re-check apply state after observer registration; a drive that already settled will not have notified the observer",
 			"apply_id", applyID, "error", err)
 		return
 	}
+	if apply == nil {
+		// The apply was created moments earlier on this same path, so a missing
+		// row is anomalous rather than an error condition. Leave the observer for
+		// the drive rather than notifying against a phantom terminal.
+		c.logger.Warn("apply not found when re-checking state after observer registration; leaving the observer for the drive",
+			"apply_id", applyID)
+		return
+	}
 	if !state.IsTerminalApplyState(apply.State) {
+		return
+	}
+	// Claim the observer before loading tasks. If the drive's own terminal path
+	// won the race and already took it, there is nothing to deliver — return
+	// early and skip the tasks query entirely.
+	obs := c.takeObserver(applyID)
+	if obs == nil {
 		return
 	}
 	tasks, err := c.storage.Tasks().GetByApplyID(ctx, applyID)
@@ -128,5 +143,5 @@ func (c *LocalClient) deliverTerminalIfSettled(ctx context.Context, applyID int6
 			"apply_id", applyID, "error", err)
 		tasks = nil
 	}
-	c.notifyTerminalObserver(apply, tasks)
+	obs.OnTerminal(apply, tasks)
 }


### PR DESCRIPTION
## Summary
Follow-up on correctness check for #635. 

It makes a dispatched apply claimable the moment its create transaction commits, but
`Apply` registers the dispatch's pending observer *after* that commit. Drive paths re-read
the observer registry per progress event, so a still-running drive picks a late observer up
on its own — but a drive fast enough to settle inside the window (e.g. a task-less no-op)
delivers `OnTerminal` to nobody. The observer is then registered after the fact and stranded
forever: never notified, never cleared (a `CommentObserver`'s PR comment would freeze
mid-progress).

## What changed

- `deliverTerminalIfSettled`: after registering the observer, `Apply` re-checks the stored
apply and delivers the missed terminal notification if the drive already settled.
- `takeObserver` (atomic remove-and-return) replaces get/notify/clear in
`notifyTerminalObserver`, so when the re-check races the drive's own terminal path, exactly
one side holds the observer and `OnTerminal` fires exactly once.

## Behaviour — dispatch racing a fast drive (before → after)

BEFORE
```
Apply: create tx commits (apply claimable) ─────────────┐
│                                                       │ poll-tick claim
▼                                                       ▼
SetObserver(applyID)                        drive starts … settles fast
│                                                       │
▼                                                       ▼
(nothing re-checks)                OnTerminal ─▶ getObserver: nil ─▶ dropped ✗
                             observer stays registered forever ✗
```
AFTER
```
Apply: create tx commits (apply claimable) ─────────────┐
│                                                       │ poll-tick claim
▼                                                       ▼
SetObserver(applyID)                        drive starts … settles fast
│                                                       │
▼                                                       ▼
deliverTerminalIfSettled:                  OnTerminal ─▶ takeObserver
apply already terminal?                    (atomic: whichever side wins
─▶ takeObserver ─▶ OnTerminal ✓             delivers exactly once) ✓
```

## Testing / validation

New integration test (`local_observer_settled_integration_test.go`): an already-terminal
apply notifies a late observer exactly once and clears the registration (a second re-check
and a racing drive-side notify are both no-ops); a non-terminal apply keeps its observer for
the coming drive.

