### PR TITLE
fix(github): plan authorizes on the resolved database and scopes truncated-repo lookups

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -562,7 +562,8 @@ type DatabaseConfig struct {
 
 // PRCommandAuthorizationConfig configures actor authorization for mutating
 // SchemaBot GitHub PR comment commands (apply, stop, cutover, rollback,
-// unlock, and their confirmation variants).
+// unlock, and their confirmation variants), and for user-issued plan
+// commands that resolve to a configured database.
 type PRCommandAuthorizationConfig struct {
 	// Enabled turns on fail-closed actor authorization for mutating PR
 	// commands.
@@ -751,6 +752,48 @@ func (c *ServerConfig) RepoAdmins(repo string) (teams, users []string) {
 // truncated-tree fallback must keep failing closed, because a partial probe
 // could return a confidently wrong result (a single config where a full scan
 // would find several, or a "database not found" for a config that exists).
+// SchemaDirHintsForDatabase returns the configured schema directories of the
+// named database when it accepts changes from repo, sorted and deduplicated.
+// A database-scoped truncated-tree probe only needs this database's
+// directories, so a repo with hundreds of configured databases costs a few
+// API calls instead of a scan of every configured directory.
+//
+// exhaustive reports whether the returned directories cover every location
+// this database's policy-valid config could live in. It is true with no
+// directories when the database does not exist or does not accept the repo —
+// no policy-valid config location exists, so an empty probe result is
+// authoritative. It is false when the database has no allowed_dirs
+// restriction or a wildcard ("*") or repo-root (".") entry, where the config
+// could live anywhere and the probe must keep failing closed.
+func (c *ServerConfig) SchemaDirHintsForDatabase(repo, database string) (dirs []string, exhaustive bool) {
+	db, ok := c.Databases[database]
+	if !ok {
+		return nil, true
+	}
+	if len(db.AllowedRepos) > 0 && !repoAllowed(db.AllowedRepos, repo) {
+		return nil, true
+	}
+	if len(db.AllowedDirs) == 0 {
+		return nil, false
+	}
+	seen := make(map[string]struct{})
+	exhaustive = true
+	for _, dir := range db.AllowedDirs {
+		normalized, err := normalizeSchemaPath(dir)
+		if err != nil || normalized == "*" || normalized == "." {
+			exhaustive = false
+			continue
+		}
+		if _, dup := seen[normalized]; dup {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		dirs = append(dirs, normalized)
+	}
+	slices.Sort(dirs)
+	return dirs, exhaustive
+}
+
 func (c *ServerConfig) SchemaDirHintsForRepo(repo string) (dirs []string, exhaustive bool) {
 	seen := make(map[string]struct{})
 	exhaustive = true

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -3342,6 +3342,48 @@ func TestSchemaDirHintsForRepoNotExhaustiveWhenDatabaseHasNoAllowedDirs(t *testi
 	assert.False(t, exhaustive, "a database without allowed_dirs accepts a config anywhere in the repo")
 }
 
+func TestSchemaDirHintsForDatabase(t *testing.T) {
+	cfg := &ServerConfig{
+		Databases: map[string]DatabaseConfig{
+			"widgets": {
+				AllowedRepos: []string{"octocat/hello-world"},
+				AllowedDirs:  []string{"apps/widgets/schema", "apps/widgets/legacy/"},
+			},
+			"open": {
+				AllowedRepos: []string{"octocat/hello-world"},
+			},
+			"wild": {
+				AllowedRepos: []string{"octocat/hello-world"},
+				AllowedDirs:  []string{"apps/wild/schema", "*"},
+			},
+			"payments": {
+				AllowedRepos: []string{"octocat/other-repo"},
+				AllowedDirs:  []string{"payments/schema"},
+			},
+		},
+	}
+
+	dirs, exhaustive := cfg.SchemaDirHintsForDatabase("octocat/hello-world", "widgets")
+	assert.Equal(t, []string{"apps/widgets/legacy", "apps/widgets/schema"}, dirs)
+	assert.True(t, exhaustive, "every allowed dir is a literal directory")
+
+	dirs, exhaustive = cfg.SchemaDirHintsForDatabase("octocat/hello-world", "open")
+	assert.Empty(t, dirs)
+	assert.False(t, exhaustive, "a database without allowed_dirs accepts a config anywhere")
+
+	dirs, exhaustive = cfg.SchemaDirHintsForDatabase("octocat/hello-world", "wild")
+	assert.Equal(t, []string{"apps/wild/schema"}, dirs)
+	assert.False(t, exhaustive, "a wildcard entry accepts configs outside every probe-able directory")
+
+	dirs, exhaustive = cfg.SchemaDirHintsForDatabase("octocat/hello-world", "payments")
+	assert.Empty(t, dirs)
+	assert.True(t, exhaustive, "a database that does not accept the repo has no policy-valid config location in it")
+
+	dirs, exhaustive = cfg.SchemaDirHintsForDatabase("octocat/hello-world", "unknown")
+	assert.Empty(t, dirs)
+	assert.True(t, exhaustive, "an unconfigured database has no policy-valid config location")
+}
+
 func TestSchemaDirHintsForRepoNoMatches(t *testing.T) {
 	cfg := &ServerConfig{
 		Databases: map[string]DatabaseConfig{

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -59,13 +59,12 @@ type Client struct {
 	// configuration set at construction; never mutated afterwards.
 	trustedCheckAppSlugs []string
 
-	// configDirHints returns the configured schema directories that may serve
-	// a repo, used by config discovery as probe targets when GitHub truncates
-	// the repository tree and a whole-repo scan is impossible, plus whether
-	// those directories provably cover every policy-valid config location.
-	// Static configuration set at construction; never mutated afterwards. Nil
-	// when the embedder has no directory configuration to offer.
-	configDirHints func(repo string) (dirs []string, exhaustive bool)
+	// configDirHints supplies the configured schema directories used by
+	// config discovery as probe targets when GitHub truncates the repository
+	// tree and a whole-repo scan is impossible. Static configuration set at
+	// construction; never mutated afterwards. Nil when the embedder has no
+	// directory configuration to offer.
+	configDirHints ConfigDirHints
 
 	// slugFetchMu serialises slug-fetch attempts so concurrent
 	// ForInstallation callers do not thundering-herd retry on startup
@@ -115,13 +114,29 @@ func WithTrustedCheckAppSlugs(slugs []string) ClientOption {
 	}
 }
 
+// ConfigDirHints supplies the server-configured schema directories that
+// config discovery probes when GitHub truncates the repository tree (repos
+// beyond the Trees API response cap), where a whole-repo scan is impossible.
+// Both methods report whether the returned directories provably cover every
+// policy-valid config location for their scope; non-exhaustive hints are
+// never probed, keeping discovery fail-closed.
+type ConfigDirHints interface {
+	// SchemaDirHintsForRepo returns the directories of every database that
+	// accepts changes from repo.
+	SchemaDirHintsForRepo(repo string) (dirs []string, exhaustive bool)
+	// SchemaDirHintsForDatabase returns only the named database's
+	// directories, for database-scoped lookups that need not pay a scan of
+	// every configured directory. exhaustive is true with no directories
+	// when the database does not serve the repo at all — an empty probe
+	// result is then authoritative.
+	SchemaDirHintsForDatabase(repo, database string) (dirs []string, exhaustive bool)
+}
+
 // WithConfigDirHints provides the configured schema directories that may serve
-// a given repo, plus whether they provably cover every policy-valid config
-// location. Config discovery probes these directories for schemabot.yaml
-// files when GitHub truncates the repository tree (repos beyond the Trees API
-// response cap), where a whole-repo scan is impossible; non-exhaustive hints
-// are never probed, keeping discovery fail-closed.
-func WithConfigDirHints(hints func(repo string) (dirs []string, exhaustive bool)) ClientOption {
+// a given repo. Config discovery probes these directories for schemabot.yaml
+// files when GitHub truncates the repository tree, where a whole-repo scan is
+// impossible.
+func WithConfigDirHints(hints ConfigDirHints) ClientOption {
 	return func(c *Client) {
 		c.configDirHints = hints
 	}
@@ -351,12 +366,11 @@ type InstallationClient struct {
 	// configuration copied from the parent Client; never mutated.
 	trustedCheckAppSlugs []string
 
-	// configDirHints returns the configured schema directories that may serve
-	// a repo (and whether they are exhaustive), used by config discovery as
-	// probe targets when GitHub truncates the repository tree. Copied from
-	// the parent Client; nil when the embedder has no directory configuration
-	// to offer.
-	configDirHints func(repo string) (dirs []string, exhaustive bool)
+	// configDirHints supplies the configured schema directories used by
+	// config discovery as probe targets when GitHub truncates the repository
+	// tree. Copied from the parent Client; nil when the embedder has no
+	// directory configuration to offer.
+	configDirHints ConfigDirHints
 
 	// checkStatusSingleflight is owned by the parent Client factory and
 	// shared across every InstallationClient it produces so concurrent
@@ -381,7 +395,7 @@ func (ic *InstallationClient) InstallationID() int64 {
 // a repo, used by config discovery when GitHub truncates the repository tree.
 // Production clients receive this from the parent Client (WithConfigDirHints);
 // this setter exists for directly-constructed clients (tests, library use).
-func (ic *InstallationClient) SetConfigDirHints(hints func(repo string) (dirs []string, exhaustive bool)) {
+func (ic *InstallationClient) SetConfigDirHints(hints ConfigDirHints) {
 	ic.configDirHints = hints
 }
 

--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -65,6 +65,9 @@ type DatabaseNotFoundError struct {
 }
 
 func (e *DatabaseNotFoundError) Error() string {
+	if len(e.AvailableDatabases) == 0 {
+		return fmt.Sprintf("database '%s' not found", e.DatabaseName)
+	}
 	return fmt.Sprintf("database '%s' not found. Available databases: %s",
 		e.DatabaseName, strings.Join(e.AvailableDatabases, ", "))
 }
@@ -137,36 +140,7 @@ func (ic *InstallationClient) FindAllConfigs(ctx context.Context, repo, ref stri
 		return result, nil
 	}
 
-	var configPaths []string
-	for _, entry := range entries {
-		if entry.Type == "blob" && strings.HasSuffix(entry.Path, ConfigFileName) {
-			configPaths = append(configPaths, entry.Path)
-		}
-	}
-
-	result := &FindAllConfigsResult{}
-	if len(configPaths) == 0 {
-		return result, nil
-	}
-
-	for _, configPath := range configPaths {
-		config, err := ic.FetchConfig(ctx, repo, configPath, ref)
-		if err != nil {
-			ic.logger.Warn("failed to parse config", "path", configPath, "error", err)
-			result.InvalidConfigs = append(result.InvalidConfigs, InvalidConfigInfo{
-				Path:  configPath,
-				Error: err.Error(),
-			})
-			continue
-		}
-
-		schemaDir := path.Dir(configPath)
-		result.ValidConfigs = append(result.ValidConfigs, DiscoveredConfig{
-			Config:    config,
-			Path:      configPath,
-			SchemaDir: schemaDir,
-		})
-	}
+	result := ic.collectConfigsFromTree(ctx, repo, ref, entries)
 
 	ic.logger.Debug("config discovery complete",
 		"valid", len(result.ValidConfigs),
@@ -174,6 +148,61 @@ func (ic *InstallationClient) FindAllConfigs(ctx context.Context, repo, ref stri
 		"repo", repo,
 	)
 	return result, nil
+}
+
+// collectConfigsFromTree fetches and parses every schemabot.yaml among the
+// given tree entries. Unparseable configs are reported as invalid rather than
+// failing the whole discovery.
+func (ic *InstallationClient) collectConfigsFromTree(ctx context.Context, repo, ref string, entries []TreeEntry) *FindAllConfigsResult {
+	result := &FindAllConfigsResult{}
+	for _, entry := range entries {
+		if entry.Type != "blob" || !strings.HasSuffix(entry.Path, ConfigFileName) {
+			continue
+		}
+		config, err := ic.FetchConfig(ctx, repo, entry.Path, ref)
+		if err != nil {
+			ic.logger.Warn("failed to parse config", "path", entry.Path, "error", err)
+			result.InvalidConfigs = append(result.InvalidConfigs, InvalidConfigInfo{
+				Path:  entry.Path,
+				Error: err.Error(),
+			})
+			continue
+		}
+		result.ValidConfigs = append(result.ValidConfigs, DiscoveredConfig{
+			Config:    config,
+			Path:      entry.Path,
+			SchemaDir: path.Dir(entry.Path),
+		})
+	}
+	return result
+}
+
+// findAllConfigsForDatabase discovers configs for a database-scoped lookup.
+// With a complete tree it returns the full discovery result (scoped=false).
+// With a truncated tree it probes only the named database's configured
+// schema directories (scoped=true): absence there is authoritative for the
+// database, but the result does not enumerate other databases' configs. When
+// the database's directories cannot be probed exhaustively, it fails closed
+// with ErrGitTreeTruncated.
+func (ic *InstallationClient) findAllConfigsForDatabase(ctx context.Context, repo, ref, databaseName string) (*FindAllConfigsResult, bool, error) {
+	entries, truncated, err := ic.FetchGitTree(ctx, repo, ref)
+	if err != nil {
+		return nil, false, fmt.Errorf("fetch git tree: %w", err)
+	}
+	if !truncated {
+		return ic.collectConfigsFromTree(ctx, repo, ref, entries), false, nil
+	}
+	result, ok, hintErr := ic.findConfigsInDatabaseHintDirs(ctx, repo, ref, databaseName)
+	if hintErr != nil {
+		return nil, false, fmt.Errorf("discover schemabot config in configured schema dirs of database %s in repo %s ref %s: %w", databaseName, repo, ref, hintErr)
+	}
+	if !ok {
+		return nil, false, fmt.Errorf("discover schemabot config for database %s in repo %s ref %s: %w", databaseName, repo, ref, ErrGitTreeTruncated)
+	}
+	ic.logger.Info("git tree truncated; scoped config discovery to the database's configured schema dirs",
+		"repo", repo, "ref", ref, "database", databaseName,
+		"valid", len(result.ValidConfigs), "invalid", len(result.InvalidConfigs))
+	return result, true, nil
 }
 
 // findConfigsInHintDirs discovers schemabot.yaml configs by scanning the
@@ -196,7 +225,7 @@ func (ic *InstallationClient) findConfigsInHintDirs(ctx context.Context, repo, r
 		ic.logger.Debug("no config dir hints configured; cannot scan truncated repo", "repo", repo, "ref", ref)
 		return nil, false, nil
 	}
-	hints, exhaustive := ic.configDirHints(repo)
+	hints, exhaustive := ic.configDirHints.SchemaDirHintsForRepo(repo)
 	if !exhaustive {
 		ic.logger.Warn("configured schema dirs do not cover every policy-valid config location (a database allows configs outside any probe-able directory); keeping fail-closed truncation error",
 			"repo", repo, "ref", ref, "hint_dirs", len(hints))
@@ -207,15 +236,60 @@ func (ic *InstallationClient) findConfigsInHintDirs(ctx context.Context, repo, r
 		return nil, false, nil
 	}
 
+	result, err := ic.scanHintDirsForConfigs(ctx, repo, ref, hints)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if len(result.ValidConfigs) == 0 && len(result.InvalidConfigs) == 0 {
+		ic.logger.Warn("configured schema dirs contain no configs; keeping fail-closed truncation error",
+			"repo", repo, "ref", ref, "hint_dirs", len(hints))
+		return nil, false, nil
+	}
+	return result, true, nil
+}
+
+// findConfigsInDatabaseHintDirs discovers schemabot.yaml configs by scanning
+// only the named database's configured schema directories, for lookups that
+// already know which database they want. ok is false when the client has no
+// hints or the database's directories are not exhaustive (its config could
+// live outside any probe-able directory) — the caller must keep failing
+// closed with the truncation error. Unlike the repo-wide scan, an empty
+// result with exhaustive directories IS authoritative: no policy-valid
+// location for this database's config was left unscanned.
+func (ic *InstallationClient) findConfigsInDatabaseHintDirs(ctx context.Context, repo, ref, databaseName string) (*FindAllConfigsResult, bool, error) {
+	if ic.configDirHints == nil {
+		ic.logger.Debug("no config dir hints configured; cannot scan truncated repo",
+			"repo", repo, "ref", ref, "database", databaseName)
+		return nil, false, nil
+	}
+	hints, exhaustive := ic.configDirHints.SchemaDirHintsForDatabase(repo, databaseName)
+	if !exhaustive {
+		ic.logger.Warn("database's configured schema dirs do not cover every policy-valid config location; keeping fail-closed truncation error",
+			"repo", repo, "ref", ref, "database", databaseName, "hint_dirs", len(hints))
+		return nil, false, nil
+	}
+
+	result, err := ic.scanHintDirsForConfigs(ctx, repo, ref, hints)
+	if err != nil {
+		return nil, false, err
+	}
+	return result, true, nil
+}
+
+// scanHintDirsForConfigs scans the recursive subtree of each directory for
+// schemabot.yaml files. The scan is recursive per directory, so configs
+// nested below a directory are found (allowed_dirs matching is prefix-based).
+func (ic *InstallationClient) scanHintDirsForConfigs(ctx context.Context, repo, ref string, dirs []string) (*FindAllConfigsResult, error) {
 	result := &FindAllConfigsResult{}
 	seen := make(map[string]struct{})
 	// Hint directories often share path prefixes; memoize the shallow
 	// per-level fetches so shared levels cost one API call per scan.
 	levelCache := make(map[string][]TreeEntry)
-	for _, dir := range hints {
+	for _, dir := range dirs {
 		entries, found, err := ic.fetchGitSubtreeCached(ctx, repo, ref, dir, levelCache)
 		if err != nil {
-			return nil, false, fmt.Errorf("scan configured schema dir %s: %w", dir, err)
+			return nil, fmt.Errorf("scan configured schema dir %s: %w", dir, err)
 		}
 		if !found {
 			ic.logger.Debug("configured schema dir does not exist at ref; skipping",
@@ -249,38 +323,61 @@ func (ic *InstallationClient) findConfigsInHintDirs(ctx context.Context, repo, r
 			})
 		}
 	}
-
-	if len(result.ValidConfigs) == 0 && len(result.InvalidConfigs) == 0 {
-		ic.logger.Warn("configured schema dirs contain no configs; keeping fail-closed truncation error",
-			"repo", repo, "ref", ref, "hint_dirs", len(hints))
-		return nil, false, nil
-	}
-	return result, true, nil
+	return result, nil
 }
 
-// FindConfigByDatabaseName finds a schemabot.yaml config by database name.
+// FindConfigByDatabaseName finds a schemabot.yaml config by database name:
+// first among the PR's changed files, then by searching the repository.
 func (ic *InstallationClient) FindConfigByDatabaseName(ctx context.Context, repo string, pr int, databaseName string) (*SchemabotConfig, string, error) {
+	config, configDir, found, err := ic.FindConfigByDatabaseNameInPR(ctx, repo, pr, databaseName)
+	if err != nil {
+		return nil, "", err
+	}
+	if found {
+		return config, configDir, nil
+	}
+	return ic.FindConfigByDatabaseNameInRepo(ctx, repo, pr, databaseName)
+}
+
+// FindConfigByDatabaseNameInPR finds the named database's schemabot.yaml
+// among the configs reachable from the PR's changed files. found is false
+// when the PR does not touch that database's schema — resolving it then
+// requires the repository-wide search (FindConfigByDatabaseNameInRepo),
+// which callers may want to gate or avoid.
+func (ic *InstallationClient) FindConfigByDatabaseNameInPR(ctx context.Context, repo string, pr int, databaseName string) (*SchemabotConfig, string, bool, error) {
+	prInfo, err := ic.FetchPullRequest(ctx, repo, pr)
+	if err != nil {
+		return nil, "", false, fmt.Errorf("fetch PR info: %w", err)
+	}
+
+	files, err := ic.FetchPRFiles(ctx, repo, pr)
+	if err != nil {
+		return nil, "", false, fmt.Errorf("fetch PR files: %w", err)
+	}
+
+	prConfigs, err := ic.FindConfigsForPRFiles(ctx, repo, prInfo.HeadSHA, files)
+	if err != nil {
+		return nil, "", false, fmt.Errorf("find configs for PR: %w", err)
+	}
+	config, configDir, ok, err := selectConfigByDatabaseName(databaseName, prConfigs)
+	if err != nil {
+		return nil, "", false, err
+	}
+	return config, configDir, ok, nil
+}
+
+// FindConfigByDatabaseNameInRepo finds the named database's schemabot.yaml by
+// searching the repository at the PR's head. When the repository tree is
+// truncated, the search probes only the named database's configured schema
+// directories, so it stays cheap regardless of how many databases the server
+// configures for the repo.
+func (ic *InstallationClient) FindConfigByDatabaseNameInRepo(ctx context.Context, repo string, pr int, databaseName string) (*SchemabotConfig, string, error) {
 	prInfo, err := ic.FetchPullRequest(ctx, repo, pr)
 	if err != nil {
 		return nil, "", fmt.Errorf("fetch PR info: %w", err)
 	}
 
-	files, err := ic.FetchPRFiles(ctx, repo, pr)
-	if err != nil {
-		return nil, "", fmt.Errorf("fetch PR files: %w", err)
-	}
-
-	prConfigs, err := ic.FindConfigsForPRFiles(ctx, repo, prInfo.HeadSHA, files)
-	if err != nil {
-		return nil, "", fmt.Errorf("find configs for PR: %w", err)
-	}
-	if config, configDir, ok, err := selectConfigByDatabaseName(databaseName, prConfigs); err != nil {
-		return nil, "", err
-	} else if ok {
-		return config, configDir, nil
-	}
-
-	result, err := ic.FindAllConfigs(ctx, repo, prInfo.HeadSHA)
+	result, scoped, err := ic.findAllConfigsForDatabase(ctx, repo, prInfo.HeadSHA, databaseName)
 	if err != nil {
 		return nil, "", fmt.Errorf("find configs: %w", err)
 	}
@@ -291,6 +388,21 @@ func (ic *InstallationClient) FindConfigByDatabaseName(ctx context.Context, repo
 			invalidPaths = append(invalidPaths, ic.Path)
 		}
 		return nil, "", fmt.Errorf("%w at %s", ErrInvalidConfig, strings.Join(invalidPaths, ", "))
+	}
+
+	if scoped {
+		config, configDir, ok, err := selectConfigByDatabaseName(databaseName, result.ValidConfigs)
+		if err != nil {
+			return nil, "", err
+		}
+		if !ok {
+			// The scoped scan covered every directory this database's config
+			// could live in, so absence is authoritative. Other databases
+			// were not enumerated, so no available-databases list is offered.
+			return nil, "", &DatabaseNotFoundError{DatabaseName: databaseName}
+		}
+		ic.logger.Debug("found config for database via scoped truncated-tree probe", "database", databaseName, "path", configDir)
+		return config, configDir, nil
 	}
 
 	if len(result.ValidConfigs) == 0 {

--- a/pkg/github/config_test.go
+++ b/pkg/github/config_test.go
@@ -718,6 +718,19 @@ func registerDirectoryContent(t *testing.T, mux *http.ServeMux, endpointPath str
 // subtrees resolve: shallow fetches of the root and intermediate levels return
 // directory entries, and the apps/widgets/schema subtree lists subtreeEntries
 // (paths relative to that directory).
+// registerConfigTestPullRequest serves PR #1 with head SHA abc123, matching
+// the tree fixtures used by the truncated-repo config tests.
+func registerConfigTestPullRequest(t *testing.T, mux *http.ServeMux) {
+	t.Helper()
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"head": map[string]any{"ref": "feature", "sha": "abc123"},
+			"base": map[string]any{"ref": "main", "sha": "def456"},
+			"user": map[string]any{"login": "mona"},
+		}))
+	})
+}
+
 func registerTruncatedRepoWithSchemaSubtree(t *testing.T, mux *http.ServeMux, subtreeEntries []map[string]any) {
 	t.Helper()
 
@@ -760,13 +773,27 @@ func registerGitBlob(t *testing.T, mux *http.ServeMux, sha, content string) {
 	})
 }
 
-func widgetsConfigDirHints(t *testing.T, dirs ...string) func(repo string) ([]string, bool) {
-	t.Helper()
+// testConfigDirHints implements ConfigDirHints for tests: the repo-wide scan
+// and every database-scoped lookup return the same directories.
+type testConfigDirHints struct {
+	t          *testing.T
+	dirs       []string
+	exhaustive bool
+}
 
-	return func(repo string) ([]string, bool) {
-		require.Equal(t, "octocat/hello-world", repo)
-		return dirs, true
-	}
+func (h testConfigDirHints) SchemaDirHintsForRepo(repo string) ([]string, bool) {
+	require.Equal(h.t, "octocat/hello-world", repo)
+	return h.dirs, h.exhaustive
+}
+
+func (h testConfigDirHints) SchemaDirHintsForDatabase(repo, _ string) ([]string, bool) {
+	require.Equal(h.t, "octocat/hello-world", repo)
+	return h.dirs, h.exhaustive
+}
+
+func widgetsConfigDirHints(t *testing.T, dirs ...string) ConfigDirHints {
+	t.Helper()
+	return testConfigDirHints{t: t, dirs: dirs, exhaustive: true}
 }
 
 // A repo-root schema path cannot be recovered through a subtree fetch when
@@ -870,6 +897,68 @@ func TestFindAllConfigsTruncatedTreeFailsClosedWhenNoHintsForRepo(t *testing.T) 
 	assert.ErrorIs(t, err, ErrGitTreeTruncated)
 }
 
+// A database-scoped lookup on a truncated repo probes only the named
+// database's configured directories: the config is found without scanning
+// every configured directory in the repo.
+func TestFindConfigByDatabaseNameInRepoTruncatedUsesScopedProbe(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerTruncatedRepoWithSchemaSubtree(t, mux, []map[string]any{
+		{"path": "schemabot.yaml", "type": "blob", "sha": "blob-config", "mode": "100644"},
+	})
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema/schemabot.yaml", "database: widgets\ntype: mysql\n")
+	registerConfigTestPullRequest(t, mux)
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ic.SetConfigDirHints(widgetsConfigDirHints(t, "apps/widgets/schema"))
+
+	config, configDir, err := ic.FindConfigByDatabaseNameInRepo(t.Context(), "octocat/hello-world", 1, "widgets")
+
+	require.NoError(t, err)
+	assert.Equal(t, "widgets", config.Database)
+	assert.Equal(t, "apps/widgets/schema", configDir)
+}
+
+// A scoped probe that lists the database's configured directories completely
+// and finds no config for it is authoritative: the caller gets a clear
+// not-found error, with no misleading available-databases list (other
+// databases were never enumerated).
+func TestFindConfigByDatabaseNameInRepoTruncatedScopedProbeNotFound(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerTruncatedRepoWithSchemaSubtree(t, mux, []map[string]any{
+		{"path": "schemabot.yaml", "type": "blob", "sha": "blob-config", "mode": "100644"},
+	})
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema/schemabot.yaml", "database: widgets\ntype: mysql\n")
+	registerConfigTestPullRequest(t, mux)
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ic.SetConfigDirHints(widgetsConfigDirHints(t, "apps/widgets/schema"))
+
+	_, _, err := ic.FindConfigByDatabaseNameInRepo(t.Context(), "octocat/hello-world", 1, "payments")
+
+	var notFound *DatabaseNotFoundError
+	require.ErrorAs(t, err, &notFound)
+	assert.Equal(t, "payments", notFound.DatabaseName)
+	assert.Empty(t, notFound.AvailableDatabases)
+	assert.NotContains(t, err.Error(), "Available databases")
+}
+
+// A database whose own directories cannot be probed exhaustively keeps the
+// fail-closed truncation error for scoped lookups, exactly like the
+// repo-wide scan.
+func TestFindConfigByDatabaseNameInRepoTruncatedNotExhaustiveFailsClosed(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerTruncatedRepoWithSchemaSubtree(t, mux, nil)
+	registerConfigTestPullRequest(t, mux)
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ic.SetConfigDirHints(testConfigDirHints{t: t, dirs: []string{"apps/widgets/schema"}, exhaustive: false})
+
+	_, _, err := ic.FindConfigByDatabaseNameInRepo(t.Context(), "octocat/hello-world", 1, "widgets")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrGitTreeTruncated)
+}
+
 // A database that allows configs outside every probe-able directory (no
 // allowed_dirs, a wildcard, or a repo-root entry) makes the hint list
 // non-exhaustive: a partial probe could return a confidently wrong result, so
@@ -883,10 +972,7 @@ func TestFindAllConfigsTruncatedTreeFailsClosedWhenHintsNotExhaustive(t *testing
 	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema/schemabot.yaml", "database: widgets\ntype: mysql\n")
 
 	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
-	ic.SetConfigDirHints(func(repo string) ([]string, bool) {
-		require.Equal(t, "octocat/hello-world", repo)
-		return []string{"apps/widgets/schema"}, false
-	})
+	ic.SetConfigDirHints(testConfigDirHints{t: t, dirs: []string{"apps/widgets/schema"}, exhaustive: false})
 
 	_, err := ic.FindAllConfigs(t.Context(), "octocat/hello-world", "abc123")
 

--- a/pkg/serve/serve.go
+++ b/pkg/serve/serve.go
@@ -627,7 +627,7 @@ func buildSingleAppWebhookRuntime(serverConfig *api.ServerConfig, svc *api.Servi
 	appID := serverConfig.GitHub.ResolveAppID()
 	ghClient := ghclient.NewClient(appID, []byte(ghPrivateKey), logger,
 		ghclient.WithTrustedCheckAppSlugs(serverConfig.GitHub.TrustedCheckAppSlugs),
-		ghclient.WithConfigDirHints(serverConfig.SchemaDirHintsForRepo))
+		ghclient.WithConfigDirHints(serverConfig))
 	handler := webhook.NewHandler(svc, ghClient, []byte(ghWebhookSecret), logger,
 		webhook.WithRepoWebhookSecret([]byte(repoWebhookSecret)))
 	logger.Info("GitHub webhook endpoint registered",
@@ -689,7 +689,7 @@ func buildMultiAppWebhookRuntime(serverConfig *api.ServerConfig, svc *api.Servic
 
 		clients[e.name] = ghclient.NewClient(e.id, []byte(privateKey), logger,
 			ghclient.WithTrustedCheckAppSlugs(e.cfg.TrustedCheckAppSlugs),
-			ghclient.WithConfigDirHints(serverConfig.SchemaDirHintsForRepo))
+			ghclient.WithConfigDirHints(serverConfig))
 		secretsByApp[e.name] = []byte(secret)
 		appByID[e.id] = e.name
 

--- a/pkg/webhook/actor_authorization_test.go
+++ b/pkg/webhook/actor_authorization_test.go
@@ -914,6 +914,104 @@ func actorAuthStorageTestHandler(cfg *api.ServerConfig, store storage.Storage, i
 
 // commentRecorder returns a mux handler that captures posted PR comment bodies
 // on the given channel and responds like the GitHub create-comment API.
+// A user-issued plan reads the resolved database's live schema, so an actor
+// who is neither an admin nor one of that database's operators is blocked
+// with a rejection that lists who can run the command.
+func TestPlanForResolvedDatabaseBlocksUnauthorizedActor(t *testing.T) {
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 2)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", commentRecorder(t, comments))
+
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+	cfg := actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
+		cfg.PRCommandAuthorization.AdminUsers = []string{"hubot"}
+	})
+	h := actorAuthTestHandler(cfg, installClient)
+
+	blocked := h.planForResolvedDatabaseBlocked(t.Context(), "octocat/hello-world", 1, 12345, "mona", "orders", "")
+
+	assert.True(t, blocked)
+	body := requireComment(t, comments, "unauthorized plan comment")
+	assert.Contains(t, body, "SchemaBot Command Not Authorized")
+	assert.Contains(t, body, "@mona is not authorized")
+}
+
+// The database's configured operator users satisfy the plan gate: planning
+// requires the same access the database's mutating commands do.
+func TestPlanForResolvedDatabaseAllowsDatabaseOperator(t *testing.T) {
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 2)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", commentRecorder(t, comments))
+
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+	cfg := actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
+		db := cfg.Databases["orders"]
+		db.OperatorUsers = []string{"mona"}
+		cfg.Databases["orders"] = db
+	})
+	h := actorAuthTestHandler(cfg, installClient)
+
+	blocked := h.planForResolvedDatabaseBlocked(t.Context(), "octocat/hello-world", 1, 12345, "mona", "orders", "")
+
+	assert.False(t, blocked)
+	select {
+	case body := <-comments:
+		t.Fatalf("no comment should be posted for an authorized operator, got %q", body)
+	default:
+	}
+}
+
+// With PR command authorization disabled, plan keeps its ungated behavior.
+func TestPlanForResolvedDatabaseUngatedWhenAuthorizationDisabled(t *testing.T) {
+	client, _ := setupGitHubServer(t)
+
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+	h := actorAuthTestHandler(actorAuthTestConfig(false), installClient)
+
+	blocked := h.planForResolvedDatabaseBlocked(t.Context(), "octocat/hello-world", 1, 12345, "mona", "orders", "")
+
+	assert.False(t, blocked)
+}
+
+// A database not configured on this deployment defers to the downstream
+// ownership handling, so fan-out deployments stay silent instead of posting
+// authorization rejections for databases they do not manage.
+func TestPlanForResolvedDatabaseSkipsGateForUnconfiguredDatabase(t *testing.T) {
+	client, _ := setupGitHubServer(t)
+
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+	cfg := actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
+		cfg.PRCommandAuthorization.AdminUsers = []string{"hubot"}
+	})
+	h := actorAuthTestHandler(cfg, installClient)
+
+	blocked := h.planForResolvedDatabaseBlocked(t.Context(), "octocat/hello-world", 1, 12345, "mona", "someone-elses-db", "")
+
+	assert.False(t, blocked)
+}
+
+// The full plan command path authorizes the actor once discovery resolves
+// the database — even when the PR itself touches that database's schema,
+// planning it requires the database's configured principals.
+func TestHandleMultiEnvPlanBlocksUnauthorizedActorAfterDiscovery(t *testing.T) {
+	client, mux := setupGitHubServer(t)
+	registerApplyDiscoveryEndpoints(t, mux, "orders")
+	comments := make(chan string, 2)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", commentRecorder(t, comments))
+
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+	cfg := actorAuthTestConfig(true, func(cfg *api.ServerConfig) {
+		cfg.PRCommandAuthorization.AdminUsers = []string{"hubot"}
+	})
+	h := actorAuthStorageTestHandler(cfg, &emptyStorage{}, installClient)
+
+	h.handleMultiEnvPlan("octocat/hello-world", 1, "orders", "", 12345, "mona", false, true, 0)
+
+	body := requireComment(t, comments, "unauthorized plan comment")
+	assert.Contains(t, body, "SchemaBot Command Not Authorized")
+	assert.Contains(t, body, "@mona is not authorized")
+}
+
 func commentRecorder(t *testing.T, comments chan<- string) http.HandlerFunc {
 	t.Helper()
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -84,6 +84,13 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 		return
 	}
 
+	// A user-issued plan reads the resolved database's live schema, so it
+	// requires that database's configured principals.
+	if h.planForResolvedDatabaseBlocked(ctx, repo, pr, installationID, requestedBy, schemaResult.Database, environment) {
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "plan blocked by actor authorization"})
+		return
+	}
+
 	// Build PlanRequest in the format expected by the API service
 	prNumber := int32(pr)
 	deployment := ""
@@ -160,6 +167,38 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 	})
 }
 
