### PR TITLE
fix(serve): decouple liveness from the storage database

### DIFF
--- a/charts/schemabot/Chart.yaml
+++ b/charts/schemabot/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: schemabot
 description: GitOps for database schemas
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: "v0.1.3"
 maintainers:
   - name: aparajon

--- a/charts/schemabot/templates/deployment.yaml
+++ b/charts/schemabot/templates/deployment.yaml
@@ -66,10 +66,11 @@ spec:
           # Startup gates liveness until the server finishes boot (schema
           # ensure + listeners), allowing a slow start — e.g. waiting out a
           # storage credential rotation — without liveness killing the pod.
-          # The budget must comfortably exceed the storage schema-ensure
-          # bounds (waiting on the cross-pod advisory lock plus the online
-          # DDL timeout, with retries), so a boot that is legitimately busy
-          # applying storage DDL is never killed mid-apply.
+          # The budget must comfortably exceed the server's storage boot
+          # bounds (the boot retry budget plus a final attempt running to the
+          # schema-ensure timeout: cross-pod advisory lock wait plus the
+          # online DDL timeout), so a boot that is legitimately waiting on
+          # storage or applying storage DDL is never killed mid-apply.
           startupProbe:
             httpGet:
               path: /livez

--- a/charts/schemabot/templates/deployment.yaml
+++ b/charts/schemabot/templates/deployment.yaml
@@ -63,14 +63,30 @@ spec:
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          # Startup gates liveness until the server finishes boot (schema
+          # ensure + listeners), allowing a slow start — e.g. waiting out a
+          # storage credential rotation — without liveness killing the pod.
+          startupProbe:
+            httpGet:
+              path: /livez
+              port: http
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 60
+          # Liveness is process-only (/livez): it restarts the pod for faults a
+          # restart can fix (wedged process), never for dependency outages. A
+          # storage outage keeps pods alive so in-flight schema changes continue
+          # and the pool reconnects in place.
           livenessProbe:
             httpGet:
-              path: /health
+              path: /livez
               port: http
-            initialDelaySeconds: 10
             periodSeconds: 30
             timeoutSeconds: 3
             failureThreshold: 3
+          # Readiness is dependency-aware (/health pings storage): an instance
+          # that cannot reach storage is pulled from the Service until it
+          # recovers, without being restarted.
           readinessProbe:
             httpGet:
               path: /health

--- a/charts/schemabot/templates/deployment.yaml
+++ b/charts/schemabot/templates/deployment.yaml
@@ -66,13 +66,17 @@ spec:
           # Startup gates liveness until the server finishes boot (schema
           # ensure + listeners), allowing a slow start — e.g. waiting out a
           # storage credential rotation — without liveness killing the pod.
+          # The budget must comfortably exceed the storage schema-ensure
+          # bounds (waiting on the cross-pod advisory lock plus the online
+          # DDL timeout, with retries), so a boot that is legitimately busy
+          # applying storage DDL is never killed mid-apply.
           startupProbe:
             httpGet:
               path: /livez
               port: http
             periodSeconds: 5
             timeoutSeconds: 3
-            failureThreshold: 60
+            failureThreshold: 180
           # Liveness is process-only (/livez): it restarts the pod for faults a
           # restart can fix (wedged process), never for dependency outages. A
           # storage outage keeps pods alive so in-flight schema changes continue

--- a/docs/storage-outage-behavior.md
+++ b/docs/storage-outage-behavior.md
@@ -39,11 +39,18 @@ crash-loop backoff on top of the outage. Readiness carries the dependency
 check: an instance that cannot reach storage is pulled from the Service and
 rejoins the moment storage recovers.
 
+Boot is patient for the same reason: a pod that starts (or restarts) during
+the outage retries storage boot inside the startup-probe budget, re-resolving
+the DSN on every attempt so a rotated credential is picked up as soon as the
+mounted secret refreshes, instead of crash-looping until the outage ends.
+
 During a shared-cause outage (every replica loses storage at once), all pods go
 unready together and the Service has no endpoints. Inbound webhooks and API
 calls fail at the connection level for the duration. That is honest — those
