### PR TITLE
feat(tern): queue volume adjustments as durable control requests

### DIFF
--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -1923,8 +1923,8 @@ func (s *Service) handleVolume(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.Volume < 1 || req.Volume > 11 {
-		s.writeError(w, http.StatusBadRequest, "volume must be between 1 and 11")
+	if req.Volume < storage.MinVolume || req.Volume > storage.MaxVolume {
+		s.writeError(w, http.StatusBadRequest, fmt.Sprintf("volume must be between %d and %d", storage.MinVolume, storage.MaxVolume))
 		return
 	}
 
@@ -1940,8 +1940,8 @@ func (s *Service) handleVolume(w http.ResponseWriter, r *http.Request) {
 	}
 	metrics.RecordControlOperation(r.Context(), "volume", apply.Database, apply.Deployment, apply.Environment, controlStatus(resp.Accepted))
 	if resp.Accepted {
-		s.logControlOperationForApply(r.Context(), apply, resolveCaller(r.Context(), req.Caller), storage.LogEventInfo,
-			fmt.Sprintf("Volume changed from %d to %d", resp.PreviousVolume, resp.NewVolume))
+		s.logControlOperationForApply(r.Context(), apply, resolveCaller(r.Context(), req.Caller), storage.LogEventVolumeRequested,
+			fmt.Sprintf("Volume change to %d queued; the driver applies it at its next progress check", req.Volume))
 	}
 
 	s.writeJSON(w, http.StatusOK, &apitypes.VolumeResponse{

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -3732,12 +3732,14 @@ func TestTernHealth(t *testing.T) {
 }
 
 func TestVolumeHandler(t *testing.T) {
-	t.Run("success returns volume values", func(t *testing.T) {
+	// A volume adjustment is queued as a durable control request for the
+	// driving instance, so the accepted response carries the queued target
+	// level; the previous level is only known to the driver and stays unset.
+	t.Run("accepted queue returns target volume", func(t *testing.T) {
 		mock := &mockTernClient{
 			volumeResp: &ternv1.VolumeResponse{
-				Accepted:       true,
-				PreviousVolume: 3,
-				NewVolume:      11,
+				Accepted:  true,
+				NewVolume: 11,
 			},
 		}
 		svc := newControlTestService(mock, activeTestApply("apply-vol123"))
@@ -3756,16 +3758,16 @@ func TestVolumeHandler(t *testing.T) {
 		err := json.NewDecoder(w.Body).Decode(&resp)
 		require.NoError(t, err, "failed to decode response")
 
-		// Verify the response includes volume values (not zeros)
 		assert.Equal(t, true, resp["accepted"])
 		prevVol, _ := resp["previous_volume"].(float64) // JSON numbers are float64
 		newVol, _ := resp["new_volume"].(float64)
-		assert.Equal(t, float64(3), prevVol)
+		assert.Equal(t, float64(0), prevVol)
 		assert.Equal(t, float64(11), newVol)
 
 		require.NotNil(t, mock.volumeReq, "expected volume request to be captured")
 		assert.Equal(t, "apply-vol123", mock.volumeReq.ApplyId)
 		assert.Equal(t, "staging", mock.volumeReq.Environment)
+		assert.Equal(t, int32(11), mock.volumeReq.Volume)
 	})
 
 	t.Run("invalid volume range", func(t *testing.T) {

--- a/pkg/cmd/commands/volume.go
+++ b/pkg/cmd/commands/volume.go
@@ -49,13 +49,16 @@ func (cmd *VolumeCmd) Run(g *Globals) error {
 	if state.IsState(curState, state.Apply.Failed) {
 		return fmt.Errorf("schema change failed - cannot adjust volume")
 	}
-	if !state.IsState(curState, state.Apply.Running, state.Apply.RunningDegraded, state.Apply.CuttingOver, state.Apply.WaitingForCutover, state.Apply.Stopped) {
+	if state.IsState(curState, state.Apply.Stopped) {
+		return fmt.Errorf("schema change is stopped - start it first, then adjust volume")
+	}
+	if !state.IsState(curState, state.Apply.Running, state.Apply.RunningDegraded, state.Apply.CuttingOver, state.Apply.WaitingForCutover) {
 		return fmt.Errorf("cannot adjust volume in state: %s", curState)
 	}
 
 	// Call volume API
 	var volumeResult *apitypes.VolumeResponse
-	err = withLoading("Updating schema change volume...", true, func() error {
+	err = withLoading("Queueing schema change volume adjustment...", true, func() error {
 		var volumeErr error
 		volumeResult, volumeErr = client.CallVolumeAPI(ep, cmd.Environment, cmd.ApplyID, cmd.Volume)
 		return volumeErr
@@ -68,7 +71,7 @@ func (cmd *VolumeCmd) Run(g *Globals) error {
 		return err
 	}
 
-	fmt.Printf("Volume adjusted: %d → %d\n", int(volumeResult.PreviousVolume), int(volumeResult.NewVolume))
+	fmt.Printf("Volume change to %d queued; the driver applies it at its next progress check.\n", int(volumeResult.NewVolume))
 
 	if !cmd.Watch {
 		printWatchInstructions(cmd.ApplyID, cmd.Database, cmd.Environment)

--- a/pkg/storage/mysqlstore/control_requests_test.go
+++ b/pkg/storage/mysqlstore/control_requests_test.go
@@ -371,3 +371,98 @@ func createControlRequestTestApply(t *testing.T, store *Storage, applyIdentifier
 	require.NoError(t, err)
 	return applyID
 }
+
+// A volume control request carries its desired level in the row's metadata so
+// the driving instance can retune the engine from storage alone. The level
+// must survive the full request/pending/complete lifecycle, and re-requesting
+// after resolution must reset the row with the new level — a completed
+// adjustment never pins the payload of a later one.
+func TestControlRequestStore_VolumeRequestLifecycleRoundTripsLevel(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	applyID := createControlRequestTestApply(t, store, "apply_control_request_volume")
+	firstMetadata, err := storage.EncodeVolumeControlRequestMetadata(3)
+	require.NoError(t, err)
+	first, alreadyPending, err := store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     applyID,
+		Operation:   storage.ControlOperationVolume,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "operator-a",
+		Metadata:    firstMetadata,
+	})
+	require.NoError(t, err)
+	require.False(t, alreadyPending)
+
+	pending, err := store.ControlRequests().GetPending(ctx, applyID, storage.ControlOperationVolume)
+	require.NoError(t, err)
+	require.NotNil(t, pending)
+	level, err := storage.DecodeVolumeControlRequestMetadata(pending.Metadata)
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), level)
+
+	require.NoError(t, store.ControlRequests().CompletePending(ctx, applyID, storage.ControlOperationVolume))
+	pending, err = store.ControlRequests().GetPending(ctx, applyID, storage.ControlOperationVolume)
+	require.NoError(t, err)
+	assert.Nil(t, pending)
+	completed := getControlRequestByID(t, store, first.ID)
+	require.NotNil(t, completed)
+	assert.Equal(t, storage.ControlRequestCompleted, completed.Status)
+
+	secondMetadata, err := storage.EncodeVolumeControlRequestMetadata(9)
+	require.NoError(t, err)
+	second, alreadyPending, err := store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     applyID,
+		Operation:   storage.ControlOperationVolume,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "operator-b",
+		Metadata:    secondMetadata,
+	})
+	require.NoError(t, err)
+	require.False(t, alreadyPending)
+	assert.Equal(t, first.ID, second.ID)
+	assert.Equal(t, storage.ControlRequestPending, second.Status)
+	level, err = storage.DecodeVolumeControlRequestMetadata(second.Metadata)
+	require.NoError(t, err)
+	assert.Equal(t, int32(9), level)
+}
+
+// While a volume request is pending it is immutable: a second request returns
+// the existing row and its original level untouched. The tern layer relies on
+// this to reject a different-level request instead of silently changing the
+// level the driver is about to read, apply, and complete.
+func TestControlRequestStore_VolumeRequestPendingKeepsOriginalLevel(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	applyID := createControlRequestTestApply(t, store, "apply_control_request_volume_pending")
+	firstMetadata, err := storage.EncodeVolumeControlRequestMetadata(5)
+	require.NoError(t, err)
+	first, alreadyPending, err := store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     applyID,
+		Operation:   storage.ControlOperationVolume,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "operator-a",
+		Metadata:    firstMetadata,
+	})
+	require.NoError(t, err)
+	require.False(t, alreadyPending)
+
+	secondMetadata, err := storage.EncodeVolumeControlRequestMetadata(11)
+	require.NoError(t, err)
+	second, alreadyPending, err := store.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     applyID,
+		Operation:   storage.ControlOperationVolume,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "operator-b",
+		Metadata:    secondMetadata,
+	})
+	require.NoError(t, err)
+	require.True(t, alreadyPending)
+	assert.Equal(t, first.ID, second.ID)
+	level, err := storage.DecodeVolumeControlRequestMetadata(second.Metadata)
+	require.NoError(t, err)
+	assert.Equal(t, int32(5), level, "a pending volume request must keep the level it was queued with")
+}

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"encoding/json"
+	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -798,7 +799,59 @@ const (
 	// 'start': 'start' resumes stopped work and carries no claim-ordering
 	// clause, so it cannot release a paused rollout.
 	ControlOperationRelease ControlOperation = "release"
+	// ControlOperationVolume adjusts the speed/concurrency of a running schema
+	// change. Durable because only the instance driving the apply holds the
+	// engine state for the running schema change, and a volume RPC can land on
+	// any instance sharing the route's storage. The desired level travels in
+	// the request metadata (see VolumeControlRequestMetadata); the driver
+	// retunes the engine at its next progress tick.
+	ControlOperationVolume ControlOperation = "volume"
 )
+
+// MinVolume and MaxVolume bound the volume scale shared by every engine:
+// 1 = maximum throttle (least production impact), 11 = no throttle (fastest).
+const (
+	MinVolume int32 = 1
+	MaxVolume int32 = 11
+)
+
+// VolumeControlRequestMetadata is the JSON payload stored on a volume control
+// request. The row carries the desired level so the driving instance can
+// retune the engine without a synchronous exchange with the requester.
+type VolumeControlRequestMetadata struct {
+	Volume int32 `json:"volume"`
+}
+
+// EncodeVolumeControlRequestMetadata serializes the desired volume level for
+// storage on a volume control request, rejecting out-of-range levels so an
+// invalid request is refused at write time rather than discovered by the
+// driver.
+func EncodeVolumeControlRequestMetadata(volume int32) ([]byte, error) {
+	if volume < MinVolume || volume > MaxVolume {
+		return nil, fmt.Errorf("volume %d is out of range: must be between %d and %d", volume, MinVolume, MaxVolume)
+	}
+	data, err := json.Marshal(VolumeControlRequestMetadata{Volume: volume})
+	if err != nil {
+		return nil, fmt.Errorf("encode volume control request metadata for level %d: %w", volume, err)
+	}
+	return data, nil
+}
+
+// DecodeVolumeControlRequestMetadata parses the desired volume level from a
+// volume control request's metadata, validating the shared volume range.
+func DecodeVolumeControlRequestMetadata(metadata []byte) (int32, error) {
+	if len(metadata) == 0 {
+		return 0, fmt.Errorf("volume control request metadata is empty")
+	}
+	var payload VolumeControlRequestMetadata
+	if err := json.Unmarshal(metadata, &payload); err != nil {
+		return 0, fmt.Errorf("decode volume control request metadata: %w", err)
+	}
+	if payload.Volume < MinVolume || payload.Volume > MaxVolume {
+		return 0, fmt.Errorf("volume %d in control request metadata is out of range: must be between %d and %d", payload.Volume, MinVolume, MaxVolume)
+	}
+	return payload.Volume, nil
+}
 
 // ControlRequestStatus is the durable processing status for a control request.
 type ControlRequestStatus string
@@ -1074,6 +1127,7 @@ const (
 	LogEventCancelRequested     = "cancel_requested"
 	LogEventStartRequested      = "start_requested"
 	LogEventReleaseRequested    = "release_requested"
+	LogEventVolumeRequested     = "volume_requested"
 	LogEventDeployTriggered     = "deploy_triggered"
 	LogEventCutoverTriggered    = "cutover_triggered"
 	LogEventSkipRevertTriggered = "skip_revert_triggered"

--- a/pkg/storage/types_test.go
+++ b/pkg/storage/types_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -116,5 +117,53 @@ func TestApplyOptionsFromMapIgnoresInvalidVolume(t *testing.T) {
 
 		assert.Zero(t, options.Volume)
 		assert.Empty(t, options.Map())
+	}
+}
+
+// TestVolumeControlRequestMetadataRoundTrip verifies the desired level a
+// volume control request carries survives the storage encode/decode round
+// trip for every level on the shared volume scale.
+func TestVolumeControlRequestMetadataRoundTrip(t *testing.T) {
+	for volume := MinVolume; volume <= MaxVolume; volume++ {
+		metadata, err := EncodeVolumeControlRequestMetadata(volume)
+		require.NoError(t, err)
+		assert.JSONEq(t, fmt.Sprintf(`{"volume":%d}`, volume), string(metadata))
+
+		decoded, err := DecodeVolumeControlRequestMetadata(metadata)
+		require.NoError(t, err)
+		assert.Equal(t, volume, decoded)
+	}
+}
+
+// TestEncodeVolumeControlRequestMetadataRejectsOutOfRange verifies an
+// out-of-range level is refused at write time so the driver never reads an
+// unactionable volume request.
+func TestEncodeVolumeControlRequestMetadataRejectsOutOfRange(t *testing.T) {
+	for _, volume := range []int32{0, -1, 12} {
+		_, err := EncodeVolumeControlRequestMetadata(volume)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "out of range")
+	}
+}
+
+// TestDecodeVolumeControlRequestMetadataRejectsInvalidPayloads verifies the
+// driver refuses empty, malformed, and out-of-range payloads with a decode
+// error instead of retuning the engine to an unintended level.
+func TestDecodeVolumeControlRequestMetadataRejectsInvalidPayloads(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata []byte
+	}{
+		{name: "empty", metadata: nil},
+		{name: "malformed json", metadata: []byte(`{"volume":`)},
+		{name: "missing volume", metadata: []byte(`{}`)},
+		{name: "below range", metadata: []byte(`{"volume":0}`)},
+		{name: "above range", metadata: []byte(`{"volume":12}`)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := DecodeVolumeControlRequestMetadata(tt.metadata)
+			require.Error(t, err)
+		})
 	}
 }

--- a/pkg/tern/control_requests.go
+++ b/pkg/tern/control_requests.go
@@ -47,15 +47,17 @@ func completePendingControlRequests(ctx context.Context, store storage.Storage, 
 
 // completePendingRequestsForTerminalApply completes the pending control
 // requests that a terminal apply moots: a pending stop is settled (the apply
-// can no longer be stopped), and a pending revert or skip-revert can no longer
-// act because the revert window is gone. Sweeping all three keeps a request
-// issued moments before the apply settled — or one that lost to a contradictory
-// command — from lingering pending forever.
+// can no longer be stopped), a pending revert or skip-revert can no longer
+// act because the revert window is gone, and a pending volume adjustment has
+// no running copy left to retune. Sweeping them keeps a request issued moments
+// before the apply settled — or one that lost to a contradictory command —
+// from lingering pending forever.
 func completePendingRequestsForTerminalApply(ctx context.Context, store storage.Storage, apply *storage.Apply) error {
 	for _, op := range []storage.ControlOperation{
 		storage.ControlOperationStop,
 		storage.ControlOperationRevert,
 		storage.ControlOperationSkipRevert,
+		storage.ControlOperationVolume,
 	} {
 		if err := completePendingControlRequests(ctx, store, apply, op); err != nil {
 			return err

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -745,6 +745,18 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 			"apply_id", apply.ApplyIdentifier, "error", err)
 		return true
 	}
+	// A volume failure never aborts the drive: the copy continues at its
+	// current volume and a still-pending request is retried at the next tick.
+	// A lost lease is the exception — this owner must stop driving.
+	if err := c.processPendingVolumeControlRequest(ctx, apply, eng, creds, resumeState); err != nil {
+		if errors.Is(err, storage.ErrApplyLeaseLost) {
+			c.logger.Warn("pending volume request processing lost the apply lease; current apply owner will exit for operator retry",
+				"apply_id", apply.ApplyIdentifier, "error", err)
+			return true
+		}
+		c.logger.Warn("pending volume request processing failed; the drive continues and retries at the next progress tick",
+			"apply_id", apply.ApplyIdentifier, "error", err)
+	}
 
 	opts := storage.ApplyOptionsFromMap(options)
 	controlReq := &engine.ControlRequest{

--- a/pkg/tern/local_apply_sequential.go
+++ b/pkg/tern/local_apply_sequential.go
@@ -328,6 +328,19 @@ func (c *LocalClient) pollTaskToCompletion(ctx context.Context, apply *storage.A
 					"apply_id", apply.ApplyIdentifier, "task_id", task.TaskIdentifier, "error", err)
 				return taskAbort
 			}
+			// A volume failure never aborts the drive: the copy continues at
+			// its current volume and a still-pending request is retried at the
+			// next tick. A lost lease is the exception — this owner must stop
+			// driving.
+			if err := c.processPendingVolumeControlRequest(ctx, apply, eng, creds, resumeState); err != nil {
+				if errors.Is(err, storage.ErrApplyLeaseLost) {
+					c.logger.Warn("pending volume request processing lost the apply lease; current apply owner will exit for operator retry",
+						"apply_id", apply.ApplyIdentifier, "task_id", task.TaskIdentifier, "error", err)
+					return taskAbort
+				}
+				c.logger.Warn("pending volume request processing failed; the drive continues and retries at the next progress tick",
+					"apply_id", apply.ApplyIdentifier, "task_id", task.TaskIdentifier, "error", err)
+			}
 
 			// Re-fetch task state from storage to detect external changes (e.g., Stop).
 			// This also guards against a race where a new apply starts and the engine's

--- a/pkg/tern/local_apply_sequential.go
+++ b/pkg/tern/local_apply_sequential.go
@@ -212,6 +212,8 @@ func (c *LocalClient) runEngineTask(ctx context.Context, apply *storage.Apply, t
 	c.transitionTaskState(ctx, task, 0, state.Task.Running, "")
 	c.logger.Info("task running", "task_id", task.TaskIdentifier, "table", task.TableName)
 
+	c.convergeTaskVolumeToStoredLevel(ctx, apply, task, taskCreds, result.ResumeState)
+
 	// Poll to completion. Thread the engine's returned resume state into the
 	// poll: a sharded engine (Strata) identifies the operation to report on from
 	// ResumeState.Metadata and errors without it, so Progress must carry what

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -3093,7 +3093,7 @@ func TestLocalClient_Start_NoStoppedMigration(t *testing.T) {
 	assert.Contains(t, err.Error(), "no stopped schema change")
 }
 
-func TestLocalClient_Volume_NoActiveMigration(t *testing.T) {
+func TestLocalClient_Volume_NoActiveSchemaChange(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -1450,10 +1450,15 @@ func (c *LocalClient) Volume(ctx context.Context, req *ternv1.VolumeRequest) (*t
 	// A terminal apply has no running copy to retune; reject synchronously
 	// rather than queue a request no driver will ever service. This includes
 	// stopped applies — resume the schema change first, then adjust volume.
+	// Rejections travel as unaccepted responses (not errors) so callers across
+	// the gRPC boundary can distinguish them from transport or storage failures.
 	if state.IsTerminalApplyState(apply.State) {
 		c.logger.Warn("volume rejected: schema change is not active",
 			"apply_id", apply.ApplyIdentifier, "state", apply.State, "volume", req.Volume)
-		return nil, fmt.Errorf("schema change %s is %s; volume can only be adjusted while it is running", apply.ApplyIdentifier, apply.State)
+		return &ternv1.VolumeResponse{
+			Accepted:     false,
+			ErrorMessage: fmt.Sprintf("Schema change %s is %s; volume can only be adjusted while it is running", apply.ApplyIdentifier, apply.State),
+		}, nil
 	}
 
 	return c.queueVolumeRequest(ctx, apply, req.Volume)
@@ -1494,7 +1499,11 @@ func (c *LocalClient) queueVolumeRequest(ctx context.Context, apply *storage.App
 				"database", apply.Database,
 				"environment", apply.Environment,
 				"error", decodeErr)
-			return nil, fmt.Errorf("a volume adjustment is already queued for apply %s; retry after the driver resolves it", apply.ApplyIdentifier)
+			c.wakeOperator(apply)
+			return &ternv1.VolumeResponse{
+				Accepted:     false,
+				ErrorMessage: fmt.Sprintf("A volume adjustment is already queued for apply %s; retry after the driver resolves it", apply.ApplyIdentifier),
+			}, nil
 		}
 		if pendingVolume != volume {
 			c.logger.Info("volume rejected: a different volume adjustment is already queued",
@@ -1503,7 +1512,10 @@ func (c *LocalClient) queueVolumeRequest(ctx context.Context, apply *storage.App
 				"environment", apply.Environment,
 				"pending_volume", pendingVolume,
 				"requested_volume", volume)
-			return nil, fmt.Errorf("a volume adjustment to %d is already queued for apply %s; the driver applies it at its next progress check — retry afterwards", pendingVolume, apply.ApplyIdentifier)
+			return &ternv1.VolumeResponse{
+				Accepted:     false,
+				ErrorMessage: fmt.Sprintf("A volume adjustment to %d is already queued for apply %s; the driver applies it at its next progress check — retry afterwards", pendingVolume, apply.ApplyIdentifier),
+			}, nil
 		}
 		c.logger.Info("volume request already pending for apply driver",
 			"apply_id", apply.ApplyIdentifier,

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -1427,36 +1427,190 @@ func (c *LocalClient) buildControlRequest(ctx context.Context, task *storage.Tas
 	return req, nil
 }
 
-// Volume modifies the schema change speed/concurrency in-flight.
+// Volume adjusts the speed/concurrency of an in-flight schema change by
+// queueing a durable volume request. Only the instance driving the apply holds
+// the engine state for the running schema change, and a volume RPC can land on
+// any instance sharing this route's storage — so the request is recorded for
+// the driver, which retunes the engine at its next progress tick. The response
+// reports the queued target level; the previous level is only known to the
+// driver, so PreviousVolume is left unset.
 func (c *LocalClient) Volume(ctx context.Context, req *ternv1.VolumeRequest) (*ternv1.VolumeResponse, error) {
-	if req.Volume < 1 || req.Volume > 11 {
-		return nil, fmt.Errorf("volume must be between 1 and 11")
+	if req.Volume < storage.MinVolume || req.Volume > storage.MaxVolume {
+		return nil, fmt.Errorf("volume must be between %d and %d", storage.MinVolume, storage.MaxVolume)
 	}
-
-	task, creds, eng, err := c.controlSetup(ctx)
+	c.logger.Info("Volume requested", "database", c.config.Database, "type", c.config.Type, "apply_id", req.ApplyId, "environment", req.Environment, "volume", req.Volume)
+	apply, err := c.resolveControlApply(ctx, req.ApplyId, "volume")
 	if err != nil {
 		return nil, err
 	}
-	controlReq, err := c.buildControlRequest(ctx, task, creds, eng, engine.ControlVolume)
-	if err != nil {
-		return nil, fmt.Errorf("build volume request for task %s: %w", task.TaskIdentifier, err)
+	if apply == nil {
+		return nil, fmt.Errorf("no active schema change")
 	}
 
-	result, err := eng.Volume(ctx, &engine.VolumeRequest{
-		Database:    c.config.Database,
-		Volume:      req.Volume,
-		ResumeState: controlReq.ResumeState,
-		Credentials: controlReq.Credentials,
+	// A terminal apply has no running copy to retune; reject synchronously
+	// rather than queue a request no driver will ever service. This includes
+	// stopped applies — resume the schema change first, then adjust volume.
+	if state.IsTerminalApplyState(apply.State) {
+		c.logger.Warn("volume rejected: schema change is not active",
+			"apply_id", apply.ApplyIdentifier, "state", apply.State, "volume", req.Volume)
+		return nil, fmt.Errorf("schema change %s is %s; volume can only be adjusted while it is running", apply.ApplyIdentifier, apply.State)
+	}
+
+	return c.queueVolumeRequest(ctx, apply, req.Volume)
+}
+
+// queueVolumeRequest records a durable volume control request carrying the
+// desired level in its metadata and wakes the operator. A pending volume
+// request is immutable until the driver resolves it: a second request for the
+// same level is an idempotent accept, while a different level is rejected with
+// retry guidance. This keeps the level the driver reads, applies, and completes
+// unambiguous — there is no window where a superseding write could make the
+// driver complete a level it never applied.
+func (c *LocalClient) queueVolumeRequest(ctx context.Context, apply *storage.Apply, volume int32) (*ternv1.VolumeResponse, error) {
+	controlStore := c.storage.ControlRequests()
+	if controlStore == nil {
+		return nil, fmt.Errorf("control request store is not available")
+	}
+	metadata, err := storage.EncodeVolumeControlRequestMetadata(volume)
+	if err != nil {
+		return nil, fmt.Errorf("encode volume request for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	requestedBy := "tern-grpc"
+	controlReq, alreadyPending, err := controlStore.RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationVolume,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: requestedBy,
+		Metadata:    metadata,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("volume failed: %w", err)
+		return nil, fmt.Errorf("record volume control request for apply %s: %w", apply.ApplyIdentifier, err)
 	}
-
+	if alreadyPending {
+		pendingVolume, decodeErr := storage.DecodeVolumeControlRequestMetadata(controlReq.Metadata)
+		if decodeErr != nil {
+			c.logger.Warn("volume rejected: pending volume request has undecodable metadata; the driver will fail it at its next progress tick",
+				"apply_id", apply.ApplyIdentifier,
+				"database", apply.Database,
+				"environment", apply.Environment,
+				"error", decodeErr)
+			return nil, fmt.Errorf("a volume adjustment is already queued for apply %s; retry after the driver resolves it", apply.ApplyIdentifier)
+		}
+		if pendingVolume != volume {
+			c.logger.Info("volume rejected: a different volume adjustment is already queued",
+				"apply_id", apply.ApplyIdentifier,
+				"database", apply.Database,
+				"environment", apply.Environment,
+				"pending_volume", pendingVolume,
+				"requested_volume", volume)
+			return nil, fmt.Errorf("a volume adjustment to %d is already queued for apply %s; the driver applies it at its next progress check — retry afterwards", pendingVolume, apply.ApplyIdentifier)
+		}
+		c.logger.Info("volume request already pending for apply driver",
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"volume", volume,
+			"requested_by", requestedBy)
+	} else {
+		c.logger.Info("volume request queued for apply driver",
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"volume", volume,
+			"requested_by", requestedBy)
+		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventVolumeRequested, storage.LogSourceSchemaBot,
+			fmt.Sprintf("Volume change to %d queued for apply driver%s", volume, callerApplyLogSuffix(requestedBy)), "", "")
+	}
+	c.wakeOperator(apply)
 	return &ternv1.VolumeResponse{
-		Accepted:       result.Accepted,
-		PreviousVolume: result.PreviousVolume,
-		NewVolume:      result.NewVolume,
+		Accepted:  true,
+		NewVolume: volume,
 	}, nil
+}
+
+// processPendingVolumeControlRequest services a pending volume request from
+// the driving instance's progress tick. The desired level travels in the
+// request's metadata; the driver retunes the engine's running schema change
+// and completes the request. Volume is a tuning knob, not a safety operation:
+// an engine rejection fails the request terminally and the copy continues at
+// its current volume, and a storage error is returned for the caller to log
+// and retry at the next tick without aborting the drive.
+func (c *LocalClient) processPendingVolumeControlRequest(ctx context.Context, apply *storage.Apply, eng engine.Engine, creds *engine.Credentials, resumeState *engine.ResumeState) error {
+	controlReq, err := pendingControlRequest(ctx, c.storage, apply, storage.ControlOperationVolume)
+	if err != nil {
+		return err
+	}
+	if controlReq == nil {
+		return nil
+	}
+	caller := controlRequestCaller(controlReq)
+	volume, err := storage.DecodeVolumeControlRequestMetadata(controlReq.Metadata)
+	if err != nil {
+		c.logger.Warn("pending volume request has invalid metadata; failing the request and continuing at the current volume",
+			append(apply.LogAttrs(), "requested_by", caller, "error", err)...)
+		return failPendingControlRequests(ctx, c.storage, apply, storage.ControlOperationVolume, fmt.Sprintf("volume request metadata is invalid: %v", err))
+	}
+	result, err := eng.Volume(ctx, &engine.VolumeRequest{
+		Database:    apply.Database,
+		Volume:      volume,
+		ResumeState: resumeState,
+		Credentials: creds,
+	})
+	if err != nil {
+		c.logger.Warn("engine rejected pending volume request; schema change continues at its current volume",
+			append(apply.LogAttrs(), "volume", volume, "requested_by", caller, "error", err)...)
+		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelWarn, storage.LogEventError, storage.LogSourceSchemaBot,
+			fmt.Sprintf("Volume change to %d failed: %v; schema change continues at its current volume", volume, err), "", "")
+		return failPendingControlRequests(ctx, c.storage, apply, storage.ControlOperationVolume, err.Error())
+	}
+	if result == nil || !result.Accepted {
+		message := "not accepted"
+		if result != nil && result.Message != "" {
+			message = result.Message
+		}
+		c.logger.Warn("engine did not accept pending volume request; schema change continues at its current volume",
+			append(apply.LogAttrs(), "volume", volume, "requested_by", caller, "message", message)...)
+		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelWarn, storage.LogEventError, storage.LogSourceSchemaBot,
+			fmt.Sprintf("Volume change to %d was not accepted: %s; schema change continues at its current volume", volume, message), "", "")
+		return failPendingControlRequests(ctx, c.storage, apply, storage.ControlOperationVolume, message)
+	}
+	if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationVolume); err != nil {
+		return err
+	}
+	c.logger.Info("pending volume request applied",
+		append(apply.LogAttrs(), "previous_volume", result.PreviousVolume, "volume", result.NewVolume, "requested_by", caller)...)
+	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventInfo, storage.LogSourceSchemaBot,
+		fmt.Sprintf("Volume changed from %d to %d%s", result.PreviousVolume, result.NewVolume, callerApplyLogSuffix(caller)), "", "")
+	if err := c.recordAppliedVolume(ctx, apply, result.NewVolume); err != nil {
+		c.logger.Warn("failed to record applied volume on apply options; progress will keep reporting the previous volume",
+			append(apply.LogAttrs(), "volume", result.NewVolume, "error", err)...)
+	}
+	return nil
+}
+
+// recordAppliedVolume persists the volume the engine is now running at onto
+// the apply's stored options, which progress and the CLI read the volume from.
+// The apply row is reloaded first so this targeted options write does not
+// clobber state another write advanced past the drive's in-memory copy.
+func (c *LocalClient) recordAppliedVolume(ctx context.Context, apply *storage.Apply, volume int32) error {
+	if volume < storage.MinVolume || volume > storage.MaxVolume {
+		return fmt.Errorf("engine reported applied volume %d out of range for apply %s", volume, apply.ApplyIdentifier)
+	}
+	stored, err := c.storage.Applies().Get(ctx, apply.ID)
+	if err != nil {
+		return fmt.Errorf("load apply %s to record applied volume: %w", apply.ApplyIdentifier, err)
+	}
+	if stored == nil {
+		return fmt.Errorf("load apply %s to record applied volume: %w", apply.ApplyIdentifier, storage.ErrApplyNotFound)
+	}
+	opts := stored.GetOptions()
+	opts.Volume = int(volume)
+	stored.SetOptions(opts)
+	if err := c.storage.Applies().Update(ctx, stored); err != nil {
+		return fmt.Errorf("record applied volume %d on apply %s: %w", volume, apply.ApplyIdentifier, err)
+	}
+	apply.Options = stored.Options
+	return nil
 }
 
 // Revert reverts a completed schema change during the revert window.

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -1461,6 +1461,27 @@ func (c *LocalClient) Volume(ctx context.Context, req *ternv1.VolumeRequest) (*t
 		}, nil
 	}
 
+	// A volume request is apply-scoped, but a multi-deployment (fan-out) apply
+	// runs one engine per operation: whichever operation driver ticked first
+	// would retune only its own deployment's schema change and complete the
+	// request, leaving sibling deployments copying at the old level while the
+	// request row, progress, and the CLI all report the adjustment as applied.
+	// Reject the shape outright until volume requests are scoped per operation.
+	// Operation rows are created at dispatch and never grow while an apply
+	// runs, so this queue-time check cannot be raced by fan-out.
+	operations, err := c.storage.ApplyOperations().ListByApply(ctx, apply.ID)
+	if err != nil {
+		return nil, fmt.Errorf("load operations for apply %s to gate volume request: %w", apply.ApplyIdentifier, err)
+	}
+	if len(operations) > 1 {
+		c.logger.Warn("volume rejected: apply fans out to multiple deployments",
+			"apply_id", apply.ApplyIdentifier, "operation_count", len(operations), "volume", req.Volume)
+		return &ternv1.VolumeResponse{
+			Accepted:     false,
+			ErrorMessage: fmt.Sprintf("Apply %s fans out to %d deployments; volume adjustment is not supported for multi-deployment applies", apply.ApplyIdentifier, len(operations)),
+		}, nil
+	}
+
 	return c.queueVolumeRequest(ctx, apply, req.Volume)
 }
 
@@ -1490,6 +1511,32 @@ func (c *LocalClient) queueVolumeRequest(ctx context.Context, apply *storage.App
 	})
 	if err != nil {
 		return nil, fmt.Errorf("record volume control request for apply %s: %w", apply.ApplyIdentifier, err)
+	}
+	// The apply's state was checked before this insert, and the driver may have
+	// settled the apply — and run its terminal pending-request sweep — in
+	// between. A request recorded after that sweep would linger pending forever
+	// with no driver left to service it, so re-check and sweep it here.
+	storedApply, err := c.storage.Applies().Get(ctx, apply.ID)
+	if err != nil {
+		return nil, fmt.Errorf("reload apply %s after recording volume request: %w", apply.ApplyIdentifier, err)
+	}
+	if storedApply == nil {
+		return nil, fmt.Errorf("reload apply %s after recording volume request: apply row not found", apply.ApplyIdentifier)
+	}
+	if state.IsTerminalApplyState(storedApply.State) {
+		c.logger.Info("volume request arrived as the apply settled; sweeping it and rejecting",
+			"apply_id", apply.ApplyIdentifier,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"state", storedApply.State,
+			"volume", volume)
+		if sweepErr := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationVolume); sweepErr != nil {
+			return nil, fmt.Errorf("sweep volume request for settled apply %s: %w", apply.ApplyIdentifier, sweepErr)
+		}
+		return &ternv1.VolumeResponse{
+			Accepted:     false,
+			ErrorMessage: fmt.Sprintf("Schema change %s is %s; volume can only be adjusted while it is running", apply.ApplyIdentifier, storedApply.State),
+		}, nil
 	}
 	if alreadyPending {
 		pendingVolume, decodeErr := storage.DecodeVolumeControlRequestMetadata(controlReq.Metadata)
@@ -1556,6 +1603,22 @@ func (c *LocalClient) processPendingVolumeControlRequest(ctx context.Context, ap
 		return nil
 	}
 	caller := controlRequestCaller(controlReq)
+	// A fan-out apply runs one engine per operation, so an apply-scoped volume
+	// request cannot be delivered to every deployment's schema change from one
+	// driver's tick. Fail it closed rather than retune a single deployment and
+	// report the adjustment as applied everywhere. Queue-time gating rejects
+	// this shape before a request is recorded; this guard covers a request that
+	// reached storage anyway.
+	operations, err := c.storage.ApplyOperations().ListByApply(ctx, apply.ID)
+	if err != nil {
+		return fmt.Errorf("load operations for apply %s to service volume request: %w", apply.ApplyIdentifier, err)
+	}
+	if len(operations) > 1 {
+		c.logger.Warn("pending volume request targets a multi-deployment apply; failing it without retuning any engine",
+			append(apply.LogAttrs(), "operation_count", len(operations), "requested_by", caller)...)
+		return failPendingControlRequests(ctx, c.storage, apply, storage.ControlOperationVolume,
+			fmt.Sprintf("apply fans out to %d deployments; volume adjustment is not supported for multi-deployment applies", len(operations)))
+	}
 	volume, err := storage.DecodeVolumeControlRequestMetadata(controlReq.Metadata)
 	if err != nil {
 		c.logger.Warn("pending volume request has invalid metadata; failing the request and continuing at the current volume",
@@ -1623,6 +1686,50 @@ func (c *LocalClient) recordAppliedVolume(ctx context.Context, apply *storage.Ap
 	}
 	apply.Options = stored.Options
 	return nil
+}
+
+// convergeTaskVolumeToStoredLevel retunes a newly started task's schema change
+// to the apply's stored volume level. Engine volume lives with each running
+// schema change, so a task started after an operator adjusted the volume — a
+// later table in a sequential drive, or a resumed apply — would otherwise run
+// at the engine default while stored options, progress, and the CLI all report
+// the adjusted level. Volume is a tuning knob, not a safety operation: a
+// rejection is logged and the task continues at the engine default rather than
+// failing the drive.
+func (c *LocalClient) convergeTaskVolumeToStoredLevel(ctx context.Context, apply *storage.Apply, task *storage.Task, creds *engine.Credentials, resumeState *engine.ResumeState) {
+	volume := int32(apply.GetOptions().Volume)
+	if volume == 0 {
+		c.logger.Debug("no stored volume level on apply options; task starts at the engine default",
+			"apply_id", apply.ApplyIdentifier, "task_id", task.TaskIdentifier)
+		return
+	}
+	if volume < storage.MinVolume || volume > storage.MaxVolume {
+		c.logger.Warn("stored volume level is out of range; task starts at the engine default",
+			append(task.LogAttrs(), "volume", volume)...)
+		return
+	}
+	result, err := c.getEngine().Volume(ctx, &engine.VolumeRequest{
+		Database:    apply.Database,
+		Volume:      volume,
+		ResumeState: resumeState,
+		Credentials: creds,
+	})
+	if err != nil {
+		c.logger.Warn("engine rejected converging task to the stored volume level; task continues at the engine default",
+			append(task.LogAttrs(), "volume", volume, "error", err)...)
+		return
+	}
+	if result == nil || !result.Accepted {
+		message := "not accepted"
+		if result != nil && result.Message != "" {
+			message = result.Message
+		}
+		c.logger.Warn("engine did not accept converging task to the stored volume level; task continues at the engine default",
+			append(task.LogAttrs(), "volume", volume, "message", message)...)
+		return
+	}
+	c.logger.Info("task volume converged to the apply's stored level",
+		append(task.LogAttrs(), "volume", volume)...)
 }
 
 // Revert reverts a completed schema change during the revert window.

--- a/pkg/tern/local_control_volume_integration_test.go
+++ b/pkg/tern/local_control_volume_integration_test.go
@@ -191,13 +191,16 @@ func TestLocalClient_VolumeQueuedCrossInstanceAppliedBySequentialDrive(t *testin
 
 	// A different level while one is pending is rejected with retry guidance,
 	// so the level the driver reads, applies, and completes stays unambiguous.
-	_, err = receivingClient.Volume(ctx, &ternv1.VolumeRequest{
+	// The rejection travels as an unaccepted response, not an error, so callers
+	// across the gRPC boundary can tell a conflict from a transport failure.
+	conflicting, err := receivingClient.Volume(ctx, &ternv1.VolumeRequest{
 		ApplyId:     apply.ApplyIdentifier,
 		Environment: localClientTestEnvironment,
 		Volume:      3,
 	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "already queued")
+	require.NoError(t, err)
+	assert.False(t, conflicting.Accepted, "a conflicting level must not be accepted")
+	assert.Contains(t, conflicting.ErrorMessage, "already queued")
 
 	driveNextQueuedApply(t, stor, drivingClient)
 
@@ -348,13 +351,14 @@ func TestLocalClient_VolumeRejectsTerminalApplyAndInvalidLevel(t *testing.T) {
 	require.NotNil(t, settled)
 	require.Equal(t, state.Apply.Completed, settled.State)
 
-	_, err = client.Volume(ctx, &ternv1.VolumeRequest{
+	rejected, err := client.Volume(ctx, &ternv1.VolumeRequest{
 		ApplyId:     apply.ApplyIdentifier,
 		Environment: localClientTestEnvironment,
 		Volume:      5,
 	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "volume can only be adjusted while it is running")
+	require.NoError(t, err)
+	assert.False(t, rejected.Accepted, "a terminal apply must not accept a volume adjustment")
+	assert.Contains(t, rejected.ErrorMessage, "volume can only be adjusted while it is running")
 
 	req, err := stor.ControlRequests().GetByOperation(ctx, apply.ID, storage.ControlOperationVolume)
 	require.NoError(t, err)

--- a/pkg/tern/local_control_volume_integration_test.go
+++ b/pkg/tern/local_control_volume_integration_test.go
@@ -1,0 +1,362 @@
+//go:build integration
+
+package tern
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/engine"
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// volumeTrackingEngine models a schema change that stays running until the
+// driver delivers a volume adjustment, then completes. It records every
+// Volume call so a test can prove which engine instance the driver retuned
+// and with which level.
+type volumeTrackingEngine struct {
+	engine.Engine
+
+	mu             sync.Mutex
+	volumeLevels   []int32
+	volumeAttempts int
+	volumeErr      error
+}
+
+func (e *volumeTrackingEngine) Name() string { return "volume-tracking" }
+
+func (e *volumeTrackingEngine) Plan(context.Context, *engine.PlanRequest) (*engine.PlanResult, error) {
+	return &engine.PlanResult{}, nil
+}
+
+func (e *volumeTrackingEngine) Apply(context.Context, *engine.ApplyRequest) (*engine.ApplyResult, error) {
+	return &engine.ApplyResult{Accepted: true}, nil
+}
+
+// Progress keeps the schema change observable mid-flight until a volume
+// adjustment has been attempted, so the drive's progress ticks are guaranteed
+// to see the pending request before the apply settles.
+func (e *volumeTrackingEngine) Progress(context.Context, *engine.ProgressRequest) (*engine.ProgressResult, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.volumeAttempts == 0 {
+		return &engine.ProgressResult{State: engine.StateRunning}, nil
+	}
+	return &engine.ProgressResult{State: engine.StateCompleted}, nil
+}
+
+func (e *volumeTrackingEngine) Volume(_ context.Context, req *engine.VolumeRequest) (*engine.VolumeResult, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.volumeAttempts++
+	if e.volumeErr != nil {
+		return nil, e.volumeErr
+	}
+	e.volumeLevels = append(e.volumeLevels, req.Volume)
+	return &engine.VolumeResult{Accepted: true, PreviousVolume: 4, NewVolume: req.Volume}, nil
+}
+
+func (e *volumeTrackingEngine) recordedVolumes() []int32 {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]int32(nil), e.volumeLevels...)
+}
+
+// newVolumeControlClient builds a MySQL-type LocalClient backed by the shared
+// container with a volume-tracking engine installed.
+func newVolumeControlClient(t *testing.T, dsn string, stor storage.Storage) (*LocalClient, *volumeTrackingEngine) {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	client, err := NewLocalClient(LocalConfig{
+		Database:  "testdb",
+		Type:      storage.DatabaseTypeMySQL,
+		TargetDSN: dsn,
+	}, stor, logger)
+	require.NoError(t, err)
+	t.Cleanup(func() { utils.CloseAndLog(client) })
+	eng := &volumeTrackingEngine{}
+	client.spiritEngine = eng
+	return client, eng
+}
+
+// dispatchQueuedApplyWithOptions dispatches an apply with one table change and
+// the given apply options through LocalClient.Apply, returning the stored
+// apply row, still queued for the operator.
+func dispatchQueuedApplyWithOptions(t *testing.T, stor storage.Storage, client *LocalClient, options map[string]string) *storage.Apply {
+	t.Helper()
+	ctx := t.Context()
+	plan := &storage.Plan{
+		PlanIdentifier: fmt.Sprintf("plan-volume-%d", time.Now().UnixNano()),
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Deployment:     "testdb",
+		Environment:    localClientTestEnvironment,
+		CreatedAt:      time.Now(),
+		Namespaces: map[string]*storage.NamespacePlanData{
+			"testdb": {Tables: []storage.TableChange{{
+				Namespace: "testdb",
+				Table:     "users",
+				DDL:       "ALTER TABLE `users` ADD COLUMN volume_note VARCHAR(255)",
+				Operation: "alter",
+			}}},
+		},
+	}
+	planID, err := stor.Plans().Create(ctx, plan)
+	require.NoError(t, err)
+	plan.ID = planID
+
+	resp, err := client.Apply(ctx, &ternv1.ApplyRequest{
+		PlanId:      plan.PlanIdentifier,
+		Database:    "testdb",
+		Type:        storage.DatabaseTypeMySQL,
+		Environment: localClientTestEnvironment,
+		Options:     options,
+	})
+	require.NoError(t, err)
+	require.True(t, resp.Accepted)
+
+	apply, err := stor.Applies().GetByApplyIdentifier(ctx, resp.ApplyId)
+	require.NoError(t, err)
+	require.NotNil(t, apply)
+	require.Equal(t, state.Apply.Pending, apply.State, "a dispatched apply must be queued, not driven inline")
+	return apply
+}
+
+// requireStoredVolume asserts the apply's stored options carry the given
+// volume level — the value progress and the CLI display.
+func requireStoredVolume(t *testing.T, stor storage.Storage, applyID int64, want int) {
+	t.Helper()
+	stored, err := stor.Applies().Get(t.Context(), applyID)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.Equal(t, want, stored.GetOptions().Volume, "stored apply options must carry the applied volume")
+}
+
+// A volume adjustment is a durable control request: it can be issued against
+// any client instance sharing the route's storage — not just the instance that
+// ends up driving the apply — and the driver delivers it to its own engine at
+// a progress tick. This exercises the sequential (per-task) drive path: the
+// request is queued through one client, a different client drives the apply,
+// and only the driving client's engine is retuned. The request completes and
+// the applied level lands on the stored apply options so progress reports it.
+func TestLocalClient_VolumeQueuedCrossInstanceAppliedBySequentialDrive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+	cleanupTestTables(t, dsn)
+
+	ctx := t.Context()
+	stor := createStorage(t, dsn)
+	defer utils.CloseAndLog(stor)
+	drivingClient, drivingEngine := newVolumeControlClient(t, dsn, stor)
+	receivingClient, receivingEngine := newVolumeControlClient(t, dsn, stor)
+
+	apply := dispatchQueuedApplyWithOptions(t, stor, drivingClient, nil)
+
+	// The RPC lands on an instance that will never drive this apply.
+	volumeResp, err := receivingClient.Volume(ctx, &ternv1.VolumeRequest{
+		ApplyId:     apply.ApplyIdentifier,
+		Environment: localClientTestEnvironment,
+		Volume:      9,
+	})
+	require.NoError(t, err)
+	assert.True(t, volumeResp.Accepted)
+	assert.Equal(t, int32(9), volumeResp.NewVolume, "the accepted response must echo the queued target level")
+	assert.Zero(t, volumeResp.PreviousVolume, "the previous level is only known to the driver")
+	requireControlRequestStatus(t, stor, apply.ID, storage.ControlOperationVolume, storage.ControlRequestPending)
+
+	// Re-requesting the same level while pending is an idempotent accept.
+	again, err := receivingClient.Volume(ctx, &ternv1.VolumeRequest{
+		ApplyId:     apply.ApplyIdentifier,
+		Environment: localClientTestEnvironment,
+		Volume:      9,
+	})
+	require.NoError(t, err)
+	assert.True(t, again.Accepted)
+
+	// A different level while one is pending is rejected with retry guidance,
+	// so the level the driver reads, applies, and completes stays unambiguous.
+	_, err = receivingClient.Volume(ctx, &ternv1.VolumeRequest{
+		ApplyId:     apply.ApplyIdentifier,
+		Environment: localClientTestEnvironment,
+		Volume:      3,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already queued")
+
+	driveNextQueuedApply(t, stor, drivingClient)
+
+	assert.Equal(t, []int32{9}, drivingEngine.recordedVolumes(),
+		"the driving instance's engine must receive the queued level exactly once")
+	assert.Empty(t, receivingEngine.recordedVolumes(),
+		"the instance that accepted the RPC must never touch its own engine")
+	requireControlRequestStatus(t, stor, apply.ID, storage.ControlOperationVolume, storage.ControlRequestCompleted)
+	requireStoredVolume(t, stor, apply.ID, 9)
+
+	settled, err := stor.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, settled)
+	assert.Equal(t, state.Apply.Completed, settled.State)
+}
+
+// The grouped (atomic) drive path services a pending volume request from its
+// progress tick just like the sequential path. A MySQL apply with
+// defer_cutover drives through the grouped poll, so a volume queued before the
+// claim must reach the engine, complete the request, and land on the stored
+// apply options.
+func TestLocalClient_VolumeQueuedAppliedByGroupedDrive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+	cleanupTestTables(t, dsn)
+
+	ctx := t.Context()
+	stor := createStorage(t, dsn)
+	defer utils.CloseAndLog(stor)
+	client, eng := newVolumeControlClient(t, dsn, stor)
+
+	apply := dispatchQueuedApplyWithOptions(t, stor, client, map[string]string{"defer_cutover": "true"})
+
+	volumeResp, err := client.Volume(ctx, &ternv1.VolumeRequest{
+		ApplyId:     apply.ApplyIdentifier,
+		Environment: localClientTestEnvironment,
+		Volume:      2,
+	})
+	require.NoError(t, err)
+	assert.True(t, volumeResp.Accepted)
+	requireControlRequestStatus(t, stor, apply.ID, storage.ControlOperationVolume, storage.ControlRequestPending)
+
+	driveNextQueuedApply(t, stor, client)
+
+	assert.Equal(t, []int32{2}, eng.recordedVolumes(),
+		"the grouped drive must deliver the queued level to the engine exactly once")
+	requireControlRequestStatus(t, stor, apply.ID, storage.ControlOperationVolume, storage.ControlRequestCompleted)
+	requireStoredVolume(t, stor, apply.ID, 2)
+
+	settled, err := stor.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, settled)
+	assert.Equal(t, state.Apply.Completed, settled.State)
+}
+
+// Volume is a tuning knob, not a safety operation: when the engine rejects the
+// adjustment the request fails terminally with the engine's error, the copy
+// continues at its current volume, and the drive itself still runs to
+// completion.
+func TestLocalClient_VolumeEngineFailureFailsRequestWithoutAbortingDrive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+	cleanupTestTables(t, dsn)
+
+	ctx := t.Context()
+	stor := createStorage(t, dsn)
+	defer utils.CloseAndLog(stor)
+	client, eng := newVolumeControlClient(t, dsn, stor)
+	eng.volumeErr = fmt.Errorf("throttle service unavailable")
+
+	apply := dispatchQueuedApplyWithOptions(t, stor, client, nil)
+
+	volumeResp, err := client.Volume(ctx, &ternv1.VolumeRequest{
+		ApplyId:     apply.ApplyIdentifier,
+		Environment: localClientTestEnvironment,
+		Volume:      7,
+	})
+	require.NoError(t, err)
+	assert.True(t, volumeResp.Accepted)
+
+	driveNextQueuedApply(t, stor, client)
+
+	req, err := stor.ControlRequests().GetByOperation(ctx, apply.ID, storage.ControlOperationVolume)
+	require.NoError(t, err)
+	require.NotNil(t, req)
+	assert.Equal(t, storage.ControlRequestFailed, req.Status,
+		"an engine rejection must fail the request terminally so the driver stops retrying it")
+	assert.Contains(t, req.ErrorMessage, "throttle service unavailable")
+	requireStoredVolume(t, stor, apply.ID, 0)
+
+	settled, err := stor.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, settled)
+	assert.Equal(t, state.Apply.Completed, settled.State,
+		"a failed volume adjustment must never abort the drive")
+}
+
+// A terminal apply has no running copy to retune, so a volume request against
+// it is rejected synchronously instead of queueing work no driver will ever
+// service. An out-of-range level is rejected before anything is recorded.
+func TestLocalClient_VolumeRejectsTerminalApplyAndInvalidLevel(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+	cleanupTestTables(t, dsn)
+
+	ctx := t.Context()
+	stor := createStorage(t, dsn)
+	defer utils.CloseAndLog(stor)
+	// The invocation-tracking engine completes on its first progress poll, so
+	// the apply settles without needing a volume adjustment to unblock it.
+	client, _ := newTasklessControlClient(t, dsn, stor)
+
+	apply := dispatchQueuedApply(t, stor, client, []storage.TableChange{{
+		Namespace: "testdb",
+		Table:     "users",
+		DDL:       "ALTER TABLE `users` ADD COLUMN volume_note VARCHAR(255)",
+		Operation: "alter",
+	}})
+
+	for _, level := range []int32{0, 12} {
+		_, err := client.Volume(ctx, &ternv1.VolumeRequest{
+			ApplyId:     apply.ApplyIdentifier,
+			Environment: localClientTestEnvironment,
+			Volume:      level,
+		})
+		require.Error(t, err, "volume level %d must be rejected", level)
+		assert.Contains(t, err.Error(), "volume must be between")
+	}
+
+	driveNextQueuedApply(t, stor, client)
+	settled, err := stor.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, settled)
+	require.Equal(t, state.Apply.Completed, settled.State)
+
+	_, err = client.Volume(ctx, &ternv1.VolumeRequest{
+		ApplyId:     apply.ApplyIdentifier,
+		Environment: localClientTestEnvironment,
+		Volume:      5,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "volume can only be adjusted while it is running")
+
+	req, err := stor.ControlRequests().GetByOperation(ctx, apply.ID, storage.ControlOperationVolume)
+	require.NoError(t, err)
+	assert.Nil(t, req, "a rejected volume request must record nothing")
+}

--- a/pkg/tern/local_control_volume_integration_test.go
+++ b/pkg/tern/local_control_volume_integration_test.go
@@ -364,3 +364,169 @@ func TestLocalClient_VolumeRejectsTerminalApplyAndInvalidLevel(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, req, "a rejected volume request must record nothing")
 }
+
+// insertSiblingOperation adds a second apply_operation row for a different
+// deployment, giving the apply the multi-deployment fan-out shape where each
+// operation's driver holds its own engine.
+func insertSiblingOperation(t *testing.T, stor storage.Storage, applyID int64) {
+	t.Helper()
+	_, err := stor.ApplyOperations().Insert(t.Context(), &storage.ApplyOperation{
+		ApplyID:    applyID,
+		Deployment: "testdb-sibling",
+		Target:     "testdb-sibling",
+		State:      state.ApplyOperation.Pending,
+	})
+	require.NoError(t, err)
+}
+
+// A multi-deployment (fan-out) apply runs one engine per operation, so an
+// apply-scoped volume request could only ever retune the first operation
+// driver's deployment while reporting the adjustment as applied everywhere.
+// The request is rejected at queue time with nothing recorded, and a request
+// that reached storage anyway is failed by the driver without retuning any
+// engine.
+func TestLocalClient_VolumeRejectsMultiDeploymentApply(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+	cleanupTestTables(t, dsn)
+
+	ctx := t.Context()
+	stor := createStorage(t, dsn)
+	defer utils.CloseAndLog(stor)
+	client, eng := newVolumeControlClient(t, dsn, stor)
+
+	apply := dispatchQueuedApplyWithOptions(t, stor, client, nil)
+	insertSiblingOperation(t, stor, apply.ID)
+
+	rejected, err := client.Volume(ctx, &ternv1.VolumeRequest{
+		ApplyId:     apply.ApplyIdentifier,
+		Environment: localClientTestEnvironment,
+		Volume:      9,
+	})
+	require.NoError(t, err)
+	assert.False(t, rejected.Accepted, "a fan-out apply must not accept an apply-scoped volume adjustment")
+	assert.Contains(t, rejected.ErrorMessage, "multi-deployment")
+
+	req, err := stor.ControlRequests().GetByOperation(ctx, apply.ID, storage.ControlOperationVolume)
+	require.NoError(t, err)
+	assert.Nil(t, req, "a queue-time rejection must record nothing")
+
+	// A request that reached storage anyway (recorded before fan-out gating
+	// could see the sibling operation) is failed by the driver's tick without
+	// retuning any engine.
+	metadata, err := storage.EncodeVolumeControlRequestMetadata(9)
+	require.NoError(t, err)
+	_, _, err = stor.ControlRequests().RequestPending(ctx, &storage.ApplyControlRequest{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationVolume,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "test",
+		Metadata:    metadata,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, client.processPendingVolumeControlRequest(ctx, apply, eng, nil, nil))
+	requireControlRequestStatus(t, stor, apply.ID, storage.ControlOperationVolume, storage.ControlRequestFailed)
+	assert.Empty(t, eng.recordedVolumes(), "no engine may be retuned for a fan-out apply")
+}
+
+// A volume request races the drive settling: the state check passes while the
+// apply is still running, the driver settles the apply and runs its terminal
+// pending-request sweep, and only then does the request row land. The queue
+// path re-checks after the insert, sweeps its own request, and rejects — so no
+// pending row lingers forever with no driver left to service it.
+func TestLocalClient_VolumeQueuedAfterSettleIsSweptAndRejected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+	cleanupTestTables(t, dsn)
+
+	ctx := t.Context()
+	stor := createStorage(t, dsn)
+	defer utils.CloseAndLog(stor)
+	client, eng := newVolumeControlClient(t, dsn, stor)
+
+	apply := dispatchQueuedApplyWithOptions(t, stor, client, nil)
+
+	// Nudge the tracking engine past its running phase so the drive settles
+	// without needing a queued volume adjustment.
+	eng.mu.Lock()
+	eng.volumeAttempts = 1
+	eng.mu.Unlock()
+	driveNextQueuedApply(t, stor, client)
+
+	// The dispatch-time apply snapshot still reads as non-terminal, modelling a
+	// state check that passed just before the driver settled the apply.
+	rejected, err := client.queueVolumeRequest(ctx, apply, 5)
+	require.NoError(t, err)
+	assert.False(t, rejected.Accepted, "a request that raced the settle must not be accepted")
+	assert.Contains(t, rejected.ErrorMessage, "volume can only be adjusted while it is running")
+
+	requireControlRequestStatus(t, stor, apply.ID, storage.ControlOperationVolume, storage.ControlRequestCompleted)
+	assert.Empty(t, eng.recordedVolumes(), "a swept request must never reach an engine")
+}
+
+// Engine volume lives with each running schema change, so on a sequential
+// multi-table apply a task started after the adjustment would run at the
+// engine default while stored options, progress, and the CLI report the
+// adjusted level. Each newly started task converges to the apply's stored
+// level, so the display stays true for the whole drive.
+func TestLocalClient_VolumeConvergesLaterTasksToStoredLevel(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+	cleanupTestTables(t, dsn)
+
+	ctx := t.Context()
+	stor := createStorage(t, dsn)
+	defer utils.CloseAndLog(stor)
+	client, eng := newVolumeControlClient(t, dsn, stor)
+
+	apply := dispatchQueuedApply(t, stor, client, []storage.TableChange{
+		{
+			Namespace: "testdb",
+			Table:     "users",
+			DDL:       "ALTER TABLE `users` ADD COLUMN volume_note VARCHAR(255)",
+			Operation: "alter",
+		},
+		{
+			Namespace: "testdb",
+			Table:     "orders",
+			DDL:       "ALTER TABLE `orders` ADD COLUMN volume_note VARCHAR(255)",
+			Operation: "alter",
+		},
+	})
+
+	volumeResp, err := client.Volume(ctx, &ternv1.VolumeRequest{
+		ApplyId:     apply.ApplyIdentifier,
+		Environment: localClientTestEnvironment,
+		Volume:      9,
+	})
+	require.NoError(t, err)
+	require.True(t, volumeResp.Accepted)
+
+	driveNextQueuedApply(t, stor, client)
+
+	assert.Equal(t, []int32{9, 9}, eng.recordedVolumes(),
+		"the first task is retuned by the pending request and the second converges to the stored level at start")
+	requireControlRequestStatus(t, stor, apply.ID, storage.ControlOperationVolume, storage.ControlRequestCompleted)
+	requireStoredVolume(t, stor, apply.ID, 9)
+
+	settled, err := stor.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, settled)
+	assert.Equal(t, state.Apply.Completed, settled.State)
+}


### PR DESCRIPTION
## Why this matters

Volume was the only control operation delivered in-process: the RPC handler called the local engine directly, so it only worked when the request happened to land on the instance driving the apply. With dispatched applies driven wherever the operator claimed them, a volume adjustment sent to any other pod — or through any other client instance — failed with "no active schema change" even though the copy was running fine. Every other control verb (stop, cancel, start, cutover) already solved this with durable requests.

## What it does

Volume becomes the fifth durable control request. The RPC validates and records the request (the level rides in the control-request row's metadata), wakes the operator, and returns "queued"; the driver services it from its next progress tick — in both the grouped and sequential drive paths, alongside the existing cutover servicing — retunes the engine, completes the request, and writes the applied level back onto the apply's stored options so progress converges to the real value.

```
before:  volume RPC ──▶ local engine of whichever instance answered
                          └▶ not the driver? "no active schema change" ❌

after:   volume RPC ──▶ durable control request + operator wake ✅
         driver tick ─▶ pending volume? ──▶ eng.Volume ──▶ complete request
                                             └▶ engine failure: request fails,
                                                the copy continues at the old volume
```

Semantics worth noting:

- A pending volume request is immutable until the driver resolves it: re-requesting the same level is an idempotent accept, a different level is rejected with guidance to retry after the pending one lands — so the driver can never complete a level it did not apply.
- Terminal applies (including stopped — there is no driver to service the request) reject with guidance instead of queuing something nothing will consume; requests still pending when an apply reaches a terminal state are swept, and a request that races the settle is re-checked after the insert and swept by the queue path itself, so no pending row can linger with no driver left to service it.
- Multi-deployment (fan-out) applies reject volume with guidance, at queue time and again at the driver's tick: each operation's driver holds its own engine, so an apply-scoped request could only retune one deployment while reporting the adjustment as applied everywhere. Per-operation delivery is a tracked follow-up.
- The stored level is the apply's desired volume: a task started after the adjustment (a later table in a sequential drive, or a resumed apply) converges to it at start, so stored options, progress, and the CLI stay true for the whole drive.
- The CLI and API now say the adjustment is queued and when it takes effect, instead of claiming an instant "X → Y" that may not have happened yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
