### PR TITLE
fix(github): parse any configured environment in -e flag

### DIFF
--- a/pkg/webhook/commands.go
+++ b/pkg/webhook/commands.go
@@ -125,7 +125,7 @@ func NewCommandParser() *CommandParser {
 		mentionRegex:      regexp.MustCompile(`(?im)^ {0,3}schemabot(?:[ \t]+|$)`),
 		helpRegex:         regexp.MustCompile(`(?im)^ {0,3}schemabot[ \t]+help\b`),
 		applyIDRegex:      regexp.MustCompile(`(?i)\b(apply[_-][a-f0-9]+)\b`),
-		environmentRegex:  regexp.MustCompile(`(?i)-e\s+(staging|production)`),
+		environmentRegex:  regexp.MustCompile(`(?i)-e\s+([a-z0-9][a-z0-9_-]*)`),
 		databaseRegex:     regexp.MustCompile(`(?i)-d\s+([a-zA-Z0-9_-]+)`),
 		tenantRegex:       regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`),
 		tenantFlagRegex:   regexp.MustCompile(`(?i)(?:^|\s)(?:--tenant|-t)(?:[ \t]+([^\s]+))?`),

--- a/pkg/webhook/commands_test.go
+++ b/pkg/webhook/commands_test.go
@@ -299,6 +299,16 @@ func TestParseCommand(t *testing.T) {
 			},
 		},
 		{
+			name: "env flag does not consume a following flag",
+			body: "schemabot apply -e --tenant alpha",
+			expected: CommandResult{
+				Action:     "apply",
+				Tenant:     "alpha",
+				MissingEnv: true,
+				IsMention:  true,
+			},
+		},
+		{
 			name: "plan with database flag",
 			body: "schemabot plan -e staging -d my-database",
 			expected: CommandResult{

--- a/pkg/webhook/commands_test.go
+++ b/pkg/webhook/commands_test.go
@@ -279,6 +279,26 @@ func TestParseCommand(t *testing.T) {
 			},
 		},
 		{
+			name: "apply with custom environment (qa)",
+			body: "schemabot apply -e qa",
+			expected: CommandResult{
+				Action:      "apply",
+				Environment: "qa",
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
+			name: "apply with custom environment (load)",
+			body: "schemabot apply -e load",
+			expected: CommandResult{
+				Action:      "apply",
+				Environment: "load",
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
 			name: "plan with database flag",
 			body: "schemabot plan -e staging -d my-database",
 			expected: CommandResult{


### PR DESCRIPTION
## Summary
The PR-comment parser hard-coded the `-e` flag to only match `staging` or
`production`. Any other environment defined in `allowed_environments` /
`environment_order` (e.g. a `qa` or `load` stage) failed to parse, so
`schemabot apply -e <env>` was silently treated as "missing env" and
rejected. `plan` without `-e` already fans out to all configured
environments, so only apply/confirm-style commands were affected.

## What
Widen `environmentRegex` to accept any environment token
(`-e\s+([a-z0-9][a-z0-9_-]*)`). The leading-alphanumeric requirement keeps
it from swallowing a following flag (e.g. `-e --tenant`). Unknown or
unowned environments still fail closed downstream via
`IsEnvironmentAllowed`, so widening the parser does not loosen any safety
gate.

## Before / after
```
before:  -e staging | -e production          (only these two parse)
-e qa, -e load, ...  ->  missing env, command rejected
```

```
after:   -e <any configured env>  ->  parsed, then validated against
allowed_environments (unknown envs still fail closed)
```