### PR TITLE
feat(config): accept on_failure pause to activate the release gate

### DIFF
--- a/deploy/local/config/grpc-schemabot-multideploy.yaml
+++ b/deploy/local/config/grpc-schemabot-multideploy.yaml
@@ -19,7 +19,11 @@
 #                             predecessor land (OC-5), the healthy sibling parks
 #                             at waiting_for_cutover and the scenario is expected
 #                             to fail.
-# Both use cutover_policy: barrier and deployment_order [eu, us].
+#   - production-pause     -> on_failure: pause: a failed deployment holds the
+#                             rollout in the non-terminal paused state until an
+#                             operator releases it (continue) or stops it (abort)
+#                             via `schemabot release` / `schemabot stop`.
+# All use cutover_policy: barrier and deployment_order [eu, us].
 
 # SchemaBot's own storage database
 storage:
@@ -50,12 +54,25 @@ databases:
             target: testapp
           us:
             target: testapp
+      production-pause:
+        cutover_policy: barrier
+        on_failure: pause
+        deployment_order:
+          - eu
+          - us
+        deployments:
+          eu:
+            target: testapp
+          us:
+            target: testapp
 
-# Per-deployment Tern gRPC endpoints. Both environments reuse the same Terns.
+# Per-deployment Tern gRPC endpoints. All environments reuse the same Terns.
 tern_deployments:
   eu:
     production: "tern-eu:9090"
     production-continue: "tern-eu:9090"
+    production-pause: "tern-eu:9090"
   us:
     production: "tern-us:9090"
     production-continue: "tern-us:9090"
+    production-pause: "tern-us:9090"

--- a/deploy/local/config/grpc-schemabot-multideploy.yaml
+++ b/deploy/local/config/grpc-schemabot-multideploy.yaml
@@ -21,8 +21,9 @@
 #                             to fail.
 #   - production-pause     -> on_failure: pause: a failed deployment holds the
 #                             rollout in the non-terminal paused state until an
-#                             operator releases it (continue) or stops it (abort)
-#                             via `schemabot release` / `schemabot stop`.
+#                             operator releases it (`schemabot release`) so the
+#                             remaining deployments proceed, or aborts it with
+#                             `schemabot stop`.
 # All use cutover_policy: barrier and deployment_order [eu, us].
 
 # SchemaBot's own storage database

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -648,12 +648,11 @@ type EnvironmentConfig struct {
 	// terminally fails. "halt" (the default, also used when unset) stops the
 	// rollout — later deployments in deployment_order are not started. "continue"
 	// drops a terminal-failed deployment as a blocker so the rollout attempts
-	// every deployment instead of stopping at the first failure. "pause" is a
-	// known value reserved for a future release-gate behaviour and is rejected
-	// at validation until that machinery lands. It governs only rollout
-	// continuation; the apply's pass/fail verdict and the merge gate stay
-	// fail-closed on any failed deployment. Only meaningful alongside a
-	// Deployments map.
+	// every deployment instead of stopping at the first failure. "pause" holds
+	// the rollout after a failure until a human releases it (continue) or stops
+	// it (abort) via the release gate. It governs only rollout continuation; the
+	// apply's pass/fail verdict and the merge gate stay fail-closed on any
+	// failed deployment. Only meaningful alongside a Deployments map.
 	OnFailure string `yaml:"on_failure,omitempty"`
 
 	// For PlanetScale/Vitess:
@@ -862,11 +861,9 @@ func (c *ServerConfig) Validate() error {
 					return fmt.Errorf("database %q environment %q sets on_failure without a deployments map", name, env)
 				}
 				switch envConfig.OnFailure {
-				case storage.OnFailureHalt, storage.OnFailureContinue:
-				case storage.OnFailurePause:
-					return fmt.Errorf("database %q environment %q sets on_failure %q which is not yet supported; use %q or %q", name, env, storage.OnFailurePause, storage.OnFailureHalt, storage.OnFailureContinue)
+				case storage.OnFailureHalt, storage.OnFailureContinue, storage.OnFailurePause:
 				default:
-					return fmt.Errorf("database %q environment %q has invalid on_failure %q (want %q or %q)", name, env, envConfig.OnFailure, storage.OnFailureHalt, storage.OnFailureContinue)
+					return fmt.Errorf("database %q environment %q has invalid on_failure %q (want %q, %q, or %q)", name, env, envConfig.OnFailure, storage.OnFailureHalt, storage.OnFailureContinue, storage.OnFailurePause)
 				}
 			}
 			switch {

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -649,9 +649,10 @@ type EnvironmentConfig struct {
 	// rollout — later deployments in deployment_order are not started. "continue"
 	// drops a terminal-failed deployment as a blocker so the rollout attempts
 	// every deployment instead of stopping at the first failure. "pause" holds
-	// the rollout after a failure until a human releases it (continue) or stops
-	// it (abort) via the release gate. It governs only rollout continuation; the
-	// apply's pass/fail verdict and the merge gate stay fail-closed on any
+	// the rollout after a failure until a human releases it (via the release
+	// control op) so the remaining deployments proceed; to abort instead, use
+	// the separate stop/cancel control op. It governs only rollout continuation;
+	// the apply's pass/fail verdict and the merge gate stay fail-closed on any
 	// failed deployment. Only meaningful alongside a Deployments map.
 	OnFailure string `yaml:"on_failure,omitempty"`
 

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -33,6 +33,7 @@ func TestServerConfig_OnFailure(t *testing.T) {
 					"unset":    {Target: "payments", Deployment: "payments-a"},
 					"halt":     {Deployments: map[string]DeploymentTarget{"payments-a": {Target: "payments"}}, OnFailure: storage.OnFailureHalt},
 					"continue": {Deployments: map[string]DeploymentTarget{"payments-a": {Target: "payments"}}, OnFailure: storage.OnFailureContinue},
+					"pause":    {Deployments: map[string]DeploymentTarget{"payments-a": {Target: "payments"}}, OnFailure: storage.OnFailurePause},
 				},
 			},
 		},
