### PR TITLE
fix(github): fall back to configured schema dirs when the repo tree is truncated

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -737,6 +737,40 @@ func (c *ServerConfig) RepoAdmins(repo string) (teams, users []string) {
 	return repoConfig.AdminTeams, repoConfig.AdminUsers
 }
 
+// SchemaDirHintsForRepo returns the configured schema directories of every
+// database that accepts changes from repo, sorted and deduplicated. Config
+// discovery uses these as probe targets when GitHub truncates the repository
+// tree (repos beyond the Trees API response cap), where a whole-repo scan is
+// impossible. Wildcard and empty entries carry no directory to probe and are
+// skipped; a database with no allowed_repos restriction accepts any trusted
+// repo, so its directories are always included.
+func (c *ServerConfig) SchemaDirHintsForRepo(repo string) []string {
+	seen := make(map[string]struct{})
+	var dirs []string
+	for _, db := range c.Databases {
+		if len(db.AllowedRepos) > 0 && !repoAllowed(db.AllowedRepos, repo) {
+			continue
+		}
+		for _, dir := range db.AllowedDirs {
+			// Normalize exactly like the allowed_dirs policy checks so the
+			// probed directories match what the policy would accept. Wildcard
+			// and repo-root entries name no directory to probe; invalid
+			// entries are rejected at config load and cannot appear here.
+			normalized, err := normalizeSchemaPath(dir)
+			if err != nil || normalized == "*" || normalized == "." {
+				continue
+			}
+			if _, ok := seen[normalized]; ok {
+				continue
+			}
+			seen[normalized] = struct{}{}
+			dirs = append(dirs, normalized)
+		}
+	}
+	slices.Sort(dirs)
+	return dirs
+}
+
 // DeploymentTarget is one entry in EnvironmentConfig.Deployments. It carries
 // the per-deployment override values for a multi-deployment environment. The
 // enclosing map key identifies the Tern deployment (and must also appear in

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -741,23 +741,39 @@ func (c *ServerConfig) RepoAdmins(repo string) (teams, users []string) {
 // database that accepts changes from repo, sorted and deduplicated. Config
 // discovery uses these as probe targets when GitHub truncates the repository
 // tree (repos beyond the Trees API response cap), where a whole-repo scan is
-// impossible. Wildcard and empty entries carry no directory to probe and are
-// skipped; a database with no allowed_repos restriction accepts any trusted
-// repo, so its directories are always included.
-func (c *ServerConfig) SchemaDirHintsForRepo(repo string) []string {
+// impossible. A database with no allowed_repos restriction accepts any
+// trusted repo, so its directories are always included.
+//
+// exhaustive reports whether the returned directories cover every location a
+// policy-valid config could live in. A database with no allowed_dirs
+// restriction, or with a wildcard ("*") or repo-root (".") entry, accepts a
+// config in directories no hint list can cover — for such a repo the
+// truncated-tree fallback must keep failing closed, because a partial probe
+// could return a confidently wrong result (a single config where a full scan
+// would find several, or a "database not found" for a config that exists).
+func (c *ServerConfig) SchemaDirHintsForRepo(repo string) (dirs []string, exhaustive bool) {
 	seen := make(map[string]struct{})
-	var dirs []string
+	exhaustive = true
 	for _, db := range c.Databases {
 		if len(db.AllowedRepos) > 0 && !repoAllowed(db.AllowedRepos, repo) {
 			continue
 		}
+		if len(db.AllowedDirs) == 0 {
+			// The allowed_dirs policy only restricts databases that configure
+			// it; this database accepts a config anywhere in the repo.
+			exhaustive = false
+			continue
+		}
 		for _, dir := range db.AllowedDirs {
 			// Normalize exactly like the allowed_dirs policy checks so the
-			// probed directories match what the policy would accept. Wildcard
-			// and repo-root entries name no directory to probe; invalid
-			// entries are rejected at config load and cannot appear here.
+			// probed directories match what the policy would accept.
 			normalized, err := normalizeSchemaPath(dir)
 			if err != nil || normalized == "*" || normalized == "." {
+				// Wildcard and repo-root entries accept configs that no
+				// directory probe can cover. (Invalid entries are rejected at
+				// config load; treating them as non-exhaustive here costs
+				// nothing and stays fail-closed.)
+				exhaustive = false
 				continue
 			}
 			if _, ok := seen[normalized]; ok {
@@ -768,7 +784,7 @@ func (c *ServerConfig) SchemaDirHintsForRepo(repo string) []string {
 		}
 	}
 	slices.Sort(dirs)
-	return dirs
+	return dirs, exhaustive
 }
 
 // DeploymentTarget is one entry in EnvironmentConfig.Deployments. It carries

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -3298,9 +3298,48 @@ func TestSchemaDirHintsForRepo(t *testing.T) {
 		},
 	}
 
-	hints := cfg.SchemaDirHintsForRepo("octocat/hello-world")
+	hints, exhaustive := cfg.SchemaDirHintsForRepo("octocat/hello-world")
 
 	assert.Equal(t, []string{"apps/widgets/legacy", "apps/widgets/schema", "shared/schema"}, hints)
+	assert.False(t, exhaustive, "the unbounded database accepts configs outside every probe-able directory")
+}
+
+func TestSchemaDirHintsForRepoExhaustiveWhenAllDirsLiteral(t *testing.T) {
+	cfg := &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"widgets": {
+				AllowedRepos: []string{"octocat/hello-world"},
+				AllowedDirs:  []string{"apps/widgets/schema"},
+			},
+			"payments": {
+				AllowedRepos: []string{"octocat/other-repo"},
+			},
+		},
+	}
+
+	hints, exhaustive := cfg.SchemaDirHintsForRepo("octocat/hello-world")
+
+	assert.Equal(t, []string{"apps/widgets/schema"}, hints)
+	assert.True(t, exhaustive, "every repo-eligible database restricts configs to literal directories")
+}
+
+func TestSchemaDirHintsForRepoNotExhaustiveWhenDatabaseHasNoAllowedDirs(t *testing.T) {
+	cfg := &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"widgets": {
+				AllowedRepos: []string{"octocat/hello-world"},
+				AllowedDirs:  []string{"apps/widgets/schema"},
+			},
+			"open": {
+				AllowedRepos: []string{"octocat/hello-world"},
+			},
+		},
+	}
+
+	hints, exhaustive := cfg.SchemaDirHintsForRepo("octocat/hello-world")
+
+	assert.Equal(t, []string{"apps/widgets/schema"}, hints)
+	assert.False(t, exhaustive, "a database without allowed_dirs accepts a config anywhere in the repo")
 }
 
 func TestSchemaDirHintsForRepoNoMatches(t *testing.T) {
@@ -3313,5 +3352,7 @@ func TestSchemaDirHintsForRepoNoMatches(t *testing.T) {
 		},
 	}
 
-	assert.Empty(t, cfg.SchemaDirHintsForRepo("octocat/hello-world"))
+	hints, exhaustive := cfg.SchemaDirHintsForRepo("octocat/hello-world")
+	assert.Empty(t, hints)
+	assert.True(t, exhaustive, "no repo-eligible database means no policy-valid config location exists")
 }

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -3276,3 +3276,42 @@ func TestPendingDropsTargetsResolveEachPass(t *testing.T) {
 	assert.Equal(t, 0, unresolved)
 	assert.Equal(t, pendingdrops.Target{Database: "mydb", Environment: "staging", DSN: dsn}, targets[0])
 }
