### PR TITLE
feat(github): volume PR comment command, accepted template, and progress rendering

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -3032,7 +3032,7 @@ Cutover is already in progress. SchemaBot will keep reporting progress from the 
 **Environment**: `staging`
 **Requested by**: @alice
 
-Volume change to 8 queued; the driver applies it at its next progress check. Status remains available from the PR progress comment or CLI.
+Volume change to 8 requested. SchemaBot will adjust the speed of this schema change shortly; status remains available from the PR progress comment or CLI.
 
 </details>
 
@@ -5497,7 +5497,7 @@ Cutover is already in progress. SchemaBot will keep reporting progress from the 
 **Environment**: `staging`
 **Requested by**: @alice
 
-Volume change to 8 queued; the driver applies it at its next progress check. Status remains available from the PR progress comment or CLI.
+Volume change to 8 requested. SchemaBot will adjust the speed of this schema change shortly; status remains available from the PR progress comment or CLI.
 
 
 </details>

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -770,6 +770,7 @@ schemabot apply -e staging --allow-unsafe
 | `schemabot start <apply-id> -e <env>` | Resume a stopped deployment |
 | `schemabot release <apply-id> -e <env>` | Release a paused rollout to proceed |
 | `schemabot cutover <apply-id> -e <env>` | Complete a deferred cutover |
+| `schemabot volume <apply-id> -e <env> -v <level>` | Adjust schema change speed (1=slowest, 11=fastest) |
 | `schemabot rollback <apply-id> -e <env> [-t <tenant>]` | Generate a rollback plan |
 | `schemabot rollback-confirm -e <env> [-t <tenant>]` | Execute a rollback |
 
@@ -800,6 +801,7 @@ That command wasn't recognized. Available commands:
 | `schemabot start <apply-id> -e <env>` | Resume a stopped deployment |
 | `schemabot release <apply-id> -e <env>` | Release a paused rollout to proceed |
 | `schemabot cutover <apply-id> -e <env>` | Complete a deferred cutover |
+| `schemabot volume <apply-id> -e <env> -v <level>` | Adjust schema change speed (1=slowest, 11=fastest) |
 | `schemabot rollback <apply-id> -e <env> [-t <tenant>]` | Generate a rollback plan |
 | `schemabot rollback-confirm -e <env> [-t <tenant>]` | Execute a rollback |
 
@@ -994,6 +996,7 @@ That command wasn't recognized. Available commands:
 | `schemabot start <apply-id> -e <env>` | Resume a stopped deployment |
 | `schemabot release <apply-id> -e <env>` | Release a paused rollout to proceed |
 | `schemabot cutover <apply-id> -e <env>` | Complete a deferred cutover |
+| `schemabot volume <apply-id> -e <env> -v <level>` | Adjust schema change speed (1=slowest, 11=fastest) |
 | `schemabot rollback <apply-id> -e <env> [-t <tenant>]` | Generate a rollback plan |
 | `schemabot rollback-confirm -e <env> [-t <tenant>]` | Execute a rollback |
 

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -3032,7 +3032,7 @@ Cutover is already in progress. SchemaBot will keep reporting progress from the 
 **Environment**: `staging`
 **Requested by**: @alice
 
-Volume change to 8 requested. SchemaBot will adjust the speed of this schema change shortly; status remains available from the PR progress comment or CLI.
+Volume change to 8 requested. SchemaBot will adjust the speed of this schema change shortly; the progress comment on this PR shows the current level.
 
 </details>
 
@@ -5497,7 +5497,7 @@ Cutover is already in progress. SchemaBot will keep reporting progress from the 
 **Environment**: `staging`
 **Requested by**: @alice
 
-Volume change to 8 requested. SchemaBot will adjust the speed of this schema change shortly; status remains available from the PR progress comment or CLI.
+Volume change to 8 requested. SchemaBot will adjust the speed of this schema change shortly; the progress comment on this PR shows the current level.
 
 
 </details>

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -1884,6 +1884,37 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 </details>
 
 <details>
