### PR TITLE
feat(api): webhooks redrive endpoint

### DIFF
--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -695,6 +695,7 @@ func (s *Service) ConfigureRoutes(mux *http.ServeMux) {
 	handle("GET /api/status", s.handleStatus)
 	handle("GET /api/logs/{database}", s.handleLogs)
 	handle("GET /api/logs", s.handleLogsWithoutDatabase)
+	handle("POST /api/webhooks/redrive", s.handleWebhookRedrive)
 
 	// Lock API (database-level locking)
 	handle("POST /api/locks/acquire", s.handleLockAcquire)

--- a/pkg/api/webhook_ops_handlers.go
+++ b/pkg/api/webhook_ops_handlers.go
@@ -17,6 +17,7 @@ import (
 	gh "github.com/google/go-github/v86/github"
 
 	"github.com/block/schemabot/pkg/apitypes"
+	ghclient "github.com/block/schemabot/pkg/github"
 )
 
 const (
@@ -185,12 +186,15 @@ func newWebhookRedriveGitHubClient(app webhookRedriveApp, logger *slog.Logger) (
 	if privateKey == "" {
 		return nil, fmt.Errorf("app %q private key resolved to empty value", app.name)
 	}
-	transport, err := ghinstallation.NewAppsTransport(http.DefaultTransport, app.id, []byte(privateKey))
+	appsTransport, err := ghinstallation.NewAppsTransport(http.DefaultTransport, app.id, []byte(privateKey))
 	if err != nil {
 		return nil, fmt.Errorf("create GitHub App transport for app %q: %w", app.name, err)
 	}
-	client := gh.NewClient(&http.Client{Transport: transport, Timeout: 30 * time.Second})
-	client.DisableRateLimitCheck = true
+	// A crawl issues many list/detail/redeliver calls per run, so wrap the
+	// transport with the shared secondary-rate-limit handling (bounded sleep
+	// on a 403 secondary limit) that every other GitHub client here uses,
+	// rather than issuing bare requests that would trip the limit mid-crawl.
+	client := gh.NewClient(&http.Client{Transport: ghclient.NewRateLimitedTransport(appsTransport), Timeout: 30 * time.Second})
 	logger.Info("created GitHub App webhook redrive client", "app_name", app.name, "app_id", app.id)
 	return client, nil
 }
@@ -199,6 +203,13 @@ func redriveWebhookAppDeliveries(ctx context.Context, client webhookRedriveDeliv
 	result := WebhookRedriveResult{AppName: appName, DryRun: dryRun}
 	cursor := startCursor
 	historyExhausted := false
+	// A GitHub delivery record is immutable: a failed delivery stays "failed"
+	// forever, and a redelivery is a new record sharing the original's GUID.
+	// Track GUIDs whose attempt succeeded so a failed original is not
+	// re-redelivered when a newer redelivery of it already succeeded. The
+	// crawl walks newest→oldest, so the success is seen before its failed
+	// original — keeping repeated redrives of a stable window convergent.
+	succeededGUIDs := make(map[string]struct{})
 	for result.Pages < maxPages {
 		result.Pages++
 		deliveries, resp, err := client.ListHookDeliveries(ctx, &gh.ListCursorOptions{PerPage: webhookRedrivePageSize, Cursor: cursor})
@@ -219,14 +230,37 @@ func redriveWebhookAppDeliveries(ctx context.Context, client webhookRedriveDeliv
 				continue
 			}
 			result.OldestFetched = delivered.Format(time.RFC3339)
-			if !delivered.Before(windowStart) && !delivered.After(windowEnd) && webhookRedriveDeliverySelected(delivery) {
-				selection, ok, err := webhookRedriveSelectionFor(ctx, client, delivery, repo, pr)
-				if err != nil {
-					return result, err
+
+			guid := delivery.GetGUID()
+			if webhookDeliverySucceeded(delivery) {
+				if guid != "" {
+					succeededGUIDs[guid] = struct{}{}
 				}
-				if ok {
-					result.Selected = append(result.Selected, selection)
+				continue
+			}
+			if delivered.Before(windowStart) || delivered.After(windowEnd) || !webhookRedriveEventEligible(delivery) {
+				continue
+			}
+			if _, ok := succeededGUIDs[guid]; ok && guid != "" {
+				// A newer redelivery of this delivery already succeeded during
+				// this crawl; skip it so a re-run over a stable window does not
+				// re-fire downstream events.
+				continue
+			}
+			selection, ok, err := webhookRedriveSelectionFor(ctx, client, delivery, repo, pr)
+			if err != nil {
+				// A per-delivery detail-fetch or payload-parse failure must not
+				// abort the whole crawl; skip this one and keep going so the
+				// operator still gets (and can act on) the rest.
+				result.Skipped++
+				if logger != nil {
+					logger.Warn("skipping webhook delivery whose detail could not be resolved for repo/PR filtering",
+						"app_name", appName, "delivery_id", delivery.GetID(), "event", delivery.GetEvent(), "action", delivery.GetAction(), "error", err)
 				}
+				continue
+			}
+			if ok {
+				result.Selected = append(result.Selected, selection)
 			}
 		}
 		oldestInPage := deliveries[len(deliveries)-1].GetDeliveredAt().Time
@@ -282,8 +316,19 @@ func waitWebhookRedriveDelay(ctx context.Context) error {
 	}
 }
 
-func webhookRedriveDeliverySelected(delivery *gh.HookDelivery) bool {
-	if delivery == nil || delivery.GetID() == 0 || strings.EqualFold(delivery.GetStatus(), "OK") {
+// webhookDeliverySucceeded reports whether a delivery's own attempt succeeded.
+// GitHub's status string mirrors the HTTP response text ("OK", "Accepted",
+// …), so any 2xx status code is the robust success predicate — matching on
+// the literal "OK" would misclassify a 202 as a failure and redrive it.
+func webhookDeliverySucceeded(delivery *gh.HookDelivery) bool {
+	return delivery.GetStatusCode()/100 == 2
+}
+
+// webhookRedriveEventEligible reports whether a delivery is one of the
+// check-creating events a redrive targets. It does not consider success or
+// failure — the caller redrives only the failed ones.
+func webhookRedriveEventEligible(delivery *gh.HookDelivery) bool {
+	if delivery == nil || delivery.GetID() == 0 {
 		return false
 	}
 	switch delivery.GetEvent() {
@@ -328,7 +373,11 @@ func webhookRedriveSelectionFor(ctx context.Context, client webhookRedriveDelive
 		return selection, false, nil
 	}
 	// check_suite and merge_group payloads can carry several pull requests;
-	// the delivery is selected when any of them matches the filter.
+	// the delivery is selected when any of them matches the filter. A
+	// pr-filtered redrive intentionally skips deliveries whose payload names
+	// no pull request — merge_group deliveries and check_suite deliveries for
+	// fork PRs — since the filter cannot confirm they belong to the requested
+	// PR. Run without --pr (repo-scoped) to include those.
 	if pr != 0 {
 		if !slices.Contains(payload.prs, pr) {
 			return selection, false, nil

--- a/pkg/api/webhook_ops_handlers.go
+++ b/pkg/api/webhook_ops_handlers.go
@@ -1,0 +1,391 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/bradleyfalzon/ghinstallation/v2"
+	gh "github.com/google/go-github/v86/github"
+
+	"github.com/block/schemabot/pkg/apitypes"
+)
+
+const (
+	webhookRedrivePageSize = 100
+	webhookRedriveDelay    = 150 * time.Millisecond
+
+	// webhookOpsRequestTimeout bounds the webhook operator endpoints, which
+	// crawl GitHub delivery history or every open PR and routinely need far
+	// longer than the server-wide write timeout allows.
+	webhookOpsRequestTimeout = 15 * time.Minute
+
+	// webhookRedriveMaxPagesPerRequest bounds one redrive request's listing so
+	// each HTTP request finishes in seconds; callers continue via the cursor.
+	webhookRedriveMaxPagesPerRequest = 25
+)
+
+// webhookOpsRequestError marks a failure caused by the request itself
+// (validation, unknown app name), as opposed to a server-side or GitHub-side
+// failure while executing it — the two need different HTTP status codes so
+// operators know whether to fix the request or investigate the server.
+type webhookOpsRequestError struct{ err error }
+
+func (e *webhookOpsRequestError) Error() string { return e.err.Error() }
+func (e *webhookOpsRequestError) Unwrap() error { return e.err }
+
+func webhookOpsRequestErrorf(format string, args ...any) error {
+	return &webhookOpsRequestError{err: fmt.Errorf(format, args...)}
+}
+
+// extendWebhookOpsDeadline lifts the server-wide write timeout for a webhook
+// operator request and returns a context bounded to the same budget, so the
+// crawl can outlive the default timeout without running unbounded.
+func (s *Service) extendWebhookOpsDeadline(w http.ResponseWriter, r *http.Request) (context.Context, context.CancelFunc) {
+	if err := http.NewResponseController(w).SetWriteDeadline(time.Now().Add(webhookOpsRequestTimeout)); err != nil {
+		s.logger.Warn("failed to extend webhook ops write deadline; the server-wide write timeout still applies",
+			"path", r.URL.Path, "error", err)
+	}
+	return context.WithTimeout(r.Context(), webhookOpsRequestTimeout)
+}
+
+func (s *Service) writeWebhookOpsError(w http.ResponseWriter, err error) {
+	var reqErr *webhookOpsRequestError
+	if errors.As(err, &reqErr) {
+		s.writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	s.writeError(w, http.StatusInternalServerError, err.Error())
+}
+
+type WebhookRedriveRequest = apitypes.WebhookRedriveRequest
+type WebhookRedriveResponse = apitypes.WebhookRedriveResponse
+type WebhookRedriveResult = apitypes.WebhookRedriveResult
+type WebhookRedriveSelection = apitypes.WebhookRedriveSelection
+
+type webhookRedriveDeliveryClient interface {
+	ListHookDeliveries(ctx context.Context, opts *gh.ListCursorOptions) ([]*gh.HookDelivery, *gh.Response, error)
+	GetHookDelivery(ctx context.Context, deliveryID int64) (*gh.HookDelivery, *gh.Response, error)
+	RedeliverHookDelivery(ctx context.Context, deliveryID int64) (*gh.HookDelivery, *gh.Response, error)
+}
+
+type webhookRedriveApp struct {
+	name   string
+	id     int64
+	config GitHubAppConfig
+}
+
+func (s *Service) handleWebhookRedrive(w http.ResponseWriter, r *http.Request) {
+	var req WebhookRedriveRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeBodyDecodeError(w, err)
+		return
+	}
+	ctx, cancel := s.extendWebhookOpsDeadline(w, r)
+	defer cancel()
+	response, err := executeWebhookRedrive(ctx, s.config, req, s.logger)
+	if err != nil {
+		s.writeWebhookOpsError(w, err)
+		return
+	}
+	s.writeJSON(w, http.StatusOK, response)
+}
+
+func executeWebhookRedrive(ctx context.Context, cfg *ServerConfig, req WebhookRedriveRequest, logger *slog.Logger) (*WebhookRedriveResponse, error) {
+	if req.MaxPages <= 0 {
+		return nil, webhookOpsRequestErrorf("max_pages must be positive")
+	}
+	windowStart, err := time.Parse(time.RFC3339, req.WindowStart)
+	if err != nil {
+		return nil, webhookOpsRequestErrorf("parse window_start %q as RFC3339: %v", req.WindowStart, err)
+	}
+	windowEnd, err := time.Parse(time.RFC3339, req.WindowEnd)
+	if err != nil {
+		return nil, webhookOpsRequestErrorf("parse window_end %q as RFC3339: %v", req.WindowEnd, err)
+	}
+	if windowEnd.Before(windowStart) {
+		return nil, webhookOpsRequestErrorf("window_end must be at or after window_start")
+	}
+	if req.PR < 0 {
+		return nil, webhookOpsRequestErrorf("pr must be non-negative; 0 disables PR filtering")
+	}
+	if req.Cursor != "" && req.App == "" {
+		return nil, webhookOpsRequestErrorf("cursor continuation requires app to be set")
+	}
+	apps, err := webhookRedriveApps(cfg, req.App)
+	if err != nil {
+		return nil, err
+	}
+	maxPages := min(req.MaxPages, webhookRedriveMaxPagesPerRequest)
+	if logger == nil {
+		logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	}
+	response := &WebhookRedriveResponse{}
+	for _, app := range apps {
+		client, err := newWebhookRedriveGitHubClient(app, logger)
+		if err != nil {
+			return nil, err
+		}
+		result, err := redriveWebhookAppDeliveries(ctx, client.Apps, app.name, req.Cursor, windowStart, windowEnd, maxPages, req.DryRun, req.Repo, req.PR, logger)
+		if err != nil {
+			return nil, err
+		}
+		response.Results = append(response.Results, result)
+	}
+	return response, nil
+}
+
+func webhookRedriveApps(cfg *ServerConfig, onlyApp string) ([]webhookRedriveApp, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("server config is nil")
+	}
+	configured := cfg.Apps
+	if len(configured) == 0 {
+		if !cfg.GitHub.Configured() {
+			return nil, fmt.Errorf("no GitHub App is configured")
+		}
+		configured = map[string]GitHubAppConfig{"default": cfg.GitHub}
+	}
+	names := make([]string, 0, len(configured))
+	for name := range configured {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	apps := make([]webhookRedriveApp, 0, len(names))
+	for _, name := range names {
+		if onlyApp != "" && name != onlyApp {
+			continue
+		}
+		appConfig := configured[name]
+		appID := appConfig.ResolveAppID()
+		if appID == 0 {
+			return nil, fmt.Errorf("app %q has empty or unparseable app-id", name)
+		}
+		apps = append(apps, webhookRedriveApp{name: name, id: appID, config: appConfig})
+	}
+	if len(apps) == 0 {
+		return nil, webhookOpsRequestErrorf("no configured GitHub App named %q", onlyApp)
+	}
+	return apps, nil
+}
+
+func newWebhookRedriveGitHubClient(app webhookRedriveApp, logger *slog.Logger) (*gh.Client, error) {
+	privateKey, err := app.config.ResolvePrivateKey()
+	if err != nil {
+		return nil, fmt.Errorf("resolve private key for app %q: %w", app.name, err)
+	}
+	if privateKey == "" {
+		return nil, fmt.Errorf("app %q private key resolved to empty value", app.name)
+	}
+	transport, err := ghinstallation.NewAppsTransport(http.DefaultTransport, app.id, []byte(privateKey))
+	if err != nil {
+		return nil, fmt.Errorf("create GitHub App transport for app %q: %w", app.name, err)
+	}
+	client := gh.NewClient(&http.Client{Transport: transport, Timeout: 30 * time.Second})
+	client.DisableRateLimitCheck = true
+	logger.Info("created GitHub App webhook redrive client", "app_name", app.name, "app_id", app.id)
+	return client, nil
+}
+
+func redriveWebhookAppDeliveries(ctx context.Context, client webhookRedriveDeliveryClient, appName, startCursor string, windowStart, windowEnd time.Time, maxPages int, dryRun bool, repo string, pr int, logger *slog.Logger) (WebhookRedriveResult, error) {
+	result := WebhookRedriveResult{AppName: appName, DryRun: dryRun}
+	cursor := startCursor
+	historyExhausted := false
+	for result.Pages < maxPages {
+		result.Pages++
+		deliveries, resp, err := client.ListHookDeliveries(ctx, &gh.ListCursorOptions{PerPage: webhookRedrivePageSize, Cursor: cursor})
+		if err != nil {
+			return result, fmt.Errorf("list GitHub App webhook deliveries for app %q: %w", appName, err)
+		}
+		if len(deliveries) == 0 {
+			historyExhausted = true
+			break
+		}
+		for _, delivery := range deliveries {
+			result.Fetched++
+			delivered := delivery.GetDeliveredAt().Time
+			if delivered.IsZero() {
+				if logger != nil {
+					logger.Warn("skipping webhook delivery with missing delivered_at", "app_name", appName, "delivery_id", delivery.GetID(), "event", delivery.GetEvent(), "action", delivery.GetAction())
+				}
+				continue
+			}
+			result.OldestFetched = delivered.Format(time.RFC3339)
+			if !delivered.Before(windowStart) && !delivered.After(windowEnd) && webhookRedriveDeliverySelected(delivery) {
+				selection, ok, err := webhookRedriveSelectionFor(ctx, client, delivery, repo, pr)
+				if err != nil {
+					return result, err
+				}
+				if ok {
+					result.Selected = append(result.Selected, selection)
+				}
+			}
+		}
+		oldestInPage := deliveries[len(deliveries)-1].GetDeliveredAt().Time
+		if !oldestInPage.IsZero() && oldestInPage.Before(windowStart) {
+			result.ReachedWindowStart = true
+			break
+		}
+		if resp == nil || resp.Cursor == "" {
+			historyExhausted = true
+			break
+		}
+		cursor = resp.Cursor
+	}
+	// Coverage is reported as facts, not errors: a follow-up request with
+	// next_cursor continues the listing, and history_exhausted tells the
+	// caller that older deliveries no longer exist on GitHub. The caller
+	// decides whether incomplete coverage fails its run.
+	if !result.ReachedWindowStart {
+		result.HistoryExhausted = historyExhausted
+		if !historyExhausted {
+			result.NextCursor = cursor
+		}
+	}
+	if dryRun {
+		return result, nil
+	}
+	for i, selected := range result.Selected {
+		if _, _, err := client.RedeliverHookDelivery(ctx, selected.ID); err != nil {
+			result.Failed++
+			if logger != nil {
+				logger.Warn("GitHub webhook redelivery failed", "app_name", appName, "delivery_id", selected.ID, "repo", selected.Repo, "pr", selected.PR, "event", selected.Event, "action", selected.Action, "error", err)
+			}
+			continue
+		}
+		result.Redelivered++
+		if i < len(result.Selected)-1 {
+			if err := waitWebhookRedriveDelay(ctx); err != nil {
+				return result, fmt.Errorf("wait between GitHub webhook redeliveries for app %q: %w", appName, err)
+			}
+		}
+	}
+	return result, nil
+}
+
+func waitWebhookRedriveDelay(ctx context.Context) error {
+	timer := time.NewTimer(webhookRedriveDelay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func webhookRedriveDeliverySelected(delivery *gh.HookDelivery) bool {
+	if delivery == nil || delivery.GetID() == 0 || strings.EqualFold(delivery.GetStatus(), "OK") {
+		return false
+	}
+	switch delivery.GetEvent() {
+	case "pull_request":
+		switch delivery.GetAction() {
+		case "opened", "synchronize", "reopened", "ready_for_review":
+			return true
+		}
+	case "check_suite":
+		return delivery.GetAction() == "requested"
+	case "merge_group":
+		return delivery.GetAction() == "checks_requested"
+	}
+	return false
+}
+
+func webhookRedriveSelectionFor(ctx context.Context, client webhookRedriveDeliveryClient, delivery *gh.HookDelivery, repo string, pr int) (WebhookRedriveSelection, bool, error) {
+	selection := WebhookRedriveSelection{
+		ID:          delivery.GetID(),
+		DeliveredAt: delivery.GetDeliveredAt().Format(time.RFC3339),
+		Event:       delivery.GetEvent(),
+		Action:      delivery.GetAction(),
+		Status:      delivery.GetStatus(),
+		StatusCode:  delivery.GetStatusCode(),
+	}
+	if repo == "" && pr == 0 {
+		return selection, true, nil
+	}
+	detail, _, err := client.GetHookDelivery(ctx, delivery.GetID())
+	if err != nil {
+		return selection, false, fmt.Errorf("get GitHub App webhook delivery %d details for repo/PR filtering: %w", delivery.GetID(), err)
+	}
+	payload, err := webhookRedrivePayloadMetadata(detail)
+	if err != nil {
+		return selection, false, fmt.Errorf("parse GitHub App webhook delivery %d payload for repo/PR filtering: %w", delivery.GetID(), err)
+	}
+	selection.Repo = payload.repo
+	if len(payload.prs) > 0 {
+		selection.PR = payload.prs[0]
+	}
+	if repo != "" && !strings.EqualFold(payload.repo, repo) {
+		return selection, false, nil
+	}
+	// check_suite and merge_group payloads can carry several pull requests;
+	// the delivery is selected when any of them matches the filter.
+	if pr != 0 {
+		if !slices.Contains(payload.prs, pr) {
+			return selection, false, nil
+		}
+		selection.PR = pr
+	}
+	return selection, true, nil
+}
+
+type webhookRedrivePayload struct {
+	repo string
+	prs  []int
+}
+
+func webhookRedrivePayloadMetadata(delivery *gh.HookDelivery) (webhookRedrivePayload, error) {
+	if delivery == nil || delivery.Request == nil || delivery.Request.RawPayload == nil {
+		return webhookRedrivePayload{}, fmt.Errorf("delivery payload is missing")
+	}
+	var payload struct {
+		Number     int `json:"number"`
+		Repository struct {
+			FullName string `json:"full_name"`
+		} `json:"repository"`
+		PullRequest struct {
+			Number int `json:"number"`
+		} `json:"pull_request"`
+		CheckSuite struct {
+			PullRequests []struct {
+				Number int `json:"number"`
+			} `json:"pull_requests"`
+		} `json:"check_suite"`
+		MergeGroup struct {
+			PullRequests []struct {
+				Number int `json:"number"`
+			} `json:"pull_requests"`
+		} `json:"merge_group"`
+	}
+	if err := json.Unmarshal(*delivery.Request.RawPayload, &payload); err != nil {
+		return webhookRedrivePayload{}, err
+	}
+	var prs []int
+	appendPR := func(n int) {
+		if n == 0 {
+			return
+		}
+		if slices.Contains(prs, n) {
+			return
+		}
+		prs = append(prs, n)
+	}
+	appendPR(payload.PullRequest.Number)
+	appendPR(payload.Number)
+	for _, pr := range payload.CheckSuite.PullRequests {
+		appendPR(pr.Number)
+	}
+	for _, pr := range payload.MergeGroup.PullRequests {
+		appendPR(pr.Number)
+	}
+	return webhookRedrivePayload{repo: payload.Repository.FullName, prs: prs}, nil
+}

--- a/pkg/api/webhook_ops_handlers_test.go
+++ b/pkg/api/webhook_ops_handlers_test.go
@@ -55,37 +55,53 @@ func (f *fakeWebhookRedriveDeliveryClient) RedeliverHookDelivery(_ context.Conte
 	return &gh.HookDelivery{ID: new(deliveryID)}, &gh.Response{}, nil
 }
 
-func TestWebhookRedriveDeliverySelectedAllowsOnlyFailedCheckCreatingEvents(t *testing.T) {
+func TestWebhookRedriveEventEligibleMatchesCheckCreatingEvents(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name   string
 		event  string
 		action string
-		status string
 		want   bool
 	}{
-		{name: "failed pull request opened", event: "pull_request", action: "opened", status: "timed out", want: true},
-		{name: "failed pull request synchronize", event: "pull_request", action: "synchronize", status: "ERROR", want: true},
-		{name: "failed check suite requested", event: "check_suite", action: "requested", status: "ERROR", want: true},
-		{name: "failed merge group checks requested", event: "merge_group", action: "checks_requested", status: "ERROR", want: true},
-		{name: "successful delivery skipped", event: "pull_request", action: "opened", status: "OK", want: false},
-		{name: "issue comment skipped", event: "issue_comment", action: "created", status: "ERROR", want: false},
-		{name: "closed pull request skipped", event: "pull_request", action: "closed", status: "ERROR", want: false},
-		{name: "destroyed merge group skipped", event: "merge_group", action: "destroyed", status: "ERROR", want: false},
+		{name: "pull request opened", event: "pull_request", action: "opened", want: true},
+		{name: "pull request synchronize", event: "pull_request", action: "synchronize", want: true},
+		{name: "check suite requested", event: "check_suite", action: "requested", want: true},
+		{name: "merge group checks requested", event: "merge_group", action: "checks_requested", want: true},
+		{name: "issue comment excluded", event: "issue_comment", action: "created", want: false},
+		{name: "closed pull request excluded", event: "pull_request", action: "closed", want: false},
+		{name: "destroyed merge group excluded", event: "merge_group", action: "destroyed", want: false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			delivery := &gh.HookDelivery{
-				ID:     new(int64(123)),
-				Event:  new(tt.event),
-				Action: new(tt.action),
-				Status: new(tt.status),
-			}
+			delivery := &gh.HookDelivery{ID: new(int64(123)), Event: new(tt.event), Action: new(tt.action)}
+			assert.Equal(t, tt.want, webhookRedriveEventEligible(delivery))
+		})
+	}
+}
 
-			assert.Equal(t, tt.want, webhookRedriveDeliverySelected(delivery))
+// Delivery success is judged by the 2xx status code, not the literal status
+// string: a 202 ("Accepted") is a success, not a failure to redrive.
+func TestWebhookDeliverySucceededUsesStatusCode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		code int
+		want bool
+	}{
+		{name: "200 OK", code: 200, want: true},
+		{name: "202 Accepted", code: 202, want: true},
+		{name: "500 error", code: 500, want: false},
+		{name: "408 timeout", code: 408, want: false},
+		{name: "0 never delivered", code: 0, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, webhookDeliverySucceeded(&gh.HookDelivery{StatusCode: new(tt.code)}))
 		})
 	}
 }
@@ -267,6 +283,57 @@ func TestRedriveWebhookAppDeliveriesReportsExhaustedHistory(t *testing.T) {
 	assert.False(t, result.ReachedWindowStart)
 	assert.True(t, result.HistoryExhausted)
 	assert.Empty(t, result.NextCursor)
+}
+
+// A failed delivery is not re-selected when a newer redelivery of it (same
+// GUID) already succeeded during the crawl, so repeated redrives over a
+// stable window converge instead of re-firing downstream events.
+func TestRedriveWebhookAppDeliveriesSkipsAlreadySucceededRedeliveries(t *testing.T) {
+	t.Parallel()
+
+	windowStart := time.Date(2026, 7, 7, 19, 40, 0, 0, time.UTC)
+	windowEnd := time.Date(2026, 7, 7, 19, 50, 0, 0, time.UTC)
+	succeededRedelivery := webhookRedriveTestDelivery(11, windowEnd.Add(-time.Minute), "pull_request", "opened", "OK", 200)
+	succeededRedelivery.GUID = new("guid-a")
+	failedOriginalA := webhookRedriveTestDelivery(10, windowEnd.Add(-2*time.Minute), "pull_request", "opened", "ERROR", 500)
+	failedOriginalA.GUID = new("guid-a")
+	failedOriginalB := webhookRedriveTestDelivery(20, windowEnd.Add(-3*time.Minute), "pull_request", "opened", "ERROR", 500)
+	failedOriginalB.GUID = new("guid-b")
+
+	// Newest first: the successful redelivery of guid-a precedes its failed original.
+	client := &fakeWebhookRedriveDeliveryClient{pages: [][]*gh.HookDelivery{{succeededRedelivery, failedOriginalA, failedOriginalB}}}
+
+	result, err := redriveWebhookAppDeliveries(t.Context(), client, "default", "", windowStart, windowEnd, 10, true, "", 0, discardLogger())
+
+	require.NoError(t, err)
+	require.Len(t, result.Selected, 1, "guid-a already succeeded; only guid-b remains")
+	assert.Equal(t, int64(20), result.Selected[0].ID)
+}
+
+// A per-delivery detail-fetch failure during repo/PR filtering skips that one
+// delivery (counted) instead of aborting the whole crawl.
+func TestRedriveWebhookAppDeliveriesSkipsDeliveriesWithUnresolvableDetail(t *testing.T) {
+	t.Parallel()
+
+	windowStart := time.Date(2026, 7, 7, 19, 40, 0, 0, time.UTC)
+	windowEnd := time.Date(2026, 7, 7, 19, 50, 0, 0, time.UTC)
+	client := &fakeWebhookRedriveDeliveryClient{
+		pages: [][]*gh.HookDelivery{{
+			webhookRedriveTestDelivery(101, windowEnd.Add(-time.Minute), "pull_request", "opened", "ERROR", 500),
+			webhookRedriveTestDelivery(102, windowEnd.Add(-2*time.Minute), "pull_request", "opened", "ERROR", 500),
+		}},
+		details: map[int64]*gh.HookDelivery{
+			101: webhookRedriveTestDeliveryDetail(101, "octo/repo", 12),
+			// 102 has no detail → GetHookDelivery errors → skipped, not fatal.
+		},
+	}
+
+	result, err := redriveWebhookAppDeliveries(t.Context(), client, "default", "", windowStart, windowEnd, 10, true, "octo/repo", 12, discardLogger())
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Skipped)
+	require.Len(t, result.Selected, 1)
+	assert.Equal(t, int64(101), result.Selected[0].ID)
 }
 
 func webhookRedriveTestDelivery(id int64, deliveredAt time.Time, event, action, status string, statusCode int) *gh.HookDelivery {

--- a/pkg/api/webhook_ops_handlers_test.go
+++ b/pkg/api/webhook_ops_handlers_test.go
@@ -1,0 +1,304 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	gh "github.com/google/go-github/v86/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeWebhookRedriveDeliveryClient struct {
+	pages              [][]*gh.HookDelivery
+	details            map[int64]*gh.HookDelivery
+	redelivered        []int64
+	afterRedeliverHook func(deliveryID int64)
+}
+
+func (f *fakeWebhookRedriveDeliveryClient) ListHookDeliveries(_ context.Context, opts *gh.ListCursorOptions) ([]*gh.HookDelivery, *gh.Response, error) {
+	page := 0
+	if opts != nil && opts.Cursor == "page-2" {
+		page = 1
+	}
+	if page >= len(f.pages) {
+		return nil, &gh.Response{}, nil
+	}
+	resp := &gh.Response{}
+	if page+1 < len(f.pages) {
+		resp.Cursor = "page-2"
+	}
+	return f.pages[page], resp, nil
+}
+
+func (f *fakeWebhookRedriveDeliveryClient) GetHookDelivery(_ context.Context, deliveryID int64) (*gh.HookDelivery, *gh.Response, error) {
+	detail := f.details[deliveryID]
+	if detail == nil {
+		return nil, nil, errors.New("not found")
+	}
+	return detail, &gh.Response{}, nil
+}
+
+func (f *fakeWebhookRedriveDeliveryClient) RedeliverHookDelivery(_ context.Context, deliveryID int64) (*gh.HookDelivery, *gh.Response, error) {
+	if deliveryID == 999 {
+		return nil, nil, errors.New("boom")
+	}
+	f.redelivered = append(f.redelivered, deliveryID)
+	if f.afterRedeliverHook != nil {
+		f.afterRedeliverHook(deliveryID)
+	}
+	return &gh.HookDelivery{ID: new(deliveryID)}, &gh.Response{}, nil
+}
+
+func TestWebhookRedriveDeliverySelectedAllowsOnlyFailedCheckCreatingEvents(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		event  string
+		action string
+		status string
+		want   bool
+	}{
+		{name: "failed pull request opened", event: "pull_request", action: "opened", status: "timed out", want: true},
+		{name: "failed pull request synchronize", event: "pull_request", action: "synchronize", status: "ERROR", want: true},
+		{name: "failed check suite requested", event: "check_suite", action: "requested", status: "ERROR", want: true},
+		{name: "failed merge group checks requested", event: "merge_group", action: "checks_requested", status: "ERROR", want: true},
+		{name: "successful delivery skipped", event: "pull_request", action: "opened", status: "OK", want: false},
+		{name: "issue comment skipped", event: "issue_comment", action: "created", status: "ERROR", want: false},
+		{name: "closed pull request skipped", event: "pull_request", action: "closed", status: "ERROR", want: false},
+		{name: "destroyed merge group skipped", event: "merge_group", action: "destroyed", status: "ERROR", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			delivery := &gh.HookDelivery{
+				ID:     new(int64(123)),
+				Event:  new(tt.event),
+				Action: new(tt.action),
+				Status: new(tt.status),
+			}
+
+			assert.Equal(t, tt.want, webhookRedriveDeliverySelected(delivery))
+		})
+	}
+}
+
+func TestRedriveWebhookAppDeliveriesDryRunSelectsFailedDeliveriesInWindow(t *testing.T) {
+	t.Parallel()
+
+	windowStart := time.Date(2026, 7, 7, 19, 40, 0, 0, time.UTC)
+	windowEnd := time.Date(2026, 7, 7, 19, 50, 0, 0, time.UTC)
+	client := &fakeWebhookRedriveDeliveryClient{pages: [][]*gh.HookDelivery{
+		{
+			webhookRedriveTestDelivery(101, windowEnd.Add(-time.Minute), "pull_request", "opened", "timed out", 504),
+			webhookRedriveTestDelivery(102, windowEnd.Add(-2*time.Minute), "pull_request", "opened", "OK", 200),
+		},
+		{
+			webhookRedriveTestDelivery(103, windowStart.Add(time.Minute), "issue_comment", "created", "ERROR", 500),
+			webhookRedriveTestDelivery(104, windowStart.Add(-time.Minute), "pull_request", "synchronize", "ERROR", 500),
+		},
+	}}
+
+	result, err := redriveWebhookAppDeliveries(t.Context(), client, "default", "", windowStart, windowEnd, 10, true, "", 0, discardLogger())
+
+	require.NoError(t, err)
+	require.Len(t, result.Selected, 1)
+	assert.True(t, result.DryRun)
+	assert.Equal(t, int64(101), result.Selected[0].ID)
+	assert.Equal(t, 4, result.Fetched)
+	assert.Equal(t, 2, result.Pages)
+	assert.True(t, result.ReachedWindowStart)
+	assert.Empty(t, client.redelivered)
+}
+
+func TestRedriveWebhookAppDeliveriesReturnsCursorWhenWindowStartNotReached(t *testing.T) {
+	t.Parallel()
+
+	windowStart := time.Date(2026, 7, 7, 19, 40, 0, 0, time.UTC)
+	windowEnd := time.Date(2026, 7, 7, 19, 50, 0, 0, time.UTC)
+	// Two pages exist but only one is allowed: the cursor is still available
+	// when the page budget runs out, so the caller can continue the listing
+	// with a follow-up request instead of restarting from the newest page.
+	client := &fakeWebhookRedriveDeliveryClient{pages: [][]*gh.HookDelivery{
+		{webhookRedriveTestDelivery(101, windowEnd.Add(-time.Minute), "pull_request", "opened", "ERROR", 500)},
+		{webhookRedriveTestDelivery(102, windowEnd.Add(-2*time.Minute), "pull_request", "opened", "ERROR", 500)},
+	}}
+
+	result, err := redriveWebhookAppDeliveries(t.Context(), client, "default", "", windowStart, windowEnd, 1, true, "", 0, discardLogger())
+
+	require.NoError(t, err)
+	assert.False(t, result.ReachedWindowStart)
+	assert.False(t, result.HistoryExhausted)
+	assert.Equal(t, "page-2", result.NextCursor)
+}
+
+func TestRedriveWebhookAppDeliveriesRedeliversSelectedDeliveries(t *testing.T) {
+	t.Parallel()
+
+	windowStart := time.Date(2026, 7, 7, 19, 40, 0, 0, time.UTC)
+	windowEnd := time.Date(2026, 7, 7, 19, 50, 0, 0, time.UTC)
+	client := &fakeWebhookRedriveDeliveryClient{pages: [][]*gh.HookDelivery{
+		{
+			webhookRedriveTestDelivery(101, windowEnd.Add(-time.Minute), "pull_request", "opened", "ERROR", 500),
+			webhookRedriveTestDelivery(102, windowStart.Add(-time.Minute), "pull_request", "opened", "ERROR", 500),
+		},
+	}}
+
+	result, err := redriveWebhookAppDeliveries(t.Context(), client, "default", "", windowStart, windowEnd, 10, false, "", 0, discardLogger())
+
+	require.NoError(t, err)
+	assert.False(t, result.DryRun)
+	assert.Equal(t, []int64{101}, client.redelivered)
+	assert.Equal(t, 1, result.Redelivered)
+	assert.Equal(t, 0, result.Failed)
+}
+
+func TestRedriveWebhookAppDeliveriesStopsPromptlyWhenDelayContextIsCanceled(t *testing.T) {
+	t.Parallel()
+
+	windowStart := time.Date(2026, 7, 7, 19, 40, 0, 0, time.UTC)
+	windowEnd := time.Date(2026, 7, 7, 19, 50, 0, 0, time.UTC)
+	ctx, cancel := context.WithCancel(t.Context())
+	client := &fakeWebhookRedriveDeliveryClient{
+		pages: [][]*gh.HookDelivery{{
+			webhookRedriveTestDelivery(101, windowEnd.Add(-time.Minute), "pull_request", "opened", "ERROR", 500),
+			webhookRedriveTestDelivery(102, windowEnd.Add(-2*time.Minute), "pull_request", "opened", "ERROR", 500),
+			webhookRedriveTestDelivery(103, windowStart.Add(-time.Minute), "pull_request", "opened", "ERROR", 500),
+		}},
+		afterRedeliverHook: func(deliveryID int64) {
+			if deliveryID == 101 {
+				cancel()
+			}
+		},
+	}
+
+	result, err := redriveWebhookAppDeliveries(ctx, client, "default", "", windowStart, windowEnd, 10, false, "", 0, discardLogger())
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, []int64{101}, client.redelivered)
+	assert.Equal(t, 1, result.Redelivered)
+}
+
+func TestRedriveWebhookAppDeliveriesFiltersByRepoAndPullRequest(t *testing.T) {
+	t.Parallel()
+
+	windowStart := time.Date(2026, 7, 7, 19, 40, 0, 0, time.UTC)
+	windowEnd := time.Date(2026, 7, 7, 19, 50, 0, 0, time.UTC)
+	client := &fakeWebhookRedriveDeliveryClient{
+		pages: [][]*gh.HookDelivery{{
+			webhookRedriveTestDelivery(101, windowEnd.Add(-time.Minute), "pull_request", "opened", "ERROR", 500),
+			webhookRedriveTestDelivery(102, windowEnd.Add(-2*time.Minute), "pull_request", "opened", "ERROR", 500),
+			webhookRedriveTestDelivery(103, windowStart.Add(-time.Minute), "pull_request", "opened", "ERROR", 500),
+		}},
+		details: map[int64]*gh.HookDelivery{
+			101: webhookRedriveTestDeliveryDetail(101, "octo/repo", 12),
+			102: webhookRedriveTestDeliveryDetail(102, "octo/other", 12),
+		},
+	}
+
+	result, err := redriveWebhookAppDeliveries(t.Context(), client, "default", "", windowStart, windowEnd, 10, true, "octo/repo", 12, discardLogger())
+
+	require.NoError(t, err)
+	require.Len(t, result.Selected, 1)
+	assert.Equal(t, int64(101), result.Selected[0].ID)
+	assert.Equal(t, "octo/repo", result.Selected[0].Repo)
+	assert.Equal(t, 12, result.Selected[0].PR)
+}
+
+// A check_suite payload can carry several pull requests; a delivery is
+// selected when any of them matches the PR filter, so a busy-repo check_suite
+// touching the requested PR is not silently skipped.
+func TestRedriveWebhookAppDeliveriesMatchesPRAmongMultiplePayloadPRs(t *testing.T) {
+	t.Parallel()
+
+	windowStart := time.Date(2026, 7, 7, 19, 40, 0, 0, time.UTC)
+	windowEnd := time.Date(2026, 7, 7, 19, 50, 0, 0, time.UTC)
+	multiPRPayload, err := json.Marshal(map[string]any{
+		"repository": map[string]any{"full_name": "octo/repo"},
+		"check_suite": map[string]any{
+			"pull_requests": []map[string]any{{"number": 7}, {"number": 12}},
+		},
+	})
+	require.NoError(t, err)
+	raw := json.RawMessage(multiPRPayload)
+	client := &fakeWebhookRedriveDeliveryClient{
+		pages: [][]*gh.HookDelivery{{
+			webhookRedriveTestDelivery(201, windowEnd.Add(-time.Minute), "check_suite", "requested", "ERROR", 500),
+			webhookRedriveTestDelivery(202, windowStart.Add(-time.Minute), "pull_request", "opened", "ERROR", 500),
+		}},
+		details: map[int64]*gh.HookDelivery{
+			201: {ID: new(int64(201)), Request: &gh.HookRequest{RawPayload: &raw}},
+		},
+	}
+
+	result, err := redriveWebhookAppDeliveries(t.Context(), client, "default", "", windowStart, windowEnd, 10, true, "octo/repo", 12, discardLogger())
+
+	require.NoError(t, err)
+	require.Len(t, result.Selected, 1)
+	assert.Equal(t, int64(201), result.Selected[0].ID)
+	assert.Equal(t, 12, result.Selected[0].PR)
+}
+
+// When GitHub's retained delivery history ends before the requested window
+// start, the result reports the fact so the caller can distinguish "raise the
+// page budget" from "older deliveries no longer exist".
+func TestRedriveWebhookAppDeliveriesReportsExhaustedHistory(t *testing.T) {
+	t.Parallel()
+
+	windowStart := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	windowEnd := time.Date(2026, 7, 7, 19, 50, 0, 0, time.UTC)
+	client := &fakeWebhookRedriveDeliveryClient{
+		pages: [][]*gh.HookDelivery{{
+			webhookRedriveTestDelivery(301, windowEnd.Add(-time.Minute), "pull_request", "opened", "ERROR", 500),
+		}},
+	}
+
+	result, err := redriveWebhookAppDeliveries(t.Context(), client, "default", "", windowStart, windowEnd, 10, true, "", 0, discardLogger())
+
+	require.NoError(t, err)
+	assert.False(t, result.ReachedWindowStart)
+	assert.True(t, result.HistoryExhausted)
+	assert.Empty(t, result.NextCursor)
+}
+
+func webhookRedriveTestDelivery(id int64, deliveredAt time.Time, event, action, status string, statusCode int) *gh.HookDelivery {
+	return &gh.HookDelivery{
+		ID:          new(id),
+		DeliveredAt: &gh.Timestamp{Time: deliveredAt},
+		Event:       new(event),
+		Action:      new(action),
+		Status:      new(status),
+		StatusCode:  new(statusCode),
+	}
+}
+
+func webhookRedriveTestDeliveryDetail(id int64, repo string, pr int) *gh.HookDelivery {
+	payload, err := json.Marshal(map[string]any{
+		"number": pr,
+		"repository": map[string]any{
+			"full_name": repo,
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	raw := json.RawMessage(payload)
+	return &gh.HookDelivery{
+		ID: new(id),
+		Request: &gh.HookRequest{
+			RawPayload: &raw,
+		},
+	}
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -45,6 +45,53 @@ type ErrorResponse struct {
 	ErrorCode string `json:"error_code"`
 }
 
+type WebhookRedriveRequest struct {
+	WindowStart string `json:"window_start"`
+	WindowEnd   string `json:"window_end"`
+	App         string `json:"app,omitempty"`
+	Repo        string `json:"repo,omitempty"`
+	PR          int    `json:"pr,omitempty"`
+	MaxPages    int    `json:"max_pages"`
+	DryRun      bool   `json:"dry_run,omitempty"`
+	// Cursor continues a previous request's listing for one App. Each request
+	// processes a bounded number of pages so it finishes well within any
+	// intermediary HTTP timeout; the caller loops until next_cursor is empty.
+	Cursor string `json:"cursor,omitempty"`
+}
+
+type WebhookRedriveResponse struct {
+	Results []WebhookRedriveResult `json:"results"`
+}
+
+type WebhookRedriveResult struct {
+	AppName            string `json:"app_name"`
+	DryRun             bool   `json:"dry_run"`
+	Fetched            int    `json:"fetched"`
+	Pages              int    `json:"pages"`
+	OldestFetched      string `json:"oldest_fetched,omitempty"`
+	ReachedWindowStart bool   `json:"reached_window_start"`
+	// HistoryExhausted is true when GitHub's retained delivery history ended
+	// before the window start was reached: older deliveries no longer exist.
+	HistoryExhausted bool `json:"history_exhausted,omitempty"`
+	// NextCursor continues the listing in a follow-up request (with app set);
+	// empty when the window is covered or history is exhausted.
+	NextCursor  string                    `json:"next_cursor,omitempty"`
+	Selected    []WebhookRedriveSelection `json:"selected"`
+	Redelivered int                       `json:"redelivered"`
+	Failed      int                       `json:"failed"`
+}
+
+type WebhookRedriveSelection struct {
+	ID          int64  `json:"id"`
+	DeliveredAt string `json:"delivered_at"`
+	Event       string `json:"event"`
+	Action      string `json:"action"`
+	Status      string `json:"status"`
+	StatusCode  int    `json:"status_code"`
+	Repo        string `json:"repo,omitempty"`
+	PR          int    `json:"pr,omitempty"`
+}
+
 // =============================================================================
 // Request Types
 // =============================================================================

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -75,10 +75,14 @@ type WebhookRedriveResult struct {
 	HistoryExhausted bool `json:"history_exhausted,omitempty"`
 	// NextCursor continues the listing in a follow-up request (with app set);
 	// empty when the window is covered or history is exhausted.
-	NextCursor  string                    `json:"next_cursor,omitempty"`
-	Selected    []WebhookRedriveSelection `json:"selected"`
-	Redelivered int                       `json:"redelivered"`
-	Failed      int                       `json:"failed"`
+	NextCursor string                    `json:"next_cursor,omitempty"`
+	Selected   []WebhookRedriveSelection `json:"selected"`
+	// Skipped counts in-window eligible deliveries whose detail could not be
+	// resolved for repo/PR filtering; they are left out of Selected rather
+	// than aborting the crawl.
+	Skipped     int `json:"skipped,omitempty"`
+	Redelivered int `json:"redelivered"`
+	Failed      int `json:"failed"`
 }
 
 type WebhookRedriveSelection struct {

--- a/pkg/auth/tiers_test.go
+++ b/pkg/auth/tiers_test.go
@@ -21,6 +21,7 @@ func TestTierForRequest(t *testing.T) {
 		{http.MethodPost, "/api/rollback/plan", TierWrite},
 		{http.MethodPost, "/api/apply", TierWrite},
 		{http.MethodPost, "/api/cutover", TierWrite},
+		{http.MethodPost, "/api/webhooks/redrive", TierWrite},
 		{http.MethodPost, "/api/settings", TierWrite},
 		{http.MethodDelete, "/api/locks", TierWrite},
 	}

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -414,6 +414,15 @@ func (ic *InstallationClient) storeAppSlug(slug string) {
 
 const githubSecondaryRateLimitMaxSleep = 5 * time.Second
 
+// NewRateLimitedTransport wraps base with GitHub secondary-rate-limit
+// handling (bounded sleep on a 403 secondary limit), matching the transport
+// every InstallationClient uses. Exposed for App-level clients built outside
+// this package that must issue GitHub calls at volume without tripping the
+// secondary limit.
+func NewRateLimitedTransport(base http.RoundTripper) http.RoundTripper {
+	return newGitHubRateLimitTransport(base)
+}
+
 func newGitHubRateLimitTransport(base http.RoundTripper) http.RoundTripper {
 	return github_ratelimit.New(base,
 		github_secondary_ratelimit.WithSingleSleepLimit(githubSecondaryRateLimitMaxSleep, nil),


### PR DESCRIPTION
## Why this matters

When GitHub webhook deliveries fail — a delivery outage, a transient handler error — the events that create SchemaBot Check Runs (and drive plans) never land, and PRs are left without the checks branch protection expects. Operators need a native, auth-gated way to redeliver those failed deliveries instead of a hand-run GitHub API script.

## What it does

Adds `POST /api/webhooks/redrive` (write tier). Given a time window, it crawls a GitHub App's webhook delivery history, selects the failed check-creating deliveries, and redelivers them.

```
POST /api/webhooks/redrive  (window, optional repo/pr/app, dry_run)
   │  bounded, cursor-paginated passes — a few delivery pages per request
   ▼
select failed check-creating deliveries in window ──► redeliver
   (pull_request open/sync/reopen/ready, check_suite requested, merge_group)
```

- **Chunked so nothing times out.** Each request processes a few delivery pages and returns a cursor; the caller loops until the window is covered. No single request can outlive an intermediary (ingress) timeout, no matter how deep the history. The handler also lifts its own write deadline for these long operator calls.
- **Coverage reported as facts, not guesses.** A response carries `next_cursor` (more to crawl) or `history_exhausted` (GitHub no longer retains older deliveries), so the caller — not the server — decides whether incomplete coverage is acceptable.
- **Selection is precise.** Only failed deliveries for check-creating events are eligible; the `pr` filter matches any PR in a multi-PR payload; redelivery is idempotent.
- **Errors are typed.** Request-shaped failures return 400, execution failures 500.

The operator CLI that drives this endpoint (`schemabot webhooks redrive`) ships in the stacked follow-up.

## How it moves toward the northstar

A lost webhook delivery becomes a recoverable operation instead of a manual GitHub API script, keeping SchemaBot's safety checks reliable even when delivery isn't.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