@@ -41,6 +42,7 @@ func TestServerConfig_OnFailure(t *testing.T) {
 	assert.Equal(t, storage.OnFailureHalt, cfg.OnFailure("payments", "unset"), "unset defaults to halting")
 	assert.Equal(t, storage.OnFailureHalt, cfg.OnFailure("payments", "halt"), "explicit halt halts")
 	assert.Equal(t, storage.OnFailureContinue, cfg.OnFailure("payments", "continue"), "explicit continue does not halt")
+	assert.Equal(t, storage.OnFailurePause, cfg.OnFailure("payments", "pause"), "explicit pause resolves to pause")
 	assert.Equal(t, storage.OnFailureHalt, cfg.OnFailure("payments", "missing-env"), "unconfigured env defaults to halting")
 	assert.Equal(t, storage.OnFailureHalt, cfg.OnFailure("missing-db", "continue"), "unconfigured database defaults to halting")
 }
@@ -1731,15 +1733,14 @@ func TestServerConfig_DeploymentsMapValidation(t *testing.T) {
 			wantErrSub: `invalid on_failure "warp-speed"`,
 		},
 		{
-			name: "on_failure pause is rejected as not yet supported",
+			name: "on_failure pause with a deployments map is accepted",
 			envConfig: EnvironmentConfig{
 				Deployments: map[string]DeploymentTarget{
 					"payments-a": {Target: "payments"},
 				},
 				OnFailure: storage.OnFailurePause,
 			},
-			tern:       baseTern,
-			wantErrSub: `sets on_failure "pause" which is not yet supported`,
+			tern: baseTern,
 		},
 	}
 

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -59,8 +59,9 @@ const (
 	// deployment instead of stopping at the first failure.
 	OnFailureContinue = "continue"
 
-	// OnFailurePause holds the rollout after a failure until a human releases
-	// it (continue) or stops it (abort) via the release gate. Until released,
+	// OnFailurePause holds the rollout after a failure until a human releases it
+	// (via the release control op) so the remaining deployments proceed; to
+	// abort instead, use the separate stop/cancel control op. Until released,
 	// later deployments do not start and the apply reports the non-terminal
 	// paused state; the merge gate stays fail-closed on the failed deployment.
 	OnFailurePause = "pause"

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -60,8 +60,9 @@ const (
 	OnFailureContinue = "continue"
 
 	// OnFailurePause holds the rollout after a failure until a human releases
-	// it. It is a known value but not yet supported; config validation rejects
-	// it until the release machinery lands.
+	// it (continue) or stops it (abort) via the release gate. Until released,
+	// later deployments do not start and the apply reports the non-terminal
+	// paused state; the merge gate stays fail-closed on the failed deployment.
 	OnFailurePause = "pause"
 )
 


### PR DESCRIPTION
## Summary
Lifts the config-load rejection of `on_failure: pause`, the final activation gate for the paused-rollout release feature. All the plumbing (paused state, release latch, claim exemption, projection, presentation, release API/CLI, stop/reconcile handling) has already landed, so deployments can now opt in.

## What
- `validateEnvironment` accepts `on_failure: pause` (drops the dedicated "not yet supported" rejection; the invalid-value error now lists all three policies).
- Refresh the `OnFailure` field doc and the `OnFailurePause` constant doc to describe the now-active release-gate behaviour.
- Config-validation test flips pause from rejected to accepted; resolver test gains a `pause` case.
- Add a `production-pause` example environment to the multi-deployment sample config.

## Behaviour
config load: `on_failure: pause`
```text
  BEFORE                        AFTER
  validate → ✗ "not yet          validate → ok
  supported; use halt/           (pause resolves through to the
  continue"                       already-shipped release gate)
```