+<summary><a name="single-table-running-volume-tuned"></a><strong>Single Table: Running (Volume Tuned)</strong></summary>
+
+
+## Schema Change Status — Staging
+
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
+
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: In Progress | Volume: 8/11
+
+**`users`**: 🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 48%
+
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+```
+Rows: 3,500,000 / 7,200,000 · ETA: 5m 30s
+
+
+---
+
+To stop this schema change:
+```
+schemabot stop apply-a1b2c3d4e5f6 -e staging
+```
+
+_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
+
+</details>
+
+<details>
 <summary><a name="single-table-completed"></a><strong>Single Table: Completed</strong></summary>
 
 
@@ -2989,6 +3020,31 @@ Cutover request accepted. SchemaBot will complete this schema change; status rem
 
 Cutover is already in progress. SchemaBot will keep reporting progress from the existing apply.
 
+</details>
+
+<details>
+<summary><a name="volume-command-accepted"></a><strong>Volume Command Accepted</strong></summary>
+
+
+## Volume Request Accepted
+
+**Apply**: `apply-a1b2c3d4e5f67890`
+**Environment**: `staging`
+**Requested by**: @alice
+
+Volume change to 8 queued; the driver applies it at its next progress check. Status remains available from the PR progress comment or CLI.
+
+</details>
+
+<details>
+<summary><a name="volume-command-invalid-level"></a><strong>Volume Command Invalid Level</strong></summary>
+
+
+## Missing or Invalid Volume Level
+
+Usage: `schemabot volume <apply-id> -e <environment> -v <level>`
+
+The `-v` flag is required and must be a number between 1 (slowest) and 11 (fastest).
 </details>
 
 <details>
@@ -5428,6 +5484,33 @@ Cutover request accepted. SchemaBot will complete this schema change; status rem
 
 Cutover is already in progress. SchemaBot will keep reporting progress from the existing apply.
 
+
+</details>
+
+<details>
+<summary><a name="volume-command-accepted"></a><strong>Volume Command Accepted</strong></summary>
+
+
+## Volume Request Accepted
+
+**Apply**: `apply-a1b2c3d4e5f67890`
+**Environment**: `staging`
+**Requested by**: @alice
+
+Volume change to 8 queued; the driver applies it at its next progress check. Status remains available from the PR progress comment or CLI.
+
+
+</details>
+
+<details>
+<summary><a name="volume-command-invalid-level"></a><strong>Volume Command Invalid Level</strong></summary>
+
+
+## Missing or Invalid Volume Level
+
+Usage: `schemabot volume <apply-id> -e <environment> -v <level>`
+
+The `-v` flag is required and must be a number between 1 (slowest) and 11 (fastest).
 
 </details>
 

--- a/pkg/api/control_handlers.go
+++ b/pkg/api/control_handlers.go
@@ -1928,28 +1928,55 @@ func (s *Service) handleVolume(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := client.Volume(r.Context(), &ternv1.VolumeRequest{
-		ApplyId:     applyID,
-		Environment: apply.Environment,
-		Volume:      req.Volume,
-	})
+	resp, err := s.executeVolumeForApply(r.Context(), client, apply, applyID, req.Caller, req.Volume)
 	if err != nil {
-		metrics.RecordControlOperation(r.Context(), "volume", apply.Database, apply.Deployment, apply.Environment, "error")
 		s.writeControlError(w, "volume", apply, err)
 		return
 	}
-	metrics.RecordControlOperation(r.Context(), "volume", apply.Database, apply.Deployment, apply.Environment, controlStatus(resp.Accepted))
+	s.writeJSON(w, http.StatusOK, resp)
+}
+
+// ExecuteVolume queues a durable volume adjustment for an apply. The driving
+// instance retunes the engine at its next progress tick. It resolves the
+// apply's data-plane client and proxies the request, so the HTTP handler and
+// the PR-comment command share one path — the tern client owns the gating
+// (terminal apply, conflicting pending level, multi-deployment apply).
+func (s *Service) ExecuteVolume(ctx context.Context, req apitypes.ControlRequest, volume int32) (*apitypes.VolumeResponse, error) {
+	if volume < storage.MinVolume || volume > storage.MaxVolume {
+		return nil, controlHTTPErrorf(http.StatusBadRequest, "volume must be between %d and %d", storage.MinVolume, storage.MaxVolume)
+	}
+	client, apply, ternApplyID, err := s.controlTarget(ctx, "volume", req.ApplyID, req.Environment)
+	if err != nil {
+		return nil, err
+	}
+	return s.executeVolumeForApply(ctx, client, apply, ternApplyID, req.Caller, volume)
+}
+
+// executeVolumeForApply proxies the volume adjustment to the apply's tern
+// client, which queues a durable control request for the driver, and records
+// an apply log entry when the queue accepts the level.
+func (s *Service) executeVolumeForApply(ctx context.Context, client tern.Client, apply *storage.Apply, ternApplyID, caller string, volume int32) (*apitypes.VolumeResponse, error) {
+	resp, err := client.Volume(ctx, &ternv1.VolumeRequest{
+		ApplyId:     ternApplyID,
+		Environment: apply.Environment,
+		Volume:      volume,
+	})
+	if err != nil {
+		metrics.RecordControlOperation(ctx, "volume", apply.Database, apply.Deployment, apply.Environment, "error")
+		return nil, fmt.Errorf("queue volume change to %d for apply %s: %w", volume, apply.ApplyIdentifier, err)
+	}
+	metrics.RecordControlOperation(ctx, "volume", apply.Database, apply.Deployment, apply.Environment, controlStatus(resp.Accepted))
 	if resp.Accepted {
-		s.logControlOperationForApply(r.Context(), apply, resolveCaller(r.Context(), req.Caller), storage.LogEventVolumeRequested,
-			fmt.Sprintf("Volume change to %d queued; the driver applies it at its next progress check", req.Volume))
+		s.logControlOperationForApply(ctx, apply, resolveCaller(ctx, caller), storage.LogEventVolumeRequested,
+			fmt.Sprintf("Volume change to %d queued; the driver applies it at its next progress check", volume))
 	}
 
-	s.writeJSON(w, http.StatusOK, &apitypes.VolumeResponse{
+	return &apitypes.VolumeResponse{
 		Accepted:       resp.Accepted,
 		ErrorMessage:   resp.ErrorMessage,
 		PreviousVolume: resp.PreviousVolume,
 		NewVolume:      resp.NewVolume,
-	})
+	}, nil
 }
 
 // RevertRequest is the HTTP request body for POST /api/revert.

--- a/pkg/cmd/commands/preview.go
+++ b/pkg/cmd/commands/preview.go
@@ -114,7 +114,8 @@ func (cmd *PreviewCmd) Run(g *Globals) error {
 		templates.PreviewCommentActorNotAuthorized, templates.PreviewCommentActorAuthUnavailable,
 		templates.PreviewCommentDatabaseNotConfigured,
 		templates.PreviewCommentStartAccepted, templates.PreviewCommentStartPending,
-		templates.PreviewCommentCutoverAccepted, templates.PreviewCommentCutoverActive:
+		templates.PreviewCommentCutoverAccepted, templates.PreviewCommentCutoverActive,
+		templates.PreviewCommentVolumeAccepted, templates.PreviewCommentVolumeInvalid:
 		templates.PreviewCLIOutput(previewType)
 	// Paired aggregate types (PR + CLI subsections)
 	case templates.PreviewCommentPlanAll, templates.PreviewCommentLockingAll,
@@ -301,6 +302,8 @@ Apply Command Comments (GitHub PR apply commands):
   comment_start_pending         Start already pending
   comment_cutover_accepted      Cutover request accepted
   comment_cutover_active        Cutover already in progress
+  comment_volume_accepted       Volume request accepted
+  comment_volume_invalid        Volume command with a missing or invalid level
   comment_apply_all             Show all apply command previews
 
 Aggregate Types (grouped PR + CLI pairs):

--- a/pkg/cmd/internal/templates/preview.go
+++ b/pkg/cmd/internal/templates/preview.go
@@ -192,5 +192,7 @@ const (
 	PreviewCommentStartPending          PreviewType = "comment_start_pending"                // Start command when start is already pending
 	PreviewCommentCutoverAccepted       PreviewType = "comment_cutover_accepted"             // Cutover command accepted
 	PreviewCommentCutoverActive         PreviewType = "comment_cutover_active"               // Cutover command when cutover is already in progress
+	PreviewCommentVolumeAccepted        PreviewType = "comment_volume_accepted"              // Volume command accepted
+	PreviewCommentVolumeInvalid         PreviewType = "comment_volume_invalid"               // Volume command with a missing or invalid level
 	PreviewCommentApplyAllType          PreviewType = "comment_apply_all"                    // Show all apply comment previews
 )

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -76,6 +76,8 @@ func previewCommentAllOutput() {
 		{"APPLY CUTTING OVER", func() { fmt.Print(webhooktemplates.PreviewCommentApplyCuttingOver()) }},
 		{"CUTOVER COMMAND ACCEPTED", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAccepted()) }},
 		{"CUTOVER COMMAND ALREADY IN PROGRESS", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAlreadyInProgress()) }},
+		{"VOLUME COMMAND ACCEPTED", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeCommandAccepted()) }},
+		{"VOLUME COMMAND INVALID LEVEL", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeInvalidLevel()) }},
 		{"SUMMARY: COMPLETED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryCompleted()) }},
 		{"SUMMARY: FAILED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryFailed()) }},
 		{"SUMMARY: STOPPED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryStopped()) }},
@@ -124,6 +126,8 @@ func previewApplyCommandAllOutput() {
 		{"START COMMAND ALREADY PENDING", func() { fmt.Print(webhooktemplates.PreviewCommentStartCommandAlreadyRequested()) }},
 		{"CUTOVER COMMAND ACCEPTED", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAccepted()) }},
 		{"CUTOVER COMMAND ALREADY IN PROGRESS", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAlreadyInProgress()) }},
+		{"VOLUME COMMAND ACCEPTED", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeCommandAccepted()) }},
+		{"VOLUME COMMAND INVALID LEVEL", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeInvalidLevel()) }},
 		{"CHECKS GATE: NOT PASSING", func() {
 			fmt.Print(webhooktemplates.RenderApplyBlockedByNonPassingChecks("staging", []webhooktemplates.BlockingCheck{
 				{Name: "CI / unit-tests", State: "failure"},
@@ -221,6 +225,7 @@ func previewCommentApplyFlowAllOutput() {
 		{"APPLY STARTED", func() { fmt.Print(webhooktemplates.PreviewCommentApplyStarted()) }},
 		// Single-table (most common case)
 		{"SINGLE TABLE: RUNNING", func() { fmt.Print(webhooktemplates.PreviewCommentApplySingleProgress()) }},
+		{"SINGLE TABLE: RUNNING (VOLUME TUNED)", func() { fmt.Print(webhooktemplates.PreviewCommentApplySingleProgressVolume()) }},
 		{"SINGLE TABLE: COMPLETED", func() { fmt.Print(webhooktemplates.PreviewCommentApplySingleCompleted()) }},
 		{"SINGLE TABLE: FAILED", func() { fmt.Print(webhooktemplates.PreviewCommentApplySingleFailed()) }},
 		{"SINGLE TABLE: STOPPED", func() { fmt.Print(webhooktemplates.PreviewCommentApplySingleStopped()) }},
@@ -255,6 +260,8 @@ func previewCommentApplyFlowAllOutput() {
 		{"START COMMAND ALREADY PENDING", func() { fmt.Print(webhooktemplates.PreviewCommentStartCommandAlreadyRequested()) }},
 		{"CUTOVER COMMAND ACCEPTED", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAccepted()) }},
 		{"CUTOVER COMMAND ALREADY IN PROGRESS", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAlreadyInProgress()) }},
+		{"VOLUME COMMAND ACCEPTED", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeCommandAccepted()) }},
+		{"VOLUME COMMAND INVALID LEVEL", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeInvalidLevel()) }},
 		// Summaries
 		{"SUMMARY: COMPLETED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryCompleted()) }},
 		{"SUMMARY: FAILED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryFailed()) }},

--- a/pkg/cmd/internal/templates/preview_dispatch.go
+++ b/pkg/cmd/internal/templates/preview_dispatch.go
@@ -273,6 +273,10 @@ func PreviewCLIOutput(previewType PreviewType) {
 		fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAccepted())
 	case PreviewCommentCutoverActive:
 		fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAlreadyInProgress())
+	case PreviewCommentVolumeAccepted:
+		fmt.Print(webhooktemplates.PreviewCommentVolumeCommandAccepted())
+	case PreviewCommentVolumeInvalid:
+		fmt.Print(webhooktemplates.PreviewCommentVolumeInvalidLevel())
 	case PreviewCommentApplyAllType:
 		previewApplyCommandAllOutput()
 	// Paired aggregate previews (PR + CLI subsections)

--- a/pkg/webhook/action/action.go
+++ b/pkg/webhook/action/action.go
@@ -12,6 +12,7 @@ const (
 	Start           = "start"
 	Release         = "release"
 	Cutover         = "cutover"
+	Volume          = "volume"
 	Revert          = "revert"
 	SkipRevert      = "skip-revert"
 	Rollback        = "rollback"

--- a/pkg/webhook/apply.go
+++ b/pkg/webhook/apply.go
@@ -32,6 +32,7 @@ func buildApplyCommentData(apply *storage.Apply, tasks []*storage.Task, display 
 		VSchemaChanges:   display.VSchema,
 		DeployRequestURL: display.DeployRequestURL,
 		RevertExpiresAt:  display.RevertExpiresAt,
+		Volume:           apply.GetOptions().Volume,
 	}
 	if apply.StartedAt != nil {
 		data.StartedAt = apply.StartedAt.Format(time.RFC3339)

--- a/pkg/webhook/commands.go
+++ b/pkg/webhook/commands.go
@@ -144,7 +144,7 @@ func NewCommandParser() *CommandParser {
 		allowUnsafeRegex:  regexp.MustCompile(`(?i)--allow-unsafe\b`),
 		forceRegex:        regexp.MustCompile(`(?i)--force\b`),
 		autoConfirmRegex:  regexp.MustCompile(`(?i)(?:--yes\b|-y\b)`),
-		volumeFlagRegex:   regexp.MustCompile(`(?i)(?:^|\s)(?:--volume|-v)(?:[ \t]+([^\s]+))?`),
+		volumeFlagRegex:   regexp.MustCompile(`(?i)(?:^|\s)(?:--volume|-v)(?:[ \t]+([^\s]+))?(?:\s|$)`),
 	}
 }
 

--- a/pkg/webhook/commands.go
+++ b/pkg/webhook/commands.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/block/schemabot/pkg/webhook/action"
@@ -48,6 +49,13 @@ type CommandSpec struct {
 
 	// SupportsForce means `--force` is recognized.
 	SupportsForce bool
+
+	// SupportsVolumeLevel means `-v <level>` / `--volume <level>` is recognized.
+	// The parser extracts the numeric level into CommandResult.VolumeLevel and
+	// flags a present-but-unparseable value via VolumeLevelError; range
+	// validation stays with the dispatcher so the rejection comment can cite
+	// the valid range.
+	SupportsVolumeLevel bool
 }
 
 // commandSpecs is the registry of all SchemaBot commands. Order does not
@@ -71,6 +79,7 @@ var commandSpecs = []CommandSpec{
 	{Name: action.Revert, RequiresEnv: true, HasApplyID: true},
 	{Name: action.SkipRevert, RequiresEnv: true, HasApplyID: true},
 	{Name: action.Cutover, RequiresEnv: true, HasApplyID: true},
+	{Name: action.Volume, RequiresEnv: true, HasApplyID: true, SupportsVolumeLevel: true},
 	{Name: action.Rollback, RequiresEnv: true, HasApplyID: true},
 	{Name: action.RollbackConfirm, RequiresEnv: true, SupportsDeferCutover: true},
 }
@@ -116,6 +125,7 @@ type CommandParser struct {
 	allowUnsafeRegex  *regexp.Regexp
 	forceRegex        *regexp.Regexp
 	autoConfirmRegex  *regexp.Regexp
+	volumeFlagRegex   *regexp.Regexp
 }
 
 // NewCommandParser creates a new command parser.
@@ -134,6 +144,7 @@ func NewCommandParser() *CommandParser {
 		allowUnsafeRegex:  regexp.MustCompile(`(?i)--allow-unsafe\b`),
 		forceRegex:        regexp.MustCompile(`(?i)--force\b`),
 		autoConfirmRegex:  regexp.MustCompile(`(?i)(?:--yes\b|-y\b)`),
+		volumeFlagRegex:   regexp.MustCompile(`(?i)(?:^|\s)(?:--volume|-v)(?:[ \t]+([^\s]+))?`),
 	}
 }
 
@@ -154,10 +165,17 @@ type CommandResult struct {
 	AllowUnsafe  bool
 	Force        bool
 	AutoConfirm  bool
-	Found        bool
-	IsHelp       bool
-	IsMention    bool
-	MissingEnv   bool
+	// VolumeLevel is the numeric level from `-v` / `--volume` on commands whose
+	// spec opts into SupportsVolumeLevel. Zero means the flag was absent.
+	VolumeLevel int32
+	// VolumeLevelError is true when `-v` / `--volume` is present without a
+	// numeric value, so the dispatcher can post a usage comment instead of
+	// treating the command as flagless.
+	VolumeLevelError bool
+	Found            bool
+	IsHelp           bool
+	IsMention        bool
+	MissingEnv       bool
 }
 
 // ParseCommand parses a SchemaBot command from a comment body.
@@ -206,6 +224,24 @@ func (p *CommandParser) firstDirectiveLine(body string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// extractVolumeLevel returns the numeric level from `-v` / `--volume` and
+// whether the flag was present but unusable (missing value or non-numeric).
+// An absent flag returns (0, false); range validation is the dispatcher's job.
+func (p *CommandParser) extractVolumeLevel(body string) (int32, bool) {
+	match := p.volumeFlagRegex.FindStringSubmatch(body)
+	if len(match) == 0 {
+		return 0, false
+	}
+	if len(match) < 2 || match[1] == "" {
+		return 0, true
+	}
+	level, err := strconv.ParseInt(match[1], 10, 32)
+	if err != nil {
+		return 0, true
+	}
+	return int32(level), false
 }
 
 func (p *CommandParser) extractTenant(body string) (string, bool) {
@@ -275,6 +311,9 @@ func (p *CommandParser) applySpec(spec CommandSpec, body, tenant string, tenantE
 	}
 	if spec.SupportsAutoConfirm {
 		result.AutoConfirm = p.autoConfirmRegex.MatchString(body)
+	}
+	if spec.SupportsVolumeLevel {
+		result.VolumeLevel, result.VolumeLevelError = p.extractVolumeLevel(body)
 	}
 
 	if m := p.environmentRegex.FindStringSubmatch(body); len(m) >= 2 {

--- a/pkg/webhook/commands_test.go
+++ b/pkg/webhook/commands_test.go
@@ -352,6 +352,39 @@ func TestParseVolumeCommand(t *testing.T) {
 				IsMention:   true,
 			},
 		},
+		{
+			name: "flag prefix of a longer flag is not a volume flag",
+			body: "schemabot volume apply_abc123 -e staging --volume-level 5",
+			expected: CommandResult{
+				Action:      action.Volume,
+				ApplyID:     "apply_abc123",
+				Environment: "staging",
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
+			name: "word starting with -v is not a volume flag",
+			body: "schemabot volume apply_abc123 -e staging -verbose",
+			expected: CommandResult{
+				Action:      action.Volume,
+				ApplyID:     "apply_abc123",
+				Environment: "staging",
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
+			name: "level attached to the flag without a space is not parsed",
+			body: "schemabot volume apply_abc123 -e staging -v8",
+			expected: CommandResult{
+				Action:      action.Volume,
+				ApplyID:     "apply_abc123",
+				Environment: "staging",
+				Found:       true,
+				IsMention:   true,
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/webhook/commands_test.go
+++ b/pkg/webhook/commands_test.go
@@ -25,6 +25,7 @@ func TestCommandSpecs_CoverEveryDispatcherAction(t *testing.T) {
 		action.Revert,
 		action.SkipRevert,
 		action.Cutover,
+		action.Volume,
 		action.Rollback,
 		action.RollbackConfirm,
 	}
@@ -49,6 +50,7 @@ func TestCommandSpecs_FlagsRespected(t *testing.T) {
 		supportsDefer       bool
 		supportsAllowUnsafe bool
 		supportsForce       bool
+		supportsVolumeLevel bool
 	}{
 		{name: action.Help},
 		{name: action.Plan, requiresEnv: true, supportsDB: true},
@@ -66,6 +68,7 @@ func TestCommandSpecs_FlagsRespected(t *testing.T) {
 		{name: action.Revert, requiresEnv: true, hasApplyID: true},
 		{name: action.SkipRevert, requiresEnv: true, hasApplyID: true},
 		{name: action.Cutover, requiresEnv: true, hasApplyID: true},
+		{name: action.Volume, requiresEnv: true, hasApplyID: true, supportsVolumeLevel: true},
 		{name: action.Rollback, requiresEnv: true, hasApplyID: true},
 		{name: action.RollbackConfirm, requiresEnv: true, supportsDefer: true},
 	}
@@ -81,6 +84,7 @@ func TestCommandSpecs_FlagsRespected(t *testing.T) {
 			assert.Equal(t, tc.supportsDefer, spec.SupportsDeferCutover, "SupportsDeferCutover")
 			assert.Equal(t, tc.supportsAllowUnsafe, spec.SupportsAllowUnsafe, "SupportsAllowUnsafe")
 			assert.Equal(t, tc.supportsForce, spec.SupportsForce, "SupportsForce")
+			assert.Equal(t, tc.supportsVolumeLevel, spec.SupportsVolumeLevel, "SupportsVolumeLevel")
 		})
 	}
 }
@@ -238,6 +242,121 @@ func TestParseTenantFlag(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.result, parser.ParseCommand(tc.body))
+		})
+	}
+}
+
+// TestParseVolumeCommand verifies the volume command parses its apply id,
+// environment, and numeric -v/--volume level, and that a present-but-unusable
+// level is flagged via VolumeLevelError so the dispatcher can post usage help
+// instead of silently dropping the command. Range validation is deliberately
+// left to the dispatcher, so out-of-range numbers parse cleanly here.
+func TestParseVolumeCommand(t *testing.T) {
+	parser := NewCommandParser()
+
+	tests := []struct {
+		name     string
+		body     string
+		expected CommandResult
+	}{
+		{
+			name: "volume with level",
+			body: "schemabot volume apply_abc123 -e staging -v 8",
+			expected: CommandResult{
+				Action:      action.Volume,
+				ApplyID:     "apply_abc123",
+				Environment: "staging",
+				VolumeLevel: 8,
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
+			name: "volume with long flag",
+			body: "schemabot volume apply_abc123 -e production --volume 11",
+			expected: CommandResult{
+				Action:      action.Volume,
+				ApplyID:     "apply_abc123",
+				Environment: "production",
+				VolumeLevel: 11,
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
+			name: "volume missing -v flag",
+			body: "schemabot volume apply_abc123 -e staging",
+			expected: CommandResult{
+				Action:      action.Volume,
+				ApplyID:     "apply_abc123",
+				Environment: "staging",
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
+			name: "volume with -v but no value",
+			body: "schemabot volume apply_abc123 -e staging -v",
+			expected: CommandResult{
+				Action:           action.Volume,
+				ApplyID:          "apply_abc123",
+				Environment:      "staging",
+				VolumeLevelError: true,
+				Found:            true,
+				IsMention:        true,
+			},
+		},
+		{
+			name: "volume with non-numeric level",
+			body: "schemabot volume apply_abc123 -e staging -v fast",
+			expected: CommandResult{
+				Action:           action.Volume,
+				ApplyID:          "apply_abc123",
+				Environment:      "staging",
+				VolumeLevelError: true,
+				Found:            true,
+				IsMention:        true,
+			},
+		},
+		{
+			name: "volume with out-of-range level parses for dispatcher validation",
+			body: "schemabot volume apply_abc123 -e staging -v 15",
+			expected: CommandResult{
+				Action:      action.Volume,
+				ApplyID:     "apply_abc123",
+				Environment: "staging",
+				VolumeLevel: 15,
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
+			name: "volume missing environment",
+			body: "schemabot volume apply_abc123 -v 8",
+			expected: CommandResult{
+				Action:      action.Volume,
+				ApplyID:     "apply_abc123",
+				VolumeLevel: 8,
+				MissingEnv:  true,
+				IsMention:   true,
+			},
+		},
+		{
+			name: "volume missing apply id",
+			body: "schemabot volume -e staging -v 8",
+			expected: CommandResult{
+				Action:      action.Volume,
+				Environment: "staging",
+				VolumeLevel: 8,
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, parser.ParseCommand(tc.body))
 		})
 	}
 }

--- a/pkg/webhook/control.go
+++ b/pkg/webhook/control.go
@@ -369,7 +369,10 @@ func (h *Handler) handleVolumeCommand(repo string, pr int, installationID int64,
 	ctx, cancel := h.commandContext(commandTimeout)
 	defer cancel()
 
-	if !volumeCommandLevelValid(result) {
+	// A missing apply ID takes precedence over level validation so the
+	// command posts the standard missing-apply-ID guidance shared by all
+	// apply-scoped control commands (runControlCommand handles that case).
+	if result.ApplyID != "" && !volumeCommandLevelValid(result) {
 		h.logger.Warn("volume PR command rejected because the level is missing or invalid",
 			"repo", repo,
 			"pr", pr,

--- a/pkg/webhook/control.go
+++ b/pkg/webhook/control.go
@@ -352,6 +352,61 @@ func (h *Handler) handleCutoverCommand(repo string, pr int, installationID int64
 	}))
 }
 
+// volumeCommandLevelValid reports whether the parsed command carries a usable
+// volume level: the `-v` flag was present with a numeric value inside the
+// shared volume range. An absent flag parses as level 0, which the range
+// check rejects.
+func volumeCommandLevelValid(result CommandResult) bool {
+	return !result.VolumeLevelError &&
+		result.VolumeLevel >= storage.MinVolume &&
+		result.VolumeLevel <= storage.MaxVolume
+}
+
+// handleVolumeCommand handles the "schemabot volume <apply-id> -e <env> -v <level>"
+// PR comment command by queueing a durable volume adjustment that the driver
+// applies at its next progress check.
+func (h *Handler) handleVolumeCommand(repo string, pr int, installationID int64, requestedBy string, result CommandResult) {
+	ctx, cancel := h.commandContext(commandTimeout)
+	defer cancel()
+
+	if !volumeCommandLevelValid(result) {
+		h.logger.Warn("volume PR command rejected because the level is missing or invalid",
+			"repo", repo,
+			"pr", pr,
+			"apply_id", result.ApplyID,
+			"environment", result.Environment,
+			"requested_by", requestedBy,
+			"volume", result.VolumeLevel,
+			"volume_flag_error", result.VolumeLevelError)
+		h.postComment(repo, pr, installationID, templates.RenderVolumeInvalidLevel())
+		return
+	}
+
+	resp := runControlCommand(h, ctx, repo, pr, installationID, requestedBy, result, action.Volume,
+		func(ctx context.Context, req apitypes.ControlRequest) (*apitypes.VolumeResponse, error) {
+			return h.service.ExecuteVolume(ctx, req, result.VolumeLevel)
+		},
+		func(r *apitypes.VolumeResponse) bool { return r.Accepted },
+		func(r *apitypes.VolumeResponse) string { return r.ErrorMessage })
+	if resp == nil {
+		return
+	}
+
+	h.logger.Info("volume PR command accepted",
+		"repo", repo,
+		"pr", pr,
+		"apply_id", result.ApplyID,
+		"environment", result.Environment,
+		"requested_by", requestedBy,
+		"volume", result.VolumeLevel)
+	h.postComment(repo, pr, installationID, templates.RenderVolumeCommandAccepted(templates.VolumeCommandAcceptedData{
+		ApplyID:     result.ApplyID,
+		Environment: result.Environment,
+		RequestedBy: requestedBy,
+		Volume:      result.VolumeLevel,
+	}))
+}
+
 func (h *Handler) handleSkipRevertCommand(repo string, pr int, installationID int64, requestedBy string, result CommandResult) {
 	ctx, cancel := h.commandContext(commandTimeout)
 	defer cancel()

--- a/pkg/webhook/control_integration_test.go
+++ b/pkg/webhook/control_integration_test.go
@@ -774,6 +774,164 @@ func TestE2ECutoverCommandRejectsPendingStop(t *testing.T) {
 	assertReactionEventually(t, reactions)
 }
 
+// TestE2EVolumeCommandQueuesDurableRequest verifies that a PR comment volume
+// command queues a durable volume control request carrying the requested level,
+// and that the acknowledgement comment states the queued semantics — the driver
+// applies the level at its next progress check — rather than claiming the new
+// level is already in effect.
+func TestE2EVolumeCommandQueuesDurableRequest(t *testing.T) {
+	ctx := t.Context()
+	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
+	require.NoError(t, err)
+	require.NoError(t, schemabotDB.PingContext(ctx))
+
+	store := mysqlstore.New(schemabotDB)
+	applyIdentifier := "apply_ecafe123"
+	database := "volume_pr_comments_db"
+	cleanupStopCommandTestRows(t, schemabotDB, applyIdentifier, database)
+	t.Cleanup(func() {
+		cleanupStopCommandTestRows(t, schemabotDB, applyIdentifier, database)
+		utils.CloseAndLog(schemabotDB)
+	})
+	applyID := createStopCommandApply(t, store, applyIdentifier, database)
+
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 10)
+	reactions := make(chan string, 10)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Body string `json:"body"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		comments <- body.Body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+	})
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/comments/42/reactions", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Content string `json:"content"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		reactions <- body.Content
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+
+	service := apiServiceForStopCommandTest(t, store, database)
+	localClient, err := tern.NewLocalClient(tern.LocalConfig{
+		Database:  database,
+		Type:      storage.DatabaseTypeMySQL,
+		TargetDSN: e2eTargetDSN,
+	}, store, testLogger())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		utils.CloseAndLog(localClient)
+	})
+	service.RegisterTernClient(database, "staging", localClient)
+	h := &Handler{
+		service:   service,
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())}),
+		logger:    testLogger(),
+	}
+
+	postVolumeCommand(t, h, applyIdentifier, "alice", "8")
+	comment := readComment(t, comments)
+	assert.Contains(t, comment, "Volume Request Accepted")
+	assert.Contains(t, comment, "`"+applyIdentifier+"`")
+	assert.Contains(t, comment, "@alice")
+	assert.Contains(t, comment, "Volume change to 8 queued; the driver applies it at its next progress check")
+
+	controlReq, err := store.ControlRequests().GetPending(ctx, applyID, storage.ControlOperationVolume)
+	require.NoError(t, err)
+	require.NotNil(t, controlReq)
+	assert.Equal(t, storage.ControlRequestPending, controlReq.Status)
+	level, err := storage.DecodeVolumeControlRequestMetadata(controlReq.Metadata)
+	require.NoError(t, err)
+	assert.Equal(t, int32(8), level)
+
+	logs, err := store.ApplyLogs().List(ctx, storage.ApplyLogFilter{ApplyID: applyID, Limit: 20})
+	require.NoError(t, err)
+	assert.True(t, applyLogContains(logs, "Volume change to 8 queued; the driver applies it at its next progress check (caller: github:alice@octocat/hello-world#1)"))
+	assertReactionEventually(t, reactions)
+}
+
+// TestE2EVolumeCommandRejectsTerminalApply verifies that a volume command
+// against a terminal apply posts the rejection comment carrying the queue's
+// SchemaBot-authored error message and records no durable volume request —
+// there is no driver left to apply the level.
+func TestE2EVolumeCommandRejectsTerminalApply(t *testing.T) {
+	ctx := t.Context()
+	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
+	require.NoError(t, err)
+	require.NoError(t, schemabotDB.PingContext(ctx))
+
+	store := mysqlstore.New(schemabotDB)
+	applyIdentifier := "apply_ecafe456"
+	database := "volume_pr_comments_completed_db"
+	cleanupStopCommandTestRows(t, schemabotDB, applyIdentifier, database)
+	t.Cleanup(func() {
+		cleanupStopCommandTestRows(t, schemabotDB, applyIdentifier, database)
+		utils.CloseAndLog(schemabotDB)
+	})
+
+	applyID := createStopCommandApply(t, store, applyIdentifier, database)
+	storedApply, err := store.Applies().GetByApplyIdentifier(ctx, applyIdentifier)
+	require.NoError(t, err)
+	require.NotNil(t, storedApply)
+	storedApply.State = state.Apply.Completed
+	storedApply.UpdatedAt = time.Now().UTC()
+	require.NoError(t, store.Applies().Update(ctx, storedApply))
+
+	client, mux := setupGitHubServer(t)
+	comments := make(chan string, 10)
+	reactions := make(chan string, 10)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Body string `json:"body"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		comments <- body.Body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
+	})
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/comments/42/reactions", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Content string `json:"content"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		reactions <- body.Content
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+
+	service := apiServiceForStopCommandTest(t, store, database)
+	localClient, err := tern.NewLocalClient(tern.LocalConfig{
+		Database:  database,
+		Type:      storage.DatabaseTypeMySQL,
+		TargetDSN: e2eTargetDSN,
+	}, store, testLogger())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		utils.CloseAndLog(localClient)
+	})
+	service.RegisterTernClient(database, "staging", localClient)
+	h := &Handler{
+		service:   service,
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: ghclient.NewInstallationClient(client, testLogger())}),
+		logger:    testLogger(),
+	}
+
+	postVolumeCommand(t, h, applyIdentifier, "alice", "8")
+	comment := readComment(t, comments)
+	assert.Contains(t, comment, "Volume Failed")
+	assert.Contains(t, comment, "volume can only be adjusted while it is running")
+
+	pendingVolume, err := store.ControlRequests().GetPending(ctx, applyID, storage.ControlOperationVolume)
+	require.NoError(t, err)
+	assert.Nil(t, pendingVolume)
+	assertReactionEventually(t, reactions)
+}
+
 func apiServiceForStopCommandTest(t *testing.T, store storage.Storage, database string) *api.Service {
 	t.Helper()
 	return api.New(store, &api.ServerConfig{
@@ -907,6 +1065,19 @@ func postCutoverCommand(t *testing.T, h *Handler, applyIdentifier, user string) 
 	h.ServeHTTP(rr, req)
 	require.Equal(t, http.StatusOK, rr.Code)
 	assert.Contains(t, rr.Body.String(), "cutover started")
+}
+
+func postVolumeCommand(t *testing.T, h *Handler, applyIdentifier, user, level string) {
+	t.Helper()
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment:   "schemabot volume " + applyIdentifier + " -e staging -v " + level,
+		userLogin: user,
+		isPR:      true,
+	}, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "volume started")
 }
 
 func postSkipRevertCommand(t *testing.T, h *Handler, applyIdentifier, user string) {

--- a/pkg/webhook/control_integration_test.go
+++ b/pkg/webhook/control_integration_test.go
@@ -839,7 +839,7 @@ func TestE2EVolumeCommandQueuesDurableRequest(t *testing.T) {
 	assert.Contains(t, comment, "Volume Request Accepted")
 	assert.Contains(t, comment, "`"+applyIdentifier+"`")
 	assert.Contains(t, comment, "@alice")
-	assert.Contains(t, comment, "Volume change to 8 queued; the driver applies it at its next progress check")
+	assert.Contains(t, comment, "Volume change to 8 requested. SchemaBot will adjust the speed of this schema change shortly")
 
 	controlReq, err := store.ControlRequests().GetPending(ctx, applyID, storage.ControlOperationVolume)
 	require.NoError(t, err)

--- a/pkg/webhook/handler_test.go
+++ b/pkg/webhook/handler_test.go
@@ -461,6 +461,7 @@ func TestWebhookControlCommandMissingApplyID(t *testing.T) {
 		{name: "start", comment: "schemabot start -e staging", action: "start"},
 		{name: "cutover", comment: "schemabot cutover -e staging", action: "cutover"},
 		{name: "volume", comment: "schemabot volume -e staging -v 8", action: "volume"},
+		{name: "volume without level", comment: "schemabot volume -e staging", action: "volume"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/webhook/handler_test.go
+++ b/pkg/webhook/handler_test.go
@@ -460,6 +460,7 @@ func TestWebhookControlCommandMissingApplyID(t *testing.T) {
 		{name: "cancel", comment: "schemabot cancel -e staging", action: "cancel"},
 		{name: "start", comment: "schemabot start -e staging", action: "start"},
 		{name: "cutover", comment: "schemabot cutover -e staging", action: "cutover"},
+		{name: "volume", comment: "schemabot volume -e staging -v 8", action: "volume"},
 	}
 
 	for _, tt := range tests {
@@ -483,6 +484,48 @@ func TestWebhookControlCommandMissingApplyID(t *testing.T) {
 				assert.Contains(t, body, "schemabot "+tt.action+" <apply-id> -e <environment>")
 			case <-time.After(2 * time.Second):
 				t.Fatal("timed out waiting for missing apply ID comment")
+			}
+		})
+	}
+}
+
+// TestWebhookVolumeCommandInvalidLevel verifies that a volume command with a
+// missing, non-numeric, or out-of-range -v level posts a usage comment naming
+// the valid range and exact syntax instead of silently dropping the command.
+func TestWebhookVolumeCommandInvalidLevel(t *testing.T) {
+	tests := []struct {
+		name    string
+		comment string
+	}{
+		{name: "missing -v flag", comment: "schemabot volume apply_abc123 -e staging"},
+		{name: "-v without value", comment: "schemabot volume apply_abc123 -e staging -v"},
+		{name: "non-numeric level", comment: "schemabot volume apply_abc123 -e staging -v fast"},
+		{name: "level below range", comment: "schemabot volume apply_abc123 -e staging -v 0"},
+		{name: "level above range", comment: "schemabot volume apply_abc123 -e staging -v 12"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, comments, _ := newTestHandler(t)
+
+			req := buildWebhookRequest(t, webhookPayloadOpts{
+				comment: tt.comment,
+				isPR:    true,
+			}, nil)
+
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+
+			require.Equal(t, http.StatusOK, rr.Code)
+			assert.Contains(t, rr.Body.String(), "volume started")
+
+			select {
+			case body := <-comments:
+				assert.Contains(t, body, "Missing or Invalid Volume Level")
+				assert.Contains(t, body, "schemabot volume <apply-id> -e <environment> -v <level>")
+				assert.Contains(t, body, "between 1 (slowest) and 11 (fastest)")
+			case <-time.After(2 * time.Second):
+				t.Fatal("timed out waiting for invalid volume level comment")
 			}
 		})
 	}

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -340,6 +340,11 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 			h.handleCutoverCommand(repo, pr, installationID, requestedBy, result)
 		})
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "cutover started"})
+	case action.Volume:
+		h.goSafe(repo, pr, installationID, func() {
+			h.handleVolumeCommand(repo, pr, installationID, requestedBy, result)
+		})
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "volume started"})
 	case action.SkipRevert:
 		h.goSafe(repo, pr, installationID, func() {
 			h.handleSkipRevertCommand(repo, pr, installationID, requestedBy, result)
@@ -380,7 +385,8 @@ func (h *Handler) fansOutUnscopedCommand(repo string) bool {
 // own share of a shared PR; unlock releases only the participant's own database
 // locks (locks are keyed by database, not by apply). Commands that target a
 // single apply owned by one tenant — rollback and the lifecycle controls (stop,
-// cancel, start, release, cutover, skip-revert, revert) — are not in this set:
+// cancel, start, release, cutover, volume, skip-revert, revert) — are not in
+// this set:
 // an unscoped one would reach every participant and all but the owner would
 // report "apply not found", so they require an explicit -t instead.
 func actionFansOutUnscoped(a string) bool {

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -85,6 +85,11 @@ type ApplyStatusCommentData struct {
 	// comment shows the time remaining before the change becomes permanent.
 	// Empty outside the revert window or for engines without one.
 	RevertExpiresAt string
+
+	// Volume is the apply's current volume level (1=slowest, 11=fastest) from
+	// its stored options. Zero means the engine default is in effect and the
+	// comment renders no volume.
+	Volume int
 }
 
 // RenderApplyStatusComment renders a PR comment for the current apply status.
@@ -207,6 +212,12 @@ func writeApplyStatusDetail(sb *strings.Builder, data ApplyStatusCommentData) {
 		if countdown := revertWindowCountdown(data.RevertExpiresAt); countdown != "" {
 			detail += " | " + countdown
 		}
+	}
+	// The volume level only matters while the engine is actively copying; on
+	// other states (stopped, waiting for cutover, terminal) it carries no
+	// signal, so the status line stays quiet.
+	if data.Volume > 0 && state.IsState(data.State, state.Apply.Running, state.Apply.RunningDegraded) {
+		detail += fmt.Sprintf(" | Volume: %d/%d", data.Volume, storage.MaxVolume)
 	}
 	fmt.Fprintf(sb, "\n**Status**: %s\n", detail)
 }
@@ -1376,6 +1387,7 @@ func ApplyStatusFromProgress(resp *apitypes.ProgressResponse, requestedBy string
 		ErrorMessage: resp.ErrorMessage,
 		StartedAt:    resp.StartedAt,
 		CompletedAt:  resp.CompletedAt,
+		Volume:       int(resp.Volume),
 	}
 	data.RevertExpiresAt = resp.Metadata["revert_expires_at"]
 

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -356,6 +356,42 @@ func TestRenderApplyStatusComment_Running(t *testing.T) {
 	assert.Contains(t, result, "Queued")
 }
 
+// TestRenderApplyStatusComment_Volume verifies that a running apply with a
+// volume level set on its stored options shows the level compactly on the
+// Status line, and that an apply without a level (engine default) renders no
+// volume text at all.
+func TestRenderApplyStatusComment_Volume(t *testing.T) {
+	newData := func(applyState, tableStatus string, volume int) ApplyStatusCommentData {
+		return ApplyStatusCommentData{
+			Database:    "testapp",
+			Environment: "staging",
+			RequestedBy: "aparajon",
+			State:       applyState,
+			Engine:      "Spirit",
+			Volume:      volume,
+			Tables: []TableProgressData{
+				{TableName: "users", DDL: "ALTER TABLE `users` ADD INDEX `idx_email` (`email`)", Status: tableStatus, RowsCopied: 45000, RowsTotal: 100000, PercentComplete: 45},
+			},
+		}
+	}
+
+	t.Run("running apply with volume shows level on the status line", func(t *testing.T) {
+		result := RenderApplyStatusComment(newData("running", "running", 8))
+		assert.Contains(t, result, "**Status**: In Progress | Volume: 8/11")
+	})
+
+	t.Run("running apply without volume renders no volume text", func(t *testing.T) {
+		result := RenderApplyStatusComment(newData("running", "running", 0))
+		assert.Contains(t, result, "**Status**: In Progress")
+		assert.NotContains(t, result, "Volume")
+	})
+
+	t.Run("stopped apply with volume renders no volume text", func(t *testing.T) {
+		result := RenderApplyStatusComment(newData("stopped", "stopped", 8))
+		assert.NotContains(t, result, "Volume")
+	})
+}
+
 // A Vitess/PlanetScale apply labels its namespace group "Keyspace" (not "Schema"),
 // so the engine-aware label selection is exercised distinctly from the MySQL case.
 func TestRenderApplyStatusComment_VitessUsesKeyspaceLabel(t *testing.T) {

--- a/pkg/webhook/templates/help.go
+++ b/pkg/webhook/templates/help.go
@@ -14,6 +14,7 @@ func commandReference() string {
 | ` + "`schemabot start <apply-id> -e <env>`" + ` | Resume a stopped deployment |
 | ` + "`schemabot release <apply-id> -e <env>`" + ` | Release a paused rollout to proceed |
 | ` + "`schemabot cutover <apply-id> -e <env>`" + ` | Complete a deferred cutover |
+| ` + "`schemabot volume <apply-id> -e <env> -v <level>`" + ` | Adjust schema change speed (1=slowest, 11=fastest) |
 | ` + "`schemabot rollback <apply-id> -e <env> [-t <tenant>]`" + ` | Generate a rollback plan |
 | ` + "`schemabot rollback-confirm -e <env> [-t <tenant>]`" + ` | Execute a rollback |
 

--- a/pkg/webhook/templates/help_test.go
+++ b/pkg/webhook/templates/help_test.go
@@ -1,0 +1,21 @@
+package templates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRenderHelpCommentListsControlCommands verifies the help table advertises
+// every apply-scoped control command with its full syntax, so an operator can
+// copy a working command straight from the PR without consulting the docs.
+func TestRenderHelpCommentListsControlCommands(t *testing.T) {
+	rendered := RenderHelpComment()
+	assert.Contains(t, rendered, "SchemaBot Help")
+	assert.Contains(t, rendered, "`schemabot stop <apply-id> -e <env>`")
+	assert.Contains(t, rendered, "`schemabot cancel <apply-id> -e <env>`")
+	assert.Contains(t, rendered, "`schemabot start <apply-id> -e <env>`")
+	assert.Contains(t, rendered, "`schemabot cutover <apply-id> -e <env>`")
+	assert.Contains(t, rendered, "`schemabot volume <apply-id> -e <env> -v <level>`")
+	assert.Contains(t, rendered, "Adjust schema change speed (1=slowest, 11=fastest)")
+}

--- a/pkg/webhook/templates/issue_comment.go
+++ b/pkg/webhook/templates/issue_comment.go
@@ -274,6 +274,23 @@ func RenderVolumeCommandAccepted(data VolumeCommandAcceptedData) string {
 	return body
 }
 
+// PreviewCommentVolumeCommandAccepted renders a sample volume command
+// acknowledgement comment.
+func PreviewCommentVolumeCommandAccepted() string {
+	return RenderVolumeCommandAccepted(VolumeCommandAcceptedData{
+		ApplyID:     "apply-a1b2c3d4e5f67890",
+		Environment: "staging",
+		RequestedBy: "alice",
+		Volume:      8,
+	})
+}
+
+// PreviewCommentVolumeInvalidLevel renders the usage comment posted when a
+// volume command carries a missing or invalid level.
+func PreviewCommentVolumeInvalidLevel() string {
+	return RenderVolumeInvalidLevel()
+}
+
 // RenderCutoverCommandAccepted renders the acknowledgement posted when a PR
 // comment cutover command records durable cutover intent.
 func RenderCutoverCommandAccepted(data CutoverCommandAcceptedData) string {

--- a/pkg/webhook/templates/issue_comment.go
+++ b/pkg/webhook/templates/issue_comment.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/block/schemabot/pkg/apitypes"
+	"github.com/block/schemabot/pkg/storage"
 )
 
 // RenderRollbackMissingArguments renders the message posted when `schemabot rollback`
@@ -91,6 +92,16 @@ func RenderControlMissingApplyID(action string) string {
 	return fmt.Sprintf("## Missing Apply ID\n\n"+
 		"Usage: `schemabot %s <apply-id> -e <environment>`\n\n"+
 		"Use `schemabot status -e <environment>` to find the apply ID.", action)
+}
+
+// RenderVolumeInvalidLevel renders the message posted when a volume command
+// is missing the `-v` flag, carries a non-numeric value, or names a level
+// outside the supported range.
+func RenderVolumeInvalidLevel() string {
+	return fmt.Sprintf("## Missing or Invalid Volume Level\n\n"+
+		"Usage: `schemabot volume <apply-id> -e <environment> -v <level>`\n\n"+
+		"The `-v` flag is required and must be a number between %d (slowest) and %d (fastest).",
+		storage.MinVolume, storage.MaxVolume)
 }
 
 // RenderStopCommandAccepted renders the acknowledgement posted when a PR
@@ -237,6 +248,30 @@ func PreviewCommentStartCommandAlreadyRequested() string {
 		StartedCount: 1,
 		SkippedCount: 0,
 	})
+}
+
+// VolumeCommandAcceptedData contains data for a PR comment volume acknowledgement.
+type VolumeCommandAcceptedData struct {
+	ApplyID     string
+	Environment string
+	RequestedBy string
+	// Volume is the queued target level (1=slowest, 11=fastest).
+	Volume int32
+}
+
+// RenderVolumeCommandAccepted renders the acknowledgement posted when a PR
+// comment volume command queues a durable volume adjustment. The wording keeps
+// the queued semantics explicit: the driver retunes the engine at its next
+// progress check, so the new level is not yet in effect when this posts.
+func RenderVolumeCommandAccepted(data VolumeCommandAcceptedData) string {
+	body := "## Volume Request Accepted\n\n" +
+		fmt.Sprintf("**Apply**: `%s`\n", data.ApplyID) +
+		fmt.Sprintf("**Environment**: `%s`\n", data.Environment)
+	if data.RequestedBy != "" {
+		body += fmt.Sprintf("**Requested by**: @%s\n", data.RequestedBy)
+	}
+	body += fmt.Sprintf("\nVolume change to %d queued; the driver applies it at its next progress check. Status remains available from the PR progress comment or CLI.\n", data.Volume)
+	return body
 }
 
 // RenderCutoverCommandAccepted renders the acknowledgement posted when a PR

--- a/pkg/webhook/templates/issue_comment.go
+++ b/pkg/webhook/templates/issue_comment.go
@@ -260,9 +260,10 @@ type VolumeCommandAcceptedData struct {
 }
 
 // RenderVolumeCommandAccepted renders the acknowledgement posted when a PR
-// comment volume command queues a durable volume adjustment. The wording keeps
-// the queued semantics explicit: the driver retunes the engine at its next
-// progress check, so the new level is not yet in effect when this posts.
+// comment volume command queues a durable volume adjustment. The wording says
+// "shortly" rather than implying an immediate change: the new level takes
+// effect at the next progress check, so it is not yet in effect when this
+// posts.
 func RenderVolumeCommandAccepted(data VolumeCommandAcceptedData) string {
 	body := "## Volume Request Accepted\n\n" +
 		fmt.Sprintf("**Apply**: `%s`\n", data.ApplyID) +
@@ -270,7 +271,7 @@ func RenderVolumeCommandAccepted(data VolumeCommandAcceptedData) string {
 	if data.RequestedBy != "" {
 		body += fmt.Sprintf("**Requested by**: @%s\n", data.RequestedBy)
 	}
-	body += fmt.Sprintf("\nVolume change to %d queued; the driver applies it at its next progress check. Status remains available from the PR progress comment or CLI.\n", data.Volume)
+	body += fmt.Sprintf("\nVolume change to %d requested. SchemaBot will adjust the speed of this schema change shortly; status remains available from the PR progress comment or CLI.\n", data.Volume)
 	return body
 }
 

--- a/pkg/webhook/templates/issue_comment.go
+++ b/pkg/webhook/templates/issue_comment.go
@@ -271,7 +271,7 @@ func RenderVolumeCommandAccepted(data VolumeCommandAcceptedData) string {
 	if data.RequestedBy != "" {
 		body += fmt.Sprintf("**Requested by**: @%s\n", data.RequestedBy)
 	}
-	body += fmt.Sprintf("\nVolume change to %d requested. SchemaBot will adjust the speed of this schema change shortly; status remains available from the PR progress comment or CLI.\n", data.Volume)
+	body += fmt.Sprintf("\nVolume change to %d requested. SchemaBot will adjust the speed of this schema change shortly; the progress comment on this PR shows the current level.\n", data.Volume)
 	return body
 }
 

--- a/pkg/webhook/templates/issue_comment_test.go
+++ b/pkg/webhook/templates/issue_comment_test.go
@@ -161,6 +161,34 @@ func TestRenderCutoverCommandAcceptedAlreadyInProgress(t *testing.T) {
 	assert.Contains(t, rendered, "Cutover is already in progress")
 }
 
+// TestRenderVolumeCommandAccepted verifies the volume acknowledgement states
+// the queued semantics — the driver applies the level at its next progress
+// check — rather than claiming the change already took effect, and carries the
+// apply id, environment, requester, and requested level.
+func TestRenderVolumeCommandAccepted(t *testing.T) {
+	rendered := RenderVolumeCommandAccepted(VolumeCommandAcceptedData{
+		ApplyID:     "apply_abc123",
+		Environment: "staging",
+		RequestedBy: "alice",
+		Volume:      8,
+	})
+	assert.Contains(t, rendered, "Volume Request Accepted")
+	assert.Contains(t, rendered, "`apply_abc123`")
+	assert.Contains(t, rendered, "`staging`")
+	assert.Contains(t, rendered, "@alice")
+	assert.Contains(t, rendered, "Volume change to 8 queued; the driver applies it at its next progress check")
+}
+
+// TestRenderVolumeInvalidLevel verifies the rejection posted for a missing,
+// non-numeric, or out-of-range -v value tells the user the exact syntax and
+// the valid range.
+func TestRenderVolumeInvalidLevel(t *testing.T) {
+	rendered := RenderVolumeInvalidLevel()
+	assert.Contains(t, rendered, "Missing or Invalid Volume Level")
+	assert.Contains(t, rendered, "`schemabot volume <apply-id> -e <environment> -v <level>`")
+	assert.Contains(t, rendered, "between 1 (slowest) and 11 (fastest)")
+}
+
 func TestRenderRevertCommandAccepted(t *testing.T) {
 	rendered := RenderRevertCommandAccepted(RevertCommandAcceptedData{
 		ApplyID:     "apply-957642f96d634694",

--- a/pkg/webhook/templates/issue_comment_test.go
+++ b/pkg/webhook/templates/issue_comment_test.go
@@ -161,10 +161,9 @@ func TestRenderCutoverCommandAcceptedAlreadyInProgress(t *testing.T) {
 	assert.Contains(t, rendered, "Cutover is already in progress")
 }
 
-// TestRenderVolumeCommandAccepted verifies the volume acknowledgement states
-// the queued semantics — the driver applies the level at its next progress
-// check — rather than claiming the change already took effect, and carries the
-// apply id, environment, requester, and requested level.
+// TestRenderVolumeCommandAccepted verifies the volume acknowledgement says the
+// speed changes shortly — rather than claiming the change already took effect —
+// and carries the apply id, environment, requester, and requested level.
 func TestRenderVolumeCommandAccepted(t *testing.T) {
 	rendered := RenderVolumeCommandAccepted(VolumeCommandAcceptedData{
 		ApplyID:     "apply_abc123",
@@ -176,7 +175,7 @@ func TestRenderVolumeCommandAccepted(t *testing.T) {
 	assert.Contains(t, rendered, "`apply_abc123`")
 	assert.Contains(t, rendered, "`staging`")
 	assert.Contains(t, rendered, "@alice")
-	assert.Contains(t, rendered, "Volume change to 8 queued; the driver applies it at its next progress check")
+	assert.Contains(t, rendered, "Volume change to 8 requested. SchemaBot will adjust the speed of this schema change shortly")
 }
 
 // TestRenderVolumeInvalidLevel verifies the rejection posted for a missing,

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -1409,6 +1409,20 @@ func PreviewCommentApplySingleProgress() string {
 	return RenderApplyStatusComment(sampleSingleApplyData(state.Apply.Running, table))
 }
 
+// PreviewCommentApplySingleProgressVolume renders a single-table apply in
+// progress with a tuned volume level shown on the status line.
+func PreviewCommentApplySingleProgressVolume() string {
+	table := sampleSingleTable()
+	table.Status = state.Task.Running
+	table.RowsCopied = 3500000
+	table.RowsTotal = 7200000
+	table.PercentComplete = 48
+	table.ETASeconds = 330
+	data := sampleSingleApplyData(state.Apply.Running, table)
+	data.Volume = 8
+	return RenderApplyStatusComment(data)
+}
+
 // PreviewCommentApplySingleCompleted renders a single-table apply completed.
 func PreviewCommentApplySingleCompleted() string {
 	table := sampleSingleTable()


### PR DESCRIPTION
**Why this matters:** Volume shipped as a durable control request (#694) but was the only control verb with no PR comment surface — a PR author watching a slow copy had to leave GitHub and find an operator with CLI access just to turn the throughput up or down. Every other apply-affecting verb (stop, cancel, start, cutover) is available where the apply is being watched.

**What it does:**
- Adds the `schemabot volume apply_<id> -e <env> -v <level>` PR comment command, parsed through the same `CommandSpec` registry as the other verbs (actor authorization, eyes-reaction ack, and apply-ID targeting come from the shared dispatch). Missing, non-numeric, or out-of-range levels get a usage comment instead of silently dropping.
- Routes the command through a new `Service.ExecuteVolume`, and refactors the HTTP volume handler onto the same path — the comment command and the API share one execution route, so all queue-time gating (terminal apply, conflicting pending level, multi-deployment rejection) behaves identically on both surfaces.
- Adds the `Volume Request Accepted` comment template with queued semantics: the change is durable and the driver applies it at its next progress check, matching how the request actually executes.
- Renders the current volume level in the running apply's progress comment (`**Status**: In Progress | Volume: 8/11`) so the PR shows the level the driver converged to, not just that a request was accepted.

**How it moves toward the northstar:** Control of an in-flight schema change should live where the change is reviewed. This closes the last verb gap between the PR comment surface and the Admin CLI, and the shared execution path means future per-operation fan-out semantics land on both surfaces at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
