### PR TITLE
fix(serve): stop the operator before closing the gRPC client

### DIFF
--- a/pkg/serve/serve.go
+++ b/pkg/serve/serve.go
@@ -446,12 +446,14 @@ func (s *Server) Start(ctx context.Context) {
 	s.svc.StartPendingDropsCleaner(ctx)
 }
 
-// Close releases the resources the Server owns and returns the first cleanup
-// error encountered. svc.Close stops the operator and health monitor and closes
-// the service's clients and storage (the database pool), so Close only stops the
-// pending-drops cleaner, shuts down telemetry, closes the service, and closes the
-// gRPC fallback client it built itself. It does not stop any gRPC server the
-// embedder owns. Safe to call once after Start.
+// Close releases the resources the Server owns and returns all cleanup errors
+// encountered, joined together. It stops the pending-drops cleaner, stops the
+// operator (before closing the gRPC client it built, see below), shuts down
+// telemetry, closes that gRPC fallback client, and closes the service. svc.Close
+// stops the health monitor and closes the service's clients and storage (the
+// database pool); it repeats StopOperator, which is idempotent, so that is a
+// no-op. It does not stop any gRPC server the embedder owns. Safe to call once
+// after Start.
 func (s *Server) Close() error {
 	s.svc.StopPendingDropsCleaner()
 	// Stop the operator before closing the gRPC client below: RegisterGRPC set

--- a/pkg/serve/serve.go
+++ b/pkg/serve/serve.go
@@ -454,6 +454,12 @@ func (s *Server) Start(ctx context.Context) {
 // embedder owns. Safe to call once after Start.
 func (s *Server) Close() error {
 	s.svc.StopPendingDropsCleaner()
+	// Stop the operator before closing the gRPC client below: RegisterGRPC set
+	// that client as the service's default, so until the drivers drain, a claim
+	// of a queued apply can route to it — closing it first would hand a
+	// shutdown-window drive a closed client. StopOperator waits for in-flight
+	// drivers and is idempotent, so svc.Close repeating it is a no-op.
+	s.svc.StopOperator()
 
 	var errs []error
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)


### PR DESCRIPTION
## Summary
`RegisterGRPC` sets the gRPC transport's client as the service's default tern client,
so operator claims can now route drives to it. `Server.Close` closed that client *before*
`svc.Close()` stopped the operator — during the shutdown window a claim of a queued apply
could hand a drive a closed client. Self-healing (the drive fails and the apply stays
re-claimable), but it's avoidable noise and a use-after-close.

## What changed

`Server.Close` calls `svc.StopOperator()` first. `StopOperator` waits for in-flight drivers
to drain (`recoveryWg.Wait()`) and is idempotent, so the repeat inside `svc.Close()` is a
no-op.

## Behaviour — shutdown ordering (before → after)

BEFORE
```
Server.Close
│
├─▶ grpcClient.Close()               ◀── operator still running
│        ▲
│        └── shutdown-window claim routes a drive to the closed client ✗
│
└─▶ svc.Close() ─▶ StopOperator()
```
AFTER
```
Server.Close
│
├─▶ svc.StopOperator()               ◀── drains in-flight drivers first
│
├─▶ grpcClient.Close()               ◀── nothing can route to it now ✓
│
└─▶ svc.Close() ─▶ StopOperator()    (idempotent no-op)
```

## Testing / validation

`go test ./pkg/serve/` passes; the ordering change is otherwise covered by the existing
lifecycle tests.