-requests need storage — and recoverable: GitHub redelivers webhooks, and the
-reconciling pollers catch up on anything missed.
+requests need storage — and visible: GitHub marks each delivery as failed so an
+operator can redeliver it after recovery (GitHub App webhooks are never
+redelivered automatically), and the reconciling pollers converge poll-driven
+state on their next pass.
 
 ## What happens to an in-flight apply
 

--- a/docs/storage-outage-behavior.md
+++ b/docs/storage-outage-behavior.md
@@ -1,0 +1,136 @@
+# Storage Outage Behavior
+
+How a SchemaBot server behaves when its own storage database becomes
+unreachable — for example during a credential rotation window, a failover, or a
+network partition. The design goal: **a storage outage degrades the control
+plane; it never destroys in-flight schema changes, and it never converts
+uncertainty into a false verdict.**
+
+## The two databases
+
+Every apply involves two databases with independent credentials and failure
+domains:
+
+- **The target database** — where the schema change actually runs. Credentials
+  come from the apply request or the data-plane deployment.
+- **The storage database** — SchemaBot's own bookkeeping: applies, operations,
+  tasks, leases, control requests, check state.
+
+A storage outage does not affect the target database. The engine work (row
+copying, binlog application, checksumming, checkpointing) continues unaffected,
+whether it runs in-process (local drives) or in a remote data plane (gRPC
+drives). Spirit's checkpoint table lives on the *target* database, so
+resume-safety keeps advancing through a storage outage.
+
+## Probes: liveness vs readiness
+
+The Kubernetes probes encode the first-order policy:
+
+| Probe | Endpoint | Checks | On failure |
+|---|---|---|---|
+| Startup | `/livez` | process serves HTTP | boot budget before liveness arms |
+| Liveness | `/livez` | process serves HTTP | restart the pod |
+| Readiness | `/health` | storage ping | stop routing traffic |
+
+Liveness is process-only because a restart only fixes process faults (a wedged
+runtime, a deadlocked listener). An unreachable storage database is not fixable
+by restart — killing the pod would abort in-flight local drives and add
+crash-loop backoff on top of the outage. Readiness carries the dependency
+check: an instance that cannot reach storage is pulled from the Service and
+rejoins the moment storage recovers.
+
+During a shared-cause outage (every replica loses storage at once), all pods go
+unready together and the Service has no endpoints. Inbound webhooks and API
+calls fail at the connection level for the duration. That is honest — those
+requests need storage — and recoverable: GitHub redelivers webhooks, and the
+reconciling pollers catch up on anything missed.
+
+## What happens to an in-flight apply
+
+Three components with three different lifetimes:
+
+```
+storage outage begins
+      │
+      ▼
+drive loop exits within seconds        ← fail-closed on safety reads
+      │
+      │    the schema change keeps running the entire time
+      │    (engine goroutine / remote data plane — no storage
+      │     dependency, its own throttling and limits intact)
+      │
+~1 min: heartbeat stale → row claimable  (no peer can claim; they
+      │                                   share the same outage)
+      ▼
+storage recovers → operator poll re-claims the stale row
+      → reattaches to the still-running work
+      → mirroring, heartbeats, supervision resume
+```
+
+The drive loop is a supervisor: it relays control requests (stop, cancel,
+cutover) from storage to the engine, mirrors progress into storage, and
+heartbeats the lease. It is a bookkeeper, not a safety governor — everything
+that protects the target database (throttling, lock timeouts, chunk sizing,
+checksumming) lives inside the engine and keeps operating while unsupervised.
+
+## Failure taxonomy in the drive loops
+
+Storage failures during a drive fall into three deliberate categories:
+
+1. **Progress and state mirror writes: log and keep driving.** A failed task
+   or display-metadata write is logged and skipped; the next poll tick writes
+   current progress. Mirroring is idempotent — a missed write costs staleness,
+   nothing else.
+
+2. **Safety-gating reads: exit the drive attempt.** If the driver cannot read
+   pending control requests, it must not keep driving blind to a possible stop
+   or cancel. Both the local and remote drive loops exit "for operator retry"
+   on this failure, leaving the operation row claimable. The engine work is
+   unaffected by the supervisor exiting.
+
+3. **Terminal-state writes: error out, never fabricate.** A failure to persist
+   a terminal state leaves the row non-terminal and claimable; the state is
+   re-derived from tasks on the next claim. Storage uncertainty is never
+   converted into a completed apply or a passing check.
+
+## The unsupervised window
+
+Between the drive loop exiting and the post-recovery re-claim, the schema
+change runs unsupervised. During this window:
+
+- **No command can be missed.** Operators cannot stop/cancel/retune the apply —
+  but they also cannot submit those commands, because control requests are
+  written to the same storage that is down and the API is unready. Command
+  intake and command visibility fail together. Worst case, an intervention is
+  delayed by the outage duration.
+- **Progress reporting goes dark.** The PR comment freezes and status queries
+  fail until supervision reattaches.
+- **Decision points wait.** An apply reaching a state that needs the control
+  plane (for example a deferred cutover awaiting approval) parks in its safe
+  waiting state.
+
+This is the same property that lets remote data-plane applies survive
+control-plane deploys and restarts; local drives get it from the probe split
+above. The window is bounded and self-healing: outage duration, plus up to a
+minute of heartbeat staleness, plus one operator poll.
+
+## Split-brain protection on recovery
+
+After recovery there is a short race where a peer driver could claim a
+stale-heartbeat row before the original driver's next heartbeat lands. Three
+independent fences make this safe:
+
+1. **Lease tokens.** Every storage write from a drive is guarded by its lease
+   token. A claim rotates the token, so a displaced driver's writes match zero
+   rows and it receives a lease-lost error, on which it cancels its own run.
+   The lease-lost signal is only raised after a successful read proves the
+   token changed — a connection error can never be misread as a lost lease, so
+   an outage cannot trigger a false self-fence.
+2. **Engine-level locking.** A local Spirit run holds a metadata lock on the
+   target database for the duration of the run; a usurping resume cannot touch
+   the table until the original releases it. Remote drives reattach by stored
+   remote apply id, which is idempotent.
+3. **Heartbeat retry tolerance.** The operator-level heartbeat distinguishes
+   "heartbeat failed" (storage unreachable — logged, retried next tick, drive
+   continues) from "lease lost" (token mismatch — self-fence). Transient
+   storage errors do not stop a healthy drive.