+
+func TestSchemaDirHintsForRepo(t *testing.T) {
+	cfg := &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"widgets": {
+				AllowedRepos: []string{"octocat/hello-world"},
+				AllowedDirs:  []string{"apps/widgets/schema", "apps/widgets/legacy/"},
+			},
+			"payments": {
+				AllowedRepos: []string{"octocat/other-repo"},
+				AllowedDirs:  []string{"payments/schema"},
+			},
+			"anyrepo": {
+				AllowedDirs: []string{"shared/schema", "apps/widgets/schema"},
+			},
+			"unbounded": {
+				AllowedRepos: []string{"octocat/hello-world"},
+				AllowedDirs:  []string{"*", "", " ", "."},
+			},
+		},
+	}
+
+	hints := cfg.SchemaDirHintsForRepo("octocat/hello-world")
+
+	assert.Equal(t, []string{"apps/widgets/legacy", "apps/widgets/schema", "shared/schema"}, hints)
+}
+
+func TestSchemaDirHintsForRepoNoMatches(t *testing.T) {
+	cfg := &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"payments": {
+				AllowedRepos: []string{"octocat/other-repo"},
+				AllowedDirs:  []string{"payments/schema"},
+			},
+		},
+	}
+
+	assert.Empty(t, cfg.SchemaDirHintsForRepo("octocat/hello-world"))
+}

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -59,6 +59,13 @@ type Client struct {
 	// configuration set at construction; never mutated afterwards.
 	trustedCheckAppSlugs []string
 
+	// configDirHints returns the configured schema directories that may serve
+	// a repo, used by config discovery as probe targets when GitHub truncates
+	// the repository tree and a whole-repo scan is impossible. Static
+	// configuration set at construction; never mutated afterwards. Nil when
+	// the embedder has no directory configuration to offer.
+	configDirHints func(repo string) []string
+
 	// slugFetchMu serialises slug-fetch attempts so concurrent
 	// ForInstallation callers do not thundering-herd retry on startup
 	// failure. lastSlugAttempt is read+written only under this mutex.
@@ -104,6 +111,16 @@ type ClientOption func(*Client)
 func WithTrustedCheckAppSlugs(slugs []string) ClientOption {
 	return func(c *Client) {
 		c.trustedCheckAppSlugs = slugs
+	}
+}
+
+// WithConfigDirHints provides the configured schema directories that may serve
+// a given repo. Config discovery probes these directories for schemabot.yaml
+// files when GitHub truncates the repository tree (repos beyond the Trees API
+// response cap), where a whole-repo scan is impossible.
+func WithConfigDirHints(hints func(repo string) []string) ClientOption {
+	return func(c *Client) {
+		c.configDirHints = hints
 	}
 }
 
@@ -242,6 +259,7 @@ func (c *Client) ForInstallation(installationID int64) (*InstallationClient, err
 		logger:                  c.logger,
 		installationID:          installationID,
 		trustedCheckAppSlugs:    c.trustedCheckAppSlugs,
+		configDirHints:          c.configDirHints,
 		checkStatusSingleflight: c.checkStatusSingleflight,
 	}
 	ic.storeAppSlug(slug)
@@ -330,6 +348,12 @@ type InstallationClient struct {
 	// configuration copied from the parent Client; never mutated.
 	trustedCheckAppSlugs []string
 
+	// configDirHints returns the configured schema directories that may serve
+	// a repo, used by config discovery as probe targets when GitHub truncates
+	// the repository tree. Copied from the parent Client; nil when the
+	// embedder has no directory configuration to offer.
+	configDirHints func(repo string) []string
+
 	// checkStatusSingleflight is owned by the parent Client factory and
 	// shared across every InstallationClient it produces so concurrent
 	// fetches collapse across the short-lived InstallationClients
@@ -347,6 +371,14 @@ type InstallationClient struct {
 // re-fold) that must resolve a client for the same installation later.
 func (ic *InstallationClient) InstallationID() int64 {
 	return ic.installationID
+}
+
+// SetConfigDirHints provides the configured schema directories that may serve
+// a repo, used by config discovery when GitHub truncates the repository tree.
+// Production clients receive this from the parent Client (WithConfigDirHints);
+// this setter exists for directly-constructed clients (tests, library use).
+func (ic *InstallationClient) SetConfigDirHints(hints func(repo string) []string) {
+	ic.configDirHints = hints
 }
 
 // loadAppSlug returns the current app slug, or empty if not yet set.
@@ -1181,6 +1213,77 @@ func (ic *InstallationClient) FetchGitTree(ctx context.Context, repo, treeSHA st
 	return entries, ghTree.GetTruncated(), nil
 }
 
+// fetchGitTreeShallow fetches a single tree level without recursing. One
+// level stays far below the Trees API caps that truncate whole-repo recursive
+// listings, so it can resolve paths inside repositories whose full tree is
+// truncated. If GitHub ever truncates even a single level, this fails rather
+// than let the caller act on an incomplete listing.
+func (ic *InstallationClient) fetchGitTreeShallow(ctx context.Context, repo, treeSHA string) ([]TreeEntry, error) {
+	owner, repoName := splitRepo(repo)
+	ghTree, err := retryGitHubUnavailableRead(ctx, ic.logger, "fetch git tree level", []any{"repo", repo, "tree_sha", treeSHA}, func(ctx context.Context) (*gh.Tree, error) {
+		ghTree, _, err := ic.client.Git.GetTree(ctx, owner, repoName, treeSHA, false)
+		if err != nil {
+			return nil, fmt.Errorf("fetch git tree level: %w", classifyGitHubAPIError(err))
+		}
+		return ghTree, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if ghTree.GetTruncated() {
+		return nil, fmt.Errorf("fetch git tree level %s in repo %s: %w", treeSHA, repo, ErrGitTreeTruncated)
+	}
+
+	entries := make([]TreeEntry, len(ghTree.Entries))
+	for i, entry := range ghTree.Entries {
+		entries[i] = TreeEntry{
+			Path: entry.GetPath(),
+			Mode: entry.GetMode(),
+			Type: entry.GetType(),
+			SHA:  entry.GetSHA(),
+			Size: entry.GetSize(),
+		}
+	}
+	return entries, nil
+}
+
+// FetchGitSubtree fetches the recursive tree of the directory dir at ref.
+// It resolves dir one path segment at a time with shallow tree fetches, so
+// resolution works even when the repository's full recursive listing is
+// truncated; only the directory's own subtree must fit under the Trees API
+// cap. Entry paths are relative to dir. found is false when dir does not
+// exist (or is not a directory) at ref. The error wraps ErrGitTreeTruncated
+// when the subtree itself is too large to list completely.
+func (ic *InstallationClient) FetchGitSubtree(ctx context.Context, repo, ref, dir string) (entries []TreeEntry, found bool, err error) {
+	treeSHA := ref
+	for segment := range strings.SplitSeq(dir, "/") {
+		levelEntries, err := ic.fetchGitTreeShallow(ctx, repo, treeSHA)
+		if err != nil {
+			return nil, false, fmt.Errorf("resolve %s under %s in repo %s ref %s: %w", segment, dir, repo, ref, err)
+		}
+		next := ""
+		for _, entry := range levelEntries {
+			if entry.Path == segment && entry.Type == "tree" {
+				next = entry.SHA
+				break
+			}
+		}
+		if next == "" {
+			return nil, false, nil
+		}
+		treeSHA = next
+	}
+
+	entries, truncated, err := ic.FetchGitTree(ctx, repo, treeSHA)
+	if err != nil {
+		return nil, false, fmt.Errorf("fetch subtree %s in repo %s ref %s: %w", dir, repo, ref, err)
+	}
+	if truncated {
+		return nil, false, fmt.Errorf("fetch subtree %s in repo %s ref %s: %w", dir, repo, ref, ErrGitTreeTruncated)
+	}
+	return entries, true, nil
+}
+
 // FetchBlobContent fetches file content using the Git Blob API.
 func (ic *InstallationClient) FetchBlobContent(ctx context.Context, repo, blobSHA string) (string, error) {
 	owner, repoName := splitRepo(repo)
@@ -1380,16 +1483,33 @@ func (ic *InstallationClient) FetchSchemaFilesOptimized(ctx context.Context, rep
 }
 
 func (ic *InstallationClient) fetchSchemaFilesFromTree(ctx context.Context, repo string, headSHA, schemaPath string) ([]GitHubFile, error) {
+	schemaPathPrefix := schemaPath + "/"
 	entries, truncated, err := ic.FetchGitTree(ctx, repo, headSHA)
 	if err != nil {
 		return nil, fmt.Errorf("fetch git tree: %w", err)
 	}
 	if truncated {
-		return nil, fmt.Errorf("fetch schema files from %s in repo %s ref %s: %w", schemaPath, repo, headSHA, ErrGitTreeTruncated)
+		// The whole-repo listing exceeds the Trees API cap, but the schema
+		// directory's own subtree can still be listed completely. Prefix the
+		// subtree's relative paths back to repo-relative so the filtering
+		// below sees the same shape as the full-tree listing.
+		subtreeEntries, found, subtreeErr := ic.FetchGitSubtree(ctx, repo, headSHA, schemaPath)
+		if subtreeErr != nil {
+			return nil, fmt.Errorf("fetch schema files from %s in repo %s ref %s: %w", schemaPath, repo, headSHA, subtreeErr)
+		}
+		if !found {
+			ic.logger.Debug("schema path does not exist at ref; no schema files to fetch",
+				"repo", repo, "ref", headSHA, "schema_path", schemaPath)
+			return nil, nil
+		}
+		entries = make([]TreeEntry, len(subtreeEntries))
+		for i, entry := range subtreeEntries {
+			entry.Path = schemaPathPrefix + entry.Path
+			entries[i] = entry
+		}
 	}
 
 	var filesToFetch []TreeEntry
-	schemaPathPrefix := schemaPath + "/"
 	for _, entry := range entries {
 		if entry.Type != "blob" {
 			continue

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -61,10 +61,11 @@ type Client struct {
 
 	// configDirHints returns the configured schema directories that may serve
 	// a repo, used by config discovery as probe targets when GitHub truncates
-	// the repository tree and a whole-repo scan is impossible. Static
-	// configuration set at construction; never mutated afterwards. Nil when
-	// the embedder has no directory configuration to offer.
-	configDirHints func(repo string) []string
+	// the repository tree and a whole-repo scan is impossible, plus whether
+	// those directories provably cover every policy-valid config location.
+	// Static configuration set at construction; never mutated afterwards. Nil
+	// when the embedder has no directory configuration to offer.
+	configDirHints func(repo string) (dirs []string, exhaustive bool)
 
 	// slugFetchMu serialises slug-fetch attempts so concurrent
 	// ForInstallation callers do not thundering-herd retry on startup
@@ -115,10 +116,12 @@ func WithTrustedCheckAppSlugs(slugs []string) ClientOption {
 }
 
 // WithConfigDirHints provides the configured schema directories that may serve
-// a given repo. Config discovery probes these directories for schemabot.yaml
+// a given repo, plus whether they provably cover every policy-valid config
+// location. Config discovery probes these directories for schemabot.yaml
 // files when GitHub truncates the repository tree (repos beyond the Trees API
-// response cap), where a whole-repo scan is impossible.
-func WithConfigDirHints(hints func(repo string) []string) ClientOption {
+// response cap), where a whole-repo scan is impossible; non-exhaustive hints
+// are never probed, keeping discovery fail-closed.
+func WithConfigDirHints(hints func(repo string) (dirs []string, exhaustive bool)) ClientOption {
 	return func(c *Client) {
 		c.configDirHints = hints
 	}
@@ -349,10 +352,11 @@ type InstallationClient struct {
 	trustedCheckAppSlugs []string
 
 	// configDirHints returns the configured schema directories that may serve
-	// a repo, used by config discovery as probe targets when GitHub truncates
-	// the repository tree. Copied from the parent Client; nil when the
-	// embedder has no directory configuration to offer.
-	configDirHints func(repo string) []string
+	// a repo (and whether they are exhaustive), used by config discovery as
+	// probe targets when GitHub truncates the repository tree. Copied from
+	// the parent Client; nil when the embedder has no directory configuration
+	// to offer.
+	configDirHints func(repo string) (dirs []string, exhaustive bool)
 
 	// checkStatusSingleflight is owned by the parent Client factory and
 	// shared across every InstallationClient it produces so concurrent
@@ -377,7 +381,7 @@ func (ic *InstallationClient) InstallationID() int64 {
 // a repo, used by config discovery when GitHub truncates the repository tree.
 // Production clients receive this from the parent Client (WithConfigDirHints);
 // this setter exists for directly-constructed clients (tests, library use).
-func (ic *InstallationClient) SetConfigDirHints(hints func(repo string) []string) {
+func (ic *InstallationClient) SetConfigDirHints(hints func(repo string) (dirs []string, exhaustive bool)) {
 	ic.configDirHints = hints
 }
 
@@ -1255,11 +1259,25 @@ func (ic *InstallationClient) fetchGitTreeShallow(ctx context.Context, repo, tre
 // exist (or is not a directory) at ref. The error wraps ErrGitTreeTruncated
 // when the subtree itself is too large to list completely.
 func (ic *InstallationClient) FetchGitSubtree(ctx context.Context, repo, ref, dir string) (entries []TreeEntry, found bool, err error) {
+	return ic.fetchGitSubtreeCached(ctx, repo, ref, dir, nil)
+}
+
+// fetchGitSubtreeCached is FetchGitSubtree with an optional memo for the
+// shallow per-level fetches, keyed by tree SHA. Callers resolving several
+// directories at the same ref pass one map so shared path-prefix levels (and
+// the root tree) cost a single API call per scan; nil disables memoization.
+func (ic *InstallationClient) fetchGitSubtreeCached(ctx context.Context, repo, ref, dir string, levelCache map[string][]TreeEntry) (entries []TreeEntry, found bool, err error) {
 	treeSHA := ref
 	for segment := range strings.SplitSeq(dir, "/") {
-		levelEntries, err := ic.fetchGitTreeShallow(ctx, repo, treeSHA)
-		if err != nil {
-			return nil, false, fmt.Errorf("resolve %s under %s in repo %s ref %s: %w", segment, dir, repo, ref, err)
+		levelEntries, cached := levelCache[treeSHA]
+		if !cached {
+			levelEntries, err = ic.fetchGitTreeShallow(ctx, repo, treeSHA)
+			if err != nil {
+				return nil, false, fmt.Errorf("resolve %s under %s in repo %s ref %s: %w", segment, dir, repo, ref, err)
+			}
+			if levelCache != nil {
+				levelCache[treeSHA] = levelEntries
+			}
 		}
 		next := ""
 		for _, entry := range levelEntries {
@@ -1489,6 +1507,12 @@ func (ic *InstallationClient) fetchSchemaFilesFromTree(ctx context.Context, repo
 		return nil, fmt.Errorf("fetch git tree: %w", err)
 	}
 	if truncated {
+		// A repo-root schema path cannot be recovered by a subtree fetch —
+		// the root tree IS the truncated listing — so keep the truncation
+		// error rather than misreport "no schema files".
+		if schemaPath == "" || schemaPath == "." {
+			return nil, fmt.Errorf("fetch schema files from repo root of %s ref %s: %w", repo, headSHA, ErrGitTreeTruncated)
+		}
 		// The whole-repo listing exceeds the Trees API cap, but the schema
 		// directory's own subtree can still be listed completely. Prefix the
 		// subtree's relative paths back to repo-relative so the filtering

--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -113,14 +113,28 @@ type FindAllConfigsResult struct {
 	InvalidConfigs []InvalidConfigInfo
 }
 
-// FindAllConfigs uses the Tree API to discover all schemabot.yaml config files in the repository.
+// FindAllConfigs uses the Tree API to discover all schemabot.yaml config files
+// in the repository. When the repository is too large for the Trees API to
+// list completely, discovery falls back to scanning the server-configured
+// schema directories for the repo; when no such fallback is possible it fails
+// closed with ErrGitTreeTruncated.
 func (ic *InstallationClient) FindAllConfigs(ctx context.Context, repo, ref string) (*FindAllConfigsResult, error) {
 	entries, truncated, err := ic.FetchGitTree(ctx, repo, ref)
 	if err != nil {
 		return nil, fmt.Errorf("fetch git tree: %w", err)
 	}
 	if truncated {
-		return nil, fmt.Errorf("discover schemabot configs in repo %s ref %s: %w", repo, ref, ErrGitTreeTruncated)
+		result, ok, hintErr := ic.findConfigsInHintDirs(ctx, repo, ref)
+		if hintErr != nil {
+			return nil, fmt.Errorf("discover schemabot configs in configured schema dirs of repo %s ref %s: %w", repo, ref, hintErr)
+		}
+		if !ok {
+			return nil, fmt.Errorf("discover schemabot configs in repo %s ref %s: %w", repo, ref, ErrGitTreeTruncated)
+		}
+		ic.logger.Info("git tree truncated; discovered configs from configured schema dirs",
+			"repo", repo, "ref", ref,
+			"valid", len(result.ValidConfigs), "invalid", len(result.InvalidConfigs))
+		return result, nil
 	}
 
 	var configPaths []string
@@ -160,6 +174,79 @@ func (ic *InstallationClient) FindAllConfigs(ctx context.Context, repo, ref stri
 		"repo", repo,
 	)
 	return result, nil
+}
+
+// findConfigsInHintDirs discovers schemabot.yaml configs by scanning the
+// subtree of each server-configured schema directory for the repo. It serves
+// repositories whose full recursive tree GitHub truncates, where a whole-repo
+// scan is impossible. The scan is recursive per directory, so configs nested
+// below a configured directory are found (allowed_dirs matching is
+// prefix-based). Only server-managed directories are covered — a config
+// outside every configured directory would be rejected by the allowed_dirs
+// policy anyway.
+//
+// ok is false when the client has no directory hints for the repo or when the
+// hinted directories contain no config files at all: an empty result cannot
+// distinguish "repo has no configs" from "the hints do not cover the configs",
+// so the caller must keep failing closed with the truncation error instead of
+// reporting ErrNoConfig.
+func (ic *InstallationClient) findConfigsInHintDirs(ctx context.Context, repo, ref string) (*FindAllConfigsResult, bool, error) {
+	if ic.configDirHints == nil {
+		ic.logger.Debug("no config dir hints configured; cannot scan truncated repo", "repo", repo, "ref", ref)
+		return nil, false, nil
+	}
+	hints := ic.configDirHints(repo)
+	if len(hints) == 0 {
+		ic.logger.Debug("no config dir hints for repo; cannot scan truncated repo", "repo", repo, "ref", ref)
+		return nil, false, nil
+	}
+
+	result := &FindAllConfigsResult{}
+	seen := make(map[string]struct{})
+	for _, dir := range hints {
+		entries, found, err := ic.FetchGitSubtree(ctx, repo, ref, dir)
+		if err != nil {
+			return nil, false, fmt.Errorf("scan configured schema dir %s: %w", dir, err)
+		}
+		if !found {
+			ic.logger.Debug("configured schema dir does not exist at ref; skipping",
+				"repo", repo, "ref", ref, "dir", dir)
+			continue
+		}
+		for _, entry := range entries {
+			if entry.Type != "blob" || !isConfigFile(entry.Path) {
+				continue
+			}
+			configPath := dir + "/" + entry.Path
+			// Nested hint directories can surface the same config twice.
+			if _, ok := seen[configPath]; ok {
+				continue
+			}
+			seen[configPath] = struct{}{}
+
+			config, err := ic.FetchConfig(ctx, repo, configPath, ref)
+			if err != nil {
+				ic.logger.Warn("failed to parse config", "path", configPath, "error", err)
+				result.InvalidConfigs = append(result.InvalidConfigs, InvalidConfigInfo{
+					Path:  configPath,
+					Error: err.Error(),
+				})
+				continue
+			}
+			result.ValidConfigs = append(result.ValidConfigs, DiscoveredConfig{
+				Config:    config,
+				Path:      configPath,
+				SchemaDir: path.Dir(configPath),
+			})
+		}
+	}
+
+	if len(result.ValidConfigs) == 0 && len(result.InvalidConfigs) == 0 {
+		ic.logger.Warn("configured schema dirs contain no configs; keeping fail-closed truncation error",
+			"repo", repo, "ref", ref, "hint_dirs", len(hints))
+		return nil, false, nil
+	}
+	return result, true, nil
 }
 
 // FindConfigByDatabaseName finds a schemabot.yaml config by database name.

--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -181,21 +181,27 @@ func (ic *InstallationClient) FindAllConfigs(ctx context.Context, repo, ref stri
 // repositories whose full recursive tree GitHub truncates, where a whole-repo
 // scan is impossible. The scan is recursive per directory, so configs nested
 // below a configured directory are found (allowed_dirs matching is
-// prefix-based). Only server-managed directories are covered — a config
-// outside every configured directory would be rejected by the allowed_dirs
-// policy anyway.
+// prefix-based). The scan only runs when the hints are exhaustive — every
+// policy-valid config location is covered by a hinted directory — because a
+// partial probe returned as authoritative could report a single config where
+// a full scan would find several, or omit a database whose config exists.
 //
-// ok is false when the client has no directory hints for the repo or when the
-// hinted directories contain no config files at all: an empty result cannot
-// distinguish "repo has no configs" from "the hints do not cover the configs",
-// so the caller must keep failing closed with the truncation error instead of
-// reporting ErrNoConfig.
+// ok is false when the client has no directory hints for the repo, the hints
+// are not exhaustive, or the hinted directories contain no config files at
+// all: an empty result cannot distinguish "repo has no configs" from "the
+// hints do not cover the configs", so the caller must keep failing closed
+// with the truncation error instead of reporting ErrNoConfig.
 func (ic *InstallationClient) findConfigsInHintDirs(ctx context.Context, repo, ref string) (*FindAllConfigsResult, bool, error) {
 	if ic.configDirHints == nil {
 		ic.logger.Debug("no config dir hints configured; cannot scan truncated repo", "repo", repo, "ref", ref)
 		return nil, false, nil
 	}
-	hints := ic.configDirHints(repo)
+	hints, exhaustive := ic.configDirHints(repo)
+	if !exhaustive {
+		ic.logger.Warn("configured schema dirs do not cover every policy-valid config location (a database allows configs outside any probe-able directory); keeping fail-closed truncation error",
+			"repo", repo, "ref", ref, "hint_dirs", len(hints))
+		return nil, false, nil
+	}
 	if len(hints) == 0 {
 		ic.logger.Debug("no config dir hints for repo; cannot scan truncated repo", "repo", repo, "ref", ref)
 		return nil, false, nil
@@ -203,8 +209,11 @@ func (ic *InstallationClient) findConfigsInHintDirs(ctx context.Context, repo, r
 
 	result := &FindAllConfigsResult{}
 	seen := make(map[string]struct{})
+	// Hint directories often share path prefixes; memoize the shallow
+	// per-level fetches so shared levels cost one API call per scan.
+	levelCache := make(map[string][]TreeEntry)
 	for _, dir := range hints {
-		entries, found, err := ic.FetchGitSubtree(ctx, repo, ref, dir)
+		entries, found, err := ic.fetchGitSubtreeCached(ctx, repo, ref, dir, levelCache)
 		if err != nil {
 			return nil, false, fmt.Errorf("scan configured schema dir %s: %w", dir, err)
 		}

--- a/pkg/github/config_test.go
+++ b/pkg/github/config_test.go
@@ -712,3 +712,255 @@ func registerDirectoryContent(t *testing.T, mux *http.ServeMux, endpointPath str
 		require.NoError(t, json.NewEncoder(w).Encode(contents))
 	})
 }
+
+// registerTruncatedRepoWithSchemaSubtree registers git-tree handlers for a
+// repository whose whole-repo recursive listing is truncated but whose
+// subtrees resolve: shallow fetches of the root and intermediate levels return
+// directory entries, and the apps/widgets/schema subtree lists subtreeEntries
+// (paths relative to that directory).
+func registerTruncatedRepoWithSchemaSubtree(t *testing.T, mux *http.ServeMux, subtreeEntries []map[string]any) {
+	t.Helper()
+
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/abc123", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("recursive") == "1" {
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+				"truncated": true,
+				"tree":      []any{},
+			}))
+			return
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"tree": []any{
+			map[string]any{"path": "apps", "type": "tree", "sha": "tree-apps"},
+			map[string]any{"path": "README.md", "type": "blob", "sha": "blob-readme"},
+		}}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/tree-apps", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"tree": []any{
+			map[string]any{"path": "widgets", "type": "tree", "sha": "tree-widgets"},
+		}}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/tree-widgets", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"tree": []any{
+			map[string]any{"path": "schema", "type": "tree", "sha": "tree-schema"},
+		}}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/tree-schema", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"tree": subtreeEntries}))
+	})
+}
+
+func registerGitBlob(t *testing.T, mux *http.ServeMux, sha, content string) {
+	t.Helper()
+
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/blobs/"+sha, func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.Blob{
+			Content:  new(base64.StdEncoding.EncodeToString([]byte(content))),
+			Encoding: new("base64"),
+		}))
+	})
+}
+
+func widgetsConfigDirHints(t *testing.T, dirs ...string) func(repo string) []string {
+	t.Helper()
+
+	return func(repo string) []string {
+		require.Equal(t, "octocat/hello-world", repo)
+		return dirs
+	}
+}
+
+func TestFindAllConfigsTruncatedTreeFallsBackToConfigDirHints(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerTruncatedRepoWithSchemaSubtree(t, mux, []map[string]any{
+		{"path": "schemabot.yaml", "type": "blob", "sha": "blob-config", "mode": "100644"},
+		{"path": "main/widgets.sql", "type": "blob", "sha": "blob-sql", "mode": "100644"},
+	})
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema/schemabot.yaml", "database: widgets\ntype: mysql\n")
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ic.SetConfigDirHints(widgetsConfigDirHints(t, "apps/widgets/schema"))
+
+	result, err := ic.FindAllConfigs(t.Context(), "octocat/hello-world", "abc123")
+
+	require.NoError(t, err)
+	require.Len(t, result.ValidConfigs, 1)
+	assert.Equal(t, "widgets", result.ValidConfigs[0].Config.Database)
+	assert.Equal(t, "apps/widgets/schema", result.ValidConfigs[0].SchemaDir)
+	assert.Equal(t, "apps/widgets/schema/schemabot.yaml", result.ValidConfigs[0].Path)
+	assert.Empty(t, result.InvalidConfigs)
+}
+
+func TestFindAllConfigsTruncatedTreeFindsConfigNestedBelowHintDir(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerTruncatedRepoWithSchemaSubtree(t, mux, []map[string]any{
+		{"path": "payments/schemabot.yaml", "type": "blob", "sha": "blob-config", "mode": "100644"},
+		{"path": "payments/transactions.sql", "type": "blob", "sha": "blob-sql", "mode": "100644"},
+	})
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema/payments/schemabot.yaml", "database: payments\ntype: mysql\n")
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ic.SetConfigDirHints(widgetsConfigDirHints(t, "apps/widgets/schema"))
+
+	result, err := ic.FindAllConfigs(t.Context(), "octocat/hello-world", "abc123")
+
+	require.NoError(t, err)
+	require.Len(t, result.ValidConfigs, 1)
+	assert.Equal(t, "payments", result.ValidConfigs[0].Config.Database)
+	assert.Equal(t, "apps/widgets/schema/payments", result.ValidConfigs[0].SchemaDir)
+}
+
+func TestFindAllConfigsTruncatedTreeSkipsMissingHintDir(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerTruncatedRepoWithSchemaSubtree(t, mux, []map[string]any{
+		{"path": "schemabot.yaml", "type": "blob", "sha": "blob-config", "mode": "100644"},
+	})
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema/schemabot.yaml", "database: widgets\ntype: mysql\n")
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ic.SetConfigDirHints(widgetsConfigDirHints(t, "apps/gone/schema", "apps/widgets/schema"))
+
+	result, err := ic.FindAllConfigs(t.Context(), "octocat/hello-world", "abc123")
+
+	require.NoError(t, err)
+	require.Len(t, result.ValidConfigs, 1)
+	assert.Equal(t, "widgets", result.ValidConfigs[0].Config.Database)
+}
+
+func TestFindAllConfigsTruncatedTreeFailsClosedWhenHintDirsHaveNoConfigs(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerTruncatedRepoWithSchemaSubtree(t, mux, []map[string]any{
+		{"path": "main/widgets.sql", "type": "blob", "sha": "blob-sql", "mode": "100644"},
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ic.SetConfigDirHints(widgetsConfigDirHints(t, "apps/widgets/schema"))
+
+	_, err := ic.FindAllConfigs(t.Context(), "octocat/hello-world", "abc123")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrGitTreeTruncated)
+}
+
+func TestFindAllConfigsTruncatedTreeFailsClosedWhenNoHintsForRepo(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerTruncatedRepoWithSchemaSubtree(t, mux, nil)
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ic.SetConfigDirHints(widgetsConfigDirHints(t))
+
+	_, err := ic.FindAllConfigs(t.Context(), "octocat/hello-world", "abc123")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrGitTreeTruncated)
+}
+
+func TestFindAllConfigsTruncatedTreeReportsInvalidHintDirConfig(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerTruncatedRepoWithSchemaSubtree(t, mux, []map[string]any{
+		{"path": "schemabot.yaml", "type": "blob", "sha": "blob-config", "mode": "100644"},
+	})
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema/schemabot.yaml", "type: mysql\n")
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ic.SetConfigDirHints(widgetsConfigDirHints(t, "apps/widgets/schema"))
+
+	result, err := ic.FindAllConfigs(t.Context(), "octocat/hello-world", "abc123")
+
+	require.NoError(t, err)
+	assert.Empty(t, result.ValidConfigs)
+	require.Len(t, result.InvalidConfigs, 1)
+	assert.Equal(t, "apps/widgets/schema/schemabot.yaml", result.InvalidConfigs[0].Path)
+	assert.Contains(t, result.InvalidConfigs[0].Error, "database is required")
+}
+
+func TestFindConfigByDatabaseNameTruncatedTreeUsesConfigDirHints(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerPullRequest(t, mux, "abc123")
+	registerPullRequestFiles(t, mux, []*gh.CommitFile{{
+		Filename: new("docs/readme.md"),
+		Status:   new("modified"),
+	}})
+	registerTruncatedRepoWithSchemaSubtree(t, mux, []map[string]any{
+		{"path": "schemabot.yaml", "type": "blob", "sha": "blob-config", "mode": "100644"},
+	})
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema/schemabot.yaml", "database: widgets\ntype: mysql\n")
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ic.SetConfigDirHints(widgetsConfigDirHints(t, "apps/widgets/schema"))
+
+	config, schemaDir, err := ic.FindConfigByDatabaseName(t.Context(), "octocat/hello-world", 1, "widgets")
+
+	require.NoError(t, err)
+	assert.Equal(t, "widgets", config.Database)
+	assert.Equal(t, "apps/widgets/schema", schemaDir)
+}
+
+func TestFetchSchemaFilesFromTreeTruncatedRootUsesSchemaSubtree(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerTruncatedRepoWithSchemaSubtree(t, mux, []map[string]any{
+		{"path": "schemabot.yaml", "type": "blob", "sha": "blob-config", "mode": "100644"},
+		{"path": "main/widgets.sql", "type": "blob", "sha": "blob-sql", "mode": "100644"},
+	})
+	registerGitBlob(t, mux, "blob-sql", "CREATE TABLE `widgets` (`id` BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY);")
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	files, err := ic.fetchSchemaFilesFromTree(t.Context(), "octocat/hello-world", "abc123", "apps/widgets/schema")
+
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, "apps/widgets/schema/main/widgets.sql", files[0].Path)
+	assert.Equal(t, "widgets.sql", files[0].Name)
+	assert.Contains(t, files[0].Content, "CREATE TABLE")
+	assert.Contains(t, files[0].Content, "widgets")
+}
+
+func TestFetchSchemaFilesFromTreeTruncatedRootFailsClosedOnSubtreeSymlink(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerTruncatedRepoWithSchemaSubtree(t, mux, []map[string]any{
+		{"path": "linked", "type": "blob", "sha": "blob-link", "mode": "120000"},
+		{"path": "main/widgets.sql", "type": "blob", "sha": "blob-sql", "mode": "100644"},
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	_, err := ic.fetchSchemaFilesFromTree(t.Context(), "octocat/hello-world", "abc123", "apps/widgets/schema")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "symlink")
+}
+
+func TestFetchSchemaFilesFromTreeTruncatedRootMissingSchemaDirReturnsNoFiles(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerTruncatedRepoWithSchemaSubtree(t, mux, nil)
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	files, err := ic.fetchSchemaFilesFromTree(t.Context(), "octocat/hello-world", "abc123", "apps/gone/schema")
+
+	require.NoError(t, err)
+	assert.Empty(t, files)
+}
+
+func TestFetchSchemaFilesFromTreeFailsClosedWhenSubtreeAlsoTruncated(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/abc123", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("recursive") == "1" {
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"truncated": true, "tree": []any{}}))
+			return
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"tree": []any{
+			map[string]any{"path": "apps", "type": "tree", "sha": "tree-huge"},
+		}}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/tree-huge", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("recursive") == "1" {
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"truncated": true, "tree": []any{}}))
+			return
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"tree": []any{}}))
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	_, err := ic.fetchSchemaFilesFromTree(t.Context(), "octocat/hello-world", "abc123", "apps")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrGitTreeTruncated)
+}

