### PR TITLE
chore(github): review-time drift rollup polish (resolve once + log silent skips)

### DIFF
--- a/pkg/api/plan_deployment_diffs.go
+++ b/pkg/api/plan_deployment_diffs.go
@@ -60,7 +60,7 @@ type DeploymentPlanDiff struct {
 // fails closed rather than being compared against the wrong live schema.
 func (s *Service) PlanDeploymentDiffs(ctx context.Context, req PlanRequest, primaryPlan *ternv1.PlanResponse, primaryDeployment string, targets []routing.ExecutionTarget) ([]DeploymentPlanDiff, error) {
 	if len(targets) == 0 {
-		return nil, fmt.Errorf("plan deployment diffs for %s/%s: no deployment targets", req.Database, req.Environment)
+		return nil, fmt.Errorf("no deployment targets for %s/%s", req.Database, req.Environment)
 	}
 
 	// Reusing primaryPlan for the primary member assumes it was created against

--- a/pkg/api/plan_deployment_diffs.go
+++ b/pkg/api/plan_deployment_diffs.go
@@ -46,19 +46,21 @@ type DeploymentPlanDiff struct {
 // spurious primary-vs-primary mismatch.
 //
 // Per-deployment failures are captured in each result's Err so one unreachable
-// deployment neither hides the others nor aborts the rollup; only a
-// request-level failure (target resolution) returns an error. Results are
+// deployment neither hides the others nor aborts the rollup. Results are
 // returned in rollout order, primary first.
+//
+// targets is the resolved deployment set in rollout order (primary first),
+// supplied by the caller so a database/environment is resolved once per rollup
+// rather than re-resolved here. It must be non-empty.
 //
 // primaryDeployment is the deployment the reviewed primaryPlan was created
 // against (rollout index 0 at plan time). When a primaryPlan is reused, it is
 // checked against targets[0] here so a deployment-order change between plan and
 // rollup — which would map the reviewed baseline onto a different deployment —
 // fails closed rather than being compared against the wrong live schema.
-func (s *Service) PlanDeploymentDiffs(ctx context.Context, req PlanRequest, primaryPlan *ternv1.PlanResponse, primaryDeployment string) ([]DeploymentPlanDiff, error) {
-	targets, err := s.config.ResolveDatabaseTargets(req.Database, req.Environment)
-	if err != nil {
-		return nil, fmt.Errorf("resolve deployment targets for %s/%s: %w", req.Database, req.Environment, err)
+func (s *Service) PlanDeploymentDiffs(ctx context.Context, req PlanRequest, primaryPlan *ternv1.PlanResponse, primaryDeployment string, targets []routing.ExecutionTarget) ([]DeploymentPlanDiff, error) {
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("plan deployment diffs for %s/%s: no deployment targets", req.Database, req.Environment)
 	}
 
 	// Reusing primaryPlan for the primary member assumes it was created against

--- a/pkg/api/plan_deployment_diffs_test.go
+++ b/pkg/api/plan_deployment_diffs_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/routing"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/tern"
 )
@@ -40,6 +41,16 @@ func twoDeploymentService(t *testing.T, eu, us *mockTernClient) *Service {
 		"eu/production": eu,
 		"us/production": us,
 	}, logger)
+}
+
+// productionTargets resolves the testapp/production deployment set the producer
+// tests exercise, so each PlanDeploymentDiffs call is given the same resolved
+// targets the rollup would pass in.
+func productionTargets(t *testing.T, svc *Service) []routing.ExecutionTarget {
+	t.Helper()
+	targets, err := svc.config.ResolveDatabaseTargets("testapp", "production")
+	require.NoError(t, err)
+	return targets
 }
 
 func planDiffReq(t *testing.T) PlanRequest {
@@ -91,7 +102,7 @@ func TestPlanDeploymentDiffs_PrimaryReusesReviewedPlan(t *testing.T) {
 		}},
 	}
 
-	results, err := svc.PlanDeploymentDiffs(t.Context(), planDiffReq(t), primaryPlan, "eu")
+	results, err := svc.PlanDeploymentDiffs(t.Context(), planDiffReq(t), primaryPlan, "eu", productionTargets(t, svc))
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 
@@ -115,7 +126,7 @@ func TestPlanDeploymentDiffs_DiffsAllDeploymentsWhenNoPrimary(t *testing.T) {
 	us := &mockTernClient{planDiffResp: alterUsersDiff("ALTER TABLE `users` ADD COLUMN `email` varchar(255)")}
 	svc := twoDeploymentService(t, eu, us)
 
-	results, err := svc.PlanDeploymentDiffs(t.Context(), planDiffReq(t), nil, "")
+	results, err := svc.PlanDeploymentDiffs(t.Context(), planDiffReq(t), nil, "", productionTargets(t, svc))
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 
@@ -133,7 +144,7 @@ func TestPlanDeploymentDiffs_PerDeploymentErrorIsCaptured(t *testing.T) {
 	us := &mockTernClient{planDiffErr: errors.New("deployment unreachable")}
 	svc := twoDeploymentService(t, eu, us)
 
-	results, err := svc.PlanDeploymentDiffs(t.Context(), planDiffReq(t), nil, "")
+	results, err := svc.PlanDeploymentDiffs(t.Context(), planDiffReq(t), nil, "", productionTargets(t, svc))
 	require.NoError(t, err, "a single deployment failure must not abort the rollup")
 	require.Len(t, results, 2)
 
@@ -195,7 +206,7 @@ func TestPlanDeploymentDiffs_PreservesShards(t *testing.T) {
 		}},
 	}
 
-	results, err := svc.PlanDeploymentDiffs(t.Context(), planDiffReq(t), primaryPlan, "eu")
+	results, err := svc.PlanDeploymentDiffs(t.Context(), planDiffReq(t), primaryPlan, "eu", productionTargets(t, svc))
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 
@@ -224,7 +235,7 @@ func TestPlanDeploymentDiffs_PrimaryDeploymentMismatchFailsClosed(t *testing.T) 
 	primaryPlan := &ternv1.PlanResponse{PlanId: "plan_eu", Engine: ternv1.Engine_ENGINE_SPIRIT}
 
 	// targets[0] is "eu", but the reviewed plan was created against "us".
-	_, err := svc.PlanDeploymentDiffs(t.Context(), planDiffReq(t), primaryPlan, "us")
+	_, err := svc.PlanDeploymentDiffs(t.Context(), planDiffReq(t), primaryPlan, "us", productionTargets(t, svc))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "primary invariant violated")
 	assert.Nil(t, eu.planDiffReq, "must fail before diffing any deployment")