+// planForResolvedDatabaseBlocked enforces actor authorization once a
+// user-issued plan has resolved which database it targets. A plan reads the
+// database's live schema, so it requires the same configured principals as
+// the mutating commands — the database's operator teams/users and the
+// instance admins. A plan that resolves no managed database (the stuck-check
+// rescue on a no-schema-changes PR) never reaches this gate, and databases
+// not configured on this deployment defer to the downstream ownership
+// handling so fan-out deployments stay silent. When blocked, the
+// authorization path has already posted the rejection comment.
+func (h *Handler) planForResolvedDatabaseBlocked(ctx context.Context, repo string, pr int, installationID int64, requestedBy, databaseName, environment string) bool {
+	if databaseName == "" {
+		h.logger.Debug("plan resolved no database; no authorization gate", "repo", repo, "pr", pr)
+		return false
+	}
+	dbConfig := h.service.Config().Database(databaseName)
+	if dbConfig == nil {
+		h.logger.Debug("plan database is not configured on this deployment; deferring to downstream ownership handling",
+			"repo", repo, "pr", pr, "database", databaseName)
+		return false
+	}
+	authzClient, blocked := h.actorAuthorizationClient(repo, pr, installationID, requestedBy, databaseName, environment, action.Plan)
+	if blocked {
+		return true
+	}
+	if authzClient == nil {
+		h.logger.Debug("PR command authorization disabled; plan proceeds ungated",
+			"repo", repo, "pr", pr, "database", databaseName, "requested_by", requestedBy)
+		return false
+	}
+	return h.enforcePRCommandActorAuthorization(ctx, authzClient, repo, pr, installationID, requestedBy, databaseName, dbConfig.Type, environment, action.Plan)
+}
+
 // handleMultiEnvPlan runs plan for all configured environments and posts a single combined comment.
 // When isAutoPlan is true and no environments have changes or errors, the comment is skipped to reduce PR noise.
 // commentID is the command comment to acknowledge once discovery commits this