--- a/pkg/github/config_test.go
+++ b/pkg/github/config_test.go
@@ -760,13 +760,29 @@ func registerGitBlob(t *testing.T, mux *http.ServeMux, sha, content string) {
 	})
 }
 
-func widgetsConfigDirHints(t *testing.T, dirs ...string) func(repo string) []string {
+func widgetsConfigDirHints(t *testing.T, dirs ...string) func(repo string) ([]string, bool) {
 	t.Helper()
 
-	return func(repo string) []string {
+	return func(repo string) ([]string, bool) {
 		require.Equal(t, "octocat/hello-world", repo)
-		return dirs
+		return dirs, true
 	}
+}
+
+// A repo-root schema path cannot be recovered through a subtree fetch when
+// the repository tree is truncated — the root tree is the truncated listing
+// itself — so schema-file loading keeps the truncation error instead of
+// misreporting an empty schema directory.
+func TestFetchSchemaFilesFromTreeTruncatedRepoRootFailsClosed(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerTruncatedRepoWithSchemaSubtree(t, mux, nil)
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	_, err := ic.fetchSchemaFilesFromTree(t.Context(), "octocat/hello-world", "abc123", ".")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrGitTreeTruncated)
 }
 
 func TestFindAllConfigsTruncatedTreeFallsBackToConfigDirHints(t *testing.T) {
@@ -847,6 +863,30 @@ func TestFindAllConfigsTruncatedTreeFailsClosedWhenNoHintsForRepo(t *testing.T) 
 
 	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	ic.SetConfigDirHints(widgetsConfigDirHints(t))
+
+	_, err := ic.FindAllConfigs(t.Context(), "octocat/hello-world", "abc123")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrGitTreeTruncated)
+}
+
+// A database that allows configs outside every probe-able directory (no
+// allowed_dirs, a wildcard, or a repo-root entry) makes the hint list
+// non-exhaustive: a partial probe could return a confidently wrong result, so
+// discovery must keep the truncation error even when other hinted directories
+// would have yielded configs.
+func TestFindAllConfigsTruncatedTreeFailsClosedWhenHintsNotExhaustive(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerTruncatedRepoWithSchemaSubtree(t, mux, []map[string]any{
+		{"path": "schemabot.yaml", "type": "blob", "sha": "blob-config", "mode": "100644"},
+	})
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema/schemabot.yaml", "database: widgets\ntype: mysql\n")
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ic.SetConfigDirHints(func(repo string) ([]string, bool) {
+		require.Equal(t, "octocat/hello-world", repo)
+		return []string{"apps/widgets/schema"}, false
+	})
 
 	_, err := ic.FindAllConfigs(t.Context(), "octocat/hello-world", "abc123")
 

--- a/pkg/serve/serve.go
+++ b/pkg/serve/serve.go
@@ -626,7 +626,8 @@ func buildSingleAppWebhookRuntime(serverConfig *api.ServerConfig, svc *api.Servi
 
 	appID := serverConfig.GitHub.ResolveAppID()
 	ghClient := ghclient.NewClient(appID, []byte(ghPrivateKey), logger,
-		ghclient.WithTrustedCheckAppSlugs(serverConfig.GitHub.TrustedCheckAppSlugs))
+		ghclient.WithTrustedCheckAppSlugs(serverConfig.GitHub.TrustedCheckAppSlugs),
+		ghclient.WithConfigDirHints(serverConfig.SchemaDirHintsForRepo))
 	handler := webhook.NewHandler(svc, ghClient, []byte(ghWebhookSecret), logger,
 		webhook.WithRepoWebhookSecret([]byte(repoWebhookSecret)))
 	logger.Info("GitHub webhook endpoint registered",
@@ -687,7 +688,8 @@ func buildMultiAppWebhookRuntime(serverConfig *api.ServerConfig, svc *api.Servic
 		}
 
 		clients[e.name] = ghclient.NewClient(e.id, []byte(privateKey), logger,
-			ghclient.WithTrustedCheckAppSlugs(e.cfg.TrustedCheckAppSlugs))
+			ghclient.WithTrustedCheckAppSlugs(e.cfg.TrustedCheckAppSlugs),
+			ghclient.WithConfigDirHints(serverConfig.SchemaDirHintsForRepo))
 		secretsByApp[e.name] = []byte(secret)
 		appByID[e.id] = e.name
 

--- a/pkg/webhook/truncated_repo_integration_test.go
+++ b/pkg/webhook/truncated_repo_integration_test.go
@@ -1,0 +1,293 @@
+//go:build integration
+
+// Webhook integration tests for plan commands on repositories so large that
+// GitHub truncates their recursive tree listing.
+
+package webhook
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	gh "github.com/google/go-github/v86/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/api"
+	ghclient "github.com/block/schemabot/pkg/github"
+)
+
+// newE2EHandlerWithConfigDirHints mirrors newE2EHandler but wires the
+// server-configured schema directory hints into the GitHub client, matching
+// the production serve wiring so config discovery can fall back to the
+// configured directories when the repository tree is truncated.
+func newE2EHandlerWithConfigDirHints(t *testing.T, svc *api.Service, client *gh.Client) *Handler {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	installClient := ghclient.NewInstallationClient(client, logger)
+	installClient.SetConfigDirHints(svc.Config().SchemaDirHintsForRepo)
+	factory := &fakeClientFactory{client: installClient}
+	return NewHandler(svc, factory, nil, logger)
+}
+
+// setupFakeGitHubForPlanOnTruncatedRepo simulates the GitHub API of a
+// monorepo whose whole-repo recursive tree listing is truncated: recursive
+// fetches of the head commit return truncated with no entries, while shallow
+// (per-level) fetches resolve, and the schema directory's own subtree lists
+// completely. The PR diff contains no schema files, so config discovery must
+// go through the whole-repo scan rather than the changed-file probes.
+func setupFakeGitHubForPlanOnTruncatedRepo(t *testing.T, mux *http.ServeMux, schemaSQL map[string]string, schemabotConfig, ns string) *planFlowResult {
+	t.Helper()
+	return setupFakeGitHubForPlanOnTruncatedRepoWithPRState(t, mux, schemaSQL, schemabotConfig, ns, "open")
+}
+
+// setupFakeGitHubForPlanOnTruncatedRepoWithPRState is
+// setupFakeGitHubForPlanOnTruncatedRepo with the PR's lifecycle state under
+// test control, so plan-command behavior on closed PRs can be exercised.
+func setupFakeGitHubForPlanOnTruncatedRepoWithPRState(t *testing.T, mux *http.ServeMux, schemaSQL map[string]string, schemabotConfig, ns, prState string) *planFlowResult {
+	t.Helper()
+
+	result := &planFlowResult{
+		comments:  make(chan string, 10),
+		reactions: make(chan string, 10),
+		checkRuns: make(chan checkRunCapture, 10),
+	}
+
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(gh.PullRequest{
+			State: new(prState),
+			Head: &gh.PullRequestBranch{
+				Ref: new("feature-branch"),
+				SHA: new("abc123"),
+			},
+			Base: &gh.PullRequestBranch{
+				Ref: new("main"),
+				SHA: new("def456"),
+			},
+			User: &gh.User{Login: new("testuser")},
+		})
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]*gh.CommitFile{{
+			Filename: new("docs/readme.md"),
+			Status:   new("modified"),
+		}})
+	})
+
+	// The schema directory's subtree, with entry paths relative to "schema".
+	subtreeEntries := []*gh.TreeEntry{{
+		Path: new("schemabot.yaml"),
+		Mode: new("100644"),
+		Type: new("blob"),
+		SHA:  new("configsha001"),
+		Size: new(len(schemabotConfig)),
+	}}
+	blobContents := map[string]string{"configsha001": schemabotConfig}
+	blobIndex := 0
+	for name, content := range schemaSQL {
+		sha := fmt.Sprintf("blobsha%03d", blobIndex)
+		blobIndex++
+		blobContents[sha] = content
+		subtreeEntries = append(subtreeEntries, &gh.TreeEntry{
+			Path: new(ns + "/" + name),
+			Mode: new("100644"),
+			Type: new("blob"),
+			SHA:  new(sha),
+			Size: new(len(content)),
+		})
+	}
+
+	// Head commit tree: the recursive listing is truncated; the shallow
+	// listing resolves the top-level "schema" directory for the subtree walk.
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/abc123", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("recursive") == "1" {
+			_ = json.NewEncoder(w).Encode(gh.Tree{
+				SHA:       new("abc123"),
+				Entries:   []*gh.TreeEntry{},
+				Truncated: new(true),
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(gh.Tree{
+			SHA: new("abc123"),
+			Entries: []*gh.TreeEntry{{
+				Path: new("schema"),
+				Mode: new("040000"),
+				Type: new("tree"),
+				SHA:  new("treeschema001"),
+			}},
+			Truncated: new(false),
+		})
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/treeschema001", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(gh.Tree{
+			SHA:       new("treeschema001"),
+			Entries:   subtreeEntries,
+			Truncated: new(false),
+		})
+	})
+
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/blobs/", func(w http.ResponseWriter, r *http.Request) {
+		sha := r.URL.Path[len("/repos/octocat/hello-world/git/blobs/"):]
+		content, ok := blobContents[sha]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		encoded := base64.StdEncoding.EncodeToString([]byte(content))
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{"sha":"%s","content":"%s","encoding":"base64","size":%d}`, sha, encoded, len(content))
+	})
+
+	// Contents API serves only the config file. Directory listings 404 so
+	// schema files load through the git-tree path, like a repository whose
+	// schema directory the Contents walk cannot serve.
+	mux.HandleFunc("GET /repos/octocat/hello-world/contents/", func(w http.ResponseWriter, r *http.Request) {
+		filePath := r.URL.Path[len("/repos/octocat/hello-world/contents/"):]
+		if filePath == "schema/schemabot.yaml" {
+			_ = json.NewEncoder(w).Encode(gh.RepositoryContent{
+				Name:     new("schemabot.yaml"),
+				Path:     new("schema/schemabot.yaml"),
+				Content:  new(base64.StdEncoding.EncodeToString([]byte(schemabotConfig))),
+				Encoding: new("base64"),
+			})
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Body string `json:"body"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		result.comments <- body.Body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+	})
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/comments/42/reactions", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Content string `json:"content"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		result.reactions <- body.Content
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		var body checkRunCapture
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		result.checkRuns <- body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+	mux.HandleFunc("PATCH /repos/octocat/hello-world/check-runs/", func(w http.ResponseWriter, r *http.Request) {
+		var body checkRunCapture
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		result.checkRuns <- body
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+
+	registerCheckStatusRESTHandlersForAnyRef(mux, func() []checkStatusNode { return nil })
+
+	return result
+}
+
+// TestE2EPlanCommandOnTruncatedRepoDiscoversConfigViaConfiguredDirs exercises
+// database-scoped discovery on a huge monorepo: a user comments
+// `schemabot plan -e staging -d <db>` on a PR whose diff does not touch that
+// database's schema, in a repository whose recursive tree listing GitHub
+// truncates. The whole-repo config scan must recover via the
+// server-configured schema directories (databases.<db>.allowed_dirs) and the
+// schema files must load through the schema directory's own subtree, so the
+// user gets a real plan instead of a failed command they cannot act on.
+func TestE2EPlanCommandOnTruncatedRepoDiscoversConfigViaConfiguredDirs(t *testing.T) {
+	dbName := "webhook_truncated_repo_plan"
+	svc := setupE2EService(t, dbName)
+
+	serverConfig := svc.Config()
+	dbConfig := serverConfig.Databases[dbName]
+	dbConfig.AllowedDirs = []string{"schema"}
+	serverConfig.Databases[dbName] = dbConfig
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+
+	result := setupFakeGitHubForPlanOnTruncatedRepo(t, mux, schemaFiles, schemabotConfig, dbName)
+	h := newE2EHandlerWithConfigDirHints(t, svc, client)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: fmt.Sprintf("schemabot plan -e staging -d %s", dbName),
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case body := <-result.comments:
+		assert.NotContains(t, body, "truncated repository tree")
+		assert.NotContains(t, body, "Plan Failed")
+		assert.Contains(t, body, "CREATE TABLE")
+		assert.Contains(t, body, "users")
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for plan comment")
+	}
+}
+
+// TestE2EPlanCommandOnTruncatedRepoWithoutConfiguredDirsFailsClosed verifies
+// the fail-closed boundary of the truncated-tree fallback: when the server
+// config carries no schema directories for the repository, a database-scoped
+// plan's whole-repo scan has nothing safe to probe and the command must fail
+// with the truncation error rather than report that no config exists.
+func TestE2EPlanCommandOnTruncatedRepoWithoutConfiguredDirsFailsClosed(t *testing.T) {
+	dbName := "webhook_truncated_repo_no_dirs"
+	svc := setupE2EService(t, dbName)
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	result := setupFakeGitHubForPlanOnTruncatedRepo(t, mux, nil, schemabotConfig, dbName)
+	h := newE2EHandlerWithConfigDirHints(t, svc, client)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: fmt.Sprintf("schemabot plan -e staging -d %s", dbName),
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "Plan Failed")
+		assert.Contains(t, body, "truncated repository tree")
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for failure comment")
+	}
+}


