### PR TITLE
test(spirit): deflake volume-change progress assertion

### DIFF
--- a/pkg/engine/spirit/spirit_integration_test.go
+++ b/pkg/engine/spirit/spirit_integration_test.go
@@ -1743,8 +1743,15 @@ func TestEngine_Volume_PreservesProgress(t *testing.T) {
 		tableProgress := progressResult.Tables[0]
 		t.Logf("Progress after volume change: state=%v, rows_copied=%d/%d",
 			progressResult.State, tableProgress.RowsCopied, tableProgress.RowsTotal)
-		if tableProgress.RowsTotal == 0 {
-			t.Logf("Progress after volume change is still in runner setup: state=%v", progressResult.State)
+		// During the resume window the new runner can publish a table row with a
+		// known RowsTotal while RowsCopied is momentarily 0, before the checkpoint
+		// is re-applied. Skip those samples and wait for the first checkpoint-backed
+		// one. A genuine restart from the beginning is still caught: it re-copies
+		// from 0 and its first non-zero sample lands far below minExpected, and if it
+		// never republishes progress the timeout guard below fails the test.
+		if tableProgress.RowsTotal == 0 || tableProgress.RowsCopied == 0 {
+			t.Logf("Progress after volume change is still in runner setup: state=%v, rows_copied=%d/%d",
+				progressResult.State, tableProgress.RowsCopied, tableProgress.RowsTotal)
 			continue
 		}
 


### PR DESCRIPTION
## Summary
`TestEngine_Volume_PreservesProgress` could flake: after a volume change (Stop + Start), the resumed runner can publish a table row with a known `RowsTotal` while `RowsCopied` is momentarily `0`, before the checkpoint is re-applied. The poll grabbed that transient sample and read progress as `0`, failing the "progress preserved" assertion.

## What
Extend the resume/setup-window skip to also ignore samples where `RowsCopied == 0`, and assert on the first checkpoint-backed sample.

## Why
The prior guard skipped only `RowsTotal == 0` samples, leaving a race window. Safety is preserved: a genuine restart-from-zero re-copies from 0, so its first non-zero sample lands far below the expected threshold (still fails), and if it never republishes progress the existing timeout guard fails the test. Verified 8/8 passes locally via `scripts/test-flaky.sh`.

## Observed failure
Flaked on an unrelated PR's Integration Tests job: https://github.com/block/schemabot/actions/runs/29069657132/job/86288404580
```
--- FAIL: TestEngine_Volume_PreservesProgress
Progress reset after volume change! Before: 2000, After: 0 (expected at least 1000)
```