### PR TITLE
fix(github): plan command converges checks on a PR with no managed schema changes

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -134,6 +134,30 @@ This PR does not contain schema changes managed by SchemaBot. SchemaBot did not 
 </details>
 
 <details>
+<summary><a name="no-managed-schema-changes-checks-refreshed"></a><strong>No Managed Schema Changes (Checks Refreshed)</strong></summary>
+
+
+## ✅ No Managed Schema Changes
+
+*Requested by @jackjackbits at 2026-03-15 14:30:00 UTC*
+
+This PR does not contain schema changes managed by SchemaBot. The SchemaBot checks were refreshed as passing on `abcdef1234567890abcdef1234567890abcdef12`.
+
+</details>
+
+<details>
+<summary><a name="no-managed-schema-changes-gated-on-tenants"></a><strong>No Managed Schema Changes (Gated On Tenants)</strong></summary>
+
+
+## ✅ No Managed Schema Changes
+
+*Requested by @jackjackbits at 2026-03-15 14:30:00 UTC*
+
+This PR does not contain schema changes managed by this SchemaBot deployment, but it touches schema paths owned by tenant deployments. The SchemaBot check was refreshed on `abcdef1234567890abcdef1234567890abcdef12` and will pass once every tenant deployment's own check succeeds.
+
+</details>
+
+<details>
 <summary><a name="reconciliation-required-in-progress"></a><strong>Reconciliation Required (In Progress)</strong></summary>
 
 