@@ -241,21 +252,17 @@ func TestPlanDeploymentDiffs_PrimaryPlanWithoutOriginFailsClosed(t *testing.T) {
 
 	primaryPlan := &ternv1.PlanResponse{PlanId: "plan_eu", Engine: ternv1.Engine_ENGINE_SPIRIT}
 
-	_, err := svc.PlanDeploymentDiffs(t.Context(), planDiffReq(t), primaryPlan, "")
+	_, err := svc.PlanDeploymentDiffs(t.Context(), planDiffReq(t), primaryPlan, "", productionTargets(t, svc))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no origin deployment")
 }
 
-// A request-level failure (the database/environment resolves no deployments)
-// returns an error rather than a per-deployment result.
-func TestPlanDeploymentDiffs_UnresolvedTargetsError(t *testing.T) {
+// Called with no resolved targets the producer fails closed rather than
+// returning an empty result that a caller could mistake for agreement.
+func TestPlanDeploymentDiffs_NoTargetsError(t *testing.T) {
 	svc := twoDeploymentService(t, &mockTernClient{}, &mockTernClient{})
 
-	_, err := svc.PlanDeploymentDiffs(t.Context(), PlanRequest{
-		Database:    "testapp",
-		Environment: "staging", // not configured
-		Type:        storage.DatabaseTypeMySQL,
-	}, nil, "")
+	_, err := svc.PlanDeploymentDiffs(t.Context(), planDiffReq(t), nil, "", nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "resolve deployment targets")
+	assert.Contains(t, err.Error(), "no deployment targets")
 }

--- a/pkg/api/plan_review_drift.go
+++ b/pkg/api/plan_review_drift.go
@@ -20,11 +20,13 @@ import (
 // deployment that plan was created against; the producer fails closed if it no
 // longer maps to rollout index 0 at rollup time.
 //
-// The expected deployment set is resolved independently from the producer's
-// results so the rollup can enforce that the diffs cover every configured
-// deployment in rollout order — a missing, extra, or reordered deployment fails
-// closed rather than being mistaken for agreement. The returned rollup is Clean
-// only when every deployment matches.
+// The database/environment is resolved once here to the configured deployment
+// set in rollout order, then shared with the producer. The resolved order is
+// also passed to RollupDeploymentDiffs as the expected set so the rollup can
+// enforce that the producer returned one diff per deployment in that order — a
+// missing, extra, or reordered result fails closed rather than being mistaken
+// for agreement. The returned rollup is Clean only when every deployment
+// matches.
 func (s *Service) RollupReviewTimeDrift(ctx context.Context, req PlanRequest, primaryPlan *ternv1.PlanResponse, primaryDeployment string) (PlanRollup, error) {
 	targets, err := s.config.ResolveDatabaseTargets(req.Database, req.Environment)
 	if err != nil {
@@ -35,7 +37,7 @@ func (s *Service) RollupReviewTimeDrift(ctx context.Context, req PlanRequest, pr
 		expectedDeployments[i] = t.Deployment
 	}
 
-	diffs, err := s.PlanDeploymentDiffs(ctx, req, primaryPlan, primaryDeployment)
+	diffs, err := s.PlanDeploymentDiffs(ctx, req, primaryPlan, primaryDeployment, targets)
 	if err != nil {
 		return PlanRollup{}, fmt.Errorf("plan deployment diffs for %s/%s: %w", req.Database, req.Environment, err)
 	}

--- a/pkg/webhook/check_records.go
+++ b/pkg/webhook/check_records.go
@@ -82,6 +82,12 @@ func (h *Handler) storeManualPlanCheckRecord(ctx context.Context, client *ghclie
 	// so recovering (clearing) apply-owned check state here would wrongly unblock
 	// the PR. Leave the blocking check state in place for an operator to reconcile.
 	if drift.blocks() {
+		h.logger.Info("plan check is deployment-drift blocked; leaving stored check state in place and skipping apply-owned no-op recovery so the block is not cleared",
+			"repo", repo,
+			"pr", pr,
+			"database", schema.Database,
+			"database_type", schema.Type,
+			"environment", environment)
 		return headSHA, false, nil
 	}
 

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -378,6 +378,11 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName, tenant s
 	// open. Posted last so it wins over updateAggregateCheck for these envs.
 	if len(driftBlockUnstored) > 0 && multiEnvData.HeadSHA != "" {
 		h.postFailingAggregatesWithBlock(ctx, client, repo, pr, multiEnvData.HeadSHA, driftBlockUnstored, reviewTimeDeploymentDriftBlock)
+	} else if len(driftBlockUnstored) > 0 {
+		h.logger.Warn("deployment drift blocked one or more environments but no head SHA is known; the fallback failing aggregate was not posted, so an operator must re-run plan to re-establish the merge-gate block",
+			"repo", repo,
+			"pr", pr,
+			"environments", len(driftBlockUnstored))
 	}
 
 	// Auto-plan: skip comment if no changes and no errors (reduce PR noise)


### PR DESCRIPTION
## Summary
Two small polish follow-ups from the review of the review-time deployment drift gate. No change to gate behavior — the drift block still fails closed exactly as before.

## What
- Resolve the deployment target set once per rollup instead of twice: `RollupReviewTimeDrift` resolves and threads the targets into `PlanDeploymentDiffs`, which now fails closed on an empty set. The rollout-order contract check is unchanged.
- Add log lines to two previously silent drift skip paths: the drift-blocked no-op-recovery skip, and the multi-env fallback that can't post a failing aggregate when no head SHA is known.

## Why
The double resolve was redundant work, and the two silent returns left an operator unable to see why a check path was taken during triage.
