### PR TITLE
feat(github): show a single multi-env plan change inline

### DIFF
--- a/pkg/webhook/plan_test.go
+++ b/pkg/webhook/plan_test.go
@@ -716,8 +716,10 @@ func TestRenderMultiEnvPlanComment_CollapsesDDL(t *testing.T) {
 		"the plan summary should stay outside (below) the collapsed DDL")
 }
 
-// A single statement uses the singular "statement" in the collapse summary.
-func TestRenderMultiEnvPlanComment_CollapseSummarySingular(t *testing.T) {
+// A multi-environment plan with a single change is small enough to show inline,
+// so its DDL is rendered directly instead of behind a <details> block while the
+// plan summary still appears below.
+func TestRenderMultiEnvPlanComment_SingleChangeInline(t *testing.T) {
 	changes := []templates.KeyspaceChangeData{{
 		Keyspace:   "testdb",
 		Statements: []string{"ALTER TABLE `orders` ADD COLUMN `x` INT"},
@@ -729,6 +731,37 @@ func TestRenderMultiEnvPlanComment_CollapseSummarySingular(t *testing.T) {
 		Plans: map[string]*templates.PlanCommentData{
 			"staging":    {Database: "testdb", Environment: "staging", IsMySQL: true, Changes: changes},
 			"production": {Database: "testdb", Environment: "production", IsMySQL: true, Changes: changes},
+		},
+		Errors: map[string]string{},
+	}
+
+	rendered := templates.RenderMultiEnvPlanComment(data)
+
+	assert.NotContains(t, rendered, "<details>", "a single change renders inline, not collapsed")
+	assert.Contains(t, rendered, "```sql")
+	assert.Contains(t, rendered, "ALTER TABLE `orders` ADD COLUMN `x` int")
+	// The plan summary still appears (below the inline DDL).
+	assert.Contains(t, rendered, "📋 **Plan**")
+}
+
+// When a plan has more than one change overall — here a single DDL statement
+// alongside a VSchema update — the DDL still collapses, and the summary uses the
+// singular "statement" for the one statement it contains.
+func TestRenderMultiEnvPlanComment_CollapseSummarySingular(t *testing.T) {
+	changes := []templates.KeyspaceChangeData{{
+		Keyspace:       "testks",
+		Statements:     []string{"ALTER TABLE `orders` ADD COLUMN `x` INT"},
+		VSchemaChanged: true,
+		VSchemaDiff:    "+ vindex added",
+	}}
+	data := templates.MultiEnvPlanCommentData{
+		Database:     "testks",
+		IsMySQL:      false,
+		DatabaseType: "PlanetScale",
+		Environments: []string{"staging", "production"},
+		Plans: map[string]*templates.PlanCommentData{
+			"staging":    {Database: "testks", Environment: "staging", IsMySQL: false, DatabaseType: "PlanetScale", Changes: changes},
+			"production": {Database: "testks", Environment: "production", IsMySQL: false, DatabaseType: "PlanetScale", Changes: changes},
 		},
 		Errors: map[string]string{},
 	}

--- a/pkg/webhook/templates/plan.go
+++ b/pkg/webhook/templates/plan.go
@@ -815,9 +815,14 @@ func writeEnvironmentPlanSection(sb *strings.Builder, plan *PlanCommentData) {
 		return
 	}
 
-	// Detailed changes, collapsed so the DDL doesn't dominate the comment while
-	// the unsafe/lint warnings and summary below stay visible at a glance.
-	writeCollapsibleKeyspaceChanges(sb, *plan, totalStatements)
+	// Detailed changes. A single change is small enough to show inline; more
+	// than one is collapsed so the DDL doesn't dominate the comment while the
+	// unsafe/lint warnings and summary below stay visible at a glance.
+	if totalChanges == 1 {
+		writeKeyspaceChanges(sb, *plan)
+	} else {
+		writeCollapsibleKeyspaceChanges(sb, *plan, totalStatements)
+	}
 
 	// Unsafe changes warning
 	if plan.HasUnsafeChanges && len(plan.UnsafeChanges) > 0 {


### PR DESCRIPTION
## Summary
Multi-environment plan comments collapse each environment's DDL behind a
`<details>` block so a large plan doesn't dominate the comment. For a plan
with just one change that collapse adds a needless click. This renders a
single change inline and only collapses when there is more than one.

The threshold is the total change count (DDL statements + VSchema diffs),
so a lone VSchema change is also shown inline, not just a lone SQL
statement. Single-environment plans already rendered inline; this only
affects the per-environment sections of a multi-env comment.

## Behavior
```
0 changes  ->  "No schema changes detected"
1 change   ->  rendered inline (no <details>)
1 change  ->  <details><summary>Show SQL (N statements)</summary> ...
```