### PR TITLE
fix(github): fast-ack pr auto-plan webhooks

### DIFF
--- a/pkg/webhook/aggregate_check_integration_test.go
+++ b/pkg/webhook/aggregate_check_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -637,12 +638,9 @@ func TestE2EParticipantSilentOnNonSchemaPR(t *testing.T) {
 
 	// PR changed files — no schema files.
 	filesFetched := make(chan struct{})
+	var filesFetchedOnce sync.Once
 	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, _ *http.Request) {
-		select {
-		case <-filesFetched:
-		default:
-			close(filesFetched)
-		}
+		filesFetchedOnce.Do(func() { close(filesFetched) })
 		_ = json.NewEncoder(w).Encode([]*gh.CommitFile{
 			{Filename: new("README.md"), Status: new("modified")},
 		})

--- a/pkg/webhook/aggregate_check_integration_test.go
+++ b/pkg/webhook/aggregate_check_integration_test.go
@@ -590,7 +590,7 @@ func TestE2EPassingAggregateOnNonSchemaPR(t *testing.T) {
 	h.ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "no schema files in PR")
+	assert.Contains(t, rr.Body.String(), "auto-plan started")
 
 	// Wait for both passing aggregates (staging + production)
 	seen := map[string]bool{}
@@ -636,7 +636,13 @@ func TestE2EParticipantSilentOnNonSchemaPR(t *testing.T) {
 	})
 
 	// PR changed files — no schema files.
