### PR TITLE
feat(cli): checks backfill recreates missing Check Runs, redriving or synthesizing per PR

### DIFF
--- a/pkg/cmd/client/client.go
+++ b/pkg/cmd/client/client.go
@@ -80,6 +80,22 @@ func RedriveWebhooks(ctx context.Context, endpoint string, req apitypes.WebhookR
 	return &result, nil
 }
 
+func ChecksScan(ctx context.Context, endpoint string, req apitypes.ChecksScanRequest) (*apitypes.ChecksScanResponse, error) {
+	var result apitypes.ChecksScanResponse
+	if err := doSlowPostIntoCtx(ctx, endpoint, "/api/checks/scan", req, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func ChecksSynthesize(ctx context.Context, endpoint string, req apitypes.ChecksSynthesizeRequest) (*apitypes.ChecksSynthesizeResponse, error) {
+	var result apitypes.ChecksSynthesizeResponse
+	if err := doSlowPostIntoCtx(ctx, endpoint, "/api/checks/synthesize", req, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 // PullSchemaOptions controls optional live schema pull request fields.
 type PullSchemaOptions struct {
 	Namespaces    []string

--- a/pkg/cmd/commands/checks_backfill.go
+++ b/pkg/cmd/commands/checks_backfill.go
@@ -1,0 +1,342 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/block/schemabot/pkg/apitypes"
+	cmdclient "github.com/block/schemabot/pkg/cmd/client"
+)
+
+// ChecksCmd groups SchemaBot Check Run operator commands.
+type ChecksCmd struct {
+	Backfill ChecksBackfillCmd `cmd:"" help:"Find open PRs missing SchemaBot Check Runs and recreate them"`
+}
+
+// ChecksBackfillCmd finds open PRs missing SchemaBot Check Runs and recreates
+// them, choosing the right remedy per PR: redeliver the PR's failed webhook
+// delivery when GitHub still retains one, otherwise replay the auto-plan flow
+// server-side. --dry-run prints the per-PR classification without acting.
+type ChecksBackfillCmd struct {
+	Repo             string `arg:"" help:"Repository to backfill, in owner/name form"`
+	Environment      string `help:"Only backfill this environment's SchemaBot Check Run name"`
+	CheckName        string `help:"Override the SchemaBot Check Run name to look for"`
+	Limit            int    `help:"Maximum open PRs to consider; 0 considers all" default:"0"`
+	DeliveryWindow   string `help:"How far back to search delivery history for redriveable deliveries, for example 6h or 14d" default:"14d"`
+	MaxDeliveryPages int    `help:"Maximum delivery pages to search per App" default:"300"`
+	DryRun           bool   `help:"Print the per-PR classification without redelivering or synthesizing"`
+	JSON             bool   `help:"Output as JSON"`
+}
+
+// checksSynthesizeBatchSize matches the server's per-request PR cap.
+const checksSynthesizeBatchSize = 10
+
+// checksBackfillAction is one PR's classification and (after acting) outcome.
+type checksBackfillAction struct {
+	PR           int      `json:"pr"`
+	URL          string   `json:"url"`
+	Title        string   `json:"title"`
+	HeadSHA      string   `json:"head_sha"`
+	MissingNames []string `json:"missing_names"`
+	// Classification is "redrive" when GitHub still retains a failed
+	// check-creating delivery for the PR, otherwise "synthesize".
+	Classification string  `json:"classification"`
+	App            string  `json:"app,omitempty"`
+	DeliveryIDs    []int64 `json:"delivery_ids,omitempty"`
+	Outcome        string  `json:"outcome,omitempty"`
+	Error          string  `json:"error,omitempty"`
+}
+
+type checksBackfillReport struct {
+	Repo                   string                 `json:"repo"`
+	CheckNames             []string               `json:"check_names"`
+	Scanned                int                    `json:"scanned"`
+	DeliverySearchComplete bool                   `json:"delivery_search_complete"`
+	DryRun                 bool                   `json:"dry_run"`
+	Actions                []checksBackfillAction `json:"actions"`
+}
+
+func (cmd *ChecksBackfillCmd) Run(ctx context.Context, g *Globals) error {
+	if cmd.Limit < 0 {
+		return fmt.Errorf("--limit must be non-negative")
+	}
+	if cmd.MaxDeliveryPages <= 0 {
+		return fmt.Errorf("--max-delivery-pages must be positive")
+	}
+	deliveryWindow, err := parseWebhookRedriveLast(cmd.DeliveryWindow)
+	if err != nil {
+		return fmt.Errorf("parse --delivery-window: %w", err)
+	}
+	endpoint, err := g.Resolve()
+	if err != nil {
+		return err
+	}
+
+	updateProgress, stopProgress := startLiveProgress(!cmd.JSON)
+	defer stopProgress()
+
+	// Phase 1: one crawl of the retained delivery history builds the
+	// redriveable index — proving "no delivery exists" for a PR any other way
+	// would cost a crawl per PR. Partial coverage is tolerated: a PR whose
+	// failed delivery sits beyond the budget is synthesized instead, which
+	// converges to the same checks.
+	windowEnd := webhookRedriveNow()
+	windowStart := windowEnd.Add(-deliveryWindow)
+	updateProgress(fmt.Sprintf("searching delivery history for failed deliveries in %s...", cmd.Repo))
+	crawl, err := runChunkedWebhookRedrive(ctx, cmdclient.RedriveWebhooks, endpoint, apitypes.WebhookRedriveRequest{
+		WindowStart: windowStart.Format(time.RFC3339),
+		WindowEnd:   windowEnd.Format(time.RFC3339),
+		Repo:        cmd.Repo,
+		MaxPages:    cmd.MaxDeliveryPages,
+		DryRun:      true,
+	}, cmd.MaxDeliveryPages, false, func(r apitypes.WebhookRedriveResult) {
+		updateProgress(fmt.Sprintf("app %s: %d delivery pages searched, %d failed deliveries found for %s", r.AppName, r.Pages, len(r.Selected), cmd.Repo))
+	})
+	if canceled := backfillCanceledError(err, stopProgress); canceled != nil {
+		return canceled
+	}
+	if err != nil {
+		return fmt.Errorf("search delivery history: %w", err)
+	}
+	redriveable, searchComplete := indexRedriveableDeliveries(crawl)
+
+	// Phase 2: page through open PRs missing the configured Check Runs and
+	// classify each against the delivery index.
+	report := &checksBackfillReport{Repo: cmd.Repo, DeliverySearchComplete: searchComplete, DryRun: cmd.DryRun}
+	page := 1
+	for {
+		chunk, err := cmdclient.ChecksScan(ctx, endpoint, apitypes.ChecksScanRequest{
+			Repo:        cmd.Repo,
+			Environment: cmd.Environment,
+			CheckName:   cmd.CheckName,
+			Page:        page,
+		})
+		if canceled := backfillCanceledError(err, stopProgress); canceled != nil {
+			return canceled
+		}
+		if err != nil {
+			return fmt.Errorf("scan open PRs for missing Check Runs: %w", err)
+		}
+		report.CheckNames = chunk.CheckNames
+		report.Scanned += chunk.Scanned
+		for _, missing := range chunk.Missing {
+			action := checksBackfillAction{
+				PR:             missing.Number,
+				URL:            missing.URL,
+				Title:          missing.Title,
+				HeadSHA:        missing.HeadSHA,
+				MissingNames:   missing.MissingNames,
+				Classification: "synthesize",
+			}
+			if hits, ok := redriveable[missing.Number]; ok {
+				action.Classification = "redrive"
+				action.App = hits.app
+				action.DeliveryIDs = hits.ids
+			}
+			report.Actions = append(report.Actions, action)
+		}
+		updateProgress(fmt.Sprintf("scanned %d open PRs in %s, %d missing Check Runs so far", report.Scanned, cmd.Repo, len(report.Actions)))
+		if chunk.NextPage == 0 || (cmd.Limit > 0 && report.Scanned >= cmd.Limit) {
+			break
+		}
+		page = chunk.NextPage
+	}
+
+	if !cmd.DryRun {
+		// Phase 3: act — redeliver the redriveable PRs' deliveries per App,
+		// then synthesize the rest in server-bounded batches.
+		err := cmd.act(ctx, endpoint, report, updateProgress)
+		if canceled := backfillCanceledError(err, stopProgress); canceled != nil {
+			// Print what completed before the interrupt, then exit non-zero.
+			stopProgress()
+			_ = cmd.write(report)
+			return canceled
+		}
+		if err != nil {
+			return err
+		}
+	}
+	stopProgress()
+	return cmd.write(report)
+}
+
+// backfillCanceledError maps an operator cancellation (Ctrl+C) to a clean
+// stop: it clears the progress line, prints a notice, and returns ErrSilent so
+// the CLI exits non-zero without a raw "context canceled" error line. It
+// returns nil for any other error (including none) so the caller handles it
+// normally.
+func backfillCanceledError(err error, stopProgress func()) error {
+	if !errors.Is(err, context.Canceled) {
+		return nil
+	}
+	stopProgress()
+	fmt.Fprintln(os.Stderr, "checks backfill canceled")
+	return ErrSilent
+}
+
+// redriveableDeliveries is one PR's failed check-creating deliveries; all of
+// a repo's deliveries come from the App that serves it, so one App per PR.
+type redriveableDeliveries struct {
+	app string
+	ids []int64
+}
+
+// indexRedriveableDeliveries maps PR number to its failed check-creating
+// deliveries from the crawl. searchComplete is false when any App's crawl
+// stopped before covering the window (page budget), meaning some redriveable
+// PRs may classify as synthesize instead.
+func indexRedriveableDeliveries(crawl *apitypes.WebhookRedriveResponse) (map[int]redriveableDeliveries, bool) {
+	redriveable := make(map[int]redriveableDeliveries)
+	searchComplete := true
+	if crawl == nil {
+		return redriveable, searchComplete
+	}
+	for _, result := range crawl.Results {
+		if !result.ReachedWindowStart && !result.HistoryExhausted {
+			searchComplete = false
+		}
+		for _, selected := range result.Selected {
+			if selected.PR == 0 {
+				continue
+			}
+			entry := redriveable[selected.PR]
+			entry.app = result.AppName
+			entry.ids = append(entry.ids, selected.ID)
+			redriveable[selected.PR] = entry
+		}
+	}
+	return redriveable, searchComplete
+}
+
+func (cmd *ChecksBackfillCmd) act(ctx context.Context, endpoint string, report *checksBackfillReport, updateProgress func(string)) error {
+	// Redeliveries first, grouped per App so each request redelivers by ID.
+	idsByApp := make(map[string][]int64)
+	for _, action := range report.Actions {
+		if action.Classification == "redrive" {
+			idsByApp[action.App] = append(idsByApp[action.App], action.DeliveryIDs...)
+		}
+	}
+	redriveFailedByApp := make(map[string]bool)
+	for app, ids := range idsByApp {
+		updateProgress(fmt.Sprintf("redelivering %d failed deliveries via app %s...", len(ids), app))
+		resp, err := cmdclient.RedriveWebhooks(ctx, endpoint, apitypes.WebhookRedriveRequest{
+			App:         app,
+			DeliveryIDs: ids,
+		})
+		if err != nil {
+			return fmt.Errorf("redeliver failed deliveries via app %q: %w", app, err)
+		}
+		for _, result := range resp.Results {
+			if result.Failed > 0 {
+				redriveFailedByApp[app] = true
+			}
+		}
+	}
+
+	// Then synthesize, in server-bounded batches.
+	var synthesizePRs []int
+	actionByPR := make(map[int]*checksBackfillAction)
+	for i := range report.Actions {
+		action := &report.Actions[i]
+		actionByPR[action.PR] = action
+		switch action.Classification {
+		case "redrive":
+			if redriveFailedByApp[action.App] {
+				action.Outcome = "redelivered (some redeliveries failed; see server logs)"
+			} else {
+				action.Outcome = "redelivered"
+			}
+		case "synthesize":
+			synthesizePRs = append(synthesizePRs, action.PR)
+		}
+	}
+	for start := 0; start < len(synthesizePRs); start += checksSynthesizeBatchSize {
+		batch := synthesizePRs[start:min(start+checksSynthesizeBatchSize, len(synthesizePRs))]
+		updateProgress(fmt.Sprintf("synthesizing Check Runs for %d/%d PRs...", min(start+len(batch), len(synthesizePRs)), len(synthesizePRs)))
+		resp, err := cmdclient.ChecksSynthesize(ctx, endpoint, apitypes.ChecksSynthesizeRequest{Repo: cmd.Repo, PRs: batch})
+		if err != nil {
+			return fmt.Errorf("synthesize Check Runs: %w", err)
+		}
+		for _, result := range resp.Results {
+			if action, ok := actionByPR[result.PR]; ok {
+				action.Outcome = result.Outcome
+				action.Error = result.Error
+			}
+		}
+	}
+	return nil
+}
+
+func (cmd *ChecksBackfillCmd) write(report *checksBackfillReport) error {
+	if cmd.JSON {
+		return writeJSON(report)
+	}
+	return writeChecksBackfillReport(os.Stdout, report)
+}
+
+func writeChecksBackfillReport(w io.Writer, report *checksBackfillReport) error {
+	if _, err := fmt.Fprintf(w, "Scanned %d open PRs in %s for %s.\n", report.Scanned, report.Repo, strings.Join(report.CheckNames, ", ")); err != nil {
+		return err
+	}
+	if !report.DeliverySearchComplete {
+		if _, err := fmt.Fprintln(w, "Note: the delivery-history search did not cover the full window; PRs with older failed deliveries are synthesized instead (same resulting Check Runs)."); err != nil {
+			return err
+		}
+	}
+	if len(report.Actions) == 0 {
+		_, err := fmt.Fprintln(w, "No missing SchemaBot Check Runs found.")
+		return err
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	header := "PR\tHEAD SHA\tMISSING CHECKS\tACTION\tTITLE"
+	if !report.DryRun {
+		header = "PR\tHEAD SHA\tMISSING CHECKS\tOUTCOME\tTITLE"
+	}
+	if _, err := fmt.Fprintln(tw, header); err != nil {
+		return err
+	}
+	failed := 0
+	for _, action := range report.Actions {
+		status := describeBackfillPlan(action)
+		if !report.DryRun {
+			status = action.Outcome
+			if action.Error != "" {
+				status = "failed: " + action.Error
+				failed++
+			}
+		}
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", action.URL, shortSHA(action.HeadSHA), strings.Join(action.MissingNames, ", "), status, action.Title); err != nil {
+			return err
+		}
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+	if failed > 0 {
+		return fmt.Errorf("%d Check Run backfills failed; see the outcomes above", failed)
+	}
+	return nil
+}
+
+// describeBackfillPlan renders a dry-run action, naming the remedy the
+// backfill would use for the PR.
+func describeBackfillPlan(action checksBackfillAction) string {
+	if action.Classification == "redrive" {
+		return fmt.Sprintf("redrive %d failed deliveries (app %s)", len(action.DeliveryIDs), action.App)
+	}
+	return "synthesize via auto-plan (no retained delivery)"
+}
+
+func shortSHA(sha string) string {
+	if len(sha) <= 12 {
+		return sha
+	}
+	return sha[:12]
+}

--- a/pkg/cmd/commands/checks_backfill.go
+++ b/pkg/cmd/commands/checks_backfill.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -37,6 +38,11 @@ type ChecksBackfillCmd struct {
 // checksSynthesizeBatchSize matches the server's per-request PR cap.
 const checksSynthesizeBatchSize = 10
 
+// checksRedriveBatchSize bounds the delivery IDs redelivered per request, so
+// the redrive phase stays chunked (like synthesize) and no single request can
+// outlive an intermediary HTTP timeout under the server's per-delivery delay.
+const checksRedriveBatchSize = 50
+
 // checksBackfillAction is one PR's classification and (after acting) outcome.
 type checksBackfillAction struct {
 	PR           int      `json:"pr"`
@@ -50,11 +56,14 @@ type checksBackfillAction struct {
 	UntrustedConflictNames []string `json:"untrusted_conflict_names,omitempty"`
 	// Classification is "redrive" when GitHub still retains a failed
 	// check-creating delivery for the PR, otherwise "synthesize".
-	Classification string  `json:"classification"`
-	App            string  `json:"app,omitempty"`
-	DeliveryIDs    []int64 `json:"delivery_ids,omitempty"`
-	Outcome        string  `json:"outcome,omitempty"`
-	Error          string  `json:"error,omitempty"`
+	Classification string `json:"classification"`
+	// RedriveByApp groups the PR's redriveable delivery IDs by the App that
+	// owns them. A repo/PR can have retained failed deliveries in more than
+	// one App (for example after an App migration), and a delivery can only be
+	// redelivered with its own App's token, so the grouping must be preserved.
+	RedriveByApp map[string][]int64 `json:"redrive_by_app,omitempty"`
+	Outcome      string             `json:"outcome,omitempty"`
+	Error        string             `json:"error,omitempty"`
 }
 
 type checksBackfillReport struct {
@@ -139,10 +148,9 @@ func (cmd *ChecksBackfillCmd) Run(ctx context.Context, g *Globals) error {
 				UntrustedConflictNames: missing.UntrustedConflictNames,
 				Classification:         "synthesize",
 			}
-			if hits, ok := redriveable[missing.Number]; ok {
+			if byApp, ok := redriveable[missing.Number]; ok {
 				action.Classification = "redrive"
-				action.App = hits.app
-				action.DeliveryIDs = hits.ids
+				action.RedriveByApp = byApp
 			}
 			report.Actions = append(report.Actions, action)
 		}
@@ -187,17 +195,13 @@ func backfillCanceledError(err error, stopProgress func()) error {
 
 // redriveableDeliveries is one PR's failed check-creating deliveries; all of
 // a repo's deliveries come from the App that serves it, so one App per PR.
-type redriveableDeliveries struct {
-	app string
-	ids []int64
-}
 
 // indexRedriveableDeliveries maps PR number to its failed check-creating
 // deliveries from the crawl. searchComplete is false when any App's crawl
 // stopped before covering the window (page budget), meaning some redriveable
 // PRs may classify as synthesize instead.
-func indexRedriveableDeliveries(crawl *apitypes.WebhookRedriveResponse) (map[int]redriveableDeliveries, bool) {
-	redriveable := make(map[int]redriveableDeliveries)
+func indexRedriveableDeliveries(crawl *apitypes.WebhookRedriveResponse) (map[int]map[string][]int64, bool) {
+	redriveable := make(map[int]map[string][]int64)
 	searchComplete := true
 	if crawl == nil {
 		return redriveable, searchComplete
@@ -210,36 +214,47 @@ func indexRedriveableDeliveries(crawl *apitypes.WebhookRedriveResponse) (map[int
 			if selected.PR == 0 {
 				continue
 			}
-			entry := redriveable[selected.PR]
-			entry.app = result.AppName
-			entry.ids = append(entry.ids, selected.ID)
-			redriveable[selected.PR] = entry
+			byApp := redriveable[selected.PR]
+			if byApp == nil {
+				byApp = make(map[string][]int64)
+				redriveable[selected.PR] = byApp
+			}
+			// Preserve the owning App per delivery: a PR can have deliveries in
+			// more than one App, and each can only be redelivered with its own
+			// App's token.
+			byApp[result.AppName] = append(byApp[result.AppName], selected.ID)
 		}
 	}
 	return redriveable, searchComplete
 }
 
 func (cmd *ChecksBackfillCmd) act(ctx context.Context, endpoint string, report *checksBackfillReport, updateProgress func(string)) error {
-	// Redeliveries first, grouped per App so each request redelivers by ID.
+	// Redeliveries first, grouped per App (a delivery only redelivers with its
+	// own App's token) and chunked so no single request redelivers an
+	// unbounded number of deliveries.
 	idsByApp := make(map[string][]int64)
 	for _, action := range report.Actions {
-		if action.Classification == "redrive" {
-			idsByApp[action.App] = append(idsByApp[action.App], action.DeliveryIDs...)
+		for app, ids := range action.RedriveByApp {
+			idsByApp[app] = append(idsByApp[app], ids...)
 		}
 	}
 	redriveFailedByApp := make(map[string]bool)
-	for app, ids := range idsByApp {
-		updateProgress(fmt.Sprintf("redelivering %d failed deliveries via app %s...", len(ids), app))
-		resp, err := cmdclient.RedriveWebhooks(ctx, endpoint, apitypes.WebhookRedriveRequest{
-			App:         app,
-			DeliveryIDs: ids,
-		})
-		if err != nil {
-			return fmt.Errorf("redeliver failed deliveries via app %q: %w", app, err)
-		}
-		for _, result := range resp.Results {
-			if result.Failed > 0 {
-				redriveFailedByApp[app] = true
+	for _, app := range sortedKeys(idsByApp) {
+		ids := idsByApp[app]
+		for start := 0; start < len(ids); start += checksRedriveBatchSize {
+			batch := ids[start:min(start+checksRedriveBatchSize, len(ids))]
+			updateProgress(fmt.Sprintf("redelivering %d/%d failed deliveries via app %s...", min(start+len(batch), len(ids)), len(ids), app))
+			resp, err := cmdclient.RedriveWebhooks(ctx, endpoint, apitypes.WebhookRedriveRequest{
+				App:         app,
+				DeliveryIDs: batch,
+			})
+			if err != nil {
+				return fmt.Errorf("redeliver failed deliveries via app %q: %w", app, err)
+			}
+			for _, result := range resp.Results {
+				if result.Failed > 0 {
+					redriveFailedByApp[app] = true
+				}
 			}
 		}
 	}
@@ -252,7 +267,13 @@ func (cmd *ChecksBackfillCmd) act(ctx context.Context, endpoint string, report *
 		actionByPR[action.PR] = action
 		switch action.Classification {
 		case "redrive":
-			if redriveFailedByApp[action.App] {
+			anyFailed := false
+			for app := range action.RedriveByApp {
+				if redriveFailedByApp[app] {
+					anyFailed = true
+				}
+			}
+			if anyFailed {
 				action.Outcome = "redelivered (some redeliveries failed; see server logs)"
 			} else {
 				action.Outcome = "redelivered"
@@ -317,7 +338,10 @@ func writeChecksBackfillReport(w io.Writer, report *checksBackfillReport) error 
 				failed++
 			}
 		}
-		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", action.URL, shortSHA(action.HeadSHA), strings.Join(action.MissingNames, ", "), status, action.Title); err != nil {
+		// The status (server outcome/error) and the GitHub-controlled title are
+		// tab-separated cells: strip tabs/newlines so a value containing them
+		// cannot break the table layout.
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", action.URL, shortSHA(action.HeadSHA), strings.Join(action.MissingNames, ", "), sanitizeCell(status), sanitizeCell(action.Title)); err != nil {
 			return err
 		}
 	}
@@ -341,9 +365,31 @@ func writeChecksBackfillReport(w io.Writer, report *checksBackfillReport) error 
 // backfill would use for the PR.
 func describeBackfillPlan(action checksBackfillAction) string {
 	if action.Classification == "redrive" {
-		return fmt.Sprintf("redrive %d failed deliveries (app %s)", len(action.DeliveryIDs), action.App)
+		total := 0
+		for _, ids := range action.RedriveByApp {
+			total += len(ids)
+		}
+		return fmt.Sprintf("redrive %d failed deliveries (app %s)", total, strings.Join(sortedKeys(action.RedriveByApp), ", "))
 	}
 	return "synthesize via auto-plan (no retained delivery)"
+}
+
+// sortedKeys returns the map keys in deterministic order, so per-App output
+// (dry-run plan, redrive progress) does not depend on map iteration order.
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// sanitizeCell collapses tabs and newlines to spaces so a caller-influenced
+// value (a PR title, a server error string) cannot break the tab-separated
+// table layout.
+func sanitizeCell(s string) string {
+	return strings.NewReplacer("\t", " ", "\n", " ", "\r", " ").Replace(s)
 }
 
 func shortSHA(sha string) string {

--- a/pkg/cmd/commands/checks_backfill.go
+++ b/pkg/cmd/commands/checks_backfill.go
@@ -44,6 +44,10 @@ type checksBackfillAction struct {
 	Title        string   `json:"title"`
 	HeadSHA      string   `json:"head_sha"`
 	MissingNames []string `json:"missing_names"`
+	// UntrustedConflictNames are missing checks whose slot is already held by
+	// an untrusted app's Check Run; backfill recreates the trusted check but
+	// the operator likely also needs to resolve the conflicting one.
+	UntrustedConflictNames []string `json:"untrusted_conflict_names,omitempty"`
 	// Classification is "redrive" when GitHub still retains a failed
 	// check-creating delivery for the PR, otherwise "synthesize".
 	Classification string  `json:"classification"`
@@ -127,12 +131,13 @@ func (cmd *ChecksBackfillCmd) Run(ctx context.Context, g *Globals) error {
 		report.Scanned += chunk.Scanned
 		for _, missing := range chunk.Missing {
 			action := checksBackfillAction{
-				PR:             missing.Number,
-				URL:            missing.URL,
-				Title:          missing.Title,
-				HeadSHA:        missing.HeadSHA,
-				MissingNames:   missing.MissingNames,
-				Classification: "synthesize",
+				PR:                     missing.Number,
+				URL:                    missing.URL,
+				Title:                  missing.Title,
+				HeadSHA:                missing.HeadSHA,
+				MissingNames:           missing.MissingNames,
+				UntrustedConflictNames: missing.UntrustedConflictNames,
+				Classification:         "synthesize",
 			}
 			if hits, ok := redriveable[missing.Number]; ok {
 				action.Classification = "redrive"
@@ -318,6 +323,13 @@ func writeChecksBackfillReport(w io.Writer, report *checksBackfillReport) error 
 	}
 	if err := tw.Flush(); err != nil {
 		return err
+	}
+	for _, action := range report.Actions {
+		if len(action.UntrustedConflictNames) > 0 {
+			if _, err := fmt.Fprintf(w, "Note: PR #%d has checks held by an untrusted app (%s); backfill recreates the trusted check, but resolve the conflicting one too.\n", action.PR, strings.Join(action.UntrustedConflictNames, ", ")); err != nil {
+				return err
+			}
+		}
 	}
 	if failed > 0 {
 		return fmt.Errorf("%d Check Run backfills failed; see the outcomes above", failed)

--- a/pkg/cmd/commands/checks_backfill_test.go
+++ b/pkg/cmd/commands/checks_backfill_test.go
@@ -1,0 +1,50 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/apitypes"
+)
+
+// The classification core: a PR with a failed check-creating delivery in the
+// crawl is redriveable (grouped under its App); everything else synthesizes.
+// A crawl that stopped early marks the search incomplete so the report can
+// say why some PRs synthesize instead of redriving.
+func TestIndexRedriveableDeliveries(t *testing.T) {
+	redriveable, complete := indexRedriveableDeliveries(&apitypes.WebhookRedriveResponse{
+		Results: []apitypes.WebhookRedriveResult{
+			{
+				AppName:            "production",
+				ReachedWindowStart: true,
+				Selected: []apitypes.WebhookRedriveSelection{
+					{ID: 11, PR: 5},
+					{ID: 12, PR: 5},
+					{ID: 13, PR: 9},
+					{ID: 14, PR: 0},
+				},
+			},
+		},
+	})
+
+	require.True(t, complete)
+	require.Len(t, redriveable, 2)
+	assert.Equal(t, redriveableDeliveries{app: "production", ids: []int64{11, 12}}, redriveable[5])
+	assert.Equal(t, redriveableDeliveries{app: "production", ids: []int64{13}}, redriveable[9])
+
+	_, complete = indexRedriveableDeliveries(&apitypes.WebhookRedriveResponse{
+		Results: []apitypes.WebhookRedriveResult{
+			{AppName: "production", NextCursor: "c1"},
+		},
+	})
+	assert.False(t, complete, "a crawl stopped mid-window cannot prove which PRs are redriveable")
+
+	_, complete = indexRedriveableDeliveries(&apitypes.WebhookRedriveResponse{
+		Results: []apitypes.WebhookRedriveResult{
+			{AppName: "production", HistoryExhausted: true},
+		},
+	})
+	assert.True(t, complete, "exhausted history covered everything GitHub retains")
+}

--- a/pkg/cmd/commands/checks_backfill_test.go
+++ b/pkg/cmd/commands/checks_backfill_test.go
@@ -31,8 +31,8 @@ func TestIndexRedriveableDeliveries(t *testing.T) {
 
 	require.True(t, complete)
 	require.Len(t, redriveable, 2)
-	assert.Equal(t, redriveableDeliveries{app: "production", ids: []int64{11, 12}}, redriveable[5])
-	assert.Equal(t, redriveableDeliveries{app: "production", ids: []int64{13}}, redriveable[9])
+	assert.Equal(t, map[string][]int64{"production": {11, 12}}, redriveable[5])
+	assert.Equal(t, map[string][]int64{"production": {13}}, redriveable[9])
 
 	_, complete = indexRedriveableDeliveries(&apitypes.WebhookRedriveResponse{
 		Results: []apitypes.WebhookRedriveResult{
@@ -47,4 +47,25 @@ func TestIndexRedriveableDeliveries(t *testing.T) {
 		},
 	})
 	assert.True(t, complete, "exhausted history covered everything GitHub retains")
+}
+
+// A PR with retained failed deliveries in more than one App (for example
+// after an App migration) keeps each App's delivery IDs under that App, so
+// each is later redelivered with its own token rather than mixed.
+func TestIndexRedriveableDeliveriesGroupsMultipleAppsPerPR(t *testing.T) {
+	redriveable, _ := indexRedriveableDeliveries(&apitypes.WebhookRedriveResponse{
+		Results: []apitypes.WebhookRedriveResult{
+			{AppName: "old-app", ReachedWindowStart: true, Selected: []apitypes.WebhookRedriveSelection{{ID: 1, PR: 7}}},
+			{AppName: "new-app", ReachedWindowStart: true, Selected: []apitypes.WebhookRedriveSelection{{ID: 2, PR: 7}}},
+		},
+	})
+
+	assert.Equal(t, map[string][]int64{"old-app": {1}, "new-app": {2}}, redriveable[7])
+}
+
+// A PR title or server error containing tabs/newlines is neutralized so it
+// cannot break the tab-separated report layout.
+func TestSanitizeCell(t *testing.T) {
+	assert.Equal(t, "a b c", sanitizeCell("a\tb\nc"))
+	assert.Equal(t, "plain", sanitizeCell("plain"))
 }

--- a/pkg/cmd/commands/redrive_webhooks.go
+++ b/pkg/cmd/commands/redrive_webhooks.go
@@ -15,7 +15,10 @@ import (
 
 var webhookRedriveNow = func() time.Time { return time.Now().UTC() }
 
-// WebhooksCmd groups GitHub App webhook delivery operator commands.
+// WebhooksCmd groups GitHub webhook delivery operator commands. Missing
+// Check Runs are handled by `schemabot checks backfill`, which redrives or
+// synthesizes per PR; redrive here is the window-scoped tool for a known
+// delivery outage.
 type WebhooksCmd struct {
 	Redrive RedriveWebhooksCmd `cmd:"" help:"Redeliver failed GitHub App webhook deliveries from a time window"`
 }
@@ -58,7 +61,7 @@ func (cmd *RedriveWebhooksCmd) Run(ctx context.Context, g *Globals) error {
 		PR:          cmd.PR,
 		MaxPages:    cmd.MaxPages,
 		DryRun:      cmd.DryRun,
-	}, cmd.MaxPages, func(r apitypes.WebhookRedriveResult) {
+	}, cmd.MaxPages, true, func(r apitypes.WebhookRedriveResult) {
 		updateProgress(redriveProgressLine(r, windowStart, windowEnd, cmd.DryRun))
 	})
 	stopProgress()
@@ -133,7 +136,10 @@ func redriveWindowCoverage(oldestFetched, windowStart, windowEnd string) (int, b
 // requests: the server processes a few delivery pages per request and hands
 // back a cursor, so no single HTTP request can outlive an intermediary
 // timeout no matter how deep the crawl goes. maxPages is the total page
-// budget per App across all requests; incomplete coverage fails the run.
+// budget per App across all requests. With requireFullCoverage, incomplete
+// coverage fails the run; without it, the caller inspects the per-app
+// ReachedWindowStart/HistoryExhausted facts (best-effort classification
+// passes tolerate a partial crawl).
 //
 // Re-run convergence caveat: the server dedupes already-succeeded redeliveries
 // by GUID, but only within a single request (one cursor chunk). Because this
@@ -144,7 +150,7 @@ func redriveWindowCoverage(oldestFetched, windowStart, windowEnd string) (int, b
 // whose check recompute is idempotent and fail-closed and which never triggers
 // an apply; the worst case is a duplicate plan comment. Running --dry-run first
 // is the operator mitigation.
-func runChunkedWebhookRedrive(ctx context.Context, call func(context.Context, string, apitypes.WebhookRedriveRequest) (*apitypes.WebhookRedriveResponse, error), endpoint string, req apitypes.WebhookRedriveRequest, maxPages int, progress func(apitypes.WebhookRedriveResult)) (*apitypes.WebhookRedriveResponse, error) {
+func runChunkedWebhookRedrive(ctx context.Context, call func(context.Context, string, apitypes.WebhookRedriveRequest) (*apitypes.WebhookRedriveResponse, error), endpoint string, req apitypes.WebhookRedriveRequest, maxPages int, requireFullCoverage bool, progress func(apitypes.WebhookRedriveResult)) (*apitypes.WebhookRedriveResponse, error) {
 	if progress == nil {
 		progress = func(apitypes.WebhookRedriveResult) {}
 	}
@@ -184,7 +190,7 @@ func runChunkedWebhookRedrive(ctx context.Context, call func(context.Context, st
 			appResult = mergeWebhookRedriveResults(appResult, next.Results[0])
 			progress(appResult)
 		}
-		if !appResult.ReachedWindowStart {
+		if requireFullCoverage && !appResult.ReachedWindowStart {
 			if appResult.HistoryExhausted {
 				return merged, fmt.Errorf("app %q: GitHub's retained delivery history ends at %s, after the requested window start %s; older deliveries are no longer redriveable", appResult.AppName, appResult.OldestFetched, req.WindowStart)
 			}

--- a/pkg/cmd/commands/redrive_webhooks_test.go
+++ b/pkg/cmd/commands/redrive_webhooks_test.go
@@ -141,7 +141,7 @@ func TestRunChunkedWebhookRedriveFollowsCursorsAndMerges(t *testing.T) {
 
 	merged, err := runChunkedWebhookRedrive(t.Context(), call, "http://server", apitypes.WebhookRedriveRequest{
 		WindowStart: "2026-07-07T19:40:00Z", WindowEnd: "2026-07-07T19:50:00Z", MaxPages: 10,
-	}, 10, nil)
+	}, 10, true, nil)
 
 	require.NoError(t, err)
 	require.Len(t, requests, 2)
@@ -165,7 +165,7 @@ func TestRunChunkedWebhookRedriveFailsOnIncompleteCoverage(t *testing.T) {
 	}
 	_, err := runChunkedWebhookRedrive(t.Context(), budgetExhausted, "http://server", apitypes.WebhookRedriveRequest{
 		WindowStart: "2026-07-07T19:40:00Z", WindowEnd: "2026-07-07T19:50:00Z", MaxPages: 5,
-	}, 5, nil)
+	}, 5, true, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "increase --max-pages")
 
@@ -176,7 +176,7 @@ func TestRunChunkedWebhookRedriveFailsOnIncompleteCoverage(t *testing.T) {
 	}
 	_, err = runChunkedWebhookRedrive(t.Context(), historyEnded, "http://server", apitypes.WebhookRedriveRequest{
 		WindowStart: "2026-07-07T19:40:00Z", WindowEnd: "2026-07-07T19:50:00Z", MaxPages: 5,
-	}, 5, nil)
+	}, 5, true, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "retained delivery history ends")
 }
@@ -221,7 +221,7 @@ func TestRunChunkedWebhookRedriveReturnsPartialOnCancel(t *testing.T) {
 		WindowStart: "2026-07-07T19:40:00Z",
 		WindowEnd:   "2026-07-07T19:50:00Z",
 		App:         "production",
-	}, 10, nil)
+	}, 10, true, nil)
 
 	require.ErrorIs(t, err, context.Canceled)
 	require.Len(t, merged.Results, 1)

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -53,7 +53,8 @@ type CLI struct {
 	Configure  commands.ConfigureCmd  `cmd:"" help:"Configure CLI settings (endpoint, profiles)"`
 	Login      commands.LoginCmd      `cmd:"" help:"Log in via OIDC and cache a token for the active profile"`
 	Settings   commands.SettingsCmd   `cmd:"" help:"View or update schema change settings"`
-	Webhooks   commands.WebhooksCmd   `cmd:"" help:"Manage GitHub webhook operations"`
+	Webhooks   commands.WebhooksCmd   `cmd:"" help:"Manage GitHub App webhook deliveries"`
+	Checks     commands.ChecksCmd     `cmd:"" help:"Manage SchemaBot Check Runs on PRs"`
 	Serve      commands.ServeCmd      `cmd:"" help:"Start the SchemaBot HTTP API server"`
 }
 


### PR DESCRIPTION
## Why this matters

The `/api/checks/*` endpoints (#697) need an operator-facing command. Recovering a repo's PRs that are missing SchemaBot Check Runs — because they predate check enablement or lost a webhook delivery — should be one CLI invocation with a preview, not a hand-run script.

## What it does

Adds `schemabot checks backfill --repo X`, which finds open PRs missing the configured Check Runs and picks the right remedy per PR:

```
checks backfill
  ├─ one crawl of retained delivery history → redriveable index
  └─ per missing-check PR:
       ├─ failed delivery still retained ──→ redeliver it by ID (native path)
       └─ no delivery to redrive ─────────→ synthesize: replay auto-plan flow
```

- **Redrive when possible.** One chunked crawl classifies every PR at once; redriveable PRs get their exact deliveries redelivered by ID.
- **Synthesize when not.** The rest go through `/api/checks/synthesize` (the auto-plan replay).
- **`--dry-run` prints the per-PR classification** before acting and subsumes a standalone scan — one less command.

Live progress and Ctrl+C cancellation as with `schemabot webhooks redrive`.

## How it moves toward the northstar

One operator command converges every stuck PR in a repo to the state the webhooks would have produced, so required checks can be turned on without stranding existing PRs.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

