### PR TITLE
feat(inventory): add per-request dsn_from for static targets

### DIFF
--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -172,23 +172,23 @@ storage:
   dsn: env:MYSQL_DSN
 target_resolver:
   targets:
-    apse2-prod:
+    example-target:
       type: mysql
       dsn_from:
-        config_ref: secretsmanager:/pe/aurora/schemabot-pilot-prod-apse2/spirit_credentials
-        password_ref: secretsmanager:/pe/aurora/schemabot-pilot-prod-apse2/spirit_credentials#password
-        username: m_spirit
+        config_ref: secretsmanager:/example/schemabot/target-credentials
+        password_ref: secretsmanager:/example/schemabot/target-credentials#password
+        username: schemabot
 `
 	require.NoError(t, os.WriteFile(configPath, []byte(content), 0644), "write config file")
 
 	cfg, err := LoadServerConfigFromFile(configPath)
 	require.NoError(t, err)
-	target := cfg.TargetResolver.Targets["apse2-prod"]
+	target := cfg.TargetResolver.Targets["example-target"]
 	assert.Equal(t, "mysql", target.DatabaseType)
 	require.NotNil(t, target.DSNFrom)
-	assert.Equal(t, "m_spirit", target.DSNFrom.Username)
-	assert.Equal(t, "secretsmanager:/pe/aurora/schemabot-pilot-prod-apse2/spirit_credentials", target.DSNFrom.ConfigRef)
-	assert.Equal(t, "secretsmanager:/pe/aurora/schemabot-pilot-prod-apse2/spirit_credentials#password", target.DSNFrom.PasswordRef)
+	assert.Equal(t, "schemabot", target.DSNFrom.Username)
+	assert.Equal(t, "secretsmanager:/example/schemabot/target-credentials", target.DSNFrom.ConfigRef)
+	assert.Equal(t, "secretsmanager:/example/schemabot/target-credentials#password", target.DSNFrom.PasswordRef)
 }
 
 func TestLoadServerConfigFromFile_NotFound(t *testing.T) {

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -164,6 +164,33 @@ databases:
 	assert.Equal(t, map[string]string{"parseTime": "true"}, targetDSNFrom.Params)
 }
 
+func TestLoadServerConfigFromFile_StaticTargetDSNFrom(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	content := `
+storage:
+  dsn: env:MYSQL_DSN
+target_resolver:
+  targets:
+    apse2-prod:
+      type: mysql
+      dsn_from:
+        config_ref: secretsmanager:/pe/aurora/schemabot-pilot-prod-apse2/spirit_credentials
+        password_ref: secretsmanager:/pe/aurora/schemabot-pilot-prod-apse2/spirit_credentials#password
+        username: m_spirit
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(content), 0644), "write config file")
+
+	cfg, err := LoadServerConfigFromFile(configPath)
+	require.NoError(t, err)
+	target := cfg.TargetResolver.Targets["apse2-prod"]
+	assert.Equal(t, "mysql", target.DatabaseType)
+	require.NotNil(t, target.DSNFrom)
+	assert.Equal(t, "m_spirit", target.DSNFrom.Username)
+	assert.Equal(t, "secretsmanager:/pe/aurora/schemabot-pilot-prod-apse2/spirit_credentials", target.DSNFrom.ConfigRef)
+	assert.Equal(t, "secretsmanager:/pe/aurora/schemabot-pilot-prod-apse2/spirit_credentials#password", target.DSNFrom.PasswordRef)
+}
+
 func TestLoadServerConfigFromFile_NotFound(t *testing.T) {
 	_, err := LoadServerConfigFromFile("/nonexistent/config.yaml")
 	assert.Error(t, err, "expected error for nonexistent file")

--- a/pkg/inventory/static.go
+++ b/pkg/inventory/static.go
@@ -302,7 +302,10 @@ func requiredStringField(document map[string]any, key string) (string, error) {
 }
 
 // optionalNumericField reads an optional port field, accepting a string or a
-// JSON number. A missing field returns an empty string.
+// JSON number. A missing or blank field returns an empty string (the caller
+// applies the default). A value that is present must be a base-10 integer in the
+// valid TCP port range; anything else fails closed with a clear config error
+// rather than producing a confusing downstream failure (or host:0).
 func optionalNumericField(document map[string]any, key string) (string, error) {
 	value, ok := document[key]
 	if !ok {
@@ -310,15 +313,32 @@ func optionalNumericField(document map[string]any, key string) (string, error) {
 	}
 	switch v := value.(type) {
 	case string:
-		return v, nil
+		text := strings.TrimSpace(v)
+		if text == "" {
+			return "", nil
+		}
+		return normalizePort(key, text)
 	case float64:
 		if v != float64(int64(v)) {
 			return "", fmt.Errorf("key %q must be an integer", key)
 		}
-		return strconv.FormatInt(int64(v), 10), nil
+		return normalizePort(key, strconv.FormatInt(int64(v), 10))
 	case json.Number:
-		return v.String(), nil
+		return normalizePort(key, strings.TrimSpace(v.String()))
 	default:
 		return "", fmt.Errorf("key %q must be a string or number", key)
 	}
+}
+
+// normalizePort validates that text is a base-10 integer in the valid TCP port
+// range and returns its canonical form.
+func normalizePort(key, text string) (string, error) {
+	n, err := strconv.Atoi(text)
+	if err != nil {
+		return "", fmt.Errorf("key %q must be an integer port: %w", key, err)
+	}
+	if n < 1 || n > 65535 {
+		return "", fmt.Errorf("key %q must be a port between 1 and 65535, got %d", key, n)
+	}
+	return strconv.Itoa(n), nil
 }

--- a/pkg/inventory/static.go
+++ b/pkg/inventory/static.go
@@ -31,6 +31,16 @@ type StaticTarget struct {
 	// so a rotated target credential (for example one re-synced by the External
 	// Secrets Operator) is picked up without restarting the worker. Mutually
 	// exclusive with DSN.
+	//
+	// Intended backend: file: secret references (the ESO-synced case). The
+	// per-request assembly runs before the target router's client-cache lookup,
+	// and on a cache hit the freshly assembled DSN is discarded (the cached client
+	// serves the request), so today dsn_from buys rotation-safety only at the next
+	// cache miss. With secretsmanager: refs that means every routed request pays a
+	// GetSecretValue call (two, for the split config/password refs) and gains a
+	// per-request dependency on secret-backend availability with no offsetting
+	// benefit until the DSN-aware client cache lands; with file: refs the cost and
+	// availability risk are negligible. Prefer file: refs until that follow-up.
 	DSNFrom  *StaticDSNFromConfig `yaml:"dsn_from,omitempty"`
 	Metadata map[string]string    `yaml:"metadata,omitempty"`
 }

--- a/pkg/inventory/static.go
+++ b/pkg/inventory/static.go
@@ -2,8 +2,10 @@ package inventory
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"maps"
+	"strconv"
 	"strings"
 
 	"github.com/go-sql-driver/mysql"
@@ -16,16 +18,67 @@ type StaticConfig struct {
 	Targets map[string]StaticTarget `yaml:"targets"`
 }
 
-// StaticTarget is a static connection entry for one target.
+// StaticTarget is a static connection entry for one target. Exactly one of DSN
+// or DSNFrom must be set.
 type StaticTarget struct {
-	DatabaseType string            `yaml:"type"`
-	DSN          string            `yaml:"dsn"`
-	Metadata     map[string]string `yaml:"metadata,omitempty"`
+	DatabaseType string `yaml:"type"`
+	// DSN is a full connection string or secret reference. It is resolved once,
+	// when the resolver is constructed, and cached. Mutually exclusive with
+	// DSNFrom.
+	DSN string `yaml:"dsn,omitempty"`
+	// DSNFrom assembles a namespace-free MySQL DSN from separate config and
+	// password secret references. Unlike DSN it is resolved fresh on every request
+	// so a rotated target credential (for example one re-synced by the External
+	// Secrets Operator) is picked up without restarting the worker. Mutually
+	// exclusive with DSN.
+	DSNFrom  *StaticDSNFromConfig `yaml:"dsn_from,omitempty"`
+	Metadata map[string]string    `yaml:"metadata,omitempty"`
+}
+
+// StaticDSNFromConfig assembles a namespace-free MySQL DSN for a static target
+// from secret references, resolved fresh on every request. It deliberately never
+// reads a database name: the per-operation request supplies the schema, so the
+// assembled DSN carries none (a DSN with a database name is rejected).
+type StaticDSNFromConfig struct {
+	// ConfigRef is a secret reference to a JSON document holding the target's
+	// connection metadata (host and port).
+	ConfigRef string `yaml:"config_ref"`
+	// ConfigPaths selects which keys in ConfigRef hold the host and port,
+	// defaulting to "host" and "port".
+	ConfigPaths StaticDSNFromPaths `yaml:"config_paths,omitempty"`
+	// Username is the database user included in the assembled DSN.
+	Username string `yaml:"username"`
+	// PasswordRef is a secret reference to the database user's password. It is
+	// resolved fresh on every request.
+	PasswordRef string `yaml:"password_ref"`
+	// Params are appended as MySQL DSN query parameters (for example TLS
+	// settings).
+	Params map[string]string `yaml:"params,omitempty"`
+}
+
+// StaticDSNFromPaths selects the host and port keys in a StaticDSNFromConfig's
+// config document. Keys are looked up at the top level of the document.
+type StaticDSNFromPaths struct {
+	Host string `yaml:"host,omitempty"`
+	Port string `yaml:"port,omitempty"`
 }
 
 // StaticResolver resolves targets from static configuration.
 type StaticResolver struct {
-	targets map[string]Target
+	targets map[string]staticTargetEntry
+}
+
+// staticTargetEntry is one prepared static target. A dsn entry resolves once at
+// construction and caches its DSN; a dsn_from entry assembles its DSN fresh on
+// every request.
+type staticTargetEntry struct {
+	target       string
+	databaseType string
+	metadata     map[string]string
+	// dsn is set (non-nil) for entries resolved once at construction.
+	dsn *string
+	// dsnFrom is set for entries assembled fresh on every request.
+	dsnFrom *StaticDSNFromConfig
 }
 
 var _ Resolver = (*StaticResolver)(nil)
@@ -35,22 +88,22 @@ func NewStaticResolver(config StaticConfig) (*StaticResolver, error) {
 	if len(config.Targets) == 0 {
 		return nil, fmt.Errorf("static target resolver requires at least one target")
 	}
-	targets := make(map[string]Target, len(config.Targets))
+	targets := make(map[string]staticTargetEntry, len(config.Targets))
 	for target, entry := range config.Targets {
 		if target == "" {
 			return nil, fmt.Errorf("static target resolver contains an empty target key")
 		}
-		resolved, err := resolveStaticTarget(target, entry)
+		prepared, err := newStaticTargetEntry(target, entry)
 		if err != nil {
 			return nil, err
 		}
-		targets[target] = *resolved
+		targets[target] = *prepared
 	}
 	return &StaticResolver{targets: targets}, nil
 }
 
 // ResolveTarget resolves one target from static configuration.
-func (r *StaticResolver) ResolveTarget(_ context.Context, req Request) (*Target, error) {
+func (r *StaticResolver) ResolveTarget(ctx context.Context, req Request) (*Target, error) {
 	if r == nil {
 		return nil, fmt.Errorf("static target resolver is nil")
 	}
@@ -63,28 +116,52 @@ func (r *StaticResolver) ResolveTarget(_ context.Context, req Request) (*Target,
 	}
 	if strings.TrimSpace(req.DatabaseType) != "" {
 		requestedType := canonicalDatabaseType(req.DatabaseType)
-		if requestedType != entry.DatabaseType {
-			return nil, fmt.Errorf("target %q is configured for database type %q, not %q", req.Target, entry.DatabaseType, requestedType)
+		if requestedType != entry.databaseType {
+			return nil, fmt.Errorf("target %q is configured for database type %q, not %q", req.Target, entry.databaseType, requestedType)
 		}
 	}
+	dsn, err := entry.resolveDSN(ctx, req)
+	if err != nil {
+		return nil, err
+	}
 	return &Target{
-		Target:       entry.Target,
-		DatabaseType: entry.DatabaseType,
-		DSN:          entry.DSN,
-		Metadata:     maps.Clone(entry.Metadata),
+		Target:       entry.target,
+		DatabaseType: entry.databaseType,
+		DSN:          dsn,
+		Metadata:     maps.Clone(entry.metadata),
 	}, nil
 }
 
-func resolveStaticTarget(target string, entry StaticTarget) (*Target, error) {
-	if entry.DatabaseType == "" {
-		return nil, fmt.Errorf("target %q missing type", target)
-	}
+// newStaticTargetEntry prepares one static target: it validates the entry, and
+// for a dsn entry resolves and caches the DSN now, while a dsn_from entry only
+// validates its shape (its DSN is assembled per request).
+func newStaticTargetEntry(target string, entry StaticTarget) (*staticTargetEntry, error) {
 	databaseType := canonicalDatabaseType(entry.DatabaseType)
 	if databaseType == "" {
 		return nil, fmt.Errorf("target %q missing type", target)
 	}
-	if entry.DSN == "" {
+	hasDSN := entry.DSN != ""
+	hasDSNFrom := entry.DSNFrom != nil
+	switch {
+	case hasDSN && hasDSNFrom:
+		return nil, fmt.Errorf("target %q cannot configure both dsn and dsn_from", target)
+	case !hasDSN && !hasDSNFrom:
 		return nil, fmt.Errorf("target %q missing dsn", target)
+	}
+	prepared := &staticTargetEntry{
+		target:       target,
+		databaseType: databaseType,
+		metadata:     maps.Clone(entry.Metadata),
+	}
+	if hasDSNFrom {
+		if databaseType != "mysql" {
+			return nil, fmt.Errorf("target %q dsn_from is only supported for mysql, not %q", target, databaseType)
+		}
+		if err := entry.DSNFrom.validate(target); err != nil {
+			return nil, err
+		}
+		prepared.dsnFrom = entry.DSNFrom
+		return prepared, nil
 	}
 	dsn, err := secrets.Resolve(entry.DSN, "")
 	if err != nil {
@@ -96,12 +173,24 @@ func resolveStaticTarget(target string, entry StaticTarget) (*Target, error) {
 	if err := validateResolvedStaticTargetDSN(target, databaseType, dsn); err != nil {
 		return nil, err
 	}
-	return &Target{
-		Target:       target,
-		DatabaseType: databaseType,
-		DSN:          dsn,
-		Metadata:     maps.Clone(entry.Metadata),
-	}, nil
+	prepared.dsn = &dsn
+	return prepared, nil
+}
+
+// resolveDSN returns the entry's DSN: the cached value for a dsn entry, or a
+// freshly assembled namespace-free DSN for a dsn_from entry.
+func (e staticTargetEntry) resolveDSN(ctx context.Context, req Request) (string, error) {
+	if e.dsn != nil {
+		return *e.dsn, nil
+	}
+	dsn, err := e.dsnFrom.assemble(ctx, req, e.databaseType)
+	if err != nil {
+		return "", err
+	}
+	if err := validateResolvedStaticTargetDSN(e.target, e.databaseType, dsn); err != nil {
+		return "", err
+	}
+	return dsn, nil
 }
 
 func canonicalDatabaseType(databaseType string) string {
@@ -120,4 +209,116 @@ func validateResolvedStaticTargetDSN(target, databaseType, dsn string) error {
 		return fmt.Errorf("target %q MySQL DSN must not include a database name; the request supplies the namespace", target)
 	}
 	return nil
+}
+
+// validate checks that a dsn_from entry has the fields required to assemble a
+// DSN. The password is not read here — it is resolved per request so a rotated
+// credential is picked up without a restart.
+func (c *StaticDSNFromConfig) validate(target string) error {
+	if c.ConfigRef == "" {
+		return fmt.Errorf("target %q dsn_from missing config_ref", target)
+	}
+	if c.Username == "" {
+		return fmt.Errorf("target %q dsn_from missing username", target)
+	}
+	if c.PasswordRef == "" {
+		return fmt.Errorf("target %q dsn_from missing password_ref", target)
+	}
+	return nil
+}
+
+// assemble builds a namespace-free MySQL DSN from the config document (host and
+// port) and the password reference, both resolved fresh. It reuses the shared
+// MySQL assembler and the fail-closed secret-ref credential resolver so a rotated
+// password or empty secret is handled identically to the Etre data-plane path.
+func (c *StaticDSNFromConfig) assemble(ctx context.Context, req Request, databaseType string) (string, error) {
+	host, port, err := c.resolveEndpoint(req.Target)
+	if err != nil {
+		return "", err
+	}
+	creds, err := SecretRefCredentialResolver{Username: c.Username, PasswordRef: c.PasswordRef}.ResolveCredentials(ctx, req, nil)
+	if err != nil {
+		return "", err
+	}
+	assembler := MySQLConnectionAssembler{Type: databaseType, DefaultPort: port, Params: c.Params}
+	dsn, _, err := assembler.Assemble(host, nil, creds)
+	if err != nil {
+		return "", fmt.Errorf("assemble DSN for target %q: %w", req.Target, err)
+	}
+	return dsn, nil
+}
+
+// resolveEndpoint resolves the config document and reads the target host and
+// port from it. The port defaults to 3306 when absent; the database name in the
+// document, if any, is ignored (static target DSNs are namespace-free).
+func (c *StaticDSNFromConfig) resolveEndpoint(target string) (host, port string, err error) {
+	document, err := secrets.Resolve(c.ConfigRef, "")
+	if err != nil {
+		return "", "", fmt.Errorf("resolve config reference for target %q: %w", target, err)
+	}
+	if document == "" {
+		return "", "", fmt.Errorf("config reference for target %q resolved an empty value", target)
+	}
+	var config map[string]any
+	if err := json.Unmarshal([]byte(document), &config); err != nil {
+		return "", "", fmt.Errorf("parse config for target %q: %w", target, err)
+	}
+	hostKey := c.ConfigPaths.Host
+	if hostKey == "" {
+		hostKey = "host"
+	}
+	portKey := c.ConfigPaths.Port
+	if portKey == "" {
+		portKey = "port"
+	}
+	host, err = requiredStringField(config, hostKey)
+	if err != nil {
+		return "", "", fmt.Errorf("read host for target %q: %w", target, err)
+	}
+	port, err = optionalNumericField(config, portKey)
+	if err != nil {
+		return "", "", fmt.Errorf("read port for target %q: %w", target, err)
+	}
+	if port == "" {
+		port = "3306"
+	}
+	return host, port, nil
+}
+
+// requiredStringField reads a non-empty string field from the config document.
+func requiredStringField(document map[string]any, key string) (string, error) {
+	value, ok := document[key]
+	if !ok {
+		return "", fmt.Errorf("missing key %q", key)
+	}
+	text, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("key %q must be a string", key)
+	}
+	if text == "" {
+		return "", fmt.Errorf("key %q is empty", key)
+	}
+	return text, nil
+}
+
+// optionalNumericField reads an optional port field, accepting a string or a
+// JSON number. A missing field returns an empty string.
+func optionalNumericField(document map[string]any, key string) (string, error) {
+	value, ok := document[key]
+	if !ok {
+		return "", nil
+	}
+	switch v := value.(type) {
+	case string:
+		return v, nil
+	case float64:
+		if v != float64(int64(v)) {
+			return "", fmt.Errorf("key %q must be an integer", key)
+		}
+		return strconv.FormatInt(int64(v), 10), nil
+	case json.Number:
+		return v.String(), nil
+	default:
+		return "", fmt.Errorf("key %q must be a string or number", key)
+	}
 }

--- a/pkg/inventory/static.go
+++ b/pkg/inventory/static.go
@@ -51,15 +51,18 @@ type StaticTarget struct {
 // assembled DSN carries none (a DSN with a database name is rejected).
 type StaticDSNFromConfig struct {
 	// ConfigRef is a secret reference to a JSON document holding the target's
-	// connection metadata (host and port).
+	// connection metadata (host and port). Like PasswordRef it may contain a
+	// "{target}" placeholder, replaced with the request target for per-target
+	// secret naming, and is resolved fresh on every request.
 	ConfigRef string `yaml:"config_ref"`
 	// ConfigPaths selects which keys in ConfigRef hold the host and port,
 	// defaulting to "host" and "port".
 	ConfigPaths StaticDSNFromPaths `yaml:"config_paths,omitempty"`
 	// Username is the database user included in the assembled DSN.
 	Username string `yaml:"username"`
-	// PasswordRef is a secret reference to the database user's password. It is
-	// resolved fresh on every request.
+	// PasswordRef is a secret reference to the database user's password. It may
+	// contain a "{target}" placeholder, replaced with the request target for
+	// per-target secret naming, and is resolved fresh on every request.
 	PasswordRef string `yaml:"password_ref"`
 	// Params are appended as MySQL DSN query parameters (for example TLS
 	// settings).
@@ -156,7 +159,7 @@ func newStaticTargetEntry(target string, entry StaticTarget) (*staticTargetEntry
 	case hasDSN && hasDSNFrom:
 		return nil, fmt.Errorf("target %q cannot configure both dsn and dsn_from", target)
 	case !hasDSN && !hasDSNFrom:
-		return nil, fmt.Errorf("target %q missing dsn", target)
+		return nil, fmt.Errorf("target %q missing dsn or dsn_from", target)
 	}
 	prepared := &staticTargetEntry{
 		target:       target,
@@ -262,7 +265,8 @@ func (c *StaticDSNFromConfig) assemble(ctx context.Context, req Request, databas
 // port from it. The port defaults to 3306 when absent; the database name in the
 // document, if any, is ignored (static target DSNs are namespace-free).
 func (c *StaticDSNFromConfig) resolveEndpoint(target string) (host, port string, err error) {
-	document, err := secrets.Resolve(c.ConfigRef, "")
+	ref := strings.ReplaceAll(c.ConfigRef, "{target}", target)
+	document, err := secrets.Resolve(ref, "")
 	if err != nil {
 		return "", "", fmt.Errorf("resolve config reference for target %q: %w", target, err)
 	}
@@ -295,7 +299,8 @@ func (c *StaticDSNFromConfig) resolveEndpoint(target string) (host, port string,
 	return host, port, nil
 }
 
-// requiredStringField reads a non-empty string field from the config document.
+// requiredStringField reads a string field from the config document, trims
+// surrounding whitespace, and requires the result to be non-empty.
 func requiredStringField(document map[string]any, key string) (string, error) {
 	value, ok := document[key]
 	if !ok {
@@ -305,6 +310,7 @@ func requiredStringField(document map[string]any, key string) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("key %q must be a string", key)
 	}
+	text = strings.TrimSpace(text)
 	if text == "" {
 		return "", fmt.Errorf("key %q is empty", key)
 	}
@@ -333,8 +339,6 @@ func optionalNumericField(document map[string]any, key string) (string, error) {
 			return "", fmt.Errorf("key %q must be an integer", key)
 		}
 		return normalizePort(key, strconv.FormatInt(int64(v), 10))
-	case json.Number:
-		return normalizePort(key, strings.TrimSpace(v.String()))
 	default:
 		return "", fmt.Errorf("key %q must be a string or number", key)
 	}

--- a/pkg/inventory/static_test.go
+++ b/pkg/inventory/static_test.go
@@ -294,6 +294,30 @@ func TestStaticResolverDSNFromFailsClosed(t *testing.T) {
 		_, err := newResolver(t).ResolveTarget(t.Context(), Request{Target: "target-1"})
 		assert.ErrorContains(t, err, "must be a string or number")
 	})
+
+	t.Run("non-numeric string port", func(t *testing.T) {
+		t.Setenv("TARGET_CONFIG", `{"host":"db.example","port":"not-a-port"}`)
+		t.Setenv("TARGET_PASSWORD", "s3cret")
+		_, err := newResolver(t).ResolveTarget(t.Context(), Request{Target: "target-1"})
+		assert.ErrorContains(t, err, "must be an integer port")
+	})
+
+	t.Run("out-of-range port", func(t *testing.T) {
+		t.Setenv("TARGET_CONFIG", `{"host":"db.example","port":70000}`)
+		t.Setenv("TARGET_PASSWORD", "s3cret")
+		_, err := newResolver(t).ResolveTarget(t.Context(), Request{Target: "target-1"})
+		assert.ErrorContains(t, err, "between 1 and 65535")
+	})
+
+	t.Run("whitespace string port is trimmed", func(t *testing.T) {
+		t.Setenv("TARGET_CONFIG", `{"host":"db.example","port":" 3307 "}`)
+		t.Setenv("TARGET_PASSWORD", "s3cret")
+		got, err := newResolver(t).ResolveTarget(t.Context(), Request{Target: "target-1"})
+		require.NoError(t, err)
+		cfg, err := mysql.ParseDSN(got.DSN)
+		require.NoError(t, err)
+		assert.Equal(t, "db.example:3307", cfg.Addr)
+	})
 }
 
 func TestNewStaticResolverValidatesConfig(t *testing.T) {

--- a/pkg/inventory/static_test.go
+++ b/pkg/inventory/static_test.go
@@ -205,6 +205,57 @@ func TestStaticResolverDSNFromResolvesPerRequest(t *testing.T) {
 	assert.Equal(t, "new-pass", secondCfg.Passwd)
 }
 
+// Both config_ref and password_ref support the "{target}" placeholder, so a
+// single target entry can name its per-target secrets by the request target.
+func TestStaticResolverDSNFromSubstitutesTargetPlaceholder(t *testing.T) {
+	t.Setenv("CONFIG_apse2-prod", `{"host":"db.example","port":3306}`)
+	t.Setenv("PASSWORD_apse2-prod", "s3cret")
+	resolver, err := NewStaticResolver(StaticConfig{Targets: map[string]StaticTarget{
+		"apse2-prod": {
+			DatabaseType: "mysql",
+			DSNFrom: &StaticDSNFromConfig{
+				ConfigRef:   "env:CONFIG_{target}",
+				Username:    "m_spirit",
+				PasswordRef: "env:PASSWORD_{target}",
+			},
+		},
+	}})
+	require.NoError(t, err)
+
+	got, err := resolver.ResolveTarget(t.Context(), Request{Target: "apse2-prod"})
+	require.NoError(t, err)
+
+	cfg, err := mysql.ParseDSN(got.DSN)
+	require.NoError(t, err)
+	assert.Equal(t, "db.example:3306", cfg.Addr)
+	assert.Equal(t, "s3cret", cfg.Passwd)
+}
+
+// A host value with surrounding whitespace is trimmed so it can't produce a DSN
+// that only fails at dial time.
+func TestStaticResolverDSNFromTrimsHost(t *testing.T) {
+	t.Setenv("TARGET_CONFIG", `{"host":" db.example ","port":3306}`)
+	t.Setenv("TARGET_PASSWORD", "s3cret")
+	resolver, err := NewStaticResolver(StaticConfig{Targets: map[string]StaticTarget{
+		"target-1": {
+			DatabaseType: "mysql",
+			DSNFrom: &StaticDSNFromConfig{
+				ConfigRef:   "env:TARGET_CONFIG",
+				Username:    "m_spirit",
+				PasswordRef: "env:TARGET_PASSWORD",
+			},
+		},
+	}})
+	require.NoError(t, err)
+
+	got, err := resolver.ResolveTarget(t.Context(), Request{Target: "target-1"})
+	require.NoError(t, err)
+
+	cfg, err := mysql.ParseDSN(got.DSN)
+	require.NoError(t, err)
+	assert.Equal(t, "db.example:3306", cfg.Addr)
+}
+
 func TestNewStaticResolverValidatesDSNFromConfig(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -344,7 +395,7 @@ func TestNewStaticResolverValidatesConfig(t *testing.T) {
 		{
 			name:    "missing dsn",
 			config:  StaticConfig{Targets: map[string]StaticTarget{"target-1": {DatabaseType: "mysql"}}},
-			wantErr: "target \"target-1\" missing dsn",
+			wantErr: "target \"target-1\" missing dsn or dsn_from",
 		},
 	}
 

--- a/pkg/inventory/static_test.go
+++ b/pkg/inventory/static_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -117,6 +118,182 @@ func TestStaticResolverResolveTargetRejectsMySQLDSNWithDatabase(t *testing.T) {
 	}})
 
 	assert.ErrorContains(t, err, "MySQL DSN must not include a database name")
+}
+
+func TestStaticResolverResolveTargetDSNFrom(t *testing.T) {
+	t.Setenv("TARGET_CONFIG", `{"host":"db.example","port":3306,"database":"appdb"}`)
+	t.Setenv("TARGET_PASSWORD", "s3cret")
+	resolver, err := NewStaticResolver(StaticConfig{Targets: map[string]StaticTarget{
+		"apse2-prod": {
+			DatabaseType: "mysql",
+			DSNFrom: &StaticDSNFromConfig{
+				ConfigRef:   "env:TARGET_CONFIG",
+				Username:    "m_spirit",
+				PasswordRef: "env:TARGET_PASSWORD",
+			},
+			Metadata: map[string]string{"pending_drops": "false"},
+		},
+	}})
+	require.NoError(t, err)
+
+	got, err := resolver.ResolveTarget(t.Context(), Request{Target: "apse2-prod", DatabaseType: "MYSQL"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "apse2-prod", got.Target)
+	assert.Equal(t, "mysql", got.DatabaseType)
+	assert.Equal(t, map[string]string{"pending_drops": "false"}, got.Metadata)
+
+	cfg, err := mysql.ParseDSN(got.DSN)
+	require.NoError(t, err)
+	assert.Equal(t, "db.example:3306", cfg.Addr)
+	assert.Equal(t, "m_spirit", cfg.User)
+	assert.Equal(t, "s3cret", cfg.Passwd)
+	assert.Empty(t, cfg.DBName, "static target DSN must be namespace-free")
+}
+
+func TestStaticResolverDSNFromDefaultsPort(t *testing.T) {
+	t.Setenv("TARGET_CONFIG", `{"host":"db.example"}`)
+	t.Setenv("TARGET_PASSWORD", "s3cret")
+	resolver, err := NewStaticResolver(StaticConfig{Targets: map[string]StaticTarget{
+		"target-1": {
+			DatabaseType: "mysql",
+			DSNFrom: &StaticDSNFromConfig{
+				ConfigRef:   "env:TARGET_CONFIG",
+				Username:    "m_spirit",
+				PasswordRef: "env:TARGET_PASSWORD",
+			},
+		},
+	}})
+	require.NoError(t, err)
+
+	got, err := resolver.ResolveTarget(t.Context(), Request{Target: "target-1"})
+	require.NoError(t, err)
+
+	cfg, err := mysql.ParseDSN(got.DSN)
+	require.NoError(t, err)
+	assert.Equal(t, "db.example:3306", cfg.Addr)
+}
+
+// A dsn_from target resolves its credentials fresh on every request, so a
+// rotated password is picked up without rebuilding the resolver.
+func TestStaticResolverDSNFromResolvesPerRequest(t *testing.T) {
+	t.Setenv("TARGET_CONFIG", `{"host":"db.example","port":3306}`)
+	t.Setenv("TARGET_PASSWORD", "old-pass")
+	resolver, err := NewStaticResolver(StaticConfig{Targets: map[string]StaticTarget{
+		"target-1": {
+			DatabaseType: "mysql",
+			DSNFrom: &StaticDSNFromConfig{
+				ConfigRef:   "env:TARGET_CONFIG",
+				Username:    "m_spirit",
+				PasswordRef: "env:TARGET_PASSWORD",
+			},
+		},
+	}})
+	require.NoError(t, err)
+
+	first, err := resolver.ResolveTarget(t.Context(), Request{Target: "target-1"})
+	require.NoError(t, err)
+	firstCfg, err := mysql.ParseDSN(first.DSN)
+	require.NoError(t, err)
+	assert.Equal(t, "old-pass", firstCfg.Passwd)
+
+	t.Setenv("TARGET_PASSWORD", "new-pass")
+	second, err := resolver.ResolveTarget(t.Context(), Request{Target: "target-1"})
+	require.NoError(t, err)
+	secondCfg, err := mysql.ParseDSN(second.DSN)
+	require.NoError(t, err)
+	assert.Equal(t, "new-pass", secondCfg.Passwd)
+}
+
+func TestNewStaticResolverValidatesDSNFromConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		target  StaticTarget
+		wantErr string
+	}{
+		{
+			name: "both dsn and dsn_from",
+			target: StaticTarget{
+				DatabaseType: "mysql",
+				DSN:          "root@tcp(localhost:3306)/",
+				DSNFrom:      &StaticDSNFromConfig{ConfigRef: "env:X", Username: "u", PasswordRef: "env:P"},
+			},
+			wantErr: "cannot configure both dsn and dsn_from",
+		},
+		{
+			name:    "dsn_from missing config_ref",
+			target:  StaticTarget{DatabaseType: "mysql", DSNFrom: &StaticDSNFromConfig{Username: "u", PasswordRef: "env:P"}},
+			wantErr: "dsn_from missing config_ref",
+		},
+		{
+			name:    "dsn_from missing username",
+			target:  StaticTarget{DatabaseType: "mysql", DSNFrom: &StaticDSNFromConfig{ConfigRef: "env:X", PasswordRef: "env:P"}},
+			wantErr: "dsn_from missing username",
+		},
+		{
+			name:    "dsn_from missing password_ref",
+			target:  StaticTarget{DatabaseType: "mysql", DSNFrom: &StaticDSNFromConfig{ConfigRef: "env:X", Username: "u"}},
+			wantErr: "dsn_from missing password_ref",
+		},
+		{
+			name:    "dsn_from non-mysql type",
+			target:  StaticTarget{DatabaseType: "vitess", DSNFrom: &StaticDSNFromConfig{ConfigRef: "env:X", Username: "u", PasswordRef: "env:P"}},
+			wantErr: "dsn_from is only supported for mysql",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewStaticResolver(StaticConfig{Targets: map[string]StaticTarget{"target-1": tt.target}})
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestStaticResolverDSNFromFailsClosed(t *testing.T) {
+	newResolver := func(t *testing.T) *StaticResolver {
+		t.Helper()
+		resolver, err := NewStaticResolver(StaticConfig{Targets: map[string]StaticTarget{
+			"target-1": {
+				DatabaseType: "mysql",
+				DSNFrom: &StaticDSNFromConfig{
+					ConfigRef:   "env:TARGET_CONFIG",
+					Username:    "m_spirit",
+					PasswordRef: "env:TARGET_PASSWORD",
+				},
+			},
+		}})
+		require.NoError(t, err)
+		return resolver
+	}
+
+	t.Run("empty password", func(t *testing.T) {
+		t.Setenv("TARGET_CONFIG", `{"host":"db.example","port":3306}`)
+		t.Setenv("TARGET_PASSWORD", "")
+		_, err := newResolver(t).ResolveTarget(t.Context(), Request{Target: "target-1"})
+		assert.ErrorContains(t, err, "resolved to an empty value")
+	})
+
+	t.Run("missing host", func(t *testing.T) {
+		t.Setenv("TARGET_CONFIG", `{"port":3306}`)
+		t.Setenv("TARGET_PASSWORD", "s3cret")
+		_, err := newResolver(t).ResolveTarget(t.Context(), Request{Target: "target-1"})
+		assert.ErrorContains(t, err, `missing key "host"`)
+	})
+
+	t.Run("empty config document", func(t *testing.T) {
+		t.Setenv("TARGET_CONFIG", "")
+		t.Setenv("TARGET_PASSWORD", "s3cret")
+		_, err := newResolver(t).ResolveTarget(t.Context(), Request{Target: "target-1"})
+		assert.ErrorContains(t, err, "resolved an empty value")
+	})
+
+	t.Run("non-integer port", func(t *testing.T) {
+		t.Setenv("TARGET_CONFIG", `{"host":"db.example","port":true}`)
+		t.Setenv("TARGET_PASSWORD", "s3cret")
+		_, err := newResolver(t).ResolveTarget(t.Context(), Request{Target: "target-1"})
+		assert.ErrorContains(t, err, "must be a string or number")
+	})
 }
 
 func TestNewStaticResolverValidatesConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

Static `target_resolver.targets` can now assemble a namespace-free MySQL DSN at
runtime from separate config and password secret references (`dsn_from`),
resolved fresh on every request. This lets a data-plane worker read a rotated
target credential without a restart, instead of relying on a pre-resolved DSN
string baked in at startup.

## What

- Add `dsn_from` to a static target (`config_ref`, `config_paths` for
  host/port, `username`, `password_ref`, optional `params`), mutually exclusive
  with `dsn`.
- `dsn_from` targets are resolved per `ResolveTarget` call, reusing the existing
  MySQL connection assembler and the fail-closed secret-ref credential resolver.
- The assembled DSN is namespace-free: the config document's database key, if
  any, is ignored (the per-operation request supplies the schema), and a DSN
  carrying a database name is still rejected.
- Existing `dsn:` targets are unchanged — still resolved once at construction.
- MySQL-only for now; a `dsn_from` target with any other type is rejected at
  construction.

## Why

A static `dsn:` reference is resolved once when the resolver is built, so a
rotated credential is only picked up after a restart. `dsn_from` mirrors the
per-use resolution already used for storage/environment DSNs and the dynamic
resolver path, making runtime credential rotation the safe default.

## Before / after

BEFORE — static target supports only dsn:
```
NewStaticResolver (once, at startup)
dsn: → secrets.Resolve → cached DSN ──┐
▼
ResolveTarget(req) ───────────► return cached DSN
rotated credential ⇒ stale until pod restart
```
AFTER — static target also supports dsn_from:
```
NewStaticResolver (once, at startup)
dsn:      → secrets.Resolve → cached DSN     (unchanged)
dsn_from: → validate shape only (no secret read yet)

ResolveTarget(req)
dsn:      → return cached DSN                (unchanged)
dsn_from: → resolve fresh, every request:
config_ref   → host/port  (dbname ignored)
password_ref → password   (fail-closed on empty)
→ MySQL assembler → namespace-free DSN
rotated credential ⇒ picked up on next request, no restart
```

**NOTE:**
Making the client cache DSN-aware — and memoizing the per-call Secrets Manager
client while threading the caller's context so a per-request secret fetch honors
the request deadline instead of a fixed 10s background timeout — is a tracked
follow-up, out of scope for this resolver-layer change.