@@ -218,6 +257,13 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName, tenant s
 		}
 		schemaDatabase = config.Database
 	}
+	// A user-issued plan reads the resolved database's live schema, so it
+	// requires that database's configured principals. Auto-plans are
+	// system-triggered with no actor to authorize.
+	if !isAutoPlan && h.planForResolvedDatabaseBlocked(ctx, repo, pr, installationID, requestedBy, schemaDatabase, "") {
+		return
+	}
+
 	configuredEnvironments, envErr := h.configuredDatabaseEnvironments(schemaDatabase)
 	if envErr != nil {
 		if isAutoPlan {

--- a/pkg/webhook/truncated_repo_integration_test.go
+++ b/pkg/webhook/truncated_repo_integration_test.go
@@ -33,7 +33,7 @@ func newE2EHandlerWithConfigDirHints(t *testing.T, svc *api.Service, client *gh.
 	t.Helper()
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	installClient := ghclient.NewInstallationClient(client, logger)
-	installClient.SetConfigDirHints(svc.Config().SchemaDirHintsForRepo)
+	installClient.SetConfigDirHints(svc.Config())
 	factory := &fakeClientFactory{client: installClient}
 	return NewHandler(svc, factory, nil, logger)
 }


### PR DESCRIPTION
## Why this matters

A plan reads the resolved database's live schema, but the plan command was open to anyone who could comment on the repo — including planning a database their PR has nothing to do with. On very large monorepos that same command also paid a repository-wide config scan (hundreds of GitHub API calls against the installation's shared rate-limit budget, the budget check publishing depends on) for a lookup that only needed one database's directories.

## How it works

**Authorization on the resolved database.** Once a user-issued plan resolves which database it targets, the actor must be one of that database's configured operators (`operator_teams`/`operator_users`) or an instance admin — the same principals as the mutating commands. Anyone else gets the standard rejection comment listing who can run it.

```
schemabot plan …  (user-issued)
  ├─ resolves no managed database ──────────→ ungated (stuck-check rescue
  │                                            stays open to everyone)
  ├─ database not configured on this
  │  deployment ────────────────────────────→ defers silently (fan-out
  │                                            deployments post nothing)
  ├─ actor is a database operator / admin ──→ plan proceeds
  └─ otherwise ─────────────────────────────→ blocked: "not authorized,
                                               here's who can run this"
```

Auto-plans are system-triggered with no actor and stay ungated. With `pr_command_authorization` disabled, nothing changes.

**Database-scoped discovery on truncated repos.** `FindConfigByDatabaseName` now splits into a diff-scoped probe and a repository lookup, and on a repository whose tree listing GitHub truncates, the repository lookup probes only the named database's `allowed_dirs` (a few API calls) instead of every configured directory in the repo. Absence from an exhaustively-listed scoped probe is authoritative: the user gets a clear "database not found" with no misleading available-databases list, since other databases were never enumerated. A database whose own directories cannot be probed exhaustively keeps the fail-closed truncation error.

## How it moves toward the northstar

Plan keeps its self-service guarantees — anyone can rescue a stuck check — while access to a database's schema follows the database's own operator configuration, and the largest monorepos stop paying (and risking) a whole-repo scan for a one-database question.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