--- a/integration/serve_boot_retry_test.go
+++ b/integration/serve_boot_retry_test.go
@@ -1,0 +1,153 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/api"
+	"github.com/block/schemabot/pkg/serve"
+)
+
+// bootRecoveryDeadline bounds each wait on the boot goroutine: reaching the
+// retry loop, coming up after the credential heals, and stopping on cancel.
+const bootRecoveryDeadline = 30 * time.Second
+
+// storageRetryLogMessage is the warning bootStorage logs between attempts; the
+// tests synchronize on it to know the boot has entered its retry loop.
+const storageRetryLogMessage = "storage not ready, retrying"
+
+// buildResult carries Build's outcome across the goroutine boundary.
+type buildResult struct {
+	srv *serve.Server
+	err error
+}
+
+// msgSignalHandler wraps a slog.Handler and closes ch the first time a record
+// with the given message is handled, letting a test synchronize on a specific
+// server-side event without sleeping.
+type msgSignalHandler struct {
+	slog.Handler
+	msg  string
+	once *sync.Once
+	ch   chan struct{}
+}
+
+func (h *msgSignalHandler) Handle(ctx context.Context, r slog.Record) error {
+	if r.Message == h.msg {
+		h.once.Do(func() { close(h.ch) })
+	}
+	return h.Handler.Handle(ctx, r)
+}
+
+// newRetrySignalLogger returns a logger for serve.Build plus a channel that is
+// closed the first time the storage boot logs that it is retrying.
+func newRetrySignalLogger() (*slog.Logger, chan struct{}) {
+	retrying := make(chan struct{})
+	logger := slog.New(&msgSignalHandler{
+		Handler: slog.NewTextHandler(io.Discard, nil),
+		msg:     storageRetryLogMessage,
+		once:    &sync.Once{},
+		ch:      retrying,
+	})
+	return logger, retrying
+}
+
+// fileDSNConfig writes dsn to a file in the test's temp dir and returns a
+// server config whose storage DSN is the file reference, the same shape a
+// deployment uses for a secret mounted into the pod.
+func fileDSNConfig(t *testing.T, dsn string) (*api.ServerConfig, string) {
+	t.Helper()
+	dsnPath := filepath.Join(t.TempDir(), "dsn")
+	require.NoError(t, os.WriteFile(dsnPath, []byte(dsn), 0o600))
+	return &api.ServerConfig{Storage: api.StorageConfig{DSN: "file:" + dsnPath}}, dsnPath
+}
+
+// TestBuildWaitsOutStorageCredentialRotation exercises a server booting while
+// its storage credential is mid-rotation: the mounted DSN file still holds the
+// old password, so the database rejects every new connection. The boot must
+// keep retrying inside its budget — re-resolving the DSN each attempt — and
+// come up on its own once the refreshed credential lands in the file, with no
+// pod restart.
+func TestBuildWaitsOutStorageCredentialRotation(t *testing.T) {
+	staleCfg, err := mysql.ParseDSN(schemabotDSN)
+	require.NoError(t, err)
+	staleCfg.Passwd = "stale-rotated-password"
+	cfg, dsnPath := fileDSNConfig(t, staleCfg.FormatDSN())
+
+	logger, retrying := newRetrySignalLogger()
+	done := make(chan buildResult, 1)
+	go func() {
+		srv, buildErr := serve.Build(t.Context(), cfg, serve.WithLogger(logger))
+		done <- buildResult{srv: srv, err: buildErr}
+	}()
+
+	// Wait for the boot to observe the stale credential and start retrying,
+	// then heal the DSN file the way a secret-mount refresh would.
+	select {
+	case <-retrying:
+	case r := <-done:
+		t.Fatalf("Build returned before retrying: err=%v", r.err)
+	case <-time.After(bootRecoveryDeadline):
+		t.Fatal("Build never started retrying against the stale credential")
+	}
+	require.NoError(t, os.WriteFile(dsnPath, []byte(schemabotDSN), 0o600))
+
+	select {
+	case r := <-done:
+		require.NoError(t, r.err)
+		require.NotNil(t, r.srv)
+		require.NoError(t, r.srv.Close())
+	case <-time.After(bootRecoveryDeadline):
+		t.Fatal("Build did not come up after the storage credential healed")
+	}
+}
+
+// TestBuildStorageBootStopsOnContextCancel exercises shutdown while storage is
+// unreachable: a pod told to stop mid-boot must exit the retry loop promptly
+// instead of spending the rest of the boot budget.
+func TestBuildStorageBootStopsOnContextCancel(t *testing.T) {
+	unreachable := mysql.NewConfig()
+	unreachable.User = "root"
+	unreachable.Passwd = "testpassword"
+	unreachable.Net = "tcp"
+	unreachable.Addr = "127.0.0.1:1" // nothing listens here; every dial is refused
+	unreachable.DBName = "schemabot_test"
+	cfg, _ := fileDSNConfig(t, unreachable.FormatDSN())
+
+	logger, retrying := newRetrySignalLogger()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	done := make(chan buildResult, 1)
+	go func() {
+		srv, buildErr := serve.Build(ctx, cfg, serve.WithLogger(logger))
+		done <- buildResult{srv: srv, err: buildErr}
+	}()
+
+	select {
+	case <-retrying:
+	case r := <-done:
+		t.Fatalf("Build returned before retrying: err=%v", r.err)
+	case <-time.After(bootRecoveryDeadline):
+		t.Fatal("Build never started retrying against the unreachable database")
+	}
+	cancel()
+
+	select {
+	case r := <-done:
+		require.ErrorIs(t, r.err, context.Canceled)
+		require.Nil(t, r.srv)
+	case <-time.After(bootRecoveryDeadline):
+		t.Fatal("Build did not stop after context cancellation")
+	}
+}

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -3527,6 +3527,47 @@ func TestHealth(t *testing.T) {
 	})
 }
 