--- a/pkg/cmd/internal/templates/preview.go
+++ b/pkg/cmd/internal/templates/preview.go
@@ -113,6 +113,8 @@ const (
 	PreviewCommentPlanTenant            PreviewType = "comment_plan_tenant"             // Tenant-targeted plan comment
 	PreviewCommentPlanEmpty             PreviewType = "comment_plan_empty"              // Plan comment with no changes
 	PreviewCommentNoManagedSchema       PreviewType = "comment_no_managed_schema"       // No managed schema changes in current PR
+	PreviewCommentChecksRefreshed       PreviewType = "comment_checks_refreshed"        // Plan on no-schema-changes PR recreated passing checks
+	PreviewCommentChecksRefreshedTenant PreviewType = "comment_checks_refreshed_tenant" // Checks refreshed but gated on tenant deployments
 	PreviewCommentReconcileInProgress   PreviewType = "comment_reconcile_in_progress"   // Empty diff with in-progress apply-owned state
 	PreviewCommentReconcileCompleted    PreviewType = "comment_reconcile_completed"     // Empty diff with completed apply-owned state
 	PreviewCommentMultiEnv              PreviewType = "comment_multi_env"               // Multi-env plan (identical, deduplicated)

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -41,6 +41,10 @@ func previewCommentAllOutput() {
 		{"PLAN COMMENT (TENANT TARGET)", func() { fmt.Print(webhooktemplates.PreviewCommentPlanTenant()) }},
 		{"PLAN COMMENT (NO CHANGES)", func() { fmt.Print(webhooktemplates.PreviewCommentPlanNoChanges()) }},
 		{"NO MANAGED SCHEMA CHANGES", func() { fmt.Print(webhooktemplates.PreviewCommentNoManagedSchemaChanges()) }},
+		{"NO MANAGED SCHEMA CHANGES (CHECKS REFRESHED)", func() { fmt.Print(webhooktemplates.PreviewCommentNoManagedSchemaChangesChecksRefreshed()) }},
+		{"NO MANAGED SCHEMA CHANGES (GATED ON TENANTS)", func() {
+			fmt.Print(webhooktemplates.PreviewCommentNoManagedSchemaChangesChecksRefreshedGatedOnTenants())
+		}},
 		{"RECONCILIATION REQUIRED (IN PROGRESS)", func() { fmt.Print(webhooktemplates.PreviewCommentSchemaReconciliationInProgress()) }},
 		{"RECONCILIATION REQUIRED (COMPLETED)", func() { fmt.Print(webhooktemplates.PreviewCommentSchemaReconciliationCompleted()) }},
 		{"SCHEMA CHANGE APPLY (AUTOMATIC)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlan()) }},
@@ -157,6 +161,10 @@ func previewCommentPlanAllOutput() {
 		{"MYSQL PLAN (TENANT TARGET)", func() { fmt.Print(webhooktemplates.PreviewCommentPlanTenant()) }},
 		{"MYSQL PLAN (NO CHANGES)", func() { fmt.Print(webhooktemplates.PreviewCommentPlanNoChanges()) }},
 		{"NO MANAGED SCHEMA CHANGES", func() { fmt.Print(webhooktemplates.PreviewCommentNoManagedSchemaChanges()) }},
+		{"NO MANAGED SCHEMA CHANGES (CHECKS REFRESHED)", func() { fmt.Print(webhooktemplates.PreviewCommentNoManagedSchemaChangesChecksRefreshed()) }},
+		{"NO MANAGED SCHEMA CHANGES (GATED ON TENANTS)", func() {
+			fmt.Print(webhooktemplates.PreviewCommentNoManagedSchemaChangesChecksRefreshedGatedOnTenants())
+		}},
 		{"RECONCILIATION REQUIRED (IN PROGRESS)", func() { fmt.Print(webhooktemplates.PreviewCommentSchemaReconciliationInProgress()) }},
 		{"RECONCILIATION REQUIRED (COMPLETED)", func() { fmt.Print(webhooktemplates.PreviewCommentSchemaReconciliationCompleted()) }},
 		{"VITESS PLAN", func() { fmt.Print(webhooktemplates.PreviewCommentVitessPlan()) }},

--- a/pkg/cmd/internal/templates/preview_dispatch.go
+++ b/pkg/cmd/internal/templates/preview_dispatch.go
@@ -120,6 +120,10 @@ func PreviewCLIOutput(previewType PreviewType) {
 		fmt.Print(webhooktemplates.PreviewCommentPlanNoChanges())
 	case PreviewCommentNoManagedSchema:
 		fmt.Print(webhooktemplates.PreviewCommentNoManagedSchemaChanges())
+	case PreviewCommentChecksRefreshed:
+		fmt.Print(webhooktemplates.PreviewCommentNoManagedSchemaChangesChecksRefreshed())
+	case PreviewCommentChecksRefreshedTenant:
+		fmt.Print(webhooktemplates.PreviewCommentNoManagedSchemaChangesChecksRefreshedGatedOnTenants())
 	case PreviewCommentReconcileInProgress:
 		fmt.Print(webhooktemplates.PreviewCommentSchemaReconciliationInProgress())
 	case PreviewCommentReconcileCompleted:

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -179,6 +179,20 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName, tenant s
 		return
 	}
 
+	// A user-issued plan on a PR with no managed schema changes converges the
+	// checks (or explains apply-owned state) instead of searching the whole
+	// repo for a config. Auto-plan skips this: it is only dispatched for
+	// configs already discovered from the PR's changed files.
+	if !isAutoPlan {
+		if handled, err := h.handleNoManagedSchemaChangesForCommand(ctx, client, repo, pr, installationID, action.Plan, "", databaseName, requestedBy); err != nil {
+			h.logger.Error("failed to check whether plan command needs schema change reconciliation", "repo", repo, "pr", pr, "database", databaseName, "error", err)
+			h.postCommandError(repo, pr, installationID, action.Plan, "", requestedBy, err.Error())
+			return
+		} else if handled {
+			return
+		}
+	}
+
 	// Find config to get the database identity. Environments are server-owned.
 	var schemaDatabase string
 	if databaseName != "" {

--- a/pkg/webhook/plan_integration_test.go
+++ b/pkg/webhook/plan_integration_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/block/schemabot/pkg/api"
 	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/storage/mysqlstore"
 	"github.com/block/schemabot/pkg/tern"
@@ -289,6 +290,9 @@ func TestE2EPlanNoChanges(t *testing.T) {
 	assert.Equal(t, "success", check.Conclusion)
 }
 
+// TestE2EPlanConfigNotFound verifies that a plan command on a PR that changes
+// schema files with no schemabot.yaml anywhere in the repository fails with
+// the config-not-found error rather than planning unmanaged schema.
 func TestE2EPlanConfigNotFound(t *testing.T) {
 	dbName := "webhook_plan_noconfig"
 	svc := setupE2EService(t, dbName)
@@ -300,8 +304,11 @@ func TestE2EPlanConfigNotFound(t *testing.T) {
 	client := gh.NewClient(nil)
 	client.BaseURL, _ = url.Parse(server.URL + "/")
 
-	// No schemabot.yaml config — empty schema files, no config
-	result := setupFakeGitHubForPlan(t, mux, map[string]string{}, "", dbName)
+	// The PR changes a schema file, but no schemabot.yaml config exists.
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+	result := setupFakeGitHubForPlan(t, mux, schemaFiles, "", dbName)
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	installClient := ghclient.NewInstallationClient(client, logger)
@@ -326,6 +333,141 @@ func TestE2EPlanConfigNotFound(t *testing.T) {
 		assert.Contains(t, body, "No SchemaBot Configuration Found")
 	case <-time.After(10 * time.Second):
 		t.Fatal("timed out waiting for error comment")
+	}
+}
+
+// TestE2EPlanCleansStalePlanOnlyChecksBeforeConvergingAggregates verifies the
+// check-refresh path of a plan command on a PR with no managed schema changes
+// when an earlier commit left behind a stale plan-only blocking check (for
+// example the PR reverted its schema change after a plan ran). The stale
+// per-database check must be cleaned up to passing on the current head — the
+// aggregate would otherwise stay blocked and contradict the refresh comment.
+func TestE2EPlanCleansStalePlanOnlyChecksBeforeConvergingAggregates(t *testing.T) {
+	dbName := "webhook_plan_stale_converge"
+	svc := setupE2EService(t, dbName)
+	ctx := t.Context()
+
+	require.NoError(t, svc.Storage().Checks().Upsert(ctx, &storage.Check{
+		Repository:   "octocat/hello-world",
+		PullRequest:  1,
+		HeadSHA:      "oldsha111",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: dbName,
+		CheckRunID:   100,
+		HasChanges:   true,
+		Status:       checkStatusCompleted,
+		Conclusion:   checkConclusionActionRequired,
+	}))
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	result := setupFakeGitHubForPlan(t, mux, map[string]string{}, "", dbName)
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	installClient := ghclient.NewInstallationClient(client, logger)
+	factory := &fakeClientFactory{client: installClient}
+	h := NewHandler(svc, factory, nil, logger)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot plan -e staging",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "no managed schema changes handled")
+
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "No Managed Schema Changes")
+		assert.Contains(t, body, "refreshed as passing")
+		assert.Contains(t, body, "abc123")
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for check refresh comment")
+	}
+
+	check, err := svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1, "staging", "mysql", dbName)
+	require.NoError(t, err)
+	require.NotNil(t, check, "expected stored per-database check to survive cleanup")
+	assert.Equal(t, "abc123", check.HeadSHA)
+	assert.Equal(t, checkStatusCompleted, check.Status)
+	assert.Equal(t, checkConclusionSuccess, check.Conclusion)
+	assert.False(t, check.HasChanges)
+}
+
+// TestE2EPlanScopedToOneEnvironmentBlocksOnOtherEnvironmentApply verifies that
+// a plan command scoped with -e cannot convert a PR's checks to passing while
+// an apply in a different environment still owns the PR's state: the check
+// refresh spans every environment's aggregate, so apply-owned state anywhere
+// must block it with the reconciliation comment instead.
+func TestE2EPlanScopedToOneEnvironmentBlocksOnOtherEnvironmentApply(t *testing.T) {
+	dbName := "webhook_plan_cross_env_apply"
+	svc := setupE2EService(t, dbName)
+	ctx := t.Context()
+
+	apply := &storage.Apply{
+		ApplyIdentifier: "apply-cross-env",
+		Database:        dbName,
+		DatabaseType:    "mysql",
+		Environment:     "production",
+		Repository:      "octocat/hello-world",
+		PullRequest:     1,
+		State:           state.Apply.Running,
+		Engine:          "spirit",
+	}
+	applyID, err := svc.Storage().Applies().Create(ctx, apply)
+	require.NoError(t, err)
+
+	require.NoError(t, svc.Storage().Checks().Upsert(ctx, &storage.Check{
+		Repository:   "octocat/hello-world",
+		PullRequest:  1,
+		HeadSHA:      "oldsha111",
+		Environment:  "production",
+		DatabaseType: "mysql",
+		DatabaseName: dbName,
+		CheckRunID:   100,
+		ApplyID:      applyID,
+		HasChanges:   true,
+		Status:       checkStatusInProgress,
+	}))
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	result := setupFakeGitHubForPlan(t, mux, map[string]string{}, "", dbName)
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	installClient := ghclient.NewInstallationClient(client, logger)
+	factory := &fakeClientFactory{client: installClient}
+	h := NewHandler(svc, factory, nil, logger)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot plan -e staging",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "Schema Change Reconciliation Required")
+		assert.Contains(t, body, "production")
+		assert.NotContains(t, body, "refreshed as passing")
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for reconciliation comment")
 	}
 }
 

--- a/pkg/webhook/schema_reconciliation.go
+++ b/pkg/webhook/schema_reconciliation.go
@@ -9,6 +9,7 @@ import (
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/webhook/action"
 	"github.com/block/schemabot/pkg/webhook/templates"
 )
 
@@ -29,7 +30,17 @@ func (h *Handler) handleNoManagedSchemaChangesForCommand(ctx context.Context, cl
 		return false, nil
 	}
 
-	records, err := h.schemaChangeReconciliationRecords(ctx, repo, pr, environment, databaseName)
+	// A plan with no named database will converge the checks below, and that
+	// refresh spans every environment's aggregate — so the apply-owned guard
+	// must too: a plan scoped with -e must not converge checks while another
+	// environment's apply still owns this PR's state.
+	convergesChecks := commandName == action.Plan && databaseName == ""
+	recordScopeEnv := environment
+	if convergesChecks {
+		recordScopeEnv = ""
+	}
+
+	records, err := h.schemaChangeReconciliationRecords(ctx, repo, pr, recordScopeEnv, databaseName)
 	if err != nil {
 		return true, err
 	}
@@ -47,10 +58,93 @@ func (h *Handler) handleNoManagedSchemaChangesForCommand(ctx context.Context, cl
 		return true, nil
 	}
 
+	// With no current SchemaBot inputs and no apply-owned state, a plan
+	// command's remaining useful work is converging the checks: the PR may
+	// predate check enablement for the repo or have lost the webhook delivery
+	// that would have created its check, leaving branch protection waiting on
+	// a check nothing else will create. Recreate the aggregate on the current
+	// head the same way auto-plan does for a PR with no schema files. An
+	// explicitly named database is an explicit ask for that database's plan
+	// and proceeds through normal config discovery instead.
+	if convergesChecks {
+		if err := h.convergeAggregatesForNoManagedSchemaChanges(ctx, client, repo, pr, installationID, files, requestedBy); err != nil {
+			return true, err
+		}
+		return true, nil
+	}
+
 	h.logger.Debug("command found no apply-owned reconciliation state; continuing with normal config discovery",
 		"repo", repo, "pr", pr, "environment", environment,
 		"database", databaseName, "action", commandName)
 	return false, nil
+}
+
+// convergeAggregatesForNoManagedSchemaChanges recreates the aggregate check
+// state for a PR with no managed schema changes, mirroring the auto-plan
+// behavior for a PR with no schema files: an aggregate participant stays
+// silent (the leader owns the required check), a leader whose expected
+// participant paths are touched routes through the aggregate fold (which
+// fails closed until every expected participant reports), and otherwise
+// passing aggregates are posted on the current head. A comment reports the
+// outcome to the user who ran the command. A closed PR is rejected with an
+// explicit error instead: its close-time cleanup owns the stored check state.
+func (h *Handler) convergeAggregatesForNoManagedSchemaChanges(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, installationID int64, files []ghclient.PRFile, requestedBy string) error {
+	prInfo, err := client.FetchPullRequest(ctx, repo, pr)
+	if err != nil {
+		return fmt.Errorf("fetch PR info to refresh checks for PR with no managed schema changes: %w", err)
+	}
+	// A closed PR has nothing to converge: close-time cleanup already settled
+	// its stored check state, and recreating Check Runs here would resurrect
+	// rows that cleanup is authoritative over. Participants stay silent as on
+	// open PRs; otherwise the user gets an explicit error instead of a
+	// "refreshed as passing" comment on a PR that can never merge.
+	if prInfo.IsClosed() {
+		if h.isAggregateParticipant(repo) {
+			h.logger.Info("aggregate participant staying silent on plan for closed PR with no managed schema changes",
+				"repo", repo, "pr", pr, "requested_by", requestedBy)
+			return nil
+		}
+		return fmt.Errorf("PR #%d in %s is closed; SchemaBot refreshes check state only for open PRs", pr, repo)
+	}
+
+	headSHA := prInfo.HeadSHA
+	timestamp := templates.NowFunc().UTC().Format("2006-01-02 15:04:05")
+
+	// Stale plan-only checks from commits whose schema changes were since
+	// reverted would keep the aggregate blocked, so clean them up first —
+	// the same cleanup auto-plan runs before posting aggregates. Apply-owned
+	// records were already handled by the caller; cleanup independently
+	// retains them as blocking.
+	h.cleanupStaleChecks(repo, pr, headSHA, installationID, nil)
+
+	if h.isAggregateParticipant(repo) {
+		h.logger.Info("aggregate participant staying silent on plan for PR with no managed schema changes",
+			"repo", repo, "pr", pr, "head_sha", headSHA, "requested_by", requestedBy)
+		return nil
+	}
+
+	if h.leaderExpectsParticipantsForPR(repo, files) {
+		h.logger.Info("plan found no leader-managed schema changes but expected participant paths are touched; aggregate gate will block until participants report",
+			"repo", repo, "pr", pr, "head_sha", headSHA, "requested_by", requestedBy)
+		h.updateAggregateCheck(ctx, client, repo, pr, headSHA)
+		h.postComment(repo, pr, installationID, templates.RenderNoManagedSchemaChangesChecksRefreshed(templates.NoManagedSchemaChangesChecksRefreshedData{
+			RequestedBy:    requestedBy,
+			Timestamp:      timestamp,
+			HeadSHA:        headSHA,
+			GatedOnTenants: true,
+		}))
+		return nil
+	}
+
+	h.logger.Info("plan found no managed schema changes; refreshing passing aggregate checks",
+		"repo", repo, "pr", pr, "head_sha", headSHA, "requested_by", requestedBy)
+	h.postPassingAggregates(ctx, client, repo, pr, headSHA)
+	h.postComment(repo, pr, installationID, templates.RenderNoManagedSchemaChangesChecksRefreshed(templates.NoManagedSchemaChangesChecksRefreshedData{
+		RequestedBy: requestedBy,
+		Timestamp:   timestamp,
+		HeadSHA:     headSHA,
+	}))
+	return nil
 }
 
 func prHasCurrentSchemaBotFiles(files []ghclient.PRFile) bool {

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -94,6 +94,29 @@ func PreviewCommentNoManagedSchemaChanges() string {
 	})
 }
 
