### PR TITLE
chore(deps): bump block/vitess for mysqltopo notification refcount fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -264,7 +264,7 @@ require (
 )
 
 // needed for Strata and vtcombo OnlineDDL suppport
-replace vitess.io/vitess => github.com/block/vitess v0.0.0-20260702135400-add994347c62
+replace vitess.io/vitess => github.com/block/vitess v0.0.0-20260703150944-881ec2298245
 
 // needed for SPATIAL index support in Spirit v0.13.0
 replace github.com/pingcap/tidb/pkg/parser => github.com/block/tidb/pkg/parser v0.0.0-20260506200501-e528fd979fc8

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/block/spirit v0.15.2-0.20260629112820-8f451ff83766 h1:zMEF7E4k886bl2u
 github.com/block/spirit v0.15.2-0.20260629112820-8f451ff83766/go.mod h1:ku7mCCKx7Wk4QrMa/mHnsqQhZkoUD2vdBkpjJEDk4lY=
 github.com/block/tidb/pkg/parser v0.0.0-20260506200501-e528fd979fc8 h1:+OfdTacrEyjlqcRUpBFX9uJ6ROBq6cUjwY4DClhnsdU=
 github.com/block/tidb/pkg/parser v0.0.0-20260506200501-e528fd979fc8/go.mod h1:zDLDsfNBU5+L6T4J9/OgWAHc/WZvMUjbpgHqQ/t3yKo=
-github.com/block/vitess v0.0.0-20260702135400-add994347c62 h1:mIWQ8KeqzsJ6xLQfYs6Vp9zmi47ermvOL1RCFW0dE3U=
-github.com/block/vitess v0.0.0-20260702135400-add994347c62/go.mod h1:tOLnFt2ryuSGSYZ9NxLjsRhYrWxGBxz/z0zxrvuWYwE=
+github.com/block/vitess v0.0.0-20260703150944-881ec2298245 h1:R7e7uAxl6WIZpeY957JDsrZtuihck6vm7QgRooI295U=
+github.com/block/vitess v0.0.0-20260703150944-881ec2298245/go.mod h1:tOLnFt2ryuSGSYZ9NxLjsRhYrWxGBxz/z0zxrvuWYwE=
 github.com/bndr/gotabulate v1.1.2 h1:yC9izuZEphojb9r+KYL4W9IJKO/ceIO8HDwxMA24U4c=
 github.com/bndr/gotabulate v1.1.2/go.mod h1:0+8yUgaPTtLRTjf49E8oju7ojpU11YmXyvq1LbPAb3U=
 github.com/bradleyfalzon/ghinstallation/v2 v2.18.0 h1:WPqnN6NS9XvYlOgZQAIseN7Z1uAiE+UxgDKlW7FvFuU=


### PR DESCRIPTION
Bumps the `vitess.io/vitess` replace from `add994347c62` (block/vitess#18) to `881ec2298245`, picking up [block/vitess#20](https://github.com/block/vitess/pull/20): mysqltopo notification-system references are now instance-scoped instead of schema-keyed. Previously, topo-connection churn in one process could drive the shared per-schema refcount to zero underneath a live watch, permanently killing topology watches — consumers served stale topology until restart. Deterministic regression tests live in the linked PR.

Verification: `go build ./...` and `go test` for the vitess-dependent packages (`pkg/state`, `pkg/localscale`, `pkg/engine`) against the new pin — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)