+	filesFetched := make(chan struct{})
 	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, _ *http.Request) {
+		select {
+		case <-filesFetched:
+		default:
+			close(filesFetched)
+		}
 		_ = json.NewEncoder(w).Encode([]*gh.CommitFile{
 			{Filename: new("README.md"), Status: new("modified")},
 		})
@@ -672,10 +678,16 @@ func TestE2EParticipantSilentOnNonSchemaPR(t *testing.T) {
 	h.ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "aggregate participant, staying silent")
+	assert.Contains(t, rr.Body.String(), "auto-plan started")
 
-	// The skip is synchronous (it returns before scheduling any passing
-	// aggregate), so a brief drain confirms no check run was posted.
+	// Wait until async config discovery reads the PR files, then drain
+	// briefly to confirm the participant stayed silent instead of publishing an
+	// aggregate on a PR with no managed schema changes.
+	select {
+	case <-filesFetched:
+	case <-time.After(webhookIntegrationCheckRunDeadline):
+		t.Fatal("timed out waiting for participant auto-plan discovery")
+	}
 	select {
 	case cr := <-checkRuns:
 		t.Fatalf("participant posted a check run on a non-schema PR: %q", cr.Name)
@@ -1151,7 +1163,7 @@ func TestE2EPassingAggregateOnSQLWithoutSchemabotYAML(t *testing.T) {
 	h.ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "no schema files in PR")
+	assert.Contains(t, rr.Body.String(), "auto-plan started")
 
 	// Should post passing aggregate even though .sql files changed
 	select {
@@ -1229,7 +1241,7 @@ func TestE2EPassingAggregateWithoutAllowedEnvs(t *testing.T) {
 	h.ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "no schema files in PR")
+	assert.Contains(t, rr.Body.String(), "auto-plan started")
 
 	// Single-instance mode posts a global "SchemaBot" passing aggregate
 	select {

--- a/pkg/webhook/auto_plan_integration_test.go
+++ b/pkg/webhook/auto_plan_integration_test.go
@@ -460,7 +460,7 @@ func TestE2EAutoPlanNoSchemaFiles(t *testing.T) {
 	h.ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "no schema files in PR")
+	assert.Contains(t, rr.Body.String(), "auto-plan started")
 }
 
 // TestE2EGitHubUnavailableDuringConfigDiscoveryPublishesFailingAggregates
@@ -519,7 +519,7 @@ func TestE2EGitHubUnavailableDuringConfigDiscoveryPublishesFailingAggregates(t *
 	h.ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "config discovery failed")
+	assert.Contains(t, rr.Body.String(), "auto-plan started")
 
 	seen := map[string]bool{}
 	for i := range 2 {
@@ -539,9 +539,13 @@ func TestE2EGitHubUnavailableDuringConfigDiscoveryPublishesFailingAggregates(t *
 	// Each aggregate stores a machine-readable GitHub-unavailable blocking
 	// reason so operators can distinguish this from a schema/config error.
 	for _, env := range []string{"staging", "production"} {
-		check, err := svc.Storage().Checks().Get(t.Context(), "octocat/hello-world", 1, env, aggregateSentinel, aggregateSentinel)
-		require.NoError(t, err)
-		require.NotNil(t, check)
+		var check *storage.Check
+		require.Eventually(t, func() bool {
+			var err error
+			check, err = svc.Storage().Checks().Get(t.Context(), "octocat/hello-world", 1, env, aggregateSentinel, aggregateSentinel)
+			require.NoError(t, err)
+			return check != nil
+		}, webhookIntegrationCheckRunDeadline, 100*time.Millisecond, "stored aggregate check should be visible for %s", env)
 		assert.Equal(t, githubConfigDiscoveryUnavailableBlock.blockingReason, check.BlockingReason)
 		assert.Contains(t, check.ErrorMessage, githubConfigDiscoveryUnavailableBlock.message)
 	}
@@ -587,7 +591,7 @@ func TestE2EGitHubUnavailableDuringAutoPlanDoesNotPublishCheckRun(t *testing.T) 
 	h.ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "config discovery failed")
+	assert.Contains(t, rr.Body.String(), "auto-plan started")
 
 	// Publishing a check run without a verified head SHA could mark the wrong
 	// commit, so no GitHub or stored aggregate check should be created.
@@ -943,7 +947,7 @@ func TestE2EAutoPlanManagedDirMissingConfigBlocks(t *testing.T) {
 	h.ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "schema change under managed directory has no config")
+	assert.Contains(t, rr.Body.String(), "auto-plan started")
 
 	var aggregateCheck checkRunCapture
 	select {
@@ -958,9 +962,13 @@ func TestE2EAutoPlanManagedDirMissingConfigBlocks(t *testing.T) {
 	assert.Contains(t, aggregateCheck.Output.Summary, "schemabot.yaml")
 	assert.Contains(t, aggregateCheck.Output.Summary, "allowed_dirs")
 
-	check, err := svc.Storage().Checks().Get(t.Context(), "octocat/hello-world", 1, aggregateSentinel, aggregateSentinel, aggregateSentinel)
-	require.NoError(t, err)
-	require.NotNil(t, check, "managed-dir-missing-config auto-plan must store a failing aggregate check")
+	var check *storage.Check
+	require.Eventually(t, func() bool {
+		var err error
+		check, err = svc.Storage().Checks().Get(t.Context(), "octocat/hello-world", 1, aggregateSentinel, aggregateSentinel, aggregateSentinel)
+		require.NoError(t, err)
+		return check != nil
+	}, webhookIntegrationCheckRunDeadline, 100*time.Millisecond, "managed-dir-missing-config auto-plan must store a failing aggregate check")
 	assert.Equal(t, "abc123", check.HeadSHA)
 	assert.Equal(t, "completed", check.Status)
 	assert.Equal(t, "failure", check.Conclusion)

--- a/pkg/webhook/auto_plan_integration_test.go
+++ b/pkg/webhook/auto_plan_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -489,11 +490,67 @@ func TestE2EAutoPlanNoSchemaFiles(t *testing.T) {
 	case <-time.After(webhookIntegrationCheckRunDeadline):
 		t.Fatal("timed out waiting for no-schema passing aggregate check run")
 	}
+	var check *storage.Check
+	var checkErr error
+	require.Eventually(t, func() bool {
+		check, checkErr = svc.Storage().Checks().Get(t.Context(), "octocat/hello-world", 1, aggregateSentinel, aggregateSentinel, aggregateSentinel)
+		return checkErr == nil && check != nil
+	}, webhookIntegrationCheckRunDeadline, 100*time.Millisecond, "no-schema auto-plan should store a passing aggregate check")
+	require.NoError(t, checkErr)
+	require.NotNil(t, check)
+	assert.Equal(t, "abc123", check.HeadSHA)
+	assert.Equal(t, checkStatusCompleted, check.Status)
+	assert.Equal(t, checkConclusionSuccess, check.Conclusion)
 	select {
 	case body := <-comments:
 		t.Fatalf("expected no plan comment for no-schema auto-plan, got: %s", body)
 	case <-time.After(250 * time.Millisecond):
 	}
+}
+
+// TestE2EAutoPlanBootstrapDoesNotBlockWebhookAck verifies that pull-request
+// auto-plan acknowledges the webhook before GitHub client construction runs.
+// Client construction can perform remote GitHub calls, so the response path must
+// not depend on it being fast or available.
+func TestE2EAutoPlanBootstrapDoesNotBlockWebhookAck(t *testing.T) {
+	svc := setupE2EServiceWithAllowedEnvs(t, []string{"staging"})
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	bootstrapStarted := make(chan struct{})
+	bootstrapRelease := make(chan struct{})
+	factory := &fakeClientFactory{
+		forInstallationStarted: bootstrapStarted,
+		forInstallationRelease: bootstrapRelease,
+		forInstallationErr:     errors.New("github unavailable"),
+	}
+
+	h := NewHandler(svc, factory, nil, logger)
+	req := buildPRWebhookRequest(t, prWebhookPayloadOpts{
+		action:  "opened",
+		headSHA: "abc123",
+		headRef: "feature-branch",
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	served := make(chan struct{})
+	go func() {
+		h.ServeHTTP(rr, req)
+		close(served)
+	}()
+
+	select {
+	case <-served:
+	case <-time.After(time.Second):
+		require.FailNow(t, "webhook response waited for auto-plan bootstrap")
+	}
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "auto-plan started")
+
+	select {
+	case <-bootstrapStarted:
+	case <-time.After(webhookIntegrationCheckRunDeadline):
+		require.FailNow(t, "timed out waiting for async auto-plan bootstrap")
+	}
+	close(bootstrapRelease)
 }
 
 // TestE2EGitHubUnavailableDuringConfigDiscoveryPublishesFailingAggregates

--- a/pkg/webhook/auto_plan_integration_test.go
+++ b/pkg/webhook/auto_plan_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -436,13 +437,26 @@ func TestE2EAutoPlanNoSchemaFiles(t *testing.T) {
 	})
 
 	// PR changed files — only non-schema files
+	filesFetched := make(chan struct{})
+	var filesFetchedOnce sync.Once
 	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, r *http.Request) {
+		filesFetchedOnce.Do(func() { close(filesFetched) })
 		files := []*gh.CommitFile{
 			{Filename: new("README.md"), Status: new("modified")},
 			{Filename: new("main.go"), Status: new("modified")},
 		}
 		_ = json.NewEncoder(w).Encode(files)
 	})
+	checkRuns := make(chan checkRunCapture, 1)
+	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		var body checkRunCapture
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		checkRuns <- body
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+	comments := make(chan string, 1)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", commentRecorder(t, comments))
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	installClient := ghclient.NewInstallationClient(client, logger)
@@ -461,6 +475,25 @@ func TestE2EAutoPlanNoSchemaFiles(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rr.Code)
 	assert.Contains(t, rr.Body.String(), "auto-plan started")
+	select {
+	case <-filesFetched:
+	case <-time.After(webhookIntegrationCheckRunDeadline):
+		t.Fatal("timed out waiting for no-schema auto-plan discovery")
+	}
+	select {
+	case cr := <-checkRuns:
+		assert.Equal(t, aggregateCheckName, cr.Name)
+		assert.Equal(t, checkStatusCompleted, cr.Status)
+		assert.Equal(t, checkConclusionSuccess, cr.Conclusion)
+		assert.Equal(t, "abc123", cr.HeadSHA)
+	case <-time.After(webhookIntegrationCheckRunDeadline):
+		t.Fatal("timed out waiting for no-schema passing aggregate check run")
+	}
+	select {
+	case body := <-comments:
+		t.Fatalf("expected no plan comment for no-schema auto-plan, got: %s", body)
+	case <-time.After(250 * time.Millisecond):
+	}
 }
 
 // TestE2EGitHubUnavailableDuringConfigDiscoveryPublishesFailingAggregates
@@ -540,12 +573,13 @@ func TestE2EGitHubUnavailableDuringConfigDiscoveryPublishesFailingAggregates(t *
 	// reason so operators can distinguish this from a schema/config error.
 	for _, env := range []string{"staging", "production"} {
 		var check *storage.Check
+		var checkErr error
 		require.Eventually(t, func() bool {
-			var err error
-			check, err = svc.Storage().Checks().Get(t.Context(), "octocat/hello-world", 1, env, aggregateSentinel, aggregateSentinel)
-			require.NoError(t, err)
-			return check != nil
+			check, checkErr = svc.Storage().Checks().Get(t.Context(), "octocat/hello-world", 1, env, aggregateSentinel, aggregateSentinel)
+			return checkErr == nil && check != nil
 		}, webhookIntegrationCheckRunDeadline, 100*time.Millisecond, "stored aggregate check should be visible for %s", env)
+		require.NoError(t, checkErr)
+		require.NotNil(t, check)
 		assert.Equal(t, githubConfigDiscoveryUnavailableBlock.blockingReason, check.BlockingReason)
 		assert.Contains(t, check.ErrorMessage, githubConfigDiscoveryUnavailableBlock.message)
 	}
@@ -566,7 +600,10 @@ func TestE2EGitHubUnavailableDuringAutoPlanDoesNotPublishCheckRun(t *testing.T) 
 
 	// The initial PR lookup fails, so SchemaBot does not know which commit SHA
 	// a check run should target.
+	prFetchAttempted := make(chan struct{})
+	var prFetchAttemptedOnce sync.Once
 	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		prFetchAttemptedOnce.Do(func() { close(prFetchAttempted) })
 		w.WriteHeader(http.StatusInternalServerError)
 	})
 
@@ -592,6 +629,11 @@ func TestE2EGitHubUnavailableDuringAutoPlanDoesNotPublishCheckRun(t *testing.T) 
 
 	require.Equal(t, http.StatusOK, rr.Code)
 	assert.Contains(t, rr.Body.String(), "auto-plan started")
+	select {
+	case <-prFetchAttempted:
+	case <-time.After(webhookIntegrationCheckRunDeadline):
+		t.Fatal("timed out waiting for auto-plan to verify PR head")
+	}
 
 	// Publishing a check run without a verified head SHA could mark the wrong
 	// commit, so no GitHub or stored aggregate check should be created.
@@ -963,12 +1005,13 @@ func TestE2EAutoPlanManagedDirMissingConfigBlocks(t *testing.T) {
 	assert.Contains(t, aggregateCheck.Output.Summary, "allowed_dirs")
 
 	var check *storage.Check
+	var checkErr error
 	require.Eventually(t, func() bool {
-		var err error
-		check, err = svc.Storage().Checks().Get(t.Context(), "octocat/hello-world", 1, aggregateSentinel, aggregateSentinel, aggregateSentinel)
-		require.NoError(t, err)
-		return check != nil
+		check, checkErr = svc.Storage().Checks().Get(t.Context(), "octocat/hello-world", 1, aggregateSentinel, aggregateSentinel, aggregateSentinel)
+		return checkErr == nil && check != nil
 	}, webhookIntegrationCheckRunDeadline, 100*time.Millisecond, "managed-dir-missing-config auto-plan must store a failing aggregate check")
+	require.NoError(t, checkErr)
+	require.NotNil(t, check)
 	assert.Equal(t, "abc123", check.HeadSHA)
 	assert.Equal(t, "completed", check.Status)
 	assert.Equal(t, "failure", check.Conclusion)

--- a/pkg/webhook/check_run.go
+++ b/pkg/webhook/check_run.go
@@ -197,7 +197,7 @@ func (h *Handler) handleCheckRunRerequest(ctx context.Context, w http.ResponseWr
 		"check_run_id", payload.CheckRun.ID,
 		"check_name", payload.CheckRun.Name)
 
-	message := h.runAutoPlanForPR(ctx, client, repo, pr, payload.CheckRun.HeadSHA, installationID, "check_run.rerequested", "check_run.rerequested", "")
+	message := h.runAutoPlanForPR(ctx, client, repo, pr, payload.CheckRun.HeadSHA, installationID, "check_run.rerequested", "check_run.rerequested", "", "")
 
 	h.writeJSON(w, http.StatusOK, map[string]string{"message": message})
 }

--- a/pkg/webhook/checks_backfill.go
+++ b/pkg/webhook/checks_backfill.go
@@ -29,6 +29,6 @@ func (h *Handler) BackfillPRCheckRuns(ctx context.Context, repo string, pr int, 
 	}
 	h.logger.Info("backfilling Check Runs via the auto-plan flow",
 		"repo", repo, "pr", pr, "head_sha", prInfo.HeadSHA)
-	message := h.runAutoPlanForPR(ctx, client, repo, pr, prInfo.HeadSHA, installationID, "checks.backfill", "checks.backfill", "")
+	message := h.runAutoPlanForPR(ctx, client, repo, pr, prInfo.HeadSHA, installationID, "checks.backfill", "checks.backfill", "", "")
 	return message, nil
 }

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -542,7 +542,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.handleCheckRun(ctx, w, body)
 		metrics.RecordWebhookEvent(ctx, metricApp, eventType, action, repo, "processed")
 	case "pull_request":