+// PreviewCommentNoManagedSchemaChangesChecksRefreshed renders the plan-command
+// outcome for a PR with no managed schema changes and no apply-owned state:
+// the SchemaBot checks were recreated as passing on the current head.
+func PreviewCommentNoManagedSchemaChangesChecksRefreshed() string {
+	return RenderNoManagedSchemaChangesChecksRefreshed(NoManagedSchemaChangesChecksRefreshedData{
+		RequestedBy: previewRequestedBy,
+		Timestamp:   "2026-03-15 14:30:00",
+		HeadSHA:     previewHeadSHA,
+	})
+}
+
+// PreviewCommentNoManagedSchemaChangesChecksRefreshedGatedOnTenants renders
+// the aggregate-leader variant of the checks-refreshed comment: the refreshed
+// check gates on tenant deployments' own checks for the touched schema paths.
+func PreviewCommentNoManagedSchemaChangesChecksRefreshedGatedOnTenants() string {
+	return RenderNoManagedSchemaChangesChecksRefreshed(NoManagedSchemaChangesChecksRefreshedData{
+		RequestedBy:    previewRequestedBy,
+		Timestamp:      "2026-03-15 14:30:00",
+		HeadSHA:        previewHeadSHA,
+		GatedOnTenants: true,
+	})
+}
+
 // PreviewCommentSchemaReconciliationInProgress renders the reconciliation
 // comment for a PR whose current diff no longer contains managed schema files
 // while a stored apply from that PR is still running.

