### PR TITLE
feat(cli): webhooks redrive command with live progress and cancellation

### DIFF
--- a/pkg/cmd/client/client.go
+++ b/pkg/cmd/client/client.go
@@ -72,6 +72,14 @@ func ListDatabases(endpoint string, opts ListDatabasesOptions) (*apitypes.Databa
 	return &result, nil
 }
 
+func RedriveWebhooks(ctx context.Context, endpoint string, req apitypes.WebhookRedriveRequest) (*apitypes.WebhookRedriveResponse, error) {
+	var result apitypes.WebhookRedriveResponse
+	if err := doSlowPostIntoCtx(ctx, endpoint, "/api/webhooks/redrive", req, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 // PullSchemaOptions controls optional live schema pull request fields.
 type PullSchemaOptions struct {
 	Namespaces    []string

--- a/pkg/cmd/client/request.go
+++ b/pkg/cmd/client/request.go
@@ -25,6 +25,12 @@ var authTransport = &bearerTransport{base: http.DefaultTransport}
 // Uses a 30s timeout to avoid hanging indefinitely on network stalls.
 var httpClient = &http.Client{Timeout: 30 * time.Second, Transport: authTransport}
 
+// webhookOpsHTTPClient serves the webhook operator endpoints, which crawl
+// GitHub delivery history or every open PR server-side and routinely need far
+// longer than the default client timeout. Matches the server's own budget
+// for these routes.
+var webhookOpsHTTPClient = &http.Client{Timeout: 15 * time.Minute, Transport: authTransport}
+
 // SetAuthToken configures the Bearer token attached to every CLI request. An
 // empty token leaves requests unauthenticated, which is correct against a
 // server with auth disabled. Surrounding whitespace is trimmed so a token
@@ -159,17 +165,34 @@ func doSendBody(endpoint, method, path string, body any) error {
 // doPostInto sends a JSON POST to endpoint+path and unmarshals the JSON response into result.
 // Returns an *APIError for non-200 responses (use IsNotFound to check for 404).
 func doPostInto(endpoint, path string, body any, result any) error {
+	return doPostIntoWithClient(context.Background(), httpClient, endpoint, path, body, result)
+}
+
+// doSlowPostIntoCtx is doPostInto with the long-running webhook ops client and
+// a caller-supplied context, for operator endpoints whose server-side work
+// legitimately outlives the default timeout and that must stop promptly when
+// the operator cancels (Ctrl+C).
+func doSlowPostIntoCtx(ctx context.Context, endpoint, path string, body any, result any) error {
+	return doPostIntoWithClient(ctx, webhookOpsHTTPClient, endpoint, path, body, result)
+}
+
+func doPostIntoWithClient(ctx context.Context, client *http.Client, endpoint, path string, body any, result any) error {
 	jsonBody, err := json.Marshal(body)
 	if err != nil {
 		return fmt.Errorf("marshal request body: %w", err)
 	}
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, endpoint+path, bytes.NewReader(jsonBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint+path, bytes.NewReader(jsonBody))
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := httpClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
+		// Surface a canceled context as-is so callers can tell an operator
+		// cancellation apart from a real connection failure.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		return FormatConnectionError(endpoint, err)
 	}
 	defer func() { _ = resp.Body.Close() }()

--- a/pkg/cmd/commands/common.go
+++ b/pkg/cmd/commands/common.go
@@ -221,6 +221,62 @@ func withLoading(message string, show bool, fn func() error) error {
 	return err
 }
 
+// startLiveProgress renders a spinner with a caller-updated status line on
+// stderr, for chunked operations that report progress between requests.
+// update replaces the status text; stop clears the line. Both are no-ops when
+// show is false or stderr is not a terminal, so scripted runs stay clean.
+func startLiveProgress(show bool) (update func(string), stop func()) {
+	if !show || !loadingSpinnerTerminal() {
+		return func(string) {}, func() {}
+	}
+
+	var mu sync.Mutex
+	message := ""
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		frame := 0
+		ticker := time.NewTicker(loadingSpinnerInterval)
+		defer ticker.Stop()
+		for {
+			mu.Lock()
+			current := message
+			mu.Unlock()
+			if current != "" {
+				if _, err := fmt.Fprintf(loadingSpinnerWriter, "\r\033[2K%s%s %s%s", templates.ANSIDim, loadingSpinnerFrames[frame%len(loadingSpinnerFrames)], current, templates.ANSIReset); err != nil {
+					return
+				}
+			}
+			frame++
+			select {
+			case <-done:
+				if _, err := fmt.Fprint(loadingSpinnerWriter, "\r\033[2K"); err != nil {
+					return
+				}
+				return
+			case <-ticker.C:
+			}
+		}
+	})
+
+	update = func(text string) {
+		mu.Lock()
+		message = text
+		mu.Unlock()
+	}
+	// stop is idempotent: callers commonly invoke it explicitly on the success
+	// path and again via defer, and a plain close(done) would panic the second
+	// time.
+	var stopOnce sync.Once
+	stop = func() {
+		stopOnce.Do(func() {
+			close(done)
+			wg.Wait()
+		})
+	}
+	return update, stop
+}
+
 // requireControlScope validates the explicit fields that scope a control operation.
 func requireControlScope(applyID, environment string) error {
 	if applyID == "" {

--- a/pkg/cmd/commands/redrive_webhooks.go
+++ b/pkg/cmd/commands/redrive_webhooks.go
@@ -134,6 +134,16 @@ func redriveWindowCoverage(oldestFetched, windowStart, windowEnd string) (int, b
 // back a cursor, so no single HTTP request can outlive an intermediary
 // timeout no matter how deep the crawl goes. maxPages is the total page
 // budget per App across all requests; incomplete coverage fails the run.
+//
+// Re-run convergence caveat: the server dedupes already-succeeded redeliveries
+// by GUID, but only within a single request (one cursor chunk). Because this
+// loop spreads a large window across independent requests, a re-run over a
+// window big enough that a delivery's successful-redelivery record and its
+// failed original fall in different chunks can redeliver that original again.
+// This is safe — a re-redelivered event only re-enters the auto-plan flow,
+// whose check recompute is idempotent and fail-closed and which never triggers
+// an apply; the worst case is a duplicate plan comment. Running --dry-run first
+// is the operator mitigation.
 func runChunkedWebhookRedrive(ctx context.Context, call func(context.Context, string, apitypes.WebhookRedriveRequest) (*apitypes.WebhookRedriveResponse, error), endpoint string, req apitypes.WebhookRedriveRequest, maxPages int, progress func(apitypes.WebhookRedriveResult)) (*apitypes.WebhookRedriveResponse, error) {
 	if progress == nil {
 		progress = func(apitypes.WebhookRedriveResult) {}

--- a/pkg/cmd/commands/redrive_webhooks.go
+++ b/pkg/cmd/commands/redrive_webhooks.go
@@ -121,7 +121,9 @@ func redriveWindowCoverage(oldestFetched, windowStart, windowEnd string) (int, b
 		return 0, false
 	}
 	covered := min(max(end.Sub(oldest), 0), total)
-	return int(covered * 100 / total), true
+	// Compute the percentage in float64: covered*100 as a Duration (int64
+	// nanoseconds) would overflow for windows longer than a few years.
+	return int(float64(covered) / float64(total) * 100), true
 }
 
 // runChunkedWebhookRedrive covers the window with a series of bounded server
@@ -271,12 +273,15 @@ func writeRedriveWebhookResponse(response *apitypes.WebhookRedriveResponse, dryR
 	totalFailed := 0
 	for _, result := range response.Results {
 		totalFailed += result.Failed
-		for _, selected := range result.Selected {
-			if _, err := fmt.Fprintf(os.Stderr, "selected app=%s id=%d delivered_at=%s event=%s action=%s status=%s status_code=%d repo=%s pr=%d\n",
-				result.AppName, selected.ID, selected.DeliveredAt, selected.Event, selected.Action, selected.Status, selected.StatusCode, selected.Repo, selected.PR); err != nil {
-				return err
-			}
-			if dryRun {
+		// The per-delivery detail is the dry-run's selection preview and can be
+		// very large on a wide window, so print it only for --dry-run; a real
+		// redrive reports the per-app redelivered/failed summary below.
+		if dryRun {
+			for _, selected := range result.Selected {
+				if _, err := fmt.Fprintf(os.Stderr, "selected app=%s id=%d delivered_at=%s event=%s action=%s status=%s status_code=%d repo=%s pr=%d\n",
+					result.AppName, selected.ID, selected.DeliveredAt, selected.Event, selected.Action, selected.Status, selected.StatusCode, selected.Repo, selected.PR); err != nil {
+					return err
+				}
 				if _, err := fmt.Fprintf(os.Stdout, "%d\n", selected.ID); err != nil {
 					return err
 				}

--- a/pkg/cmd/commands/redrive_webhooks.go
+++ b/pkg/cmd/commands/redrive_webhooks.go
@@ -181,6 +181,7 @@ func mergeWebhookRedriveResults(base, next apitypes.WebhookRedriveResult) apityp
 	base.Fetched += next.Fetched
 	base.Pages += next.Pages
 	base.Selected = append(base.Selected, next.Selected...)
+	base.Skipped += next.Skipped
 	base.Redelivered += next.Redelivered
 	base.Failed += next.Failed
 	base.OldestFetched = next.OldestFetched

--- a/pkg/cmd/commands/redrive_webhooks.go
+++ b/pkg/cmd/commands/redrive_webhooks.go
@@ -98,6 +98,9 @@ func redriveProgressLine(r apitypes.WebhookRedriveResult, windowStart, windowEnd
 	if r.Failed > 0 {
 		line += fmt.Sprintf(", %d failed", r.Failed)
 	}
+	if r.Skipped > 0 {
+		line += fmt.Sprintf(", %d skipped", r.Skipped)
+	}
 	return line
 }
 
@@ -142,7 +145,7 @@ func runChunkedWebhookRedrive(ctx context.Context, call func(context.Context, st
 	if err != nil {
 		return merged, err
 	}
-	for _, result := range first.Results {
+	for i, result := range first.Results {
 		appResult := result
 		progress(appResult)
 		for appResult.NextCursor != "" && appResult.Pages < maxPages {
@@ -157,9 +160,12 @@ func runChunkedWebhookRedrive(ctx context.Context, call func(context.Context, st
 				Cursor:      appResult.NextCursor,
 			})
 			if err != nil {
-				// Keep the work completed for this app so far, then surface the
-				// error (a cancellation is reported to the operator by Run).
+				// Keep every app's work completed so far — this app's partial
+				// plus the untouched first-chunk results of the apps not yet
+				// reached (their first request already redelivered) — then
+				// surface the error (a cancellation is reported by Run).
 				merged.Results = append(merged.Results, appResult)
+				merged.Results = append(merged.Results, first.Results[i+1:]...)
 				return merged, fmt.Errorf("continue webhook redrive for app %q: %w", appResult.AppName, err)
 			}
 			if len(next.Results) != 1 {
@@ -271,8 +277,10 @@ func writeRedriveWebhookResponse(response *apitypes.WebhookRedriveResponse, dryR
 		return nil
 	}
 	totalFailed := 0
+	totalSkipped := 0
 	for _, result := range response.Results {
 		totalFailed += result.Failed
+		totalSkipped += result.Skipped
 		// The per-delivery detail is the dry-run's selection preview and can be
 		// very large on a wide window, so print it only for --dry-run; a real
 		// redrive reports the per-app redelivered/failed summary below.
@@ -289,16 +297,20 @@ func writeRedriveWebhookResponse(response *apitypes.WebhookRedriveResponse, dryR
 		}
 		var err error
 		if dryRun {
-			_, err = fmt.Fprintf(os.Stderr, "app=%s dry_run_selected=%d\n", result.AppName, len(result.Selected))
+			_, err = fmt.Fprintf(os.Stderr, "app=%s dry_run_selected=%d skipped=%d\n", result.AppName, len(result.Selected), result.Skipped)
 		} else {
-			_, err = fmt.Fprintf(os.Stdout, "app=%s redelivered=%d failed=%d\n", result.AppName, result.Redelivered, result.Failed)
+			_, err = fmt.Fprintf(os.Stdout, "app=%s redelivered=%d failed=%d skipped=%d\n", result.AppName, result.Redelivered, result.Failed, result.Skipped)
 		}
 		if err != nil {
 			return err
 		}
 	}
-	if totalFailed > 0 {
-		return fmt.Errorf("%d webhook redeliveries failed; see the per-app counts above and the server logs", totalFailed)
+	// A skipped delivery is an in-window eligible delivery whose detail could
+	// not be resolved for filtering — it may have needed redriving but was
+	// dropped, so the window is not fully covered. Fail like a redelivery
+	// failure so a scripted run detects the under-coverage and can re-run.
+	if totalFailed > 0 || totalSkipped > 0 {
+		return fmt.Errorf("webhook redrive incomplete: %d redeliveries failed, %d eligible deliveries skipped (detail unresolved); see the per-app counts above and the server logs", totalFailed, totalSkipped)
 	}
 	return nil
 }

--- a/pkg/cmd/commands/redrive_webhooks.go
+++ b/pkg/cmd/commands/redrive_webhooks.go
@@ -1,0 +1,298 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/block/schemabot/pkg/apitypes"
+	cmdclient "github.com/block/schemabot/pkg/cmd/client"
+)
+
+var webhookRedriveNow = func() time.Time { return time.Now().UTC() }
+
+// WebhooksCmd groups GitHub App webhook delivery operator commands.
+type WebhooksCmd struct {
+	Redrive RedriveWebhooksCmd `cmd:"" help:"Redeliver failed GitHub App webhook deliveries from a time window"`
+}
+
+// RedriveWebhooksCmd redelivers failed GitHub App webhook deliveries from a time window.
+type RedriveWebhooksCmd struct {
+	WindowStart string `arg:"" optional:"" help:"Inclusive RFC3339 window start, for example 2026-07-07T19:40:00Z"`
+	WindowEnd   string `arg:"" optional:"" help:"Inclusive RFC3339 window end, for example 2026-07-07T19:50:00Z"`
+	Last        string `help:"Convenience window ending now, for example 1h, 6h, 2d, or '2 days'"`
+	App         string `help:"Configured GitHub App name to redrive; defaults to all configured Apps"`
+	Repo        string `help:"Only redrive deliveries for this repository, in owner/name form"`
+	PR          int    `help:"Only redrive deliveries for this pull request number"`
+	MaxPages    int    `help:"Maximum delivery pages to scan per App" default:"300"`
+	DryRun      bool   `help:"Print selected delivery IDs without redelivering"`
+}
+
+func (cmd *RedriveWebhooksCmd) Run(ctx context.Context, g *Globals) error {
+	if cmd.MaxPages <= 0 {
+		return fmt.Errorf("--max-pages must be positive")
+	}
+	windowStart, windowEnd, err := cmd.resolveWindow()
+	if err != nil {
+		return err
+	}
+	if cmd.PR < 0 {
+		return fmt.Errorf("--pr must be non-negative; 0 disables PR filtering")
+	}
+	endpoint, err := g.Resolve()
+	if err != nil {
+		return err
+	}
+	updateProgress, stopProgress := startLiveProgress(true)
+	defer stopProgress()
+	updateProgress("listing GitHub App webhook deliveries...")
+	merged, err := runChunkedWebhookRedrive(ctx, cmdclient.RedriveWebhooks, endpoint, apitypes.WebhookRedriveRequest{
+		WindowStart: windowStart,
+		WindowEnd:   windowEnd,
+		App:         cmd.App,
+		Repo:        cmd.Repo,
+		PR:          cmd.PR,
+		MaxPages:    cmd.MaxPages,
+		DryRun:      cmd.DryRun,
+	}, cmd.MaxPages, func(r apitypes.WebhookRedriveResult) {
+		updateProgress(redriveProgressLine(r, windowStart, windowEnd, cmd.DryRun))
+	})
+	stopProgress()
+	if errors.Is(err, context.Canceled) {
+		return reportWebhookRedriveCanceled(merged, cmd.DryRun)
+	}
+	if err != nil {
+		return err
+	}
+	return writeRedriveWebhookResponse(merged, cmd.DryRun)
+}
+
+// reportWebhookRedriveCanceled prints what the redrive completed before the
+// operator interrupted it, then returns ErrSilent so the CLI exits non-zero
+// without a raw "context canceled" error line.
+func reportWebhookRedriveCanceled(partial *apitypes.WebhookRedriveResponse, dryRun bool) error {
+	fmt.Fprintln(os.Stderr, "redrive canceled")
+	if partial != nil && !dryRun {
+		for _, result := range partial.Results {
+			fmt.Fprintf(os.Stderr, "app=%s redelivered=%d failed=%d (before cancel)\n", result.AppName, result.Redelivered, result.Failed)
+		}
+	}
+	return ErrSilent
+}
+
+// redriveProgressLine summarizes one app's crawl so far: how far back through
+// the window the listing has reached, and what has been selected/redelivered.
+func redriveProgressLine(r apitypes.WebhookRedriveResult, windowStart, windowEnd string, dryRun bool) string {
+	line := fmt.Sprintf("app %s: %d pages, %d deliveries scanned", r.AppName, r.Pages, r.Fetched)
+	if pct, ok := redriveWindowCoverage(r.OldestFetched, windowStart, windowEnd); ok && !r.ReachedWindowStart {
+		line += fmt.Sprintf(" (%d%% of window)", pct)
+	}
+	if dryRun {
+		return fmt.Sprintf("%s, %d selected (dry run)", line, len(r.Selected))
+	}
+	line += fmt.Sprintf(", %d selected, %d redelivered", len(r.Selected), r.Redelivered)
+	if r.Failed > 0 {
+		line += fmt.Sprintf(", %d failed", r.Failed)
+	}
+	return line
+}
+
+// redriveWindowCoverage reports how much of the window the crawl has walked
+// back through, from the newest deliveries toward the window start.
+func redriveWindowCoverage(oldestFetched, windowStart, windowEnd string) (int, bool) {
+	oldest, err := time.Parse(time.RFC3339, oldestFetched)
+	if err != nil {
+		return 0, false
+	}
+	start, err := time.Parse(time.RFC3339, windowStart)
+	if err != nil {
+		return 0, false
+	}
+	end, err := time.Parse(time.RFC3339, windowEnd)
+	if err != nil {
+		return 0, false
+	}
+	total := end.Sub(start)
+	if total <= 0 {
+		return 0, false
+	}
+	covered := min(max(end.Sub(oldest), 0), total)
+	return int(covered * 100 / total), true
+}
+
+// runChunkedWebhookRedrive covers the window with a series of bounded server
+// requests: the server processes a few delivery pages per request and hands
+// back a cursor, so no single HTTP request can outlive an intermediary
+// timeout no matter how deep the crawl goes. maxPages is the total page
+// budget per App across all requests; incomplete coverage fails the run.
+func runChunkedWebhookRedrive(ctx context.Context, call func(context.Context, string, apitypes.WebhookRedriveRequest) (*apitypes.WebhookRedriveResponse, error), endpoint string, req apitypes.WebhookRedriveRequest, maxPages int, progress func(apitypes.WebhookRedriveResult)) (*apitypes.WebhookRedriveResponse, error) {
+	if progress == nil {
+		progress = func(apitypes.WebhookRedriveResult) {}
+	}
+	// merged accumulates completed work so a cancellation mid-crawl can still
+	// report what was redelivered before the operator interrupted.
+	merged := &apitypes.WebhookRedriveResponse{}
+	first, err := call(ctx, endpoint, req)
+	if err != nil {
+		return merged, err
+	}
+	for _, result := range first.Results {
+		appResult := result
+		progress(appResult)
+		for appResult.NextCursor != "" && appResult.Pages < maxPages {
+			next, err := call(ctx, endpoint, apitypes.WebhookRedriveRequest{
+				WindowStart: req.WindowStart,
+				WindowEnd:   req.WindowEnd,
+				App:         appResult.AppName,
+				Repo:        req.Repo,
+				PR:          req.PR,
+				MaxPages:    maxPages - appResult.Pages,
+				DryRun:      req.DryRun,
+				Cursor:      appResult.NextCursor,
+			})
+			if err != nil {
+				// Keep the work completed for this app so far, then surface the
+				// error (a cancellation is reported to the operator by Run).
+				merged.Results = append(merged.Results, appResult)
+				return merged, fmt.Errorf("continue webhook redrive for app %q: %w", appResult.AppName, err)
+			}
+			if len(next.Results) != 1 {
+				return merged, fmt.Errorf("continue webhook redrive for app %q: expected one result, got %d", appResult.AppName, len(next.Results))
+			}
+			appResult = mergeWebhookRedriveResults(appResult, next.Results[0])
+			progress(appResult)
+		}
+		if !appResult.ReachedWindowStart {
+			if appResult.HistoryExhausted {
+				return merged, fmt.Errorf("app %q: GitHub's retained delivery history ends at %s, after the requested window start %s; older deliveries are no longer redriveable", appResult.AppName, appResult.OldestFetched, req.WindowStart)
+			}
+			return merged, fmt.Errorf("app %q: window start %s not reached within %d pages; increase --max-pages", appResult.AppName, req.WindowStart, maxPages)
+		}
+		merged.Results = append(merged.Results, appResult)
+	}
+	return merged, nil
+}
+
+func mergeWebhookRedriveResults(base, next apitypes.WebhookRedriveResult) apitypes.WebhookRedriveResult {
+	base.Fetched += next.Fetched
+	base.Pages += next.Pages
+	base.Selected = append(base.Selected, next.Selected...)
+	base.Redelivered += next.Redelivered
+	base.Failed += next.Failed
+	base.OldestFetched = next.OldestFetched
+	base.ReachedWindowStart = next.ReachedWindowStart
+	base.HistoryExhausted = next.HistoryExhausted
+	base.NextCursor = next.NextCursor
+	return base
+}
+
+func (cmd *RedriveWebhooksCmd) resolveWindow() (string, string, error) {
+	if cmd.Last != "" {
+		if cmd.WindowStart != "" || cmd.WindowEnd != "" {
+			return "", "", fmt.Errorf("use either --last or explicit window start/end, not both")
+		}
+		duration, err := parseWebhookRedriveLast(cmd.Last)
+		if err != nil {
+			return "", "", err
+		}
+		windowEnd := webhookRedriveNow()
+		windowStart := windowEnd.Add(-duration)
+		return windowStart.Format(time.RFC3339), windowEnd.Format(time.RFC3339), nil
+	}
+	if cmd.WindowStart == "" || cmd.WindowEnd == "" {
+		return "", "", fmt.Errorf("provide window start/end or use --last, for example --last 1h")
+	}
+	windowStart, err := time.Parse(time.RFC3339, cmd.WindowStart)
+	if err != nil {
+		return "", "", fmt.Errorf("parse window start %q as RFC3339: %w", cmd.WindowStart, err)
+	}
+	windowEnd, err := time.Parse(time.RFC3339, cmd.WindowEnd)
+	if err != nil {
+		return "", "", fmt.Errorf("parse window end %q as RFC3339: %w", cmd.WindowEnd, err)
+	}
+	if windowEnd.Before(windowStart) {
+		return "", "", fmt.Errorf("window end must be at or after window start")
+	}
+	return cmd.WindowStart, cmd.WindowEnd, nil
+}
+
+func parseWebhookRedriveLast(value string) (time.Duration, error) {
+	trimmed := strings.TrimSpace(strings.ToLower(value))
+	if trimmed == "" {
+		return 0, fmt.Errorf("--last must not be empty")
+	}
+	if duration, err := time.ParseDuration(trimmed); err == nil {
+		if duration <= 0 {
+			return 0, fmt.Errorf("--last must be positive")
+		}
+		return duration, nil
+	}
+
+	amountText, unit, ok := strings.Cut(trimmed, " ")
+	if !ok {
+		amountText, unit = splitWebhookRedriveLastAmountAndUnit(trimmed)
+	}
+	amount, err := strconv.Atoi(amountText)
+	if err != nil {
+		return 0, fmt.Errorf("parse --last %q: use a positive duration like 1h, 6h, 2d, or '2 days'", value)
+	}
+	if amount <= 0 {
+		return 0, fmt.Errorf("--last must be positive")
+	}
+	switch strings.TrimSpace(unit) {
+	case "d", "day", "days":
+		return time.Duration(amount) * 24 * time.Hour, nil
+	case "h", "hour", "hours":
+		return time.Duration(amount) * time.Hour, nil
+	case "m", "min", "mins", "minute", "minutes":
+		return time.Duration(amount) * time.Minute, nil
+	}
+	return 0, fmt.Errorf("parse --last %q: use a positive duration like 1h, 6h, 2d, or '2 days'", value)
+}
+
+func splitWebhookRedriveLastAmountAndUnit(value string) (string, string) {
+	for i, r := range value {
+		if r < '0' || r > '9' {
+			return value[:i], value[i:]
+		}
+	}
+	return value, ""
+}
+
+func writeRedriveWebhookResponse(response *apitypes.WebhookRedriveResponse, dryRun bool) error {
+	if response == nil {
+		return nil
+	}
+	totalFailed := 0
+	for _, result := range response.Results {
+		totalFailed += result.Failed
+		for _, selected := range result.Selected {
+			if _, err := fmt.Fprintf(os.Stderr, "selected app=%s id=%d delivered_at=%s event=%s action=%s status=%s status_code=%d repo=%s pr=%d\n",
+				result.AppName, selected.ID, selected.DeliveredAt, selected.Event, selected.Action, selected.Status, selected.StatusCode, selected.Repo, selected.PR); err != nil {
+				return err
+			}
+			if dryRun {
+				if _, err := fmt.Fprintf(os.Stdout, "%d\n", selected.ID); err != nil {
+					return err
+				}
+			}
+		}
+		var err error
+		if dryRun {
+			_, err = fmt.Fprintf(os.Stderr, "app=%s dry_run_selected=%d\n", result.AppName, len(result.Selected))
+		} else {
+			_, err = fmt.Fprintf(os.Stdout, "app=%s redelivered=%d failed=%d\n", result.AppName, result.Redelivered, result.Failed)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	if totalFailed > 0 {
+		return fmt.Errorf("%d webhook redeliveries failed; see the per-app counts above and the server logs", totalFailed)
+	}
+	return nil
+}

--- a/pkg/cmd/commands/redrive_webhooks_test.go
+++ b/pkg/cmd/commands/redrive_webhooks_test.go
@@ -1,0 +1,219 @@
+package commands
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/apitypes"
+)
+
+func TestParseWebhookRedriveLast(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		want  time.Duration
+	}{
+		{name: "go duration hours", value: "6h", want: 6 * time.Hour},
+		{name: "go duration minutes", value: "90m", want: 90 * time.Minute},
+		{name: "days suffix", value: "2d", want: 48 * time.Hour},
+		{name: "days word", value: "2 days", want: 48 * time.Hour},
+		{name: "hour word", value: "1 hour", want: time.Hour},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseWebhookRedriveLast(tt.value)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseWebhookRedriveLastRejectsInvalidValues(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []string{"", "0h", "-1h", "two days", "2 months"} {
+		t.Run(value, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := parseWebhookRedriveLast(value)
+
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestRedriveWebhooksResolveWindowFromLast(t *testing.T) {
+	fixedNow := time.Date(2026, 7, 8, 16, 0, 0, 0, time.UTC)
+	originalNow := webhookRedriveNow
+	webhookRedriveNow = func() time.Time { return fixedNow }
+	t.Cleanup(func() { webhookRedriveNow = originalNow })
+
+	cmd := RedriveWebhooksCmd{Last: "2h"}
+
+	windowStart, windowEnd, err := cmd.resolveWindow()
+
+	require.NoError(t, err)
+	assert.Equal(t, "2026-07-08T14:00:00Z", windowStart)
+	assert.Equal(t, "2026-07-08T16:00:00Z", windowEnd)
+}
+
+func TestRedriveWebhooksResolveWindowRejectsMixedShortcutAndExplicitWindow(t *testing.T) {
+	t.Parallel()
+
+	cmd := RedriveWebhooksCmd{WindowStart: "2026-07-08T14:00:00Z", WindowEnd: "2026-07-08T16:00:00Z", Last: "2h"}
+
+	_, _, err := cmd.resolveWindow()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "either --last or explicit window start/end")
+}
+
+func TestRedriveWebhooksResolveWindowRequiresWindow(t *testing.T) {
+	t.Parallel()
+
+	cmd := RedriveWebhooksCmd{}
+
+	_, _, err := cmd.resolveWindow()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "provide window start/end or use --last")
+}
+
+// A redrive that reports failed redeliveries must fail the command, so
+// scripted redrives detect partial failure from the exit code.
+func TestWriteRedriveWebhookResponseFailsOnFailedRedeliveries(t *testing.T) {
+	err := writeRedriveWebhookResponse(&apitypes.WebhookRedriveResponse{
+		Results: []apitypes.WebhookRedriveResult{
+			{AppName: "default", Redelivered: 2, Failed: 1},
+		},
+	}, false)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "1 webhook redeliveries failed")
+
+	require.NoError(t, writeRedriveWebhookResponse(&apitypes.WebhookRedriveResponse{
+		Results: []apitypes.WebhookRedriveResult{
+			{AppName: "default", Redelivered: 3},
+		},
+	}, false))
+}
+
+// The CLI covers a redrive window with a series of bounded server requests,
+// following each app's cursor until the window start is reached, and merges
+// the chunks into one per-app result.
+func TestRunChunkedWebhookRedriveFollowsCursorsAndMerges(t *testing.T) {
+	var requests []apitypes.WebhookRedriveRequest
+	call := func(_ context.Context, _ string, req apitypes.WebhookRedriveRequest) (*apitypes.WebhookRedriveResponse, error) {
+		requests = append(requests, req)
+		if req.Cursor == "" {
+			return &apitypes.WebhookRedriveResponse{Results: []apitypes.WebhookRedriveResult{
+				{AppName: "default", Pages: 2, Fetched: 200, Redelivered: 1, NextCursor: "c1",
+					Selected: []apitypes.WebhookRedriveSelection{{ID: 1}}},
+			}}, nil
+		}
+		require.Equal(t, "c1", req.Cursor)
+		require.Equal(t, "default", req.App)
+		return &apitypes.WebhookRedriveResponse{Results: []apitypes.WebhookRedriveResult{
+			{AppName: "default", Pages: 3, Fetched: 250, Redelivered: 2, ReachedWindowStart: true,
+				Selected: []apitypes.WebhookRedriveSelection{{ID: 2}, {ID: 3}}},
+		}}, nil
+	}
+
+	merged, err := runChunkedWebhookRedrive(t.Context(), call, "http://server", apitypes.WebhookRedriveRequest{
+		WindowStart: "2026-07-07T19:40:00Z", WindowEnd: "2026-07-07T19:50:00Z", MaxPages: 10,
+	}, 10, nil)
+
+	require.NoError(t, err)
+	require.Len(t, requests, 2)
+	require.Len(t, merged.Results, 1)
+	result := merged.Results[0]
+	assert.Equal(t, 5, result.Pages)
+	assert.Equal(t, 450, result.Fetched)
+	assert.Equal(t, 3, result.Redelivered)
+	assert.Len(t, result.Selected, 3)
+	assert.True(t, result.ReachedWindowStart)
+}
+
+// Incomplete coverage fails the run with the remediation that actually
+// helps: a bigger page budget when the cursor is still live, or the fact
+// that GitHub no longer retains the older deliveries.
+func TestRunChunkedWebhookRedriveFailsOnIncompleteCoverage(t *testing.T) {
+	budgetExhausted := func(_ context.Context, _ string, _ apitypes.WebhookRedriveRequest) (*apitypes.WebhookRedriveResponse, error) {
+		return &apitypes.WebhookRedriveResponse{Results: []apitypes.WebhookRedriveResult{
+			{AppName: "default", Pages: 5, NextCursor: "c9"},
+		}}, nil
+	}
+	_, err := runChunkedWebhookRedrive(t.Context(), budgetExhausted, "http://server", apitypes.WebhookRedriveRequest{
+		WindowStart: "2026-07-07T19:40:00Z", WindowEnd: "2026-07-07T19:50:00Z", MaxPages: 5,
+	}, 5, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "increase --max-pages")
+
+	historyEnded := func(_ context.Context, _ string, _ apitypes.WebhookRedriveRequest) (*apitypes.WebhookRedriveResponse, error) {
+		return &apitypes.WebhookRedriveResponse{Results: []apitypes.WebhookRedriveResult{
+			{AppName: "default", Pages: 3, HistoryExhausted: true, OldestFetched: "2026-07-07T19:45:00Z"},
+		}}, nil
+	}
+	_, err = runChunkedWebhookRedrive(t.Context(), historyEnded, "http://server", apitypes.WebhookRedriveRequest{
+		WindowStart: "2026-07-07T19:40:00Z", WindowEnd: "2026-07-07T19:50:00Z", MaxPages: 5,
+	}, 5, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "retained delivery history ends")
+}
+
+// The progress line reports how far back through the window the crawl has
+// walked, from the newest deliveries toward the window start.
+func TestRedriveWindowCoverage(t *testing.T) {
+	pct, ok := redriveWindowCoverage("2026-07-07T19:45:00Z", "2026-07-07T19:40:00Z", "2026-07-07T19:50:00Z")
+	require.True(t, ok)
+	assert.Equal(t, 50, pct)
+
+	pct, ok = redriveWindowCoverage("2026-07-07T19:39:00Z", "2026-07-07T19:40:00Z", "2026-07-07T19:50:00Z")
+	require.True(t, ok)
+	assert.Equal(t, 100, pct, "an oldest delivery before the window start caps at full coverage")
+
+	_, ok = redriveWindowCoverage("", "2026-07-07T19:40:00Z", "2026-07-07T19:50:00Z")
+	assert.False(t, ok, "no oldest timestamp yet")
+}
+
+// A cancelled context stops the chunked crawl and returns the work completed
+// so far alongside context.Canceled, so the command can report a partial
+// summary instead of losing it.
+func TestRunChunkedWebhookRedriveReturnsPartialOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	calls := 0
+	call := func(callCtx context.Context, _ string, _ apitypes.WebhookRedriveRequest) (*apitypes.WebhookRedriveResponse, error) {
+		if callCtx.Err() != nil {
+			return nil, callCtx.Err()
+		}
+		calls++
+		// First chunk completes with redeliveries and more work pending; the
+		// operator cancels before the continuation runs.
+		cancel()
+		return &apitypes.WebhookRedriveResponse{Results: []apitypes.WebhookRedriveResult{{
+			AppName:     "production",
+			Redelivered: 3,
+			NextCursor:  "page-2",
+		}}}, nil
+	}
+
+	merged, err := runChunkedWebhookRedrive(ctx, call, "http://server", apitypes.WebhookRedriveRequest{
+		WindowStart: "2026-07-07T19:40:00Z",
+		WindowEnd:   "2026-07-07T19:50:00Z",
+		App:         "production",
+	}, 10, nil)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Len(t, merged.Results, 1)
+	assert.Equal(t, 3, merged.Results[0].Redelivered, "work completed before cancel is preserved")
+}

--- a/pkg/cmd/commands/redrive_webhooks_test.go
+++ b/pkg/cmd/commands/redrive_webhooks_test.go
@@ -91,15 +91,25 @@ func TestRedriveWebhooksResolveWindowRequiresWindow(t *testing.T) {
 
 // A redrive that reports failed redeliveries must fail the command, so
 // scripted redrives detect partial failure from the exit code.
-func TestWriteRedriveWebhookResponseFailsOnFailedRedeliveries(t *testing.T) {
-	err := writeRedriveWebhookResponse(&apitypes.WebhookRedriveResponse{
+// A run with failed redeliveries or skipped (detail-unresolved) eligible
+// deliveries did not fully cover the window, so the command fails so a
+// scripted caller detects the under-coverage; a clean run succeeds.
+func TestWriteRedriveWebhookResponseFailsOnIncompleteCoverage(t *testing.T) {
+	failed := writeRedriveWebhookResponse(&apitypes.WebhookRedriveResponse{
 		Results: []apitypes.WebhookRedriveResult{
 			{AppName: "default", Redelivered: 2, Failed: 1},
 		},
 	}, false)
+	require.Error(t, failed)
+	require.Contains(t, failed.Error(), "1 redeliveries failed")
 
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "1 webhook redeliveries failed")
+	skipped := writeRedriveWebhookResponse(&apitypes.WebhookRedriveResponse{
+		Results: []apitypes.WebhookRedriveResult{
+			{AppName: "default", Redelivered: 2, Skipped: 3},
+		},
+	}, false)
+	require.Error(t, skipped)
+	require.Contains(t, skipped.Error(), "3 eligible deliveries skipped")
 
 	require.NoError(t, writeRedriveWebhookResponse(&apitypes.WebhookRedriveResponse{
 		Results: []apitypes.WebhookRedriveResult{

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -101,25 +101,30 @@ func main() {
 	sigCh := make(chan os.Signal, 2)
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
 	runCtx, cancelRun := context.WithCancel(context.Background())
+	// runDone signals the watcher that the command finished — kept separate
+	// from runCtx so the second select waits for a genuine second signal
+	// rather than the just-cancelled runCtx.
+	runDone := make(chan struct{})
 	go func() {
 		select {
 		case <-sigCh:
 			cancelRun()
-		case <-runCtx.Done():
+		case <-runDone:
 			return
 		}
 		select {
 		case <-sigCh:
 			os.Exit(130)
-		case <-runCtx.Done():
+		case <-runDone:
 		}
 	}()
 	ctx.BindTo(runCtx, (*context.Context)(nil))
 
 	err = ctx.Run(&cli.Globals)
-	// Stop intercepting signals and release the watcher goroutine now that the
-	// command is done; explicit rather than deferred, since the os.Exit below
-	// would skip a deferred call.
+	// Release the watcher and stop intercepting signals now that the command
+	// is done; explicit rather than deferred, since the os.Exit below would
+	// skip a deferred call.
+	close(runDone)
 	signal.Stop(sigCh)
 	cancelRun()
 	if err != nil {

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/alecthomas/kong"
@@ -51,6 +53,7 @@ type CLI struct {
 	Configure  commands.ConfigureCmd  `cmd:"" help:"Configure CLI settings (endpoint, profiles)"`
 	Login      commands.LoginCmd      `cmd:"" help:"Log in via OIDC and cache a token for the active profile"`
 	Settings   commands.SettingsCmd   `cmd:"" help:"View or update schema change settings"`
+	Webhooks   commands.WebhooksCmd   `cmd:"" help:"Manage GitHub webhook operations"`
 	Serve      commands.ServeCmd      `cmd:"" help:"Start the SchemaBot HTTP API server"`
 }
 
@@ -88,7 +91,19 @@ func main() {
 	}
 	client.SetAuthToken(token)
 
+	// Cancel long-running commands on Ctrl+C / SIGTERM. The first signal
+	// cancels the context so in-flight requests stop and the command can print
+	// a clean summary; a second signal restores default handling and
+	// force-terminates. Bind as the context.Context interface so command Run
+	// methods can declare a ctx parameter (kong binds concrete values by
+	// dynamic type, so an interface parameter needs BindTo).
+	runCtx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	ctx.BindTo(runCtx, (*context.Context)(nil))
+
 	err = ctx.Run(&cli.Globals)
+	// Stop intercepting signals now that the command is done; an explicit call
+	// rather than defer, since the os.Exit below would skip a deferred stop.
+	stopSignals()
 	if err != nil {
 		// ErrSilent means the error was already displayed - just exit with code 1
 		if !errors.Is(err, commands.ErrSilent) {

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -93,17 +93,35 @@ func main() {
 
 	// Cancel long-running commands on Ctrl+C / SIGTERM. The first signal
 	// cancels the context so in-flight requests stop and the command can print
-	// a clean summary; a second signal restores default handling and
-	// force-terminates. Bind as the context.Context interface so command Run
-	// methods can declare a ctx parameter (kong binds concrete values by
-	// dynamic type, so an interface parameter needs BindTo).
-	runCtx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	// a clean summary; a second signal exits immediately, so a command that
+	// does not unwind promptly can always be force-stopped. Bind the context
+	// as the context.Context interface so command Run methods can declare a
+	// ctx parameter (kong binds concrete values by dynamic type, so an
+	// interface parameter needs BindTo).
+	sigCh := make(chan os.Signal, 2)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	go func() {
+		select {
+		case <-sigCh:
+			cancelRun()
+		case <-runCtx.Done():
+			return
+		}
+		select {
+		case <-sigCh:
+			os.Exit(130)
+		case <-runCtx.Done():
+		}
+	}()
 	ctx.BindTo(runCtx, (*context.Context)(nil))
 
 	err = ctx.Run(&cli.Globals)
-	// Stop intercepting signals now that the command is done; an explicit call
-	// rather than defer, since the os.Exit below would skip a deferred stop.
-	stopSignals()
+	// Stop intercepting signals and release the watcher goroutine now that the
+	// command is done; explicit rather than deferred, since the os.Exit below
+	// would skip a deferred call.
+	signal.Stop(sigCh)
+	cancelRun()
 	if err != nil {
 		// ErrSilent means the error was already displayed - just exit with code 1
 		if !errors.Is(err, commands.ErrSilent) {


### PR DESCRIPTION
## Why this matters

The `/api/webhooks/redrive` endpoint (#690) needs an operator-facing command. Recovering lost webhook deliveries should be one CLI invocation, not a hand-run GitHub API script — and on a large repo it must not hang or leave the terminal wedged if the operator interrupts it.

## What it does

Adds `schemabot webhooks redrive`: redeliver failed GitHub App webhook deliveries in a time window (`--last 1h`, `--last 2d`, or explicit RFC3339 bounds), optionally scoped to a repo/PR/App, with `--dry-run` to preview the selection.

```
schemabot webhooks redrive --last 1h [--repo o/n] [--pr N] [--dry-run]
        │  loops the endpoint's cursor: many short requests, not one long one
        ▼
  ⠹ app production: 12 pages, 1200 scanned (68% of window), 4 redelivered
        │
        └─ Ctrl+C ─► cancel in-flight request, clear spinner,
                     print partial summary, exit non-zero
```

- **Chunked client loop** drives the endpoint's cursor so the crawl spans as many bounded requests as the window needs — no single request can outlive an intermediary (ingress) timeout.
- **Live progress** on a spinner (pages scanned, % of window covered, redelivered/failed), auto-disabled when stderr isn't a terminal.
- **Ctrl+C cancels cleanly**: a `signal.NotifyContext` cancels the in-flight request, the spinner line is cleared, and a partial summary (how many were redelivered before the interrupt) is printed. A second signal force-terminates.

## How it moves toward the northstar

A lost webhook delivery becomes a one-command, interruptible operator recovery, keeping SchemaBot's safety checks reliable even when delivery isn't.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
