### PR TITLE
feat(api): checks scan + synthesize endpoints for missing Check Run backfill

### DIFF
--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -129,7 +129,11 @@ type Service struct {
 	routingTernClient *tern.RoutingClient
 	ternMu            sync.Mutex // protects tern client caches and engineFactories
 	logger            *slog.Logger
-	clock             clock.Clock
+	// checkRunBackfiller replays the auto-plan flow for a PR to recreate
+	// missing Check Runs; wired from the webhook handler at serve startup,
+	// nil when no GitHub webhook runtime exists.
+	checkRunBackfiller CheckRunBackfiller
+	clock              clock.Clock
 
 	// engineFactories holds engine implementations for database types this build
 	// does not provide natively, registered by an embedding service via
@@ -448,6 +452,13 @@ func (s *Service) RegisterTernClient(deployment, environment string, client tern
 // TargetRouter so the durable-apply operator and routing client resolve the
 // connection from each request's target — the dynamic-resolution counterpart to
 // RegisterTernClient, without needing one registration per deployment.
+// SetCheckRunBackfiller wires the webhook handler's Check Run backfill entry
+// point into the API service, so the checks operator endpoints can replay the
+// auto-plan flow for a PR. Set once during serve startup, before traffic.
+func (s *Service) SetCheckRunBackfiller(b CheckRunBackfiller) {
+	s.checkRunBackfiller = b
+}
+
 func (s *Service) SetDefaultTernClient(client tern.Client) {
 	s.ternMu.Lock()
 	defer s.ternMu.Unlock()
@@ -696,6 +707,8 @@ func (s *Service) ConfigureRoutes(mux *http.ServeMux) {
 	handle("GET /api/logs/{database}", s.handleLogs)
 	handle("GET /api/logs", s.handleLogsWithoutDatabase)
 	handle("POST /api/webhooks/redrive", s.handleWebhookRedrive)
+	handle("POST /api/checks/scan", s.handleChecksScan)
+	handle("POST /api/checks/synthesize", s.handleChecksSynthesize)
 
 	// Lock API (database-level locking)
 	handle("POST /api/locks/acquire", s.handleLockAcquire)

--- a/pkg/api/webhook_ops_handlers.go
+++ b/pkg/api/webhook_ops_handlers.go
@@ -124,6 +124,11 @@ func executeChecksSynthesize(ctx context.Context, cfg *ServerConfig, backfiller 
 	if len(req.PRs) > checksSynthesizeMaxPRsPerRequest {
 		return nil, webhookOpsRequestErrorf("at most %d prs per request; send the rest in follow-up requests", checksSynthesizeMaxPRsPerRequest)
 	}
+	for _, pr := range req.PRs {
+		if pr <= 0 {
+			return nil, webhookOpsRequestErrorf("pr numbers must be positive; got %d", pr)
+		}
+	}
 	if backfiller == nil {
 		return nil, fmt.Errorf("check run backfill is unavailable: no GitHub webhook runtime is configured")
 	}
@@ -249,6 +254,12 @@ func executeChecksScan(ctx context.Context, cfg *ServerConfig, req ChecksScanReq
 	}
 	if req.Page < 0 {
 		return nil, webhookOpsRequestErrorf("page must be non-negative")
+	}
+	// A stale or mistyped environment would otherwise scan for a check name
+	// that can never exist and report every PR as missing it; reject it as a
+	// request error instead.
+	if req.Environment != "" && !cfg.IsEnvironmentAllowed(req.Environment) {
+		return nil, webhookOpsRequestErrorf("environment %q is not one this instance handles", req.Environment)
 	}
 	if logger == nil {
 		logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
@@ -660,25 +671,34 @@ func scanWebhookMissingChecks(ctx context.Context, client webhookMissingCheckSca
 	result := &ChecksScanResponse{Repo: repo, CheckNames: checkNames, Scanned: len(prs), NextPage: nextPage}
 	for _, pr := range prs {
 		var missing []string
+		var untrustedConflicts []string
 		for _, checkName := range checkNames {
-			run, _, err := client.FindCheckRunByName(ctx, repo, pr.HeadSHA, checkName)
+			run, untrustedApps, err := client.FindCheckRunByName(ctx, repo, pr.HeadSHA, checkName)
 			if err != nil {
 				return nil, fmt.Errorf("scan %s#%d for check %q at %s: %w", repo, pr.Number, checkName, pr.HeadSHA, err)
 			}
-			if run == nil {
-				missing = append(missing, checkName)
+			if run != nil {
+				continue
+			}
+			missing = append(missing, checkName)
+			// No trusted check exists, but a same-named one from an untrusted
+			// app does: backfill will still create the trusted check, yet the
+			// operator likely also needs to resolve the conflicting check.
+			if len(untrustedApps) > 0 {
+				untrustedConflicts = append(untrustedConflicts, checkName)
 			}
 		}
 		if len(missing) == 0 {
 			continue
 		}
 		result.Missing = append(result.Missing, MissingCheckPR{
-			Number:       pr.Number,
-			URL:          fmt.Sprintf("https://github.com/%s/pull/%d", repo, pr.Number),
-			Title:        pr.Title,
-			HeadSHA:      pr.HeadSHA,
-			HeadRef:      pr.HeadRef,
-			MissingNames: missing,
+			Number:                 pr.Number,
+			URL:                    fmt.Sprintf("https://github.com/%s/pull/%d", repo, pr.Number),
+			Title:                  pr.Title,
+			HeadSHA:                pr.HeadSHA,
+			HeadRef:                pr.HeadRef,
+			MissingNames:           missing,
+			UntrustedConflictNames: untrustedConflicts,
 		})
 	}
 	return result, nil

--- a/pkg/api/webhook_ops_handlers.go
+++ b/pkg/api/webhook_ops_handlers.go
@@ -32,6 +32,10 @@ const (
 	// webhookRedriveMaxPagesPerRequest bounds one redrive request's listing so
 	// each HTTP request finishes in seconds; callers continue via the cursor.
 	webhookRedriveMaxPagesPerRequest = 25
+
+	// webhookScanPRPageSize bounds one scan request to a single page of open
+	// PRs; callers continue via next_page.
+	webhookScanPRPageSize = 30
 )
 
 // webhookOpsRequestError marks a failure caused by the request itself
@@ -71,6 +75,79 @@ type WebhookRedriveRequest = apitypes.WebhookRedriveRequest
 type WebhookRedriveResponse = apitypes.WebhookRedriveResponse
 type WebhookRedriveResult = apitypes.WebhookRedriveResult
 type WebhookRedriveSelection = apitypes.WebhookRedriveSelection
+type ChecksScanRequest = apitypes.ChecksScanRequest
+type ChecksScanResponse = apitypes.ChecksScanResponse
+type MissingCheckPR = apitypes.MissingCheckPR
+
+// CheckRunBackfiller replays the auto-plan flow for a PR to recreate missing
+// Check Runs, exactly as the check-creating webhook delivery would have. The
+// webhook handler implements it; the API service holds it so the checks
+// operator endpoints can reach the webhook pipeline.
+type CheckRunBackfiller interface {
+	BackfillPRCheckRuns(ctx context.Context, repo string, pr int, installationID int64) (string, error)
+}
+
+type ChecksSynthesizeRequest = apitypes.ChecksSynthesizeRequest
+type ChecksSynthesizeResponse = apitypes.ChecksSynthesizeResponse
+type ChecksSynthesizeResult = apitypes.ChecksSynthesizeResult
+
+// checksSynthesizeMaxPRsPerRequest bounds one synthesize request; each PR's
+// heavy plan work runs asynchronously, so a chunk only pays discovery.
+const checksSynthesizeMaxPRsPerRequest = 10
+
+func (s *Service) handleChecksSynthesize(w http.ResponseWriter, r *http.Request) {
+	var req ChecksSynthesizeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeBodyDecodeError(w, err)
+		return
+	}
+	ctx, cancel := s.extendWebhookOpsDeadline(w, r)
+	defer cancel()
+	response, err := executeChecksSynthesize(ctx, s.config, s.checkRunBackfiller, req, s.logger)
+	if err != nil {
+		s.writeWebhookOpsError(w, err)
+		return
+	}
+	s.writeJSON(w, http.StatusOK, response)
+}
+
+func executeChecksSynthesize(ctx context.Context, cfg *ServerConfig, backfiller CheckRunBackfiller, req ChecksSynthesizeRequest, logger *slog.Logger) (*ChecksSynthesizeResponse, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("server config is nil")
+	}
+	if req.Repo == "" {
+		return nil, webhookOpsRequestErrorf("repo is required")
+	}
+	if len(req.PRs) == 0 {
+		return nil, webhookOpsRequestErrorf("prs is required")
+	}
+	if len(req.PRs) > checksSynthesizeMaxPRsPerRequest {
+		return nil, webhookOpsRequestErrorf("at most %d prs per request; send the rest in follow-up requests", checksSynthesizeMaxPRsPerRequest)
+	}
+	if backfiller == nil {
+		return nil, fmt.Errorf("check run backfill is unavailable: no GitHub webhook runtime is configured")
+	}
+	if logger == nil {
+		logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	}
+	_, installationID, err := resolveRepoInstallationClient(ctx, cfg, req.Repo, logger)
+	if err != nil {
+		return nil, err
+	}
+	response := &ChecksSynthesizeResponse{Repo: req.Repo}
+	for _, pr := range req.PRs {
+		outcome, err := backfiller.BackfillPRCheckRuns(ctx, req.Repo, pr, installationID)
+		result := ChecksSynthesizeResult{PR: pr, Outcome: outcome}
+		if err != nil {
+			// Each PR's backfill is independent; report the failure and keep
+			// going so one bad PR does not strand the rest of the batch.
+			logger.Warn("check run backfill failed for PR", "repo", req.Repo, "pr", pr, "error", err)
+			result.Error = err.Error()
+		}
+		response.Results = append(response.Results, result)
+	}
+	return response, nil
+}
 
 type webhookRedriveDeliveryClient interface {
 	ListHookDeliveries(ctx context.Context, opts *gh.ListCursorOptions) ([]*gh.HookDelivery, *gh.Response, error)
@@ -100,7 +177,26 @@ func (s *Service) handleWebhookRedrive(w http.ResponseWriter, r *http.Request) {
 	s.writeJSON(w, http.StatusOK, response)
 }
 
+func (s *Service) handleChecksScan(w http.ResponseWriter, r *http.Request) {
+	var req ChecksScanRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeBodyDecodeError(w, err)
+		return
+	}
+	ctx, cancel := s.extendWebhookOpsDeadline(w, r)
+	defer cancel()
+	response, err := executeChecksScan(ctx, s.config, req, s.logger)
+	if err != nil {
+		s.writeWebhookOpsError(w, err)
+		return
+	}
+	s.writeJSON(w, http.StatusOK, response)
+}
+
 func executeWebhookRedrive(ctx context.Context, cfg *ServerConfig, req WebhookRedriveRequest, logger *slog.Logger) (*WebhookRedriveResponse, error) {
+	if len(req.DeliveryIDs) > 0 {
+		return executeWebhookRedriveByIDs(ctx, cfg, req, logger)
+	}
 	if req.MaxPages <= 0 {
 		return nil, webhookOpsRequestErrorf("max_pages must be positive")
 	}
@@ -142,6 +238,100 @@ func executeWebhookRedrive(ctx context.Context, cfg *ServerConfig, req WebhookRe
 		response.Results = append(response.Results, result)
 	}
 	return response, nil
+}
+
+func executeChecksScan(ctx context.Context, cfg *ServerConfig, req ChecksScanRequest, logger *slog.Logger) (*ChecksScanResponse, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("server config is nil")
+	}
+	if req.Repo == "" {
+		return nil, webhookOpsRequestErrorf("repo is required")
+	}
+	if req.Page < 0 {
+		return nil, webhookOpsRequestErrorf("page must be non-negative")
+	}
+	if logger == nil {
+		logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	}
+	installationClient, _, err := resolveRepoInstallationClient(ctx, cfg, req.Repo, logger)
+	if err != nil {
+		return nil, err
+	}
+	return scanWebhookMissingChecks(ctx, installationClient, req.Repo, webhookMissingCheckNames(cfg, req.Repo, req.Environment, req.CheckName), req.Page)
+}
+
+// resolveRepoInstallationClient builds an installation-scoped GitHub client
+// for the App that serves repo, from the server config's App credentials.
+func resolveRepoInstallationClient(ctx context.Context, cfg *ServerConfig, repo string, logger *slog.Logger) (*ghclient.InstallationClient, int64, error) {
+	app, err := cfg.ResolveGitHubAppForRepo(repo)
+	if err != nil {
+		return nil, 0, err
+	}
+	appID := app.Config.ResolveAppID()
+	if appID == 0 {
+		return nil, 0, fmt.Errorf("app %q has empty or unparseable app-id", app.Name)
+	}
+	privateKey, err := app.Config.ResolvePrivateKey()
+	if err != nil {
+		return nil, 0, fmt.Errorf("resolve private key for app %q: %w", app.Name, err)
+	}
+	if privateKey == "" {
+		return nil, 0, fmt.Errorf("app %q private key resolved to empty value", app.Name)
+	}
+	client := ghclient.NewClient(appID, []byte(privateKey), logger,
+		ghclient.WithTrustedCheckAppSlugs(app.Config.TrustedCheckAppSlugs))
+	installationID, err := client.InstallationIDForRepo(ctx, repo)
+	if err != nil {
+		return nil, 0, fmt.Errorf("resolve GitHub App installation for %s: %w", repo, err)
+	}
+	installationClient, err := client.ForInstallation(installationID)
+	if err != nil {
+		return nil, 0, fmt.Errorf("create installation client for %s: %w", repo, err)
+	}
+	return installationClient, installationID, nil
+}
+
+// executeWebhookRedriveByIDs redelivers exactly the requested deliveries for
+// one App, skipping the window listing — the caller already identified the
+// failed deliveries (for example a checks backfill classification pass).
+func executeWebhookRedriveByIDs(ctx context.Context, cfg *ServerConfig, req WebhookRedriveRequest, logger *slog.Logger) (*WebhookRedriveResponse, error) {
+	if req.App == "" {
+		return nil, webhookOpsRequestErrorf("delivery_ids redelivery requires app to be set")
+	}
+	if req.Cursor != "" {
+		return nil, webhookOpsRequestErrorf("delivery_ids and cursor are mutually exclusive")
+	}
+	if req.DryRun {
+		return nil, webhookOpsRequestErrorf("delivery_ids redelivery has no dry run; the listing pass already reported the selection")
+	}
+	apps, err := webhookRedriveApps(cfg, req.App)
+	if err != nil {
+		return nil, err
+	}
+	if logger == nil {
+		logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	}
+	app := apps[0]
+	client, err := newWebhookRedriveGitHubClient(app, logger)
+	if err != nil {
+		return nil, err
+	}
+	result := WebhookRedriveResult{AppName: app.name, ReachedWindowStart: true}
+	for i, id := range req.DeliveryIDs {
+		result.Selected = append(result.Selected, WebhookRedriveSelection{ID: id})
+		if _, _, err := client.Apps.RedeliverHookDelivery(ctx, id); err != nil {
+			result.Failed++
+			logger.Warn("GitHub webhook redelivery failed", "app_name", app.name, "delivery_id", id, "error", err)
+			continue
+		}
+		result.Redelivered++
+		if i < len(req.DeliveryIDs)-1 {
+			if err := waitWebhookRedriveDelay(ctx); err != nil {
+				return nil, fmt.Errorf("wait between GitHub webhook redeliveries for app %q: %w", app.name, err)
+			}
+		}
+	}
+	return &WebhookRedriveResponse{Results: []WebhookRedriveResult{result}}, nil
 }
 
 func webhookRedriveApps(cfg *ServerConfig, onlyApp string) ([]webhookRedriveApp, error) {
@@ -437,4 +627,59 @@ func webhookRedrivePayloadMetadata(delivery *gh.HookDelivery) (webhookRedrivePay
 		appendPR(pr.Number)
 	}
 	return webhookRedrivePayload{repo: payload.Repository.FullName, prs: prs}, nil
+}
+
+func webhookMissingCheckNames(cfg *ServerConfig, repo, environment, override string) []string {
+	if override != "" {
+		return []string{override}
+	}
+	base := cfg.GitHubCheckNameBaseForRepo(repo)
+	if environment != "" {
+		return []string{fmt.Sprintf("%s (%s)", base, environment)}
+	}
+	if len(cfg.AllowedEnvironments) > 0 {
+		out := make([]string, 0, len(cfg.AllowedEnvironments))
+		for _, env := range cfg.AllowedEnvironments {
+			out = append(out, fmt.Sprintf("%s (%s)", base, env))
+		}
+		return out
+	}
+	return []string{base}
+}
+
+type webhookMissingCheckScanClient interface {
+	ListOpenPullRequestsPage(ctx context.Context, repo string, page, perPage int) ([]ghclient.OpenPullRequest, int, error)
+	FindCheckRunByName(ctx context.Context, repo, headSHA, checkName string) (*ghclient.CheckRunResult, []string, error)
+}
+
+func scanWebhookMissingChecks(ctx context.Context, client webhookMissingCheckScanClient, repo string, checkNames []string, page int) (*ChecksScanResponse, error) {
+	prs, nextPage, err := client.ListOpenPullRequestsPage(ctx, repo, page, webhookScanPRPageSize)
+	if err != nil {
+		return nil, err
+	}
+	result := &ChecksScanResponse{Repo: repo, CheckNames: checkNames, Scanned: len(prs), NextPage: nextPage}
+	for _, pr := range prs {
+		var missing []string
+		for _, checkName := range checkNames {
+			run, _, err := client.FindCheckRunByName(ctx, repo, pr.HeadSHA, checkName)
+			if err != nil {
+				return nil, fmt.Errorf("scan %s#%d for check %q at %s: %w", repo, pr.Number, checkName, pr.HeadSHA, err)
+			}
+			if run == nil {
+				missing = append(missing, checkName)
+			}
+		}
+		if len(missing) == 0 {
+			continue
+		}
+		result.Missing = append(result.Missing, MissingCheckPR{
+			Number:       pr.Number,
+			URL:          fmt.Sprintf("https://github.com/%s/pull/%d", repo, pr.Number),
+			Title:        pr.Title,
+			HeadSHA:      pr.HeadSHA,
+			HeadRef:      pr.HeadRef,
+			MissingNames: missing,
+		})
+	}
+	return result, nil
 }

--- a/pkg/api/webhook_ops_handlers_test.go
+++ b/pkg/api/webhook_ops_handlers_test.go
@@ -411,9 +411,26 @@ func TestExecuteChecksSynthesizeValidation(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "per request")
 
+	_, err = executeChecksSynthesize(t.Context(), cfg, backfiller, ChecksSynthesizeRequest{Repo: "octo/repo", PRs: []int{1, 0, 2}}, discardLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pr numbers must be positive")
+
 	_, err = executeChecksSynthesize(t.Context(), cfg, nil, ChecksSynthesizeRequest{Repo: "octo/repo", PRs: []int{1}}, discardLogger())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no GitHub webhook runtime")
+}
+
+// A stale or mistyped environment is rejected as a request error before any
+// GitHub work, rather than scanning for a check name that can never exist and
+// reporting every PR as missing it.
+func TestExecuteChecksScanRejectsDisallowedEnvironment(t *testing.T) {
+	t.Parallel()
+
+	cfg := &ServerConfig{AllowedEnvironments: []string{"staging", "production"}}
+
+	_, err := executeChecksScan(t.Context(), cfg, ChecksScanRequest{Repo: "octo/repo", Environment: "prod"}, discardLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `environment "prod" is not one this instance handles`)
 }
 
 // Redelivery by explicit delivery IDs is a precise continuation of a prior
@@ -439,6 +456,9 @@ func TestExecuteWebhookRedriveByIDsValidation(t *testing.T) {
 type fakeWebhookMissingCheckScanClient struct {
 	prs  []ghclient.OpenPullRequest
 	runs map[string]*ghclient.CheckRunResult
+	// untrusted maps headSHA+"/"+checkName to app slugs that published a
+	// same-named check but are not trusted.
+	untrusted map[string][]string
 }
 
 func (f fakeWebhookMissingCheckScanClient) ListOpenPullRequestsPage(_ context.Context, _ string, page, perPage int) ([]ghclient.OpenPullRequest, int, error) {
@@ -458,7 +478,7 @@ func (f fakeWebhookMissingCheckScanClient) ListOpenPullRequestsPage(_ context.Co
 }
 
 func (f fakeWebhookMissingCheckScanClient) FindCheckRunByName(_ context.Context, _ string, headSHA, checkName string) (*ghclient.CheckRunResult, []string, error) {
-	return f.runs[headSHA+"/"+checkName], nil, nil
+	return f.runs[headSHA+"/"+checkName], f.untrusted[headSHA+"/"+checkName], nil
 }
 
 func TestWebhookMissingCheckNamesUsesConfiguredEnvironmentNames(t *testing.T) {
@@ -495,4 +515,28 @@ func TestScanWebhookMissingChecksReportsOpenPRsMissingConfiguredChecks(t *testin
 	assert.Equal(t, 2, result.Missing[0].Number)
 	assert.Equal(t, "https://github.com/octo/repo/pull/2", result.Missing[0].URL)
 	assert.Equal(t, []string{"SchemaBot (production)"}, result.Missing[0].MissingNames)
+	assert.Empty(t, result.Missing[0].UntrustedConflictNames)
+}
+
+// A missing check whose name is already taken by an untrusted app's Check Run
+// is reported distinctly, so the operator knows backfill alone leaves a
+// conflicting check to resolve.
+func TestScanWebhookMissingChecksSurfacesUntrustedConflicts(t *testing.T) {
+	t.Parallel()
+
+	client := fakeWebhookMissingCheckScanClient{
+		prs: []ghclient.OpenPullRequest{
+			{Number: 5, Title: "untrusted conflict", HeadSHA: "sha5", HeadRef: "feature-5"},
+		},
+		untrusted: map[string][]string{
+			"sha5/SchemaBot (production)": {"some-other-app"},
+		},
+	}
+
+	result, err := scanWebhookMissingChecks(t.Context(), client, "octo/repo", []string{"SchemaBot (production)"}, 0)
+
+	require.NoError(t, err)
+	require.Len(t, result.Missing, 1)
+	assert.Equal(t, []string{"SchemaBot (production)"}, result.Missing[0].MissingNames)
+	assert.Equal(t, []string{"SchemaBot (production)"}, result.Missing[0].UntrustedConflictNames)
 }

--- a/pkg/api/webhook_ops_handlers_test.go
+++ b/pkg/api/webhook_ops_handlers_test.go
@@ -12,6 +12,8 @@ import (
 	gh "github.com/google/go-github/v86/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	ghclient "github.com/block/schemabot/pkg/github"
 )
 
 type fakeWebhookRedriveDeliveryClient struct {
@@ -368,4 +370,129 @@ func webhookRedriveTestDeliveryDetail(id int64, repo string, pr int) *gh.HookDel
 
 func discardLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+type fakeCheckRunBackfiller struct {
+	calls    []int
+	failPR   int
+	outcomes map[int]string
+}
+
+func (f *fakeCheckRunBackfiller) BackfillPRCheckRuns(_ context.Context, _ string, pr int, _ int64) (string, error) {
+	f.calls = append(f.calls, pr)
+	if pr == f.failPR {
+		return "", errors.New("boom")
+	}
+	if outcome, ok := f.outcomes[pr]; ok {
+		return outcome, nil
+	}
+	return "auto-plan started", nil
+}
+
+// Synthesize requests are validated before any GitHub work: request-shaped
+// problems are reported as such, and an instance without a webhook runtime
+// cannot backfill at all.
+func TestExecuteChecksSynthesizeValidation(t *testing.T) {
+	t.Parallel()
+
+	cfg := &ServerConfig{}
+	backfiller := &fakeCheckRunBackfiller{}
+
+	_, err := executeChecksSynthesize(t.Context(), cfg, backfiller, ChecksSynthesizeRequest{PRs: []int{1}}, discardLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "repo is required")
+
+	_, err = executeChecksSynthesize(t.Context(), cfg, backfiller, ChecksSynthesizeRequest{Repo: "octo/repo"}, discardLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "prs is required")
+
+	tooMany := make([]int, checksSynthesizeMaxPRsPerRequest+1)
+	_, err = executeChecksSynthesize(t.Context(), cfg, backfiller, ChecksSynthesizeRequest{Repo: "octo/repo", PRs: tooMany}, discardLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "per request")
+
+	_, err = executeChecksSynthesize(t.Context(), cfg, nil, ChecksSynthesizeRequest{Repo: "octo/repo", PRs: []int{1}}, discardLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no GitHub webhook runtime")
+}
+
+// Redelivery by explicit delivery IDs is a precise continuation of a prior
+// listing pass; it refuses request shapes that would silently change meaning.
+func TestExecuteWebhookRedriveByIDsValidation(t *testing.T) {
+	t.Parallel()
+
+	cfg := &ServerConfig{GitHub: GitHubConfig{AppID: "1", PrivateKey: "key"}}
+
+	_, err := executeWebhookRedrive(t.Context(), cfg, WebhookRedriveRequest{DeliveryIDs: []int64{1}}, discardLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires app")
+
+	_, err = executeWebhookRedrive(t.Context(), cfg, WebhookRedriveRequest{DeliveryIDs: []int64{1}, App: "default", Cursor: "c1"}, discardLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+
+	_, err = executeWebhookRedrive(t.Context(), cfg, WebhookRedriveRequest{DeliveryIDs: []int64{1}, App: "default", DryRun: true}, discardLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no dry run")
+}
+
+type fakeWebhookMissingCheckScanClient struct {
+	prs  []ghclient.OpenPullRequest
+	runs map[string]*ghclient.CheckRunResult
+}
+
+func (f fakeWebhookMissingCheckScanClient) ListOpenPullRequestsPage(_ context.Context, _ string, page, perPage int) ([]ghclient.OpenPullRequest, int, error) {
+	if page <= 0 {
+		page = 1
+	}
+	start := (page - 1) * perPage
+	if start >= len(f.prs) {
+		return nil, 0, nil
+	}
+	end := min(start+perPage, len(f.prs))
+	nextPage := 0
+	if end < len(f.prs) {
+		nextPage = page + 1
+	}
+	return f.prs[start:end], nextPage, nil
+}
+
+func (f fakeWebhookMissingCheckScanClient) FindCheckRunByName(_ context.Context, _ string, headSHA, checkName string) (*ghclient.CheckRunResult, []string, error) {
+	return f.runs[headSHA+"/"+checkName], nil, nil
+}
+
+func TestWebhookMissingCheckNamesUsesConfiguredEnvironmentNames(t *testing.T) {
+	t.Parallel()
+
+	cfg := &ServerConfig{
+		GitHub:              GitHubConfig{CheckName: "SchemaBot X"},
+		AllowedEnvironments: []string{"staging", "production"},
+	}
+
+	assert.Equal(t, []string{"SchemaBot X (staging)", "SchemaBot X (production)"}, webhookMissingCheckNames(cfg, "octo/repo", "", ""))
+	assert.Equal(t, []string{"SchemaBot X (production)"}, webhookMissingCheckNames(cfg, "octo/repo", "production", ""))
+	assert.Equal(t, []string{"Custom Check"}, webhookMissingCheckNames(cfg, "octo/repo", "production", "Custom Check"))
+}
+
+func TestScanWebhookMissingChecksReportsOpenPRsMissingConfiguredChecks(t *testing.T) {
+	t.Parallel()
+
+	client := fakeWebhookMissingCheckScanClient{
+		prs: []ghclient.OpenPullRequest{
+			{Number: 1, Title: "has check", HeadSHA: "sha1", HeadRef: "feature-1"},
+			{Number: 2, Title: "missing check", HeadSHA: "sha2", HeadRef: "feature-2"},
+		},
+		runs: map[string]*ghclient.CheckRunResult{
+			"sha1/SchemaBot (production)": {ID: 10, Name: "SchemaBot (production)", Status: "completed", Conclusion: "success"},
+		},
+	}
+
+	result, err := scanWebhookMissingChecks(t.Context(), client, "octo/repo", []string{"SchemaBot (production)"}, 0)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.Scanned)
+	require.Len(t, result.Missing, 1)
+	assert.Equal(t, 2, result.Missing[0].Number)
+	assert.Equal(t, "https://github.com/octo/repo/pull/2", result.Missing[0].URL)
+	assert.Equal(t, []string{"SchemaBot (production)"}, result.Missing[0].MissingNames)
 }

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -145,6 +145,11 @@ type MissingCheckPR struct {
 	HeadSHA      string   `json:"head_sha"`
 	HeadRef      string   `json:"head_ref"`
 	MissingNames []string `json:"missing_check_names"`
+	// UntrustedConflictNames are missing check names for which a same-named
+	// Check Run already exists but was created by an untrusted app. Backfill
+	// still recreates the trusted check, but the operator likely also needs to
+	// remove/rename the conflicting check or adjust the trusted-app config.
+	UntrustedConflictNames []string `json:"untrusted_conflict_check_names,omitempty"`
 }
 
 // =============================================================================

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -57,6 +57,10 @@ type WebhookRedriveRequest struct {
 	// processes a bounded number of pages so it finishes well within any
 	// intermediary HTTP timeout; the caller loops until next_cursor is empty.
 	Cursor string `json:"cursor,omitempty"`
+	// DeliveryIDs redelivers exactly these deliveries for App, skipping the
+	// window listing entirely — for callers that already identified the
+	// failed deliveries (for example a checks backfill classification pass).
+	DeliveryIDs []int64 `json:"delivery_ids,omitempty"`
 }
 
 type WebhookRedriveResponse struct {
@@ -94,6 +98,53 @@ type WebhookRedriveSelection struct {
 	StatusCode  int    `json:"status_code"`
 	Repo        string `json:"repo,omitempty"`
 	PR          int    `json:"pr,omitempty"`
+}
+
+type ChecksScanRequest struct {
+	Repo        string `json:"repo"`
+	Environment string `json:"environment,omitempty"`
+	CheckName   string `json:"check_name,omitempty"`
+	// Page selects one bounded page of open PRs (1-based; 0 means the first
+	// page). Each request scans a single page so it finishes well within any
+	// intermediary HTTP timeout; the caller loops until next_page is 0.
+	Page int `json:"page,omitempty"`
+}
+
+type ChecksScanResponse struct {
+	Repo       string           `json:"repo"`
+	CheckNames []string         `json:"check_names"`
+	Scanned    int              `json:"scanned"`
+	NextPage   int              `json:"next_page,omitempty"`
+	Missing    []MissingCheckPR `json:"missing"`
+}
+
+// ChecksSynthesizeRequest asks the server to recreate missing Check Runs for
+// specific PRs by replaying the auto-plan flow, as if the check-creating
+// webhook delivery had arrived. Used for PRs with no delivery to redrive
+// (for example PRs opened before check enablement).
+type ChecksSynthesizeRequest struct {
+	Repo string `json:"repo"`
+	PRs  []int  `json:"prs"`
+}
+
+type ChecksSynthesizeResponse struct {
+	Repo    string                   `json:"repo"`
+	Results []ChecksSynthesizeResult `json:"results"`
+}
+
+type ChecksSynthesizeResult struct {
+	PR      int    `json:"pr"`
+	Outcome string `json:"outcome"`
+	Error   string `json:"error,omitempty"`
+}
+
+type MissingCheckPR struct {
+	Number       int      `json:"number"`
+	URL          string   `json:"url"`
+	Title        string   `json:"title"`
+	HeadSHA      string   `json:"head_sha"`
+	HeadRef      string   `json:"head_ref"`
+	MissingNames []string `json:"missing_check_names"`
 }
 
 // =============================================================================

--- a/pkg/auth/tiers_test.go
+++ b/pkg/auth/tiers_test.go
@@ -22,6 +22,8 @@ func TestTierForRequest(t *testing.T) {
 		{http.MethodPost, "/api/apply", TierWrite},
 		{http.MethodPost, "/api/cutover", TierWrite},
 		{http.MethodPost, "/api/webhooks/redrive", TierWrite},
+		{http.MethodPost, "/api/checks/scan", TierWrite},
+		{http.MethodPost, "/api/checks/synthesize", TierWrite},
 		{http.MethodPost, "/api/settings", TierWrite},
 		{http.MethodDelete, "/api/locks", TierWrite},
 	}

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -609,6 +609,11 @@ func (ic *InstallationClient) ListOpenPullRequestsPage(ctx context.Context, repo
 	if page <= 0 {
 		page = 1
 	}
+	// GitHub caps page size at 100; clamp so a caller's 0/negative/oversized
+	// value behaves predictably.
+	if perPage <= 0 || perPage > 100 {
+		perPage = 100
+	}
 	opts := &gh.PullRequestListOptions{
 		State:     "open",
 		Sort:      "updated",
@@ -618,9 +623,17 @@ func (ic *InstallationClient) ListOpenPullRequestsPage(ctx context.Context, repo
 			Page:    page,
 		},
 	}
-	ghPRs, resp, err := ic.client.PullRequests.List(ctx, owner, repoName, opts)
+	var resp *gh.Response
+	ghPRs, err := retryGitHubUnavailableRead(ctx, ic.logger, "list open pull requests", []any{"repo", repo, "page", page}, func(ctx context.Context) ([]*gh.PullRequest, error) {
+		list, listResp, listErr := ic.client.PullRequests.List(ctx, owner, repoName, opts)
+		if listErr != nil {
+			return nil, classifyGitHubAPIError(listErr)
+		}
+		resp = listResp
+		return list, nil
+	})
 	if err != nil {
-		return nil, 0, fmt.Errorf("list open pull requests for %s page %d: %w", repo, page, classifyGitHubAPIError(err))
+		return nil, 0, fmt.Errorf("list open pull requests for %s page %d: %w", repo, page, err)
 	}
 	for _, pr := range ghPRs {
 		prs = append(prs, OpenPullRequest{

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -589,6 +589,55 @@ type PullRequestInfo struct {
 	State string
 }
 
+// OpenPullRequest holds the PR metadata needed for operator scans.
+type OpenPullRequest struct {
+	Number  int
+	Title   string
+	HeadRef string
+	HeadSHA string
+	BaseRef string
+	User    string
+}
+
+// ListOpenPullRequestsPage lists one page of open pull requests in a
+// repository, newest updated first. page is 1-based (0 selects the first
+// page). nextPage is 0 when no further pages exist. Fetching one bounded page
+// per call lets operator scans run as many short requests instead of one
+// long one.
+func (ic *InstallationClient) ListOpenPullRequestsPage(ctx context.Context, repo string, page, perPage int) (prs []OpenPullRequest, nextPage int, err error) {
+	owner, repoName := splitRepo(repo)
+	if page <= 0 {
+		page = 1
+	}
+	opts := &gh.PullRequestListOptions{
+		State:     "open",
+		Sort:      "updated",
+		Direction: "desc",
+		ListOptions: gh.ListOptions{
+			PerPage: perPage,
+			Page:    page,
+		},
+	}
+	ghPRs, resp, err := ic.client.PullRequests.List(ctx, owner, repoName, opts)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list open pull requests for %s page %d: %w", repo, page, classifyGitHubAPIError(err))
+	}
+	for _, pr := range ghPRs {
+		prs = append(prs, OpenPullRequest{
+			Number:  pr.GetNumber(),
+			Title:   pr.GetTitle(),
+			HeadRef: pr.GetHead().GetRef(),
+			HeadSHA: pr.GetHead().GetSHA(),
+			BaseRef: pr.GetBase().GetRef(),
+			User:    pr.GetUser().GetLogin(),
+		})
+	}
+	if resp != nil {
+		nextPage = resp.NextPage
+	}
+	return prs, nextPage, nil
+}
+
 // IsClosed reports whether the PR is closed (merged or unmerged). Callers that
 // act on a PR asynchronously — timers, reconciliation — use this to stop work
 // that only makes sense on an open PR.

--- a/pkg/serve/serve.go
+++ b/pkg/serve/serve.go
@@ -630,6 +630,7 @@ func buildSingleAppWebhookRuntime(serverConfig *api.ServerConfig, svc *api.Servi
 		ghclient.WithConfigDirHints(serverConfig))
 	handler := webhook.NewHandler(svc, ghClient, []byte(ghWebhookSecret), logger,
 		webhook.WithRepoWebhookSecret([]byte(repoWebhookSecret)))
+	svc.SetCheckRunBackfiller(handler)
 	logger.Info("GitHub webhook endpoint registered",
 		"app_id", appID, "trusted_check_app_slugs", serverConfig.GitHub.TrustedCheckAppSlugs,
 		"repo_webhook_dispatch", repoWebhookSecret != "")
@@ -704,6 +705,7 @@ func buildMultiAppWebhookRuntime(serverConfig *api.ServerConfig, svc *api.Servic
 		appByID,
 		logger,
 	)
+	svc.SetCheckRunBackfiller(handler)
 	logger.Info("GitHub multi-App webhook endpoint registered", "apps", len(serverConfig.Apps))
 	return webhookRuntime{
 		handler:                         handler,

--- a/pkg/webhook/checks_backfill.go
+++ b/pkg/webhook/checks_backfill.go
@@ -1,0 +1,34 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+)
+
+// BackfillPRCheckRuns recreates a PR's SchemaBot Check Runs by replaying the
+// auto-plan flow against the PR's current head, exactly as the check-creating
+// webhook delivery would have — a PR with no managed schema changes gets its
+// passing aggregate, a PR with schema changes gets real auto-plans, and the
+// leader/participant aggregate routing applies unchanged. Serves the checks
+// operator endpoints for PRs whose delivery was never sent (for example PRs
+// opened before check enablement) or is no longer retained by GitHub.
+func (h *Handler) BackfillPRCheckRuns(ctx context.Context, repo string, pr int, installationID int64) (string, error) {
+	client, err := h.clientForRepo(repo, installationID)
+	if err != nil {
+		return "", fmt.Errorf("create GitHub client to backfill Check Runs for %s#%d: %w", repo, pr, err)
+	}
+	prInfo, err := client.FetchPullRequest(ctx, repo, pr)
+	if err != nil {
+		return "", fmt.Errorf("fetch PR to backfill Check Runs for %s#%d: %w", repo, pr, err)
+	}
+	if prInfo.IsClosed() {
+		// Close-time cleanup owns a closed PR's check state; recreating Check
+		// Runs there would resurrect what cleanup settled.
+		h.logger.Info("Check Run backfill skipping closed PR", "repo", repo, "pr", pr)
+		return "skipped: PR is closed", nil
+	}
+	h.logger.Info("backfilling Check Runs via the auto-plan flow",
+		"repo", repo, "pr", pr, "head_sha", prInfo.HeadSHA)
+	message := h.runAutoPlanForPR(ctx, client, repo, pr, prInfo.HeadSHA, installationID, "checks.backfill", "checks.backfill", "")
+	return message, nil
+}

--- a/pkg/webhook/checks_backfill_test.go
+++ b/pkg/webhook/checks_backfill_test.go
@@ -1,0 +1,60 @@
+package webhook
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ghclient "github.com/block/schemabot/pkg/github"
+)
+
+// A Check Run backfill on a closed PR is refused: close-time cleanup owns a
+// closed PR's stored check state, so recreating Check Runs there would
+// resurrect what cleanup settled.
+func TestBackfillPRCheckRunsSkipsClosedPR(t *testing.T) {
+	client, mux := setupGitHubServer(t)
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"state": "closed",
+			"head":  map[string]any{"sha": "abc123", "ref": "feature-branch"},
+			"base":  map[string]any{"sha": "def456", "ref": "main"},
+			"user":  map[string]any{"login": "testuser"},
+		}))
+	})
+	h := actorAuthStorageTestHandler(actorAuthTestConfig(false), &emptyStorage{}, ghclient.NewInstallationClient(client, testLogger()))
+
+	outcome, err := h.BackfillPRCheckRuns(t.Context(), "octocat/hello-world", 1, 12345)
+
+	require.NoError(t, err)
+	assert.Equal(t, "skipped: PR is closed", outcome)
+}
+
+// A backfill on an open PR replays the auto-plan flow against the PR's
+// current head — for a PR with no managed schema changes, that is the
+// passing-aggregate path a real check-creating delivery would have taken.
+func TestBackfillPRCheckRunsReplaysAutoPlanFlow(t *testing.T) {
+	client, mux := setupGitHubServer(t)
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"state": "open",
+			"head":  map[string]any{"sha": "abc123", "ref": "feature-branch"},
+			"base":  map[string]any{"sha": "def456", "ref": "main"},
+			"user":  map[string]any{"login": "testuser"},
+		}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode([]map[string]string{{
+			"filename": "docs/readme.md",
+			"status":   "modified",
+		}}))
+	})
+	h := actorAuthStorageTestHandler(actorAuthTestConfig(false), &emptyStorage{}, ghclient.NewInstallationClient(client, testLogger()))
+
+	outcome, err := h.BackfillPRCheckRuns(t.Context(), "octocat/hello-world", 1, 12345)
+
+	require.NoError(t, err)
+	assert.Equal(t, "no schema files in PR", outcome)
+}


### PR DESCRIPTION
## Why this matters

A PR can be left waiting on a SchemaBot Check Run that nothing will create — it predates check enablement for the repo, or the check-creating webhook delivery was lost. Operators need a native, auth-gated way to find those PRs and recreate their checks without a hand-run GitHub API script.

## What it does

Adds the server surface for missing-Check-Run recovery (all write tier):

```
POST /api/checks/scan       → page open PRs, report which are missing the
                              configured Check Runs
POST /api/checks/synthesize → recreate a PR's Check Runs by replaying the
                              auto-plan flow (as a real delivery would have)
POST /api/webhooks/redrive  → gains a delivery-IDs mode: redeliver exactly
   (delivery_ids)             these deliveries, skipping the window crawl
```

- **Synthesize reuses the real pipeline.** It calls a `CheckRunBackfiller` the webhook handler implements (`BackfillPRCheckRuns`), which replays the auto-plan entry against the PR's current head — passing aggregates for no-schema PRs, real auto-plans for schema PRs, leader/participant routing unchanged, closed PRs refused (close-time cleanup owns their state). It's the same fail-closed path a delivery would have taken, not a new check-creation path. Wired from the webhook runtime at serve startup.
- **Scan is chunked** — one page of open PRs per request (`ListOpenPullRequestsPage`), so a big repo can't outlive an intermediary timeout.
- **Redrive-by-IDs** lets a caller that already identified failed deliveries redeliver them precisely, without re-crawling the window.

The operator CLI that drives these (`schemabot checks backfill`) ships in the stacked follow-up.

## Example payloads

**`POST /api/checks/scan`** — one page of open PRs missing the configured checks:

```json
{ "repo": "owner/repo", "environment": "production", "page": 1 }
```
```json
{
  "repo": "owner/repo",
  "check_names": ["SchemaBot (production)"],
  "scanned": 30,
  "next_page": 2,
  "missing": [
    {
      "number": 123,
      "url": "https://github.com/owner/repo/pull/123",
      "title": "Add index to orders",
      "head_sha": "abc123",
      "head_ref": "feature/orders-index",
      "missing_check_names": ["SchemaBot (production)"],
      "untrusted_conflict_check_names": ["SchemaBot (production)"]
    }
  ]
}
```
`untrusted_conflict_check_names` appears only when a same-named Check Run already exists from an untrusted app.

**`POST /api/checks/synthesize`** — recreate the checks for specific PRs (≤10 per request):

```json
{ "repo": "owner/repo", "prs": [123, 456] }
```
```json
{
  "repo": "owner/repo",
  "results": [
    { "pr": 123, "outcome": "no schema files in PR" },
    { "pr": 456, "outcome": "", "error": "fetch PR 456: not found" }
  ]
}
```

**`POST /api/webhooks/redrive`** — delivery-IDs mode (redeliver exact deliveries, no window crawl):

```json
{ "app": "production", "delivery_ids": [3830093123445358592, 3830093987654321012] }
```
```json
{
  "results": [
    { "app_name": "production", "redelivered": 2, "failed": 0, "selected": [] }
  ]
}
```

## How this differs from `webhooks redrive` (#690)

Both recover PRs whose SchemaBot checks are missing, but they operate on different objects and cover different causes — they are complements, not overlaps:

| | `webhooks redrive` (#690) | `checks scan` / `synthesize` (this PR) |
|---|---|---|
| Operates on | GitHub webhook **deliveries** | SchemaBot **Check Runs** on PRs |
| Scoped by | a **time window** (cross-repo, all Apps) | a **repo** (its open PRs) |
| Precondition | a **failed delivery must exist** to re-send | **none** — synthesize creates the check even with no delivery |
| Mechanism | re-send the original event, let it flow normally | replay the auto-plan flow server-side directly |
| Fits | a known delivery **outage** ("webhooks were down 3:00–3:20") | a repo with **stuck PRs**, whatever the cause |

The decisive gap: redrive can only re-send a delivery that once existed and failed. It **cannot** help a PR whose delivery was **never sent** (opened before check enablement) or is **no longer retained** by GitHub — there is nothing to redrive. `synthesize` handles exactly that case by recreating the check through the auto-plan flow without needing any delivery.

They compose rather than duplicate: the `checks backfill` CLI (stacked follow-up) redrives-by-ID when a delivery is still retained and synthesizes when it isn'"'"'t, so each PR gets the native remedy.

## Code-host boundary (#695)

These are GitHub-*shell* operator endpoints (webhook deliveries, Check Runs) — the host-neutral core (planning, engines, storage, reconciliation) is untouched, and check recreation already goes through a `CheckRunBackfiller` seam rather than calling GitHub from the API layer. If a second code host ever appears, this trio is a candidate to sit behind a merge-gate/status-publication capability provider; per #695 no such adapter is built now.

## How it moves toward the northstar

Required SchemaBot checks can be enabled (or re-enabled) on any repo without stranding its existing open PRs — the server can converge a stuck PR to the state the webhooks would have produced.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)