--- a/pkg/webhook/templates/reconciliation.go
+++ b/pkg/webhook/templates/reconciliation.go
@@ -39,6 +39,34 @@ func RenderNoManagedSchemaChanges(data SchemaErrorData) string {
 	return sb.String()
 }
 
+// NoManagedSchemaChangesChecksRefreshedData describes the outcome of a plan
+// command that found no managed schema changes and refreshed the PR's
+// SchemaBot check state instead of running a plan.
+type NoManagedSchemaChangesChecksRefreshedData struct {
+	RequestedBy string
+	Timestamp   string
+	HeadSHA     string
+	// GatedOnTenants marks the aggregate-leader case: the refreshed check
+	// gates on tenant deployments' own checks for the touched schema paths
+	// instead of passing unconditionally.
+	GatedOnTenants bool
+}
+
+// RenderNoManagedSchemaChangesChecksRefreshed reports that a plan command
+// found no managed schema changes and recreated the PR's SchemaBot check
+// state on the current head.
+func RenderNoManagedSchemaChangesChecksRefreshed(data NoManagedSchemaChangesChecksRefreshedData) string {
+	var sb strings.Builder
+	sb.WriteString("## ✅ No Managed Schema Changes\n\n")
+	writeRequestedLine(&sb, data.RequestedBy, data.Timestamp)
+	if data.GatedOnTenants {
+		fmt.Fprintf(&sb, "\nThis PR does not contain schema changes managed by this SchemaBot deployment, but it touches schema paths owned by tenant deployments. The SchemaBot check was refreshed on `%s` and will pass once every tenant deployment's own check succeeds.\n", data.HeadSHA)
+		return sb.String()
+	}
+	fmt.Fprintf(&sb, "\nThis PR does not contain schema changes managed by SchemaBot. The SchemaBot checks were refreshed as passing on `%s`.\n", data.HeadSHA)
+	return sb.String()
+}
+
 // RenderSchemaChangeReconciliationRequired explains that the current PR no
 // longer contains a schema change whose apply has already started.
 func RenderSchemaChangeReconciliationRequired(data SchemaChangeReconciliationData) string {

--- a/pkg/webhook/truncated_repo_integration_test.go
+++ b/pkg/webhook/truncated_repo_integration_test.go
@@ -202,6 +202,104 @@ func setupFakeGitHubForPlanOnTruncatedRepoWithPRState(t *testing.T, mux *http.Se
 	return result
 }
 
+// TestE2EPlanCommandOnNoSchemaChangesPRRecreatesPassingCheck exercises the
+// stuck-check rescue flow: a PR has no managed schema changes but its
+// SchemaBot check is missing (for example the PR predates check enablement
+// for the repo, or the check-creating webhook delivery was lost), so branch
+// protection waits on a check nothing will create. A user comments
+// `schemabot plan -e staging` to recover. The command must recreate the
+// aggregate check as passing on the current head and say so in a comment —
+// even in a repository whose recursive tree listing GitHub truncates, since
+// converging the checks for a no-schema-changes PR requires no whole-repo
+// config scan.
+func TestE2EPlanCommandOnNoSchemaChangesPRRecreatesPassingCheck(t *testing.T) {
+	dbName := "webhook_truncated_repo_converge"
+	svc := setupE2EService(t, dbName)
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	result := setupFakeGitHubForPlanOnTruncatedRepo(t, mux, nil, schemabotConfig, dbName)
+	h := newE2EHandlerWithConfigDirHints(t, svc, client)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot plan -e staging",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "No Managed Schema Changes")
+		assert.Contains(t, body, "abc123")
+		assert.NotContains(t, body, "truncated repository tree")
+		assert.NotContains(t, body, "Plan Failed")
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for no-managed-schema-changes comment")
+	}
+
+	select {
+	case cr := <-result.checkRuns:
+		assert.Contains(t, cr.Name, "SchemaBot")
+		assert.Equal(t, "completed", cr.Status)
+		assert.Equal(t, "success", cr.Conclusion)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for passing check run")
+	}
+}
+
+// TestE2EPlanCommandOnClosedPRRefusesToRecreateChecks exercises the plan
+// command on a closed PR with no managed schema changes: close-time cleanup
+// owns a closed PR's stored check state, so instead of recreating Check Runs
+// on a PR that can never merge, the command replies with an explicit error
+// and creates no Check Runs.
+func TestE2EPlanCommandOnClosedPRRefusesToRecreateChecks(t *testing.T) {
+	dbName := "webhook_truncated_repo_closed_pr"
+	svc := setupE2EService(t, dbName)
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	result := setupFakeGitHubForPlanOnTruncatedRepoWithPRState(t, mux, nil, schemabotConfig, dbName, "closed")
+	h := newE2EHandlerWithConfigDirHints(t, svc, client)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot plan -e staging",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "is closed")
+		assert.Contains(t, body, "open PRs")
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for closed-PR error comment")
+	}
+
+	select {
+	case cr := <-result.checkRuns:
+		t.Fatalf("no Check Run should be created for a closed PR, got %q (%s/%s)", cr.Name, cr.Status, cr.Conclusion)
+	default:
+	}
+}
+
 // TestE2EPlanCommandOnTruncatedRepoDiscoversConfigViaConfiguredDirs exercises
 // database-scoped discovery on a huge monorepo: a user comments
 // `schemabot plan -e staging -d <db>` on a PR whose diff does not touch that