### PR DESCRIPTION
## Why this matters

Repositories beyond GitHub's Trees API cap get a truncated recursive listing, so every whole-repo config scan (bare `schemabot plan`, `plan -e`, `plan -d` for a database outside the diff, unlock inference) fails closed with an error the user cannot act on. In the largest monorepos, that turns routine self-service commands into operator escalations.

## How it works

SchemaBot's server config already says where configs are *allowed* to live (`databases.<db>.allowed_dirs`) — a config anywhere else would be rejected by policy. So when the whole-repo listing truncates, `FindAllConfigs` doesn't need it: it walks directly to each configured directory and reads just that. The schema-file loader recovers the same way.

Git makes this possible because every directory is its own tree object listing only its *immediate* children, with pointers to its subdirectories' trees. A one-level fetch is only as big as the directory itself, so it never hits the cap — only the flattened whole-repo listing does. Resolving `apps/widgets/schema` is just following pointers, like `cd apps && cd widgets && cd schema && ls -R` instead of `ls -R` from the repo root:

```
repo root — 49k files; recursive listing → TRUNCATED ✗

fetch root, 1 level (~40 entries)     ── 1 small call
  └─ "apps" → tree a1b2c3
fetch apps, 1 level                   ── 1 small call
  └─ "widgets" → tree d4e5f6
fetch widgets, 1 level                ── 1 small call
  └─ "schema" → tree 789abc
fetch schema, RECURSIVE (rooted here) ── only this directory
  └─ schemabot.yaml, users.sql, …        must fit under the cap ✓
```

