### PR TITLE
fix(tern): ride out sustained transient outages on caller-facing reads

### DIFF
--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -163,16 +163,24 @@ type Config struct {
 // retryServiceConfig enables client-side retries for idempotent RPCs.
 //
 // The network path to a remote Tern deployment often crosses proxies and
-// service meshes, where brief connection resets or TLS handshake flaps
-// surface as UNAVAILABLE before the request reaches the server. Retrying
-// rides out sub-second blips instead of failing the caller's operation.
+// service meshes, where connection resets or TLS handshake flaps surface as
+// UNAVAILABLE before the request reaches the server. Retrying rides out the
+// blip instead of failing the caller's operation.
 //
-// Only RPCs that are safe to re-send are retried:
-//   - PullSchema: read-only live schema fetch.
-//   - Plan: each attempt produces an independent plan record and only the
-//     returned plan ID is used, so a duplicate attempt is harmless.
-//   - PlanDiff: read-only desired-vs-live diff; persists nothing.
-//   - Progress and Health: read-only.
+// Only RPCs that are safe to re-send are retried, in two budgets:
+//
+// Caller-facing reads (PullSchema, Plan, PlanDiff) get a long budget: a
+// human or review workflow is waiting on the response, and a data-plane pod
+// restart or mesh drain lasts seconds — well past a sub-second budget — so
+// these ride out up to roughly fifteen seconds before surfacing UNAVAILABLE.
+// (Plan is retry-safe because each attempt produces an independent plan
+// record and only the returned plan ID is used.) The budget must stay under
+// the API server's 30s response timeout, which bounds these calls end to end.
+//
+// Fast polls (Progress, Health) keep a sub-second budget: Progress is called
+// on tight drive loops that own their own failure handling, and Health feeds
+// the remote-deployment outage monitor, which must observe an outage promptly
+// rather than ride it out.
 //
 // State-changing RPCs (Apply, Cutover, Stop, Start, Volume, Revert,
 // SkipRevert) are intentionally not retried here: re-sending them could
@@ -183,7 +191,17 @@ const retryServiceConfig = `{
 		"name": [
 			{"service": "tern.v1.Tern", "method": "PullSchema"},
 			{"service": "tern.v1.Tern", "method": "Plan"},
-			{"service": "tern.v1.Tern", "method": "PlanDiff"},
+			{"service": "tern.v1.Tern", "method": "PlanDiff"}
+		],
+		"retryPolicy": {
+			"maxAttempts": 5,
+			"initialBackoff": "0.5s",
+			"maxBackoff": "8s",
+			"backoffMultiplier": 3.0,
+			"retryableStatusCodes": ["UNAVAILABLE"]
+		}
+	}, {
+		"name": [
 			{"service": "tern.v1.Tern", "method": "Progress"},
 			{"service": "tern.v1.Tern", "method": "Health"}
 		],

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -176,13 +176,18 @@ type Config struct {
 // (Plan is retry-safe because each attempt produces an independent plan
 // record and only the returned plan ID is used.) The budget must stay under
 // the API server's 30s response timeout, which bounds these calls end to end.
+// gRPC clamps maxAttempts to 5, so raising it further has no effect. During a
+// sustained outage a multi-environment auto-plan pays this budget per
+// environment (serial Plan + concurrent PlanDiff waves), so the whole flow
+// stays within its command timeout only for a handful of environments — the
+// exhausted calls fail closed either way.
 //
 // Fast polls (Progress, Health) keep a sub-second budget: Progress is called
 // on tight drive loops that own their own failure handling, and Health feeds
 // the remote-deployment outage monitor, which must observe an outage promptly
 // rather than ride it out.
 //
-// State-changing RPCs (Apply, Cutover, Stop, Start, Volume, Revert,
+// State-changing RPCs (Apply, Cutover, Stop, Cancel, Start, Volume, Revert,
 // SkipRevert) are intentionally not retried here: re-sending them could
 // duplicate work or advance an apply twice, and the operator's durable
 // queue already owns redelivery for dispatch failures.

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -129,8 +129,12 @@ type flakyTernServer struct {
 	mu          sync.Mutex
 	planCalls   int
 	applyCalls  int
+	pullCalls   int
+	healthCalls int
 	failPlans   int
 	failApplies int
+	failPulls   int
+	failHealths int
 }
 
 func (s *flakyTernServer) Plan(context.Context, *ternv1.PlanRequest) (*ternv1.PlanResponse, error) {
@@ -153,10 +157,36 @@ func (s *flakyTernServer) Apply(context.Context, *ternv1.ApplyRequest) (*ternv1.
 	return &ternv1.ApplyResponse{Accepted: true, ApplyId: "remote-apply-1"}, nil
 }
 
+func (s *flakyTernServer) PullSchema(context.Context, *ternv1.PullSchemaRequest) (*ternv1.PullSchemaResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pullCalls++
+	if s.pullCalls <= s.failPulls {
+		return nil, status.Error(codes.Unavailable, "upstream connect error")
+	}
+	return &ternv1.PullSchemaResponse{Database: "testdb"}, nil
+}
+
+func (s *flakyTernServer) Health(context.Context, *ternv1.HealthRequest) (*ternv1.HealthResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.healthCalls++
+	if s.healthCalls <= s.failHealths {
+		return nil, status.Error(codes.Unavailable, "upstream connect error")
+	}
+	return &ternv1.HealthResponse{Status: "ok"}, nil
+}
+
 func (s *flakyTernServer) calls() (plans, applies int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.planCalls, s.applyCalls
+}
+
+func (s *flakyTernServer) readCalls() (pulls, healths int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.pullCalls, s.healthCalls
 }
 
 // newRetryTestClient starts an in-process Tern gRPC server and connects a
@@ -199,19 +229,34 @@ func TestGRPCClientRetriesPlanOnUnavailable(t *testing.T) {
 	assert.Equal(t, 2, plans, "client should retry the failed plan attempt")
 }
 
-// Retries are bounded: a deployment that stays unavailable surfaces
-// UNAVAILABLE to the caller after the retry budget instead of retrying
-// forever.
-func TestGRPCClientPlanRetriesAreBounded(t *testing.T) {
-	server := &flakyTernServer{failPlans: 10}
+// A data-plane pod restart or mesh drain lasts seconds, not milliseconds. A
+// caller-facing read must ride out a sustained blip — several consecutive
+// UNAVAILABLE attempts — and still return the response a human is waiting on.
+func TestGRPCClientPullSchemaRidesOutSustainedUnavailable(t *testing.T) {
+	server := &flakyTernServer{failPulls: 3}
 	client := newRetryTestClient(t, server)
 
-	_, err := client.Plan(t.Context(), &ternv1.PlanRequest{Database: "testdb"})
+	resp, err := client.PullSchema(t.Context(), &ternv1.PullSchemaRequest{Database: "testdb"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "testdb", resp.GetDatabase())
+	pulls, _ := server.readCalls()
+	assert.Equal(t, 4, pulls, "the caller-facing read budget must survive a sustained blip, not just a single reset")
+}
+
+// Retries are bounded, and the fast-poll budget stays small: Health feeds the
+// remote-deployment outage monitor, which must observe an outage promptly
+// rather than ride it out.
+func TestGRPCClientHealthRetriesFailFast(t *testing.T) {
+	server := &flakyTernServer{failHealths: 10}
+	client := newRetryTestClient(t, server)
+
+	err := client.Health(t.Context())
 
 	require.Error(t, err)
 	assert.Equal(t, codes.Unavailable, status.Code(err))
-	plans, _ := server.calls()
-	assert.Equal(t, 3, plans, "client should stop after the configured attempt budget")
+	_, healths := server.readCalls()
+	assert.Equal(t, 3, healths, "fast polls must stop after the small attempt budget so outages surface promptly")
 }
 
 // Apply is state-changing, so the client surfaces a transient UNAVAILABLE


### PR DESCRIPTION
## Why this matters

An onboard or plan against a remote deployment can fail with HTTP 503 `engine_unavailable` even though the deployment is healthy moments later — a data-plane pod restart or mesh connection drain surfaces as gRPC `UNAVAILABLE` for a few seconds, and the caller's operation dies with it. The person then retries by hand and it works, which is exactly the kind of retry a client should have done itself.

The existing retry policy for idempotent RPCs only covered millisecond-scale resets: three attempts over a sub-second backoff window, all of which land inside a seconds-long blip.

## What it does

Splits the client retry policy into two budgets by what the RPC is for:

```
                     attempts   backoff        window    why
caller-facing reads      5      0.5s → 8s      ~15s      a human/review flow is waiting;
(PullSchema, Plan,                                       ride out a pod restart
 PlanDiff)                                               (bounded < the API's 30s timeout)

fast polls               3      0.2s → 2s      <1s       Health feeds the outage monitor —
(Progress, Health)                                       it must SEE outages, not ride them
                                                         out; Progress owns its own failure
                                                         handling on tight drive loops
```

State-changing RPCs (Apply, Cutover, Stop, …) remain non-retried, as before — the operator's durable queue owns redelivery.

Tests extend the existing flaky-server harness: a caller-facing read survives several consecutive `UNAVAILABLE` attempts (real jittered backoff exercised), and Health still fails fast after exactly its small budget.

**Test rework note**: `TestGRPCClientPlanRetriesAreBounded` asserted exhaustion at exactly 3 attempts — the precise behavior this change raises for Plan. Its invariant (retries are bounded) is now guarded by `TestGRPCClientHealthRetriesFailFast` on the fast group; the long group is bounded by gRPC's attempt cap and the API's response timeout.

## How it moves toward the northstar

Transient transport noise between the control plane and its data planes should be absorbed at the transport layer, sized to how long real blips last — callers see either a result or a genuine outage, and the outage monitor keeps its fast signal.

*Drafted by Claude Code (Opus 4.8).*