### PR DESCRIPTION
## Why this matters

A PR can end up waiting forever on a SchemaBot check that nothing will ever create: the PR predates check enablement for the repo, or the webhook delivery that would have created the check was lost. Branch protection shows the check as "Expected", the merge button stays grey, and no push or re-run fixes it. Until now the only way out was a repo admin disabling the required check — an operator escalation for something the PR author should be able to fix themselves.

## How it works

The natural rescue command is `schemabot plan`: it already recomputes what SchemaBot thinks of the PR. But on a PR with no managed schema changes, plan had nothing to say — it searched the repo for configs and reported an error or nothing, and never touched the checks.

Now, when a user-issued plan (bare or `-e`) finds the PR contains no managed schema changes and no apply owns any of its state, it treats the request as "make the checks reflect reality" and recreates the aggregate check on the current head — exactly what auto-plan does when a PR touches no schema files:

```
schemabot plan  (no managed schema changes in the PR)
  ├─ an apply owns state on this PR ─────────→ blocked: reconciliation comment
  ├─ PR is closed ───────────────────────────→ explicit error, no Check Runs
  ├─ this deployment is an aggregate
  │  participant ────────────────────────────→ stays silent (leader owns the check)
  ├─ leader, and tenant-owned schema paths
  │  are touched ────────────────────────────→ fail-closed aggregate fold
  │                                            (passes once every tenant reports)
  └─ otherwise ──────────────────────────────→ passing aggregate + comment
```

The guards, top to bottom:

- **Apply-owned state always wins.** If any environment's apply has started from this PR, the plan replies with the reconciliation comment instead of converging — and the guard spans *all* environments, so an `-e staging`-scoped plan cannot converge checks while a production apply still owns the PR.
- **Closed PRs are refused.** Close-time cleanup owns a closed PR's stored check state; recreating Check Runs there would resurrect what cleanup settled, on a PR that can no longer merge.
- **Multi-deployment repos stay quiet.** Every deployment watching the repo receives the same comment; participants stay silent so the user gets one answer, from the leader, and a leader whose tenants own touched paths routes through the same fail-closed fold as auto-plan rather than blindly passing.
- **Stale leftovers are cleaned first.** Plan-only checks from commits whose schema changes were since reverted fold to success before the aggregate is recomputed, using the same cleanup auto-plan runs.

An explicit `plan -d <db>` is an ask for that database's real plan and proceeds through normal config discovery instead. The user always gets a comment saying what happened (checks refreshed as passing, or gated on tenant checks).

## How it moves toward the northstar

Fail-closed gates keep their guarantees, but a stuck PR can now be recovered by the person looking at it with one comment instead of an operator escalation.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