Shallow per-level fetches are memoized per scan, so hint directories sharing a path prefix (e.g. `apps/widgets/schema` and `apps/payments/schema`) reuse the root and `apps` levels instead of re-walking them.

The fallback only runs when the configured directories are **provably exhaustive** — every location a policy-valid config could live in is covered. If any repo-eligible database has no `allowed_dirs`, or a wildcard (`*`) or repo-root (`.`) entry, its config could legally live anywhere, and a partial probe returned as authoritative could plan the wrong database (one config found where a full scan would find several) or report a misleading "database not found". In those cases — and when no directories are configured, none contain a config, or the schema path is the repo root — discovery keeps failing closed with the truncation error. Symlink handling also still fails closed.

```
FindAllConfigs(repo, ref)
  ├─ full recursive tree ── ok ───────────────→ scan for schemabot.yaml
  └─ truncated
       ├─ hints exhaustive (every db has literal allowed_dirs)
       │    └─ per-dir subtree walk ── found ─→ configs
       └─ no hints / not exhaustive / nothing found
                                     ─────────→ fail closed (ErrGitTreeTruncated)
```

## How it moves toward the northstar

Schema changes stay self-service at any repository size: the fail-closed guarantee is unchanged, but a truncated tree no longer strands users whose schema directories are perfectly listable on their own.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