+// TestLivez verifies the liveness endpoint reflects process health only: it
+// reports alive even when the storage database is unreachable, so a storage
+// outage pulls instances from the Service (readiness) instead of restarting
+// them and aborting in-flight schema changes.
+func TestLivez(t *testing.T) {
+	t.Run("alive", func(t *testing.T) {
+		svc := newTestService()
+		mux := http.NewServeMux()
+		svc.ConfigureRoutes(mux)
+
+		req := httptest.NewRequestWithContext(t.Context(), "GET", "/livez", nil)
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp map[string]string
+		err := json.NewDecoder(w.Body).Decode(&resp)
+		require.NoError(t, err, "failed to decode response")
+		assert.Equal(t, "alive", resp["status"])
+	})
+
+	t.Run("alive while storage is unreachable", func(t *testing.T) {
+		logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+		svc := New(&mockStorage{pingErr: errors.New("connection refused")}, testServerConfig(), nil, logger)
+		mux := http.NewServeMux()
+		svc.ConfigureRoutes(mux)
+
+		req := httptest.NewRequestWithContext(t.Context(), "GET", "/livez", nil)
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp map[string]string
+		err := json.NewDecoder(w.Body).Decode(&resp)
+		require.NoError(t, err, "failed to decode response")
+		assert.Equal(t, "alive", resp["status"])
+	})
+}
+
 func TestServiceClose(t *testing.T) {
 	svc := newTestService()
 	assert.NoError(t, svc.Close())

--- a/pkg/api/health_handlers.go
+++ b/pkg/api/health_handlers.go
@@ -9,6 +9,13 @@ import (
 	"github.com/block/schemabot/pkg/apitypes"
 )
 
+// handleHealth reports whether this instance can serve requests right now: it
+// pings the storage database and returns 503 when storage is unreachable. It
+// backs the readiness probe, which routes traffic away from the instance until
+// storage recovers. It must not back a liveness probe — a restart cannot fix an
+// unreachable database, and killing the process would abort in-flight drives
+// whose target-database work is unaffected by a storage outage. Liveness uses
+// handleLivez.
 func (s *Service) handleHealth(w http.ResponseWriter, r *http.Request) {
 	if err := s.storage.Ping(r.Context()); err != nil {
 		s.logger.Error("health check failed", "error", err)
@@ -16,6 +23,16 @@ func (s *Service) handleHealth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// handleLivez reports whether the process itself is alive and able to answer
+// HTTP. It deliberately checks no dependencies: liveness failure causes a
+// restart, and a restart only fixes process-level faults (a wedged runtime, a
+// deadlocked listener). Dependency health — the storage database — is readiness
+// (handleHealth), where the correct reaction is to stop routing traffic and
+// wait, not to kill the process.
+func (s *Service) handleLivez(w http.ResponseWriter, _ *http.Request) {
+	s.writeJSON(w, http.StatusOK, map[string]string{"status": "alive"})
 }
 
 func (s *Service) handleTernHealth(w http.ResponseWriter, r *http.Request) {

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -680,7 +680,10 @@ func (s *Service) ConfigureRoutes(mux *http.ServeMux) {
 		mux.HandleFunc(pattern, s.limitRequestBody(handler))
 	}
 
-	// Health endpoints
+	// Health endpoints. /livez is process liveness (no dependency checks);
+	// /health is readiness (storage-dependent). See the handler comments for
+	// why the two must not be conflated.
+	handle("GET /livez", s.handleLivez)
 	handle("GET /health", s.handleHealth)
 	handle("GET /tern-health/{deployment}/{environment}", s.handleTernHealth)
 

--- a/pkg/auth/forward_auth_test.go
+++ b/pkg/auth/forward_auth_test.go
@@ -336,7 +336,7 @@ func TestForwardAuth_SkipsInfraPaths(t *testing.T) {
 		WriteGroups:       []string{"owners"},
 	})
 
-	for _, path := range []string{"/health", "/metrics", "/webhook"} {
+	for _, path := range []string{"/livez", "/health", "/metrics", "/webhook"} {
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, path, nil)
 		req.RemoteAddr = untrustedAddr // untrusted, but these paths skip auth
 		rec := httptest.NewRecorder()

--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -185,8 +185,9 @@ func (a *OIDCAuthorizer) extractGroups(token *oidc.IDToken) ([]string, error) {
 }
 
 // skipAuth reports paths that bypass OIDC authentication: webhooks have their
-// own HMAC authentication, and health/metrics are unauthenticated
-// infrastructure endpoints.
+// own HMAC authentication, and the probe and telemetry endpoints (/livez,
+// /health, /tern-health, /metrics) are unauthenticated infrastructure
+// endpoints — kubelet probes and scrapers carry no credentials.
 func skipAuth(path string) bool {
 	switch {
 	case path == "/livez":

--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -189,6 +189,8 @@ func (a *OIDCAuthorizer) extractGroups(token *oidc.IDToken) ([]string, error) {
 // infrastructure endpoints.
 func skipAuth(path string) bool {
 	switch {
+	case path == "/livez":
+		return true
 	case path == "/health":
 		return true
 	case path == "/metrics":

--- a/pkg/auth/oidc_test.go
+++ b/pkg/auth/oidc_test.go
@@ -319,7 +319,7 @@ func TestOIDCAuthorizerBypassesNonAPIPaths(t *testing.T) {
 	p := newTestOIDCProvider(t)
 	authz := newAuthorizer(t, p, auth.OIDCConfig{Audience: "schemabot"})
 
-	for _, path := range []string{"/health", "/metrics", "/webhook", "/tern-health/cake/staging"} {
+	for _, path := range []string{"/livez", "/health", "/metrics", "/webhook", "/tern-health/cake/staging"} {
 		t.Run(path, func(t *testing.T) {
 			var ran bool
 			handler := authz.Middleware(okHandler(&ran, nil))

--- a/pkg/serve/serve.go
+++ b/pkg/serve/serve.go
@@ -240,39 +240,16 @@ func Build(ctx context.Context, cfg *api.ServerConfig, opts ...Option) (*Server,
 		return nil, fmt.Errorf("storage DSN not configured (set storage.dsn in config or MYSQL_DSN env var)")
 	}
 
-	// Apply storage schema with retries for transient failures (e.g., DNS
-	// not yet available when the container starts in Kubernetes).
+	// Storage boot is patient: failures here are expected transients — DNS may
+	// not resolve yet when the container starts, and during a credential
+	// rotation every new connection is rejected until the mounted secret
+	// catches up with the database password. Retrying inside the startup-probe
+	// budget lets the pod wait the window out instead of crash-looping
+	// through it.
 	logger.Info("ensuring storage schema")
-	var db *sql.DB
-	const maxRetries = 5
-	const pingTimeout = 10 * time.Second
-	for attempt := range maxRetries {
-		if err := api.EnsureSchema(dsn, logger); err != nil {
-			if attempt < maxRetries-1 {
-				logger.Warn("ensure schema failed, retrying", "attempt", attempt+1, "error", err)
-				time.Sleep(2 * time.Second)
-				continue
-			}
-			return nil, fmt.Errorf("ensure schema after %d attempts: %w", maxRetries, err)
-		}
-
-		db, err = mysqlconn.OpenReloadable(dsn, cfg.StorageDSN)
-		if err != nil {
-			return nil, fmt.Errorf("open database: %w", err)
-		}
-		pingCtx, pingCancel := context.WithTimeout(ctx, pingTimeout)
-		pingErr := db.PingContext(pingCtx)
-		pingCancel()
-		if pingErr != nil {
-			utils.CloseAndLog(db)
-			if attempt < maxRetries-1 {
-				logger.Warn("database ping failed, retrying", "attempt", attempt+1, "error", pingErr)
-				time.Sleep(2 * time.Second)
-				continue
-			}
-			return nil, fmt.Errorf("ping database after %d attempts: %w", maxRetries, pingErr)
-		}
-		break
+	db, err := bootStorage(ctx, cfg, logger)
+	if err != nil {
+		return nil, err
 	}
 
 	// On any error past this point, close the resources Build has opened so a
@@ -377,6 +354,68 @@ func Build(ctx context.Context, cfg *api.ServerConfig, opts ...Option) (*Server,
 		authz:           authz,
 		engines:         o.engines,
 	}, nil
+}
+
+// Storage boot retry policy. The budget is sized so that even a final attempt
+// that runs to the schema-ensure timeout still finishes inside the
+// deployment's startup-probe budget: the HTTP listener (and with it /livez)
+// only starts after boot completes, so the startup probe is what bounds a pod
+// whose storage never becomes reachable.
+const (
+	storageBootRetryBudget   = 8 * time.Minute
+	storageBootRetryInterval = 5 * time.Second
+)
+
+// bootStorage brings up the storage database for a booting server: it applies
+// the storage schema, opens the pool, and verifies connectivity, retrying
+// failed attempts until the boot budget is spent. The DSN is re-resolved on
+// every attempt so file-backed references pick up credentials rotated while
+// the server waits.
+func bootStorage(ctx context.Context, cfg *api.ServerConfig, logger *slog.Logger) (*sql.DB, error) {
+	deadline := time.Now().Add(storageBootRetryBudget)
+	for attempt := 1; ; attempt++ {
+		db, err := connectStorage(ctx, cfg, logger)
+		if err == nil {
+			return db, nil
+		}
+		if time.Until(deadline) < storageBootRetryInterval {
+			return nil, fmt.Errorf("storage not ready after %d attempts over %s: %w", attempt, storageBootRetryBudget, err)
+		}
+		logger.Warn("storage not ready, retrying",
+			"attempt", attempt,
+			"retry_in", storageBootRetryInterval,
+			"budget_remaining", time.Until(deadline).Round(time.Second),
+			"error", err)
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("storage boot canceled after %d attempts: %w", attempt, ctx.Err())
+		case <-time.After(storageBootRetryInterval):
+		}
+	}
+}
+
+// connectStorage runs a single storage boot attempt: resolve the DSN, apply
+// the storage schema, open the pool, and verify it with a ping.
+func connectStorage(ctx context.Context, cfg *api.ServerConfig, logger *slog.Logger) (*sql.DB, error) {
+	const pingTimeout = 10 * time.Second
+	dsn, err := cfg.StorageDSN()
+	if err != nil {
+		return nil, fmt.Errorf("resolve storage DSN: %w", err)
+	}
+	if err := api.EnsureSchema(dsn, logger); err != nil {
+		return nil, fmt.Errorf("ensure storage schema: %w", err)
+	}
+	db, err := mysqlconn.OpenReloadable(dsn, cfg.StorageDSN)
+	if err != nil {
+		return nil, fmt.Errorf("open storage database: %w", err)
+	}
+	pingCtx, cancel := context.WithTimeout(ctx, pingTimeout)
+	defer cancel()
+	if err := db.PingContext(pingCtx); err != nil {
+		utils.CloseAndLog(db)
+		return nil, fmt.Errorf("ping storage database: %w", err)
+	}
+	return db, nil
 }
 
 // Service returns the underlying API service for embedders that need direct


### PR DESCRIPTION
## Why this matters

Both Kubernetes probes hit `/health`, which pings the storage database. That misclassifies a dependency outage as a process fault: when storage becomes unreachable (for example during a credential rotation window), liveness kills otherwise-healthy pods — aborting in-flight local schema-change drives whose target-database work is unaffected — and crash-loop backoff then keeps pods down well after storage recovers. A restart cannot fix an unreachable database; killing the process only adds damage on top of the outage. Restarted pods made it worse: storage boot gave up after a few seconds and exited, so pods crash-looped for the rest of the outage.

## What it does

Splits the probes so each answers the question it's actually for:

```
             /livez  (process-only)         /health  (storage ping)
                │                                │
  startupProbe ─┤  boot budget before      readinessProbe
  livenessProbe─┘  liveness arms                 │
                                                 ▼
  restart only fixes process faults    pull from Service, rejoin
  (wedged runtime, dead listener)      the moment storage recovers
```

A storage outage now degrades instead of destroying: pods stay alive and unready, in-flight drives continue against their targets, lease heartbeats retry, and supervision reattaches when storage recovers. The startupProbe gives slow boots (e.g. schema-ensure waiting out a rotation window) a bounded budget instead of racing the liveness timer.

Boot is patient to match: storage boot retries inside the startup-probe budget instead of exiting seconds into the outage, re-resolving the DSN on every attempt so a pod that starts mid-rotation comes up on its own the moment the refreshed credential syncs — no restart, no crash-loop backoff.

`/livez` joins the unauthenticated infrastructure paths alongside `/health` and `/metrics` so kubelet probes work under server-side auth.

New doc: [docs/storage-outage-behavior.md](docs/storage-outage-behavior.md) — the end-to-end behavior of an in-flight apply through a storage outage (drive-loop failure taxonomy, the unsupervised window, split-brain fences on recovery).

Chart `0.1.6 → 0.1.7`.

---
*Authored by Claude Code (Opus 4.8, Claude Fable 5).*