-		h.handlePullRequest(ctx, metricApp, w, body)
+		h.handlePullRequest(ctx, metricApp, w, body, r.Header.Get(headerDeliveryID))
 		metrics.RecordWebhookEvent(ctx, metricApp, eventType, action, repo, "processed")
 	case "merge_group":
 		h.handleMergeGroup(ctx, metricApp, w, body)

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -764,7 +764,7 @@ func verifyHMAC(signature string, body, secret []byte) bool {
 func (h *Handler) recoverPanic(repo string, pr int, installationID int64) {
 	if r := recover(); r != nil {
 		stack := debug.Stack()
-		h.logger.Error("goroutine panic", "error", r, "stack", string(stack))
+		h.logger.Error("goroutine panic", "repo", repo, "pr", pr, "installation_id", installationID, "error", r, "stack", string(stack))
 		h.postComment(repo, pr, installationID,
 			fmt.Sprintf("**Internal error: goroutine panic. This is a bug — please report it.**\n```\n%v\n```", r))
 	}

--- a/pkg/webhook/leader_gate_integration_test.go
+++ b/pkg/webhook/leader_gate_integration_test.go
@@ -473,7 +473,7 @@ func TestE2ELeaderNonSchemaPRTouchingParticipantPathBlocks(t *testing.T) {
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
 	require.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "aggregate folds expected participants")
+	assert.Contains(t, rr.Body.String(), "auto-plan started")
 
 	for _, env := range []string{"staging", "production"} {
 		cr := collectAggregate(t, checkRuns, aggregateCheckNameForEnv("SchemaBot", env))
@@ -621,7 +621,7 @@ func TestE2ELeaderNonSchemaPROutsideParticipantPathsPasses(t *testing.T) {
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
 	require.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "no schema files in PR")
+	assert.Contains(t, rr.Body.String(), "auto-plan started")
 	assert.NotContains(t, rr.Body.String(), "aggregate folds expected participants")
 
 	for _, env := range []string{"staging", "production"} {

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -103,10 +103,19 @@ func (h *Handler) handlePullRequest(ctx context.Context, metricApp string, w htt
 		h.writeError(w, http.StatusInternalServerError, "failed to initialize GitHub client")
 		return
 	}
-	defer cancel()
 
-	message := h.runAutoPlanForPR(ctx, client, repo, pr, headSHA, installationID, "pull_request", payload.Action, payload.Before)
-	h.writeJSON(w, http.StatusOK, map[string]string{"message": message})
+	h.goSafe(repo, pr, installationID, func() {
+		defer cancel()
+		message := h.runAutoPlanForPR(ctx, client, repo, pr, headSHA, installationID, "pull_request", payload.Action, payload.Before)
+		h.logger.Info("auto-plan finished",
+			"action", payload.Action,
+			"repo", repo,
+			"pr", pr,
+			"head_sha", headSHA,
+			"message", message,
+		)
+	})
+	h.writeJSON(w, http.StatusOK, map[string]string{"message": "auto-plan started"})
 }
 
 func (h *Handler) autoPlanBootstrap(repo string, installationID int64) (context.Context, context.CancelFunc, *ghclient.InstallationClient, error) {

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -101,6 +101,7 @@ func (h *Handler) handlePullRequest(ctx context.Context, metricApp string, w htt
 	h.goSafe(repo, pr, installationID, func() {
 		ctx, cancel, client, err := h.autoPlanBootstrap(repo, installationID)
 		if err != nil {
+			metrics.RecordWebhookEvent(context.Background(), metricApp, "pull_request", payload.Action, repo, "auto_plan_bootstrap_failed")
 			h.logger.Error("failed to bootstrap auto-plan", "repo", repo, "pr", pr, "head_sha", headSHA, "delivery_id", deliveryID, "error", err)
 			return
 		}

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -106,8 +106,8 @@ func (h *Handler) handlePullRequest(ctx context.Context, metricApp string, w htt
 			return
 		}
 		defer cancel()
-		message := h.runAutoPlanForPR(ctx, client, repo, pr, headSHA, installationID, "pull_request", payload.Action, payload.Before)
-		h.logger.Info("auto-plan finished",
+		message := h.runAutoPlanForPR(ctx, client, repo, pr, headSHA, installationID, "pull_request", payload.Action, payload.Before, deliveryID)
+		h.logger.Info("auto-plan dispatched",
 			"action", payload.Action,
 			"repo", repo,
 			"pr", pr,
@@ -155,12 +155,12 @@ func (h *Handler) shouldPostAutoPlanComment(ctx context.Context, client *ghclien
 	return false
 }
 
-func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA string, installationID int64, source string, action string, beforeSHA string) string {
+func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA string, installationID int64, source string, action string, beforeSHA string, deliveryID string) string {
 	// Fetch the changed files once so the same list drives both config discovery
 	// and the server-managed-directory safety check below.
 	files, err := client.FetchPRFiles(ctx, repo, pr)
 	if err != nil {
-		h.logger.Error("failed to fetch PR files for auto-plan", "repo", repo, "pr", pr, "head_sha", headSHA, "source", source, "error", err)
+		h.logger.Error("failed to fetch PR files for auto-plan", "repo", repo, "pr", pr, "head_sha", headSHA, "source", source, "delivery_id", deliveryID, "error", err)
 		h.postConfigDiscoveryFailure(ctx, client, repo, pr, headSHA, err)
 		return "config discovery failed"
 	}
@@ -168,7 +168,7 @@ func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.Install
 	// Discover all configs matching changed schema files in this PR
 	configs, err := client.FindConfigsForPRFiles(ctx, repo, headSHA, files)
 	if err != nil {
-		h.logger.Error("failed to discover configs for PR", "repo", repo, "pr", pr, "head_sha", headSHA, "source", source, "error", err)
+		h.logger.Error("failed to discover configs for PR", "repo", repo, "pr", pr, "head_sha", headSHA, "source", source, "delivery_id", deliveryID, "error", err)
 		h.postConfigDiscoveryFailure(ctx, client, repo, pr, headSHA, err)
 		return "config discovery failed"
 	}
@@ -203,7 +203,7 @@ func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.Install
 	})
 
 	if len(configs) == 0 {
-		h.logger.Info("no schema files in PR, skipping auto-plan", "repo", repo, "pr", pr, "head_sha", headSHA, "source", source)
+		h.logger.Info("no schema files in PR, skipping auto-plan", "repo", repo, "pr", pr, "head_sha", headSHA, "source", source, "delivery_id", deliveryID)
 		// An aggregate participant does not own the required check for the repo —
 		// the leader does — so on a PR that touches none of this deployment's
 		// schema it has nothing to report and stays silent, rather than posting a
@@ -213,7 +213,7 @@ func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.Install
 		// protection (its check is non-required by the aggregate contract).
 		if h.isAggregateParticipant(repo) {
 			h.logger.Info("aggregate participant staying silent on PR with no managed schema changes",
-				"repo", repo, "pr", pr, "head_sha", headSHA, "source", source)
+				"repo", repo, "pr", pr, "head_sha", headSHA, "source", source, "delivery_id", deliveryID)
 			metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
 				Operation:  "aggregate_participant_skip",
 				Repository: repo,
@@ -230,14 +230,14 @@ func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.Install
 		// Check Run events arrive, converging to passing once they succeed.
 		if h.leaderExpectsParticipantsForPR(repo, files) {
 			h.logger.Info("no leader-managed schema in PR but expected participant paths are touched; aggregate gate will block until participants report",
-				"repo", repo, "pr", pr, "head_sha", headSHA, "source", source)
+				"repo", repo, "pr", pr, "head_sha", headSHA, "source", source, "delivery_id", deliveryID)
 			h.goSafe(repo, pr, installationID, func() {
 				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 				defer cancel()
 				c, err := h.clientForRepo(repo, installationID)
 				if err != nil {
 					h.logger.Error("failed to create GitHub client for participant-gated aggregate",
-						"repo", repo, "pr", pr, "head_sha", headSHA, "error", err)
+						"repo", repo, "pr", pr, "head_sha", headSHA, "delivery_id", deliveryID, "error", err)
 					return
 				}
 				h.updateAggregateCheck(ctx, c, repo, pr, headSHA)
@@ -255,7 +255,7 @@ func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.Install
 			defer cancel()
 			c, err := h.clientForRepo(repo, installationID)
 			if err != nil {
-				h.logger.Error("failed to create GitHub client for passing aggregate", "error", err)
+				h.logger.Error("failed to create GitHub client for passing aggregate", "repo", repo, "pr", pr, "head_sha", headSHA, "delivery_id", deliveryID, "error", err)
 				return
 			}
 			h.postPassingAggregates(ctx, c, repo, pr, headSHA)

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -38,7 +38,7 @@ type pullRequestPayload struct {
 
 // handlePullRequest processes GitHub pull_request webhook events.
 // On PR open/synchronize/reopen, it auto-plans all databases with schema changes.
-func (h *Handler) handlePullRequest(ctx context.Context, metricApp string, w http.ResponseWriter, body []byte) {
+func (h *Handler) handlePullRequest(ctx context.Context, metricApp string, w http.ResponseWriter, body []byte, deliveryID string) {
 	var payload pullRequestPayload
 	if err := json.Unmarshal(body, &payload); err != nil {
 		h.writeError(w, http.StatusBadRequest, "invalid pull_request payload")
@@ -95,15 +95,18 @@ func (h *Handler) handlePullRequest(ctx context.Context, metricApp string, w htt
 		"repo", repo,
 		"pr", pr,
 		"head_sha", headSHA,
+		"delivery_id", deliveryID,
 	)
 
 	ctx, cancel, client, err := h.autoPlanBootstrap(repo, installationID)
 	if err != nil {
-		h.logger.Error("failed to bootstrap auto-plan", "repo", repo, "pr", pr, "head_sha", headSHA, "error", err)
+		h.logger.Error("failed to bootstrap auto-plan", "repo", repo, "pr", pr, "head_sha", headSHA, "delivery_id", deliveryID, "error", err)
 		h.writeError(w, http.StatusInternalServerError, "failed to initialize GitHub client")
 		return
 	}
 
+	// autoPlanBootstrap returns a request-independent bounded context, so the
+	// auto-plan can finish after this webhook response is acknowledged.
 	h.goSafe(repo, pr, installationID, func() {
 		defer cancel()
 		message := h.runAutoPlanForPR(ctx, client, repo, pr, headSHA, installationID, "pull_request", payload.Action, payload.Before)
@@ -112,6 +115,7 @@ func (h *Handler) handlePullRequest(ctx context.Context, metricApp string, w htt
 			"repo", repo,
 			"pr", pr,
 			"head_sha", headSHA,
+			"delivery_id", deliveryID,
 			"message", message,
 		)
 	})

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -98,16 +98,12 @@ func (h *Handler) handlePullRequest(ctx context.Context, metricApp string, w htt
 		"delivery_id", deliveryID,
 	)
 
-	ctx, cancel, client, err := h.autoPlanBootstrap(repo, installationID)
-	if err != nil {
-		h.logger.Error("failed to bootstrap auto-plan", "repo", repo, "pr", pr, "head_sha", headSHA, "delivery_id", deliveryID, "error", err)
-		h.writeError(w, http.StatusInternalServerError, "failed to initialize GitHub client")
-		return
-	}
-
-	// autoPlanBootstrap returns a request-independent bounded context, so the
-	// auto-plan can finish after this webhook response is acknowledged.
 	h.goSafe(repo, pr, installationID, func() {
+		ctx, cancel, client, err := h.autoPlanBootstrap(repo, installationID)
+		if err != nil {
+			h.logger.Error("failed to bootstrap auto-plan", "repo", repo, "pr", pr, "head_sha", headSHA, "delivery_id", deliveryID, "error", err)
+			return
+		}
 		defer cancel()
 		message := h.runAutoPlanForPR(ctx, client, repo, pr, headSHA, installationID, "pull_request", payload.Action, payload.Before)
 		h.logger.Info("auto-plan finished",

--- a/pkg/webhook/testhelpers_test.go
+++ b/pkg/webhook/testhelpers_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 
 	gh "github.com/google/go-github/v86/github"
@@ -21,6 +22,14 @@ import (
 // fakeClientFactory returns a pre-built InstallationClient for any installation ID.
 type fakeClientFactory struct {
 	client *ghclient.InstallationClient
+	// forInstallationErr, when set, makes ForInstallation fail after any
+	// configured synchronization hooks run.
+	forInstallationErr error
+	// forInstallationStarted is closed when ForInstallation is entered.
+	forInstallationStarted chan struct{}
+	// forInstallationRelease blocks ForInstallation until closed.
+	forInstallationRelease <-chan struct{}
+	forInstallationOnce    sync.Once
 	// repoInstallationID is returned by InstallationIDForRepo. Zero defaults to
 	// 12345 so repo-webhook dispatch tests resolve a non-zero installation id.
 	repoInstallationID int64
@@ -30,6 +39,15 @@ type fakeClientFactory struct {
 }
 
 func (f *fakeClientFactory) ForInstallation(_ int64) (*ghclient.InstallationClient, error) {
+	if f.forInstallationStarted != nil {
+		f.forInstallationOnce.Do(func() { close(f.forInstallationStarted) })
+	}
+	if f.forInstallationRelease != nil {
+		<-f.forInstallationRelease
+	}
+	if f.forInstallationErr != nil {
+		return nil, f.forInstallationErr
+	}
 	return f.client, nil
 }
 


### PR DESCRIPTION
## Summary
Pull request webhooks now acknowledge quickly after validation/routing and dispatch auto-plan bootstrap, discovery, and check publication asynchronously. This keeps SchemaBot responses away from GitHub's fixed 10-second webhook delivery timeout, which is not configurable by the receiving service.

This is phase one: it reduces the synchronous webhook response path and adds delivery-GUID correlation plus a bootstrap-failure metric for async completion/failure visibility. Durable enqueue/dedup, bounded workers, graceful shutdown draining, redundant convergence signals, and check backfill remain follow-up safety nets for ack-then-crash, webhook-storm, or lost-delivery cases.

## What
- Move `pull_request` auto-plan bootstrap/discovery/check publication behind the existing safe async webhook runner.
- Return `auto-plan started` quickly after the webhook is accepted.
- Include the GitHub delivery GUID in auto-plan triggered/dispatched/error logs for incident correlation.
- Emit an `auto_plan_bootstrap_failed` webhook metric when fast-acked async work cannot bootstrap.
- Add repo/PR/install identifiers to async panic logs.
- Harden integration tests so they assert async outcomes instead of only the immediate 200 response.

## Why
GitHub webhook deliveries have a hard 10-second response timeout, and that timeout is not configurable. Auto-plan work can include GitHub client setup, PR file reads, config discovery, stale-check cleanup, and aggregate check publishing, so doing that work before returning risks GitHub recording a timed-out delivery.

This PR is the tactical fast-ack mitigation; it is not the final durable ingestion design.

```text
Before:
GitHub pull_request webhook
        │
        ▼
SchemaBot validates + bootstraps + discovers configs + refreshes checks
        │
        ▼
HTTP 200 only after synchronous work completes
```

```text
After:
GitHub pull_request webhook
        │
        ▼
SchemaBot validates/routes + starts async auto-plan
        │
        ├──▶ HTTP 200: auto-plan started
        │
        ▼
Async bootstrap + discovery + check/comment publication
        │
        ▼
Logs dispatch/failure with X-GitHub-Delivery correlation
```

## Follow-ups
- Add a tighter deadline or earlier handoff around any remaining pre-dispatch work that can consume webhook response budget.
- Add graceful shutdown draining for in-process webhook goroutines, or replace them with durable workers.
- Persist durable webhook jobs before acknowledgement, with dedup, replay, attempts, and last-error state.
- Run auto-plan/check publication through bounded workers or per-repo/PR single-flight to avoid webhook storms exhausting GitHub/API budgets.
- Add redundant convergence signals into the same durable work-item path, keeping work PR-scoped.
- Treat checks backfill as the safety net for `200 ack but missing checks`, since failed-delivery redrive only helps when GitHub records a failed delivery.
- Add started/dispatched/failed metrics keyed by delivery GUID and alert on missing completion or missing expected checks.

## References
- GitHub webhook timeout docs: https://docs.github.com/en/webhooks/testing-and-troubleshooting-webhooks/troubleshooting-webhooks#timed-out
