### PR TITLE
docs: remove the experimental warning from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 GitOps for database schemas. Define your desired schema in SQL files, open a PR, and SchemaBot plans and executes your schema changes safely.
 
-> [!WARNING]
-> **Experimental** — SchemaBot is under active development. APIs and configuration may change without notice.
-
 ## Schema Changes via Pull Request
 
 Open a PR with schema changes and SchemaBot handles the rest — plan, apply, and verify across environments:


### PR DESCRIPTION
SchemaBot has been running production schema changes across multiple databases and deployment topologies for a full development cycle, and the API and configuration surface has relatively stabilized (though we're still working on lots of planned features). The experimental warning no longer reflects the project's maturity, as we're gearing towards more broad adoption of SchemaBot internally