### PR TITLE
adds durable webhook dispatch driver pool

### DIFF
--- a/pkg/serve/serve.go
+++ b/pkg/serve/serve.go
@@ -84,6 +84,8 @@ func WithBuildInfo(version, commit, date string) Option {
 
 type webhookRuntime struct {
 	handler                         http.Handler
+	startDurableWebhookDispatch     func(context.Context)
+	stopDurableWebhookDispatch      func()
 	reconcileMissingSummaryComments func(context.Context)
 }
 
@@ -480,6 +482,9 @@ func (s *Server) Handler() http.Handler {
 // first.
 func (s *Server) Start(ctx context.Context) {
 	s.webhook.StartMissingSummaryReconciliation(ctx, s.logger)
+	if s.webhook.startDurableWebhookDispatch != nil {
+		s.webhook.startDurableWebhookDispatch(ctx)
+	}
 	s.svc.StartOperator(ctx)
 	s.svc.StartRemoteDeploymentHealthMonitor(ctx)
 	s.svc.StartPendingDropsCleaner(ctx)
@@ -495,6 +500,9 @@ func (s *Server) Start(ctx context.Context) {
 // after Start.
 func (s *Server) Close() error {
 	s.svc.StopPendingDropsCleaner()
+	if s.webhook.stopDurableWebhookDispatch != nil {
+		s.webhook.stopDurableWebhookDispatch()
+	}
 	// Stop the operator before closing the gRPC client below: RegisterGRPC set
 	// that client as the service's default, so until the drivers drain, a claim
 	// of a queued apply can route to it — closing it first would hand a
@@ -668,12 +676,15 @@ func buildSingleAppWebhookRuntime(serverConfig *api.ServerConfig, svc *api.Servi
 		ghclient.WithTrustedCheckAppSlugs(serverConfig.GitHub.TrustedCheckAppSlugs),
 		ghclient.WithConfigDirHints(serverConfig))
 	handler := webhook.NewHandler(svc, ghClient, []byte(ghWebhookSecret), logger,
-		webhook.WithRepoWebhookSecret([]byte(repoWebhookSecret)))
+		webhook.WithRepoWebhookSecret([]byte(repoWebhookSecret)),
+		webhook.WithDurableWebhookDispatch())
 	svc.SetCheckRunBackfiller(handler)
 	logger.Info("GitHub webhook endpoint registered",
 		"app_id", appID, "trusted_check_app_slugs", serverConfig.GitHub.TrustedCheckAppSlugs,
 		"repo_webhook_dispatch", repoWebhookSecret != "")
 	return webhookRuntime{
+		startDurableWebhookDispatch:     handler.StartDurableWebhookDispatch,
+		stopDurableWebhookDispatch:      handler.StopDurableWebhookDispatch,
 		handler:                         handler,
 		reconcileMissingSummaryComments: handler.ReconcileMissingSummaryComments,
 	}, nil
@@ -743,10 +754,13 @@ func buildMultiAppWebhookRuntime(serverConfig *api.ServerConfig, svc *api.Servic
 		secretsByApp,
 		appByID,
 		logger,
+		webhook.WithDurableWebhookDispatch(),
 	)
 	svc.SetCheckRunBackfiller(handler)
 	logger.Info("GitHub multi-App webhook endpoint registered", "apps", len(serverConfig.Apps))
 	return webhookRuntime{
+		startDurableWebhookDispatch:     handler.StartDurableWebhookDispatch,
+		stopDurableWebhookDispatch:      handler.StopDurableWebhookDispatch,
 		handler:                         handler,
 		reconcileMissingSummaryComments: handler.ReconcileMissingSummaryComments,
 	}, nil

--- a/pkg/storage/mysqlstore/webhook_events.go
+++ b/pkg/storage/mysqlstore/webhook_events.go
@@ -77,19 +77,22 @@ func (s *webhookEventStore) Create(ctx context.Context, event *storage.WebhookEv
 
 // reopenTerminalWebhookEvent handles the duplicate-GUID branch of Create.
 // GitHub's "Redeliver" reuses the original delivery GUID, so plain dedup would
-// make redelivery a permanent no-op for a terminally failed row — the one case
-// where an operator most needs it to work. Re-open only terminal failures:
+// make redelivery a permanent no-op for a terminal row — the one case where an
+// operator most needs it to work. Re-open both terminal states (failed and
+// completed): a completed row can still have lost its follow-on work if the
+// process died after the delivery was marked completed but before the detached
+// plan goroutines durably recorded their plans, and re-running auto-plan on the
+// same head SHA is idempotent, so a redeliver is a safe recovery lever.
 // pending/retryable/processing rows are genuinely in flight (dedup, return
-// false), and completed rows must not re-run. last_error is kept for forensics
-// until the next attempt overwrites it.
+// false). last_error is kept for forensics until the next attempt overwrites it.
 func (s *webhookEventStore) reopenTerminalWebhookEvent(ctx context.Context, provider, deliveryID, payload string, receivedAt time.Time) (bool, error) {
 	result, err := s.db.ExecContext(ctx, `
 		UPDATE webhook_events
 		SET state = ?, attempts = 0, payload = ?, received_at = ?,
 			lease_owner = NULL, lease_token = NULL, lease_expires_at = NULL,
 			retry_after = NULL, completed_at = NULL, started_at = NULL, updated_at = NOW()
-		WHERE provider = ? AND delivery_id = ? AND state = ?
-	`, storage.WebhookEventPending, payload, receivedAt, provider, deliveryID, storage.WebhookEventFailed)
+		WHERE provider = ? AND delivery_id = ? AND state IN (?, ?)
+	`, storage.WebhookEventPending, payload, receivedAt, provider, deliveryID, storage.WebhookEventFailed, storage.WebhookEventCompleted)
 	if err != nil {
 		return false, fmt.Errorf("reopen terminally failed webhook delivery (provider=%s, delivery_id=%s): %w", provider, deliveryID, err)
 	}

--- a/pkg/storage/mysqlstore/webhook_events.go
+++ b/pkg/storage/mysqlstore/webhook_events.go
@@ -246,6 +246,19 @@ func (s *webhookEventStore) MarkFailed(ctx context.Context, id int64, leaseToken
 	return s.checkWebhookEventLeaseResult(ctx, result, id, leaseToken)
 }
 
+func (s *webhookEventStore) Release(ctx context.Context, id int64, leaseToken string) error {
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE webhook_events
+		SET state = ?, attempts = GREATEST(attempts - 1, 0), lease_owner = NULL,
+			lease_token = NULL, lease_expires_at = NULL, retry_after = NULL, updated_at = NOW()
+		WHERE id = ? AND lease_token = ?
+	`, storage.WebhookEventPending, id, leaseToken)
+	if err != nil {
+		return fmt.Errorf("release webhook event %d: %w", id, err)
+	}
+	return s.checkWebhookEventLeaseResult(ctx, result, id, leaseToken)
+}
+
 func scanWebhookEvent(row *sql.Row) (*storage.WebhookEvent, error) {
 	event, err := scanWebhookEventInto(row)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/pkg/storage/mysqlstore/webhook_events.go
+++ b/pkg/storage/mysqlstore/webhook_events.go
@@ -246,10 +246,19 @@ func (s *webhookEventStore) MarkFailed(ctx context.Context, id int64, leaseToken
 	return s.checkWebhookEventLeaseResult(ctx, result, id, leaseToken)
 }
 
+// Release re-queues a claimed event as pending and refunds the attempt the
+// claim consumed. When this undoes the first claim (attempts == 1), started_at
+// is cleared so a later claim re-derives it via COALESCE(started_at, NOW()) —
+// otherwise an interrupted first claim would permanently pin started_at to the
+// cancelled attempt's time and misreport when processing actually began. The
+// started_at reset is ordered before the attempts decrement so the CASE reads
+// the pre-decrement value.
 func (s *webhookEventStore) Release(ctx context.Context, id int64, leaseToken string) error {
 	result, err := s.db.ExecContext(ctx, `
 		UPDATE webhook_events
-		SET state = ?, attempts = GREATEST(attempts - 1, 0), lease_owner = NULL,
+		SET state = ?,
+			started_at = CASE WHEN attempts <= 1 THEN NULL ELSE started_at END,
+			attempts = GREATEST(attempts - 1, 0), lease_owner = NULL,
 			lease_token = NULL, lease_expires_at = NULL, retry_after = NULL, updated_at = NOW()
 		WHERE id = ? AND lease_token = ?
 	`, storage.WebhookEventPending, id, leaseToken)

--- a/pkg/storage/mysqlstore/webhook_events_test.go
+++ b/pkg/storage/mysqlstore/webhook_events_test.go
@@ -195,6 +195,78 @@ func TestWebhookEventStore_LeaseTokenGuardsWrites(t *testing.T) {
 	require.NoError(t, store.WebhookEvents().MarkCompleted(ctx, claimed.ID, claimed.LeaseToken))
 }
 
+func TestWebhookEventStore_CreateReopensTerminallyFailedDelivery(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	inserted, err := store.WebhookEvents().Create(ctx, &storage.WebhookEvent{DeliveryID: "delivery-1", Event: "pull_request", Payload: []byte(`{"attempt":1}`)})
+	require.NoError(t, err)
+	require.True(t, inserted)
+
+	claimed, err := store.WebhookEvents().FindNext(ctx, "driver-a", time.Minute)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	require.NoError(t, store.WebhookEvents().MarkFailed(ctx, claimed.ID, claimed.LeaseToken, "permanent failure", nil))
+
+	// GitHub "Redeliver" reuses the original delivery GUID; it must re-open a
+	// terminally failed row instead of being deduplicated into a no-op.
+	inserted, err = store.WebhookEvents().Create(ctx, &storage.WebhookEvent{DeliveryID: "delivery-1", Event: "pull_request", Payload: []byte(`{"attempt":2}`)})
+	require.NoError(t, err)
+	require.True(t, inserted)
+
+	reopened, err := store.WebhookEvents().GetByDeliveryID(ctx, storage.WebhookProviderGitHub, "delivery-1")
+	require.NoError(t, err)
+	require.NotNil(t, reopened)
+	assert.Equal(t, storage.WebhookEventPending, reopened.State)
+	assert.Equal(t, 0, reopened.Attempts)
+	assert.Empty(t, reopened.LeaseToken)
+	assert.Nil(t, reopened.CompletedAt)
+	assert.Nil(t, reopened.StartedAt)
+	assert.JSONEq(t, `{"attempt":2}`, string(reopened.Payload))
+
+	reclaimed, err := store.WebhookEvents().FindNext(ctx, "driver-b", time.Minute)
+	require.NoError(t, err)
+	require.NotNil(t, reclaimed)
+	require.NoError(t, store.WebhookEvents().MarkCompleted(ctx, reclaimed.ID, reclaimed.LeaseToken))
+
+	// Completed rows must stay deduplicated: redelivery of finished work is a
+	// no-op.
+	inserted, err = store.WebhookEvents().Create(ctx, &storage.WebhookEvent{DeliveryID: "delivery-1", Event: "pull_request", Payload: []byte(`{"attempt":3}`)})
+	require.NoError(t, err)
+	require.False(t, inserted)
+}
+
+func TestWebhookEventStore_ReleaseRefundsAttemptAndRequeues(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	inserted, err := store.WebhookEvents().Create(ctx, &storage.WebhookEvent{DeliveryID: "delivery-1", Event: "pull_request", Payload: []byte(`{}`)})
+	require.NoError(t, err)
+	require.True(t, inserted)
+
+	claimed, err := store.WebhookEvents().FindNext(ctx, "driver-a", time.Minute)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	require.Equal(t, 1, claimed.Attempts)
+
+	require.ErrorIs(t, store.WebhookEvents().Release(ctx, claimed.ID, "stale-token"), storage.ErrWebhookEventLeaseLost)
+	require.NoError(t, store.WebhookEvents().Release(ctx, claimed.ID, claimed.LeaseToken))
+
+	released, err := store.WebhookEvents().GetByDeliveryID(ctx, storage.WebhookProviderGitHub, "delivery-1")
+	require.NoError(t, err)
+	require.NotNil(t, released)
+	assert.Equal(t, storage.WebhookEventPending, released.State)
+	assert.Equal(t, 0, released.Attempts, "release must refund the attempt consumed by the claim")
+	assert.Empty(t, released.LeaseToken)
+
+	reclaimed, err := store.WebhookEvents().FindNext(ctx, "driver-b", time.Minute)
+	require.NoError(t, err)
+	require.NotNil(t, reclaimed)
+	assert.Equal(t, 1, reclaimed.Attempts)
+}
+
 func TestWebhookEventStore_TerminalWritesReturnNotFoundAfterDelete(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
@@ -240,48 +312,6 @@ func TestWebhookEventStore_CreateRejectsNonPendingState(t *testing.T) {
 	stored, err := store.WebhookEvents().GetByDeliveryID(ctx, storage.WebhookProviderGitHub, "delivery-1")
 	require.NoError(t, err)
 	require.Nil(t, stored)
-}
-
-func TestWebhookEventStore_CreateReopensTerminallyFailedDelivery(t *testing.T) {
-	clearTables(t)
-	ctx := t.Context()
-	store := New(testDB)
-
-	inserted, err := store.WebhookEvents().Create(ctx, &storage.WebhookEvent{DeliveryID: "delivery-1", Event: "pull_request", Payload: []byte(`{"attempt":1}`)})
-	require.NoError(t, err)
-	require.True(t, inserted)
-
-	claimed, err := store.WebhookEvents().FindNext(ctx, "driver-a", time.Minute)
-	require.NoError(t, err)
-	require.NotNil(t, claimed)
-	require.NoError(t, store.WebhookEvents().MarkFailed(ctx, claimed.ID, claimed.LeaseToken, "permanent failure", nil))
-
-	// GitHub "Redeliver" reuses the original delivery GUID; it must re-open a
-	// terminally failed row instead of being deduplicated into a no-op.
-	inserted, err = store.WebhookEvents().Create(ctx, &storage.WebhookEvent{DeliveryID: "delivery-1", Event: "pull_request", Payload: []byte(`{"attempt":2}`)})
-	require.NoError(t, err)
-	require.True(t, inserted)
-
-	reopened, err := store.WebhookEvents().GetByDeliveryID(ctx, storage.WebhookProviderGitHub, "delivery-1")
-	require.NoError(t, err)
-	require.NotNil(t, reopened)
-	assert.Equal(t, storage.WebhookEventPending, reopened.State)
-	assert.Equal(t, 0, reopened.Attempts)
-	assert.Empty(t, reopened.LeaseToken)
-	assert.Nil(t, reopened.CompletedAt)
-	assert.Nil(t, reopened.StartedAt)
-	assert.JSONEq(t, `{"attempt":2}`, string(reopened.Payload))
-
-	reclaimed, err := store.WebhookEvents().FindNext(ctx, "driver-b", time.Minute)
-	require.NoError(t, err)
-	require.NotNil(t, reclaimed)
-	require.NoError(t, store.WebhookEvents().MarkCompleted(ctx, reclaimed.ID, reclaimed.LeaseToken))
-
-	// Completed rows must stay deduplicated: redelivery of finished work is a
-	// no-op.
-	inserted, err = store.WebhookEvents().Create(ctx, &storage.WebhookEvent{DeliveryID: "delivery-1", Event: "pull_request", Payload: []byte(`{"attempt":3}`)})
-	require.NoError(t, err)
-	require.False(t, inserted)
 }
 
 func TestWebhookEventStore_FindNextStopsReclaimingAtAttemptsCeiling(t *testing.T) {

--- a/pkg/storage/mysqlstore/webhook_events_test.go
+++ b/pkg/storage/mysqlstore/webhook_events_test.go
@@ -195,7 +195,7 @@ func TestWebhookEventStore_LeaseTokenGuardsWrites(t *testing.T) {
 	require.NoError(t, store.WebhookEvents().MarkCompleted(ctx, claimed.ID, claimed.LeaseToken))
 }
 
-func TestWebhookEventStore_CreateReopensTerminallyFailedDelivery(t *testing.T) {
+func TestWebhookEventStore_CreateReopensTerminalDelivery(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
 	store := New(testDB)
@@ -230,11 +230,22 @@ func TestWebhookEventStore_CreateReopensTerminallyFailedDelivery(t *testing.T) {
 	require.NotNil(t, reclaimed)
 	require.NoError(t, store.WebhookEvents().MarkCompleted(ctx, reclaimed.ID, reclaimed.LeaseToken))
 
-	// Completed rows must stay deduplicated: redelivery of finished work is a
-	// no-op.
+	// A completed row is also re-opened on redelivery: completion is recorded
+	// before the detached plan goroutines have durably persisted their work, so
+	// a crash in that window can lose the auto-plan while leaving the row
+	// completed. Re-running auto-plan on the same head SHA is idempotent, so an
+	// operator Redeliver is a safe recovery lever rather than a permanent no-op.
 	inserted, err = store.WebhookEvents().Create(ctx, &storage.WebhookEvent{DeliveryID: "delivery-1", Event: "pull_request", Payload: []byte(`{"attempt":3}`)})
 	require.NoError(t, err)
-	require.False(t, inserted)
+	require.True(t, inserted)
+
+	reopenedAgain, err := store.WebhookEvents().GetByDeliveryID(ctx, storage.WebhookProviderGitHub, "delivery-1")
+	require.NoError(t, err)
+	require.NotNil(t, reopenedAgain)
+	assert.Equal(t, storage.WebhookEventPending, reopenedAgain.State)
+	assert.Equal(t, 0, reopenedAgain.Attempts)
+	assert.Nil(t, reopenedAgain.CompletedAt)
+	assert.JSONEq(t, `{"attempt":3}`, string(reopenedAgain.Payload))
 }
 
 func TestWebhookEventStore_ReleaseRefundsAttemptAndRequeues(t *testing.T) {

--- a/pkg/storage/mysqlstore/webhook_events_test.go
+++ b/pkg/storage/mysqlstore/webhook_events_test.go
@@ -260,11 +260,48 @@ func TestWebhookEventStore_ReleaseRefundsAttemptAndRequeues(t *testing.T) {
 	assert.Equal(t, storage.WebhookEventPending, released.State)
 	assert.Equal(t, 0, released.Attempts, "release must refund the attempt consumed by the claim")
 	assert.Empty(t, released.LeaseToken)
+	assert.Nil(t, released.StartedAt, "releasing the first claim must clear started_at so it re-derives on reclaim")
 
 	reclaimed, err := store.WebhookEvents().FindNext(ctx, "driver-b", time.Minute)
 	require.NoError(t, err)
 	require.NotNil(t, reclaimed)
 	assert.Equal(t, 1, reclaimed.Attempts)
+	require.NotNil(t, reclaimed.StartedAt, "reclaim must set started_at to the actual processing start")
+}
+
+// A release that undoes a later claim (attempts > 1) must keep started_at,
+// which records when the earliest attempt began processing.
+func TestWebhookEventStore_ReleaseKeepsStartedAtAfterFirstAttempt(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	inserted, err := store.WebhookEvents().Create(ctx, &storage.WebhookEvent{DeliveryID: "delivery-1", Event: "pull_request", Payload: []byte(`{}`)})
+	require.NoError(t, err)
+	require.True(t, inserted)
+
+	// First claim + retryable failure so the row is claimable again.
+	first, err := store.WebhookEvents().FindNext(ctx, "driver-a", time.Minute)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	require.NotNil(t, first.StartedAt)
+	firstStartedAt := *first.StartedAt
+	retryAfter := time.Now().Add(-time.Minute)
+	require.NoError(t, store.WebhookEvents().MarkFailed(ctx, first.ID, first.LeaseToken, "boom", &retryAfter))
+
+	// Second claim (attempts == 2), then release it.
+	second, err := store.WebhookEvents().FindNext(ctx, "driver-b", time.Minute)
+	require.NoError(t, err)
+	require.NotNil(t, second)
+	require.Equal(t, 2, second.Attempts)
+	require.NoError(t, store.WebhookEvents().Release(ctx, second.ID, second.LeaseToken))
+
+	released, err := store.WebhookEvents().GetByDeliveryID(ctx, storage.WebhookProviderGitHub, "delivery-1")
+	require.NoError(t, err)
+	require.NotNil(t, released)
+	assert.Equal(t, 1, released.Attempts, "release must refund only the second attempt")
+	require.NotNil(t, released.StartedAt, "releasing a later claim must preserve the original started_at")
+	assert.WithinDuration(t, firstStartedAt, *released.StartedAt, time.Second)
 }
 
 func TestWebhookEventStore_TerminalWritesReturnNotFoundAfterDelete(t *testing.T) {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -234,6 +234,14 @@ type WebhookEventStore interface {
 	// MarkFailed marks a claimed event failed. A non-nil retryAfter keeps it
 	// retryable after that time; nil makes the failure terminal.
 	MarkFailed(ctx context.Context, id int64, leaseToken string, errMsg string, retryAfter *time.Time) error
+
+	// Release returns a claimed event to pending and refunds the attempt its
+	// claim consumed. Drivers use it when shutdown cancels in-flight
+	// processing: an interrupted claim must not consume retry budget, or
+	// repeated deploy restarts could terminally fail a delivery that never got
+	// a real processing attempt. Returns ErrWebhookEventLeaseLost when the
+	// lease token is stale.
+	Release(ctx context.Context, id int64, leaseToken string) error
 }
 
 // PlanStore manages schema change plans.

--- a/pkg/webhook/check_run.go
+++ b/pkg/webhook/check_run.go
@@ -99,7 +99,7 @@ func (h *Handler) handleParticipantCheckCompleted(ctx context.Context, w http.Re
 		return
 	}
 
-	ctx, cancel, client, err := h.autoPlanBootstrap(repo, installationID)
+	ctx, cancel, client, err := h.autoPlanBootstrap(context.Background(), repo, installationID)
 	if err != nil {
 		h.logger.Error("failed to bootstrap participant check completion re-fold",
 			"repo", repo, "pr", pr, "head_sha", payload.CheckRun.HeadSHA,
@@ -169,7 +169,7 @@ func (h *Handler) handleCheckRunRerequest(ctx context.Context, w http.ResponseWr
 		return
 	}
 
-	ctx, cancel, client, err := h.autoPlanBootstrap(repo, installationID)
+	ctx, cancel, client, err := h.autoPlanBootstrap(context.Background(), repo, installationID)
 	if err != nil {
 		h.logger.Error("failed to bootstrap check_run rerequest",
 			"repo", repo,
@@ -197,7 +197,9 @@ func (h *Handler) handleCheckRunRerequest(ctx context.Context, w http.ResponseWr
 		"check_run_id", payload.CheckRun.ID,
 		"check_name", payload.CheckRun.Name)
 
-	message := h.runAutoPlanForPR(ctx, client, repo, pr, payload.CheckRun.HeadSHA, installationID, "check_run.rerequested", "check_run.rerequested", "", "")
+	// Discovery failures are already logged and posted as a failing check
+	// inside runAutoPlanForPR; the rerequest path has no retry mechanism.
+	message, _ := h.runAutoPlanForPR(ctx, client, repo, pr, payload.CheckRun.HeadSHA, installationID, "check_run.rerequested", "check_run.rerequested", "", "")
 
 	h.writeJSON(w, http.StatusOK, map[string]string{"message": message})
 }

--- a/pkg/webhook/checks_backfill.go
+++ b/pkg/webhook/checks_backfill.go
@@ -49,6 +49,8 @@ func (h *Handler) BackfillPRCheckRuns(ctx context.Context, repo string, pr int, 
 	}
 	h.logger.Info("backfilling Check Runs via the auto-plan flow",
 		"repo", repo, "pr", pr, "head_sha", prInfo.HeadSHA)
-	message := h.runAutoPlanForPR(ctx, client, repo, pr, prInfo.HeadSHA, installationID, "checks.backfill", "checks.backfill", "", "")
+	// Discovery failures are already logged and posted as a failing check
+	// inside runAutoPlanForPR; the backfill reconciler re-runs periodically.
+	message, _ := h.runAutoPlanForPR(ctx, client, repo, pr, prInfo.HeadSHA, installationID, "checks.backfill", "checks.backfill", "", "")
 	return message, nil
 }

--- a/pkg/webhook/durable_dispatch.go
+++ b/pkg/webhook/durable_dispatch.go
@@ -1,0 +1,401 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/block/schemabot/pkg/api"
+	"github.com/block/schemabot/pkg/metrics"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+const (
+	durableWebhookRetryDelay = time.Minute
+
+	// maxDurableWebhookAttempts caps how many times a delivery is claimed
+	// before a retryable failure is recorded as terminal. Attempts increment on
+	// claim, so an unclassified permanent error (e.g. a misconfigured GitHub
+	// App) cannot retry forever.
+	maxDurableWebhookAttempts = 5
+)
+
+// StartDurableWebhookDispatch starts the durable webhook driver pool. The pool
+// is opt-in so direct handler tests and embedders keep the legacy request-path
+// behavior unless they explicitly enable durable dispatch.
+func (h *Handler) StartDurableWebhookDispatch(ctx context.Context) {
+	if !h.durableWebhookDispatch {
+		h.logger.Debug("durable webhook dispatch disabled")
+		return
+	}
+	store := h.webhookEventStore()
+	if store == nil {
+		h.logger.Warn("durable webhook dispatch disabled because webhook event storage is unavailable")
+		return
+	}
+
+	h.durableWebhookMu.Lock()
+	if h.durableWebhookStop != nil {
+		h.durableWebhookMu.Unlock()
+		h.logger.Info("durable webhook dispatch already running")
+		return
+	}
+
+	driverCount := h.durableWebhookDriverCount
+	if driverCount <= 0 {
+		driverCount = api.DefaultDrivers
+	}
+	stop := make(chan struct{})
+	wake := make(chan struct{}, driverCount)
+	driverCtx, cancel := context.WithCancel(ctx)
+	h.durableWebhookStop = stop
+	h.durableWebhookCancel = cancel
+	h.durableWebhookWake = wake
+	h.durableWebhookMu.Unlock()
+
+	for i := range driverCount {
+		driverID := i
+		h.durableWebhookWg.Go(func() {
+			h.durableWebhookDriver(driverCtx, driverID, stop, wake)
+		})
+	}
+
+	h.logger.Info("durable webhook dispatch started", "drivers", driverCount, "interval", h.durableWebhookPollInterval)
+}
+
+// StopDurableWebhookDispatch stops the durable webhook driver pool and waits for
+// in-flight claimed deliveries to finish their current drive.
+func (h *Handler) StopDurableWebhookDispatch() {
+	h.durableWebhookMu.Lock()
+	if h.durableWebhookStop == nil {
+		h.durableWebhookMu.Unlock()
+		return
+	}
+	stop := h.durableWebhookStop
+	cancel := h.durableWebhookCancel
+	h.durableWebhookStop = nil
+	h.durableWebhookCancel = nil
+	h.durableWebhookWake = nil
+	h.durableWebhookMu.Unlock()
+
+	close(stop)
+	if cancel != nil {
+		cancel()
+	}
+	h.durableWebhookWg.Wait()
+	h.logger.Info("durable webhook dispatch stopped")
+}
+
+func (h *Handler) wakeDurableWebhookDispatch() {
+	h.durableWebhookMu.Lock()
+	wake := h.durableWebhookWake
+	h.durableWebhookMu.Unlock()
+	if wake == nil {
+		return
+	}
+	select {
+	case wake <- struct{}{}:
+	default:
+	}
+}
+
+func (h *Handler) durableWebhookDriver(ctx context.Context, driverID int, stop <-chan struct{}, wake <-chan struct{}) {
+	ticker := time.NewTicker(h.durableWebhookPollInterval)
+	defer ticker.Stop()
+
+	h.logger.Debug("durable webhook driver started", "driver", driverID)
+	h.driveNextDurableWebhook(ctx, driverID)
+
+	for {
+		select {
+		case <-stop:
+			h.logger.Debug("durable webhook driver stopping", "driver", driverID)
+			return
+		case <-ctx.Done():
+			h.logger.Debug("durable webhook driver context cancelled", "driver", driverID)
+			return
+		case <-wake:
+			h.logger.Debug("durable webhook driver woke for queued delivery", "driver", driverID)
+			h.driveNextDurableWebhook(ctx, driverID)
+		case <-ticker.C:
+			h.driveNextDurableWebhook(ctx, driverID)
+		}
+	}
+}
+
+func (h *Handler) driveNextDurableWebhook(ctx context.Context, driverID int) {
+	store := h.webhookEventStore()
+	if store == nil {
+		h.logger.Warn("durable webhook driver cannot claim because webhook event storage is unavailable", "driver", driverID)
+		return
+	}
+	owner := durableWebhookLeaseOwner(driverID)
+	event, err := store.FindNext(ctx, owner, h.durableWebhookLeaseDuration)
+	if err != nil {
+		h.logger.Error("durable webhook driver failed to claim delivery", "driver", driverID, "lease_owner", owner, "error", err)
+		return
+	}
+	if event == nil {
+		h.logger.Debug("durable webhook driver found no delivery to claim", "driver", driverID)
+		return
+	}
+
+	h.logger.Info("durable webhook driver claimed delivery",
+		"driver", driverID,
+		"lease_owner", owner,
+		"provider", event.Provider,
+		"delivery_id", event.DeliveryID,
+		"event", event.Event,
+		"action", event.Action,
+		"repo", event.Repository,
+		"pr", event.PullRequest,
+		"head_sha", event.HeadSHA,
+		"attempts", event.Attempts)
+
+	runCtx, cancelRun := context.WithCancel(ctx)
+	stopHeartbeat := h.startDurableWebhookHeartbeat(runCtx, driverID, event, cancelRun)
+	process := h.processDurableWebhookEvent
+	if h.durableWebhookProcessOverride != nil {
+		process = h.durableWebhookProcessOverride
+	}
+	retry, processErr := process(runCtx, event)
+	heartbeatErr := stopHeartbeat()
+	cancelRun()
+
+	finishCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	if processErr != nil {
+		retryAfter := (*time.Time)(nil)
+		if retry && event.Attempts < maxDurableWebhookAttempts {
+			due := time.Now().Add(durableWebhookRetryDelay)
+			retryAfter = &due
+		} else if retry {
+			h.logger.Error("durable webhook delivery exhausted its retry budget and is now terminal",
+				"driver", driverID, "delivery_id", event.DeliveryID, "event", event.Event,
+				"action", event.Action, "repo", event.Repository, "pr", event.PullRequest,
+				"attempts", event.Attempts, "error", processErr)
+		}
+		if err := store.MarkFailed(finishCtx, event.ID, event.LeaseToken, processErr.Error(), retryAfter); err != nil {
+			if errors.Is(err, storage.ErrWebhookEventLeaseLost) {
+				h.logger.Warn("durable webhook driver lost the delivery lease before recording failure; another driver owns the delivery",
+					"driver", driverID, "delivery_id", event.DeliveryID, "event", event.Event,
+					"repo", event.Repository, "pr", event.PullRequest)
+				return
+			}
+			h.logger.Error("durable webhook driver failed to record delivery failure",
+				"driver", driverID, "delivery_id", event.DeliveryID, "event", event.Event,
+				"repo", event.Repository, "pr", event.PullRequest, "error", err)
+			return
+		}
+		h.logger.Warn("durable webhook driver recorded delivery failure",
+			"driver", driverID, "delivery_id", event.DeliveryID, "event", event.Event,
+			"action", event.Action, "repo", event.Repository, "pr", event.PullRequest,
+			"retry", retryAfter != nil, "error", processErr)
+		return
+	}
+	if heartbeatErr != nil {
+		// Processing reported success but the lease heartbeat failed, so
+		// ownership is uncertain: the row may already be re-claimed, or the
+		// heartbeat cancellation may have interrupted the work mid-flight. Do
+		// not mark it completed — leave the row processing so lease expiry
+		// hands it to another driver. Re-processing an already-planned delivery
+		// re-runs auto-plan on the same head SHA, which is safe.
+		h.logger.Warn("durable webhook driver skipped completion because the delivery lease heartbeat failed; leaving delivery for reclaim",
+			"driver", driverID, "delivery_id", event.DeliveryID, "event", event.Event,
+			"repo", event.Repository, "pr", event.PullRequest, "error", heartbeatErr)
+		return
+	}
+	if err := store.MarkCompleted(finishCtx, event.ID, event.LeaseToken); err != nil {
+		if errors.Is(err, storage.ErrWebhookEventLeaseLost) {
+			h.logger.Warn("durable webhook driver lost the delivery lease before recording completion; another driver owns the delivery",
+				"driver", driverID, "delivery_id", event.DeliveryID, "event", event.Event,
+				"repo", event.Repository, "pr", event.PullRequest)
+			return
+		}
+		h.logger.Error("durable webhook driver failed to mark delivery completed",
+			"driver", driverID, "delivery_id", event.DeliveryID, "event", event.Event,
+			"repo", event.Repository, "pr", event.PullRequest, "error", err)
+		return
+	}
+	h.logger.Info("durable webhook driver completed delivery",
+		"driver", driverID, "delivery_id", event.DeliveryID, "event", event.Event,
+		"action", event.Action, "repo", event.Repository, "pr", event.PullRequest)
+}
+
+// startDurableWebhookHeartbeat extends the delivery lease on a fixed cadence
+// while the event is processed. On a heartbeat failure it cancels the run
+// context so in-flight work stops. The returned join function stops the
+// heartbeat and reports the heartbeat failure (nil when the lease was held for
+// the whole run), so the driver can refuse to complete a delivery it may no
+// longer own.
+func (h *Handler) startDurableWebhookHeartbeat(ctx context.Context, driverID int, event *storage.WebhookEvent, cancelRun context.CancelFunc) func() error {
+	hbCtx, stop := context.WithCancel(ctx)
+	done := make(chan struct{})
+	var heartbeatErr error // written once before close(done)
+	interval := h.durableWebhookLeaseDuration / 3
+	if interval <= 0 {
+		interval = 10 * time.Second
+	}
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-hbCtx.Done():
+				return
+			case <-ticker.C:
+				if err := h.webhookEventStore().Heartbeat(hbCtx, event.ID, event.LeaseToken, h.durableWebhookLeaseDuration); err != nil {
+					if hbCtx.Err() != nil {
+						// The heartbeat was stopped intentionally mid-call; the
+						// interrupted call is not a lease failure.
+						return
+					}
+					h.logger.Warn("durable webhook heartbeat lost delivery lease; driver will stop",
+						"driver", driverID, "delivery_id", event.DeliveryID, "event", event.Event,
+						"repo", event.Repository, "pr", event.PullRequest, "error", err)
+					heartbeatErr = err
+					cancelRun()
+					return
+				}
+			}
+		}
+	}()
+	return func() error {
+		stop()
+		<-done
+		return heartbeatErr
+	}
+}
+
+func (h *Handler) processDurableWebhookEvent(ctx context.Context, event *storage.WebhookEvent) (retry bool, err error) {
+	if event.Provider != storage.WebhookProviderGitHub {
+		h.logger.Info("durable webhook delivery ignored because provider is unsupported",
+			"delivery_id", event.DeliveryID, "provider", event.Provider, "event", event.Event,
+			"action", event.Action, "repo", event.Repository, "pr", event.PullRequest)
+		return false, nil
+	}
+	switch event.Event {
+	case "pull_request":
+		return h.processDurablePullRequest(ctx, event)
+	default:
+		h.logger.Info("durable webhook delivery ignored because event type is unsupported",
+			"delivery_id", event.DeliveryID, "event", event.Event, "action", event.Action,
+			"repo", event.Repository, "pr", event.PullRequest)
+		return false, nil
+	}
+}
+
+// processDurablePullRequest drives the auto-plan flow for a claimed
+// pull_request delivery. The durability contract of this slice covers config
+// discovery and plan dispatch: per-database plan execution still runs in
+// detached goroutines (handleMultiEnvPlan via goSafe), exactly as on the
+// request path, and its durability is owned by the applies/tasks layer once
+// plans are created.
+func (h *Handler) processDurablePullRequest(ctx context.Context, event *storage.WebhookEvent) (retry bool, err error) {
+	var payload pullRequestPayload
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		return false, fmt.Errorf("decode durable pull_request delivery %s: %w", event.DeliveryID, err)
+	}
+
+	// The HTTP handler only enqueues auto-plannable actions, but rows can also
+	// come from replay or future producers; re-validate so a replayed "closed"
+	// action can never trigger an auto-plan.
+	switch payload.Action {
+	case "opened", "synchronize", "reopened":
+	default:
+		h.logger.Info("durable pull_request delivery ignored because action is not auto-plannable",
+			"delivery_id", event.DeliveryID, "action", payload.Action,
+			"repo", event.Repository, "pr", event.PullRequest)
+		return false, nil
+	}
+
+	installationID, err := strconv.ParseInt(event.TenantID, 10, 64)
+	if err != nil || installationID == 0 {
+		installationID = h.effectiveInstallationID(ctx, payload.Installation.ID)
+	}
+	if installationID == 0 {
+		return false, fmt.Errorf("durable pull_request delivery %s missing installation ID", event.DeliveryID)
+	}
+
+	repo := payload.Repository.FullName
+	pr := payload.PullRequest.Number
+	headSHA := payload.PullRequest.Head.SHA
+	if repo == "" || pr == 0 || headSHA == "" {
+		return false, fmt.Errorf("durable pull_request delivery %s missing repo, PR, or head SHA", event.DeliveryID)
+	}
+	if h.service != nil && !h.service.Config().IsRepoAllowed(repo) {
+		h.logger.Warn("durable pull_request delivery from unregistered repository",
+			"delivery_id", event.DeliveryID, "action", payload.Action, "repo", repo, "pr", pr,
+			"installation_id", installationID)
+		metrics.RecordUnregisteredRepositoryWebhook(ctx, "unknown", "pull_request", payload.Action, repo)
+		return false, nil
+	}
+
+	ctx, cancel, client, err := h.autoPlanBootstrap(ctx, repo, installationID)
+	if err != nil {
+		return true, fmt.Errorf("bootstrap durable auto-plan delivery %s for %s#%d: %w", event.DeliveryID, repo, pr, err)
+	}
+	defer cancel()
+
+	message, planErr := h.runAutoPlanForPR(ctx, client, repo, pr, headSHA, installationID, "pull_request", payload.Action, payload.Before, event.DeliveryID)
+	if planErr != nil {
+		return true, fmt.Errorf("auto-plan for durable delivery %s (%s#%d): %w", event.DeliveryID, repo, pr, planErr)
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		// The run was cancelled (shutdown or lease loss) — the dispatch may be
+		// partial, so keep the delivery retryable instead of completing it.
+		return true, fmt.Errorf("durable delivery %s run cancelled during auto-plan dispatch: %w", event.DeliveryID, ctxErr)
+	}
+	h.logger.Info("durable pull_request auto-plan dispatched",
+		"action", payload.Action, "repo", repo, "pr", pr, "head_sha", headSHA,
+		"delivery_id", event.DeliveryID, "message", message)
+	return false, nil
+}
+
+func (h *Handler) enqueueDurablePullRequest(ctx context.Context, payload pullRequestPayload, body []byte, deliveryID string, installationID int64) (bool, error) {
+	store := h.webhookEventStore()
+	if store == nil {
+		return false, fmt.Errorf("webhook event storage is unavailable")
+	}
+	if deliveryID == "" {
+		return false, fmt.Errorf("missing GitHub delivery ID")
+	}
+	inserted, err := store.Create(ctx, &storage.WebhookEvent{
+		Provider:    storage.WebhookProviderGitHub,
+		DeliveryID:  deliveryID,
+		Event:       "pull_request",
+		Action:      payload.Action,
+		Repository:  payload.Repository.FullName,
+		PullRequest: payload.PullRequest.Number,
+		HeadSHA:     payload.PullRequest.Head.SHA,
+		TenantID:    strconv.FormatInt(installationID, 10),
+		Payload:     body,
+	})
+	if err != nil {
+		return false, fmt.Errorf("store durable pull_request delivery %s: %w", deliveryID, err)
+	}
+	if inserted {
+		h.wakeDurableWebhookDispatch()
+	}
+	return inserted, nil
+}
+
+func (h *Handler) webhookEventStore() storage.WebhookEventStore {
+	if h.service == nil || h.service.Storage() == nil {
+		return nil
+	}
+	return h.service.Storage().WebhookEvents()
+}
+
+func durableWebhookLeaseOwner(driverID int) string {
+	hostname, err := os.Hostname()
+	if err != nil || hostname == "" {
+		hostname = "unknown-host"
+	}
+	return fmt.Sprintf("%s/%d/webhook-driver-%d", hostname, os.Getpid(), driverID)
+}

--- a/pkg/webhook/durable_dispatch.go
+++ b/pkg/webhook/durable_dispatch.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime/debug"
 	"strconv"
 	"time"
 
@@ -20,8 +21,10 @@ const (
 	// maxDurableWebhookAttempts caps how many times a delivery is claimed
 	// before a retryable failure is recorded as terminal. Attempts increment on
 	// claim, so an unclassified permanent error (e.g. a misconfigured GitHub
-	// App) cannot retry forever.
-	maxDurableWebhookAttempts = 5
+	// App) cannot retry forever. It aliases the store's claim ceiling so the
+	// driver terminalizes a delivery on the same attempt at which FindNext
+	// would stop handing it out.
+	maxDurableWebhookAttempts = storage.MaxWebhookEventAttempts
 )
 
 // StartDurableWebhookDispatch starts the durable webhook driver pool. The pool
@@ -162,13 +165,30 @@ func (h *Handler) driveNextDurableWebhook(ctx context.Context, driverID int) {
 	if h.durableWebhookProcessOverride != nil {
 		process = h.durableWebhookProcessOverride
 	}
-	retry, processErr := process(runCtx, event)
+	retry, processErr := h.safeProcessDurableWebhookEvent(runCtx, event, process)
 	heartbeatErr := stopHeartbeat()
 	cancelRun()
 
 	finishCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 	defer cancel()
 	if processErr != nil {
+		if heartbeatErr == nil && ctx.Err() != nil && errors.Is(processErr, context.Canceled) {
+			// Shutdown (not lease loss) cancelled the run mid-flight. The claim
+			// consumed an attempt when FindNext incremented the counter, but no
+			// real processing happened — refund it, or deploy-churn restarts
+			// that each claim-and-cancel the same delivery would terminally
+			// fail it without a single genuine attempt.
+			if err := store.Release(finishCtx, event.ID, event.LeaseToken); err != nil {
+				h.logger.Warn("durable webhook driver could not release delivery claim on shutdown; lease expiry will hand it to another driver",
+					"driver", driverID, "delivery_id", event.DeliveryID, "event", event.Event,
+					"repo", event.Repository, "pr", event.PullRequest, "error", err)
+				return
+			}
+			h.logger.Info("durable webhook driver released delivery claim on shutdown",
+				"driver", driverID, "delivery_id", event.DeliveryID, "event", event.Event,
+				"repo", event.Repository, "pr", event.PullRequest)
+			return
+		}
 		retryAfter := (*time.Time)(nil)
 		if retry && event.Attempts < maxDurableWebhookAttempts {
 			due := time.Now().Add(durableWebhookRetryDelay)
@@ -180,8 +200,8 @@ func (h *Handler) driveNextDurableWebhook(ctx context.Context, driverID int) {
 				"attempts", event.Attempts, "error", processErr)
 		}
 		if err := store.MarkFailed(finishCtx, event.ID, event.LeaseToken, processErr.Error(), retryAfter); err != nil {
-			if errors.Is(err, storage.ErrWebhookEventLeaseLost) {
-				h.logger.Warn("durable webhook driver lost the delivery lease before recording failure; another driver owns the delivery",
+			if errors.Is(err, storage.ErrWebhookEventLeaseLost) || errors.Is(err, storage.ErrWebhookEventNotFound) {
+				h.logger.Warn("durable webhook driver lost the delivery lease before recording failure; another driver owns the delivery or the row is gone",
 					"driver", driverID, "delivery_id", event.DeliveryID, "event", event.Event,
 					"repo", event.Repository, "pr", event.PullRequest)
 				return
@@ -191,6 +211,11 @@ func (h *Handler) driveNextDurableWebhook(ctx context.Context, driverID int) {
 				"repo", event.Repository, "pr", event.PullRequest, "error", err)
 			return
 		}
+		status := "durable_dispatch_failed"
+		if retryAfter != nil {
+			status = "durable_dispatch_retrying"
+		}
+		metrics.RecordWebhookEvent(finishCtx, h.metricAppForRepo(event.Repository), event.Event, event.Action, event.Repository, status)
 		h.logger.Warn("durable webhook driver recorded delivery failure",
 			"driver", driverID, "delivery_id", event.DeliveryID, "event", event.Event,
 			"action", event.Action, "repo", event.Repository, "pr", event.PullRequest,
@@ -210,8 +235,8 @@ func (h *Handler) driveNextDurableWebhook(ctx context.Context, driverID int) {
 		return
 	}
 	if err := store.MarkCompleted(finishCtx, event.ID, event.LeaseToken); err != nil {
-		if errors.Is(err, storage.ErrWebhookEventLeaseLost) {
-			h.logger.Warn("durable webhook driver lost the delivery lease before recording completion; another driver owns the delivery",
+		if errors.Is(err, storage.ErrWebhookEventLeaseLost) || errors.Is(err, storage.ErrWebhookEventNotFound) {
+			h.logger.Warn("durable webhook driver lost the delivery lease before recording completion; another driver owns the delivery or the row is gone",
 				"driver", driverID, "delivery_id", event.DeliveryID, "event", event.Event,
 				"repo", event.Repository, "pr", event.PullRequest)
 			return
@@ -221,9 +246,48 @@ func (h *Handler) driveNextDurableWebhook(ctx context.Context, driverID int) {
 			"repo", event.Repository, "pr", event.PullRequest, "error", err)
 		return
 	}
+	metrics.RecordWebhookEvent(finishCtx, h.metricAppForRepo(event.Repository), event.Event, event.Action, event.Repository, "durable_dispatch_completed")
 	h.logger.Info("durable webhook driver completed delivery",
 		"driver", driverID, "delivery_id", event.DeliveryID, "event", event.Event,
 		"action", event.Action, "repo", event.Repository, "pr", event.PullRequest)
+}
+
+// safeProcessDurableWebhookEvent runs process with panic recovery. The legacy
+// request path ran auto-plan under goSafe/recoverPanic; a driver panic here
+// would kill the whole process, and — because the row stays processing until
+// its lease expires and is then claimable again — every restarted replica
+// would reclaim the same poison delivery and crash-loop the fleet. A recovered
+// panic is reported as a retryable failure, so the normal attempt cap makes a
+// deterministic panic terminal instead.
+func (h *Handler) safeProcessDurableWebhookEvent(ctx context.Context, event *storage.WebhookEvent, process func(context.Context, *storage.WebhookEvent) (bool, error)) (retry bool, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			h.logger.Error("durable webhook driver recovered from panic while processing delivery",
+				"delivery_id", event.DeliveryID, "event", event.Event, "action", event.Action,
+				"repo", event.Repository, "pr", event.PullRequest,
+				"panic", fmt.Sprintf("%v", r), "stack", string(debug.Stack()))
+			retry = true
+			err = fmt.Errorf("panic processing durable webhook delivery %s: %v", event.DeliveryID, r)
+		}
+	}()
+	return process(ctx, event)
+}
+
+// metricAppForRepo resolves the metrics app_name label for repo. Driver work
+// runs outside any HTTP request, so the signed-App identity from webhook
+// verification is gone; derive the owning App from config the same way
+// signature/ownership verification does. Single-App deployments have no
+// per-repo App mapping and always report the default App name.
+func (h *Handler) metricAppForRepo(repo string) string {
+	cfg := h.config()
+	if cfg == nil || len(cfg.Apps) == 0 {
+		return defaultAppName
+	}
+	app, err := cfg.ResolveGitHubAppForRepo(repo)
+	if err != nil {
+		return metricAppName("")
+	}
+	return app.Name
 }
 
 // startDurableWebhookHeartbeat extends the delivery lease on a fixed cadence
@@ -255,12 +319,25 @@ func (h *Handler) startDurableWebhookHeartbeat(ctx context.Context, driverID int
 						// interrupted call is not a lease failure.
 						return
 					}
-					h.logger.Warn("durable webhook heartbeat lost delivery lease; driver will stop",
+					if errors.Is(err, storage.ErrWebhookEventLeaseLost) || errors.Is(err, storage.ErrWebhookEventNotFound) {
+						// Lease loss and a deleted row are both terminal for
+						// this run: the result has nowhere to land, so stop
+						// instead of finishing work that cannot be recorded.
+						h.logger.Warn("durable webhook heartbeat lost delivery lease or the delivery row is gone; driver will stop",
+							"driver", driverID, "delivery_id", event.DeliveryID, "event", event.Event,
+							"repo", event.Repository, "pr", event.PullRequest, "error", err)
+						heartbeatErr = err
+						cancelRun()
+						return
+					}
+					// A transient store error is not lease loss: the lease is
+					// still ours until it expires, so keep working and retry on
+					// the next tick. If the blip outlasts the lease and a peer
+					// claims the row, the next heartbeat returns
+					// ErrWebhookEventLeaseLost and stops the run.
+					h.logger.Warn("durable webhook heartbeat failed; will retry",
 						"driver", driverID, "delivery_id", event.DeliveryID, "event", event.Event,
 						"repo", event.Repository, "pr", event.PullRequest, "error", err)
-					heartbeatErr = err
-					cancelRun()
-					return
 				}
 			}
 		}
@@ -305,9 +382,7 @@ func (h *Handler) processDurablePullRequest(ctx context.Context, event *storage.
 	// The HTTP handler only enqueues auto-plannable actions, but rows can also
 	// come from replay or future producers; re-validate so a replayed "closed"
 	// action can never trigger an auto-plan.
-	switch payload.Action {
-	case "opened", "synchronize", "reopened":
-	default:
+	if !isAutoPlannablePullRequestAction(payload.Action) {
 		h.logger.Info("durable pull_request delivery ignored because action is not auto-plannable",
 			"delivery_id", event.DeliveryID, "action", payload.Action,
 			"repo", event.Repository, "pr", event.PullRequest)
@@ -332,12 +407,18 @@ func (h *Handler) processDurablePullRequest(ctx context.Context, event *storage.
 		h.logger.Warn("durable pull_request delivery from unregistered repository",
 			"delivery_id", event.DeliveryID, "action", payload.Action, "repo", repo, "pr", pr,
 			"installation_id", installationID)
-		metrics.RecordUnregisteredRepositoryWebhook(ctx, "unknown", "pull_request", payload.Action, repo)
+		metrics.RecordUnregisteredRepositoryWebhook(ctx, h.metricAppForRepo(repo), "pull_request", payload.Action, repo)
 		return false, nil
 	}
 
+	// Keep the driver's run context: autoPlanBootstrap rebinds ctx to a
+	// timeout-bounded work context, and the post-run cancellation check below
+	// must distinguish "shutdown or lease loss" (runCtx) from "the work outran
+	// its own timeout after already succeeding" (ctx).
+	runCtx := ctx
 	ctx, cancel, client, err := h.autoPlanBootstrap(ctx, repo, installationID)
 	if err != nil {
+		metrics.RecordWebhookEvent(runCtx, h.metricAppForRepo(repo), "pull_request", payload.Action, repo, "auto_plan_bootstrap_failed")
 		return true, fmt.Errorf("bootstrap durable auto-plan delivery %s for %s#%d: %w", event.DeliveryID, repo, pr, err)
 	}
 	defer cancel()
@@ -346,9 +427,11 @@ func (h *Handler) processDurablePullRequest(ctx context.Context, event *storage.
 	if planErr != nil {
 		return true, fmt.Errorf("auto-plan for durable delivery %s (%s#%d): %w", event.DeliveryID, repo, pr, planErr)
 	}
-	if ctxErr := ctx.Err(); ctxErr != nil {
+	if ctxErr := runCtx.Err(); ctxErr != nil {
 		// The run was cancelled (shutdown or lease loss) — the dispatch may be
 		// partial, so keep the delivery retryable instead of completing it.
+		// Checking the bootstrap-bounded ctx here would misclassify a slow but
+		// fully successful run as a failure and re-plan it on retry.
 		return true, fmt.Errorf("durable delivery %s run cancelled during auto-plan dispatch: %w", event.DeliveryID, ctxErr)
 	}
 	h.logger.Info("durable pull_request auto-plan dispatched",

--- a/pkg/webhook/durable_dispatch.go
+++ b/pkg/webhook/durable_dispatch.go
@@ -62,14 +62,17 @@ func (h *Handler) StartDurableWebhookDispatch(ctx context.Context) {
 	h.durableWebhookStop = stop
 	h.durableWebhookCancel = cancel
 	h.durableWebhookWake = wake
-	h.durableWebhookMu.Unlock()
-
+	// Register every driver goroutine on the WaitGroup while the mutex is still
+	// held. Adding to the WaitGroup concurrently with a StopDurableWebhookDispatch
+	// Wait is the documented reuse misuse; holding the lock across the spawn keeps
+	// Start and Stop from racing.
 	for i := range driverCount {
 		driverID := i
 		h.durableWebhookWg.Go(func() {
 			h.durableWebhookDriver(driverCtx, driverID, stop, wake)
 		})
 	}
+	h.durableWebhookMu.Unlock()
 
 	h.logger.Info("durable webhook dispatch started", "drivers", driverCount, "interval", h.durableWebhookPollInterval)
 }
@@ -80,6 +83,7 @@ func (h *Handler) StopDurableWebhookDispatch() {
 	h.durableWebhookMu.Lock()
 	if h.durableWebhookStop == nil {
 		h.durableWebhookMu.Unlock()
+		h.logger.Debug("durable webhook dispatch stop requested but pool is not running")
 		return
 	}
 	stop := h.durableWebhookStop
@@ -102,6 +106,10 @@ func (h *Handler) wakeDurableWebhookDispatch() {
 	wake := h.durableWebhookWake
 	h.durableWebhookMu.Unlock()
 	if wake == nil {
+		// The pool isn't running (never started, or stopped): drivers reclaim on
+		// the poll ticker, so a missed wake only delays pickup, it doesn't drop
+		// the durable row.
+		h.logger.Debug("durable webhook wake skipped because the driver pool is not running")
 		return
 	}
 	select {
@@ -111,11 +119,14 @@ func (h *Handler) wakeDurableWebhookDispatch() {
 }
 
 func (h *Handler) durableWebhookDriver(ctx context.Context, driverID int, stop <-chan struct{}, wake <-chan struct{}) {
+	// The lease owner is stable for the driver's lifetime; compute it once rather
+	// than re-deriving hostname/pid on every claim.
+	owner := durableWebhookLeaseOwner(driverID)
 	ticker := time.NewTicker(h.durableWebhookPollInterval)
 	defer ticker.Stop()
 
-	h.logger.Debug("durable webhook driver started", "driver", driverID)
-	h.driveNextDurableWebhook(ctx, driverID)
+	h.logger.Debug("durable webhook driver started", "driver", driverID, "lease_owner", owner)
+	h.drainDurableWebhooks(ctx, driverID, owner)
 
 	for {
 		select {
@@ -127,28 +138,44 @@ func (h *Handler) durableWebhookDriver(ctx context.Context, driverID int, stop <
 			return
 		case <-wake:
 			h.logger.Debug("durable webhook driver woke for queued delivery", "driver", driverID)
-			h.driveNextDurableWebhook(ctx, driverID)
+			h.drainDurableWebhooks(ctx, driverID, owner)
 		case <-ticker.C:
-			h.driveNextDurableWebhook(ctx, driverID)
+			h.drainDurableWebhooks(ctx, driverID, owner)
 		}
 	}
 }
 
-func (h *Handler) driveNextDurableWebhook(ctx context.Context, driverID int) {
+// drainDurableWebhooks claims and drives deliveries until none remain claimable,
+// so a backlog is worked down within a single wake/tick instead of one delivery
+// per signal. It stops on the first empty claim or claim error — a storage error
+// must not spin a tight loop — and on context cancellation.
+func (h *Handler) drainDurableWebhooks(ctx context.Context, driverID int, owner string) {
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		if !h.driveNextDurableWebhook(ctx, driverID, owner) {
+			return
+		}
+	}
+}
+
+// driveNextDurableWebhook claims and drives at most one delivery. It reports
+// whether a delivery was claimed, so the drain loop knows whether to continue.
+func (h *Handler) driveNextDurableWebhook(ctx context.Context, driverID int, owner string) (claimed bool) {
 	store := h.webhookEventStore()
 	if store == nil {
 		h.logger.Warn("durable webhook driver cannot claim because webhook event storage is unavailable", "driver", driverID)
-		return
+		return false
 	}
-	owner := durableWebhookLeaseOwner(driverID)
 	event, err := store.FindNext(ctx, owner, h.durableWebhookLeaseDuration)
 	if err != nil {
 		h.logger.Error("durable webhook driver failed to claim delivery", "driver", driverID, "lease_owner", owner, "error", err)
-		return
+		return false
 	}
 	if event == nil {
 		h.logger.Debug("durable webhook driver found no delivery to claim", "driver", driverID)
-		return
+		return false
 	}
 
 	h.logger.Info("durable webhook driver claimed delivery",
@@ -163,6 +190,50 @@ func (h *Handler) driveNextDurableWebhook(ctx context.Context, driverID int) {
 		"head_sha", event.HeadSHA,
 		"attempts", event.Attempts)
 
+	// A delivery reclaimed beyond the processing attempt budget was abandoned on
+	// its final attempt before recording a terminal state (e.g. a hard kill the
+	// panic recovery cannot catch) and its lease later expired. Terminalize it
+	// without processing — replaying a deterministic poison payload would just
+	// re-abandon it — so it lands in a terminal failed state that GitHub
+	// Redeliver and reconciliation can recover, instead of wedging unclaimable
+	// forever at the cap.
+	if event.Attempts > maxDurableWebhookAttempts {
+		h.terminalizeOverBudgetDelivery(ctx, driverID, store, event)
+		return true
+	}
+
+	h.driveClaimedDurableWebhook(ctx, driverID, store, event)
+	return true
+}
+
+// terminalizeOverBudgetDelivery records a terminal failure for a delivery that
+// was reclaimed after exhausting its processing attempt budget, without running
+// the (possibly poison) work again.
+func (h *Handler) terminalizeOverBudgetDelivery(ctx context.Context, driverID int, store storage.WebhookEventStore, event *storage.WebhookEvent) {
+	finishCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	termErr := fmt.Sprintf("durable webhook delivery %s reclaimed after exhausting its processing attempt budget (%d attempts)", event.DeliveryID, event.Attempts)
+	if err := store.MarkFailed(finishCtx, event.ID, event.LeaseToken, termErr, nil); err != nil {
+		if errors.Is(err, storage.ErrWebhookEventLeaseLost) || errors.Is(err, storage.ErrWebhookEventNotFound) {
+			h.logger.Warn("durable webhook driver lost the lease before terminalizing an over-budget delivery; another driver owns it or the row is gone",
+				"driver", driverID, "delivery_id", event.DeliveryID, "event", event.Event,
+				"repo", event.Repository, "pr", event.PullRequest)
+			return
+		}
+		h.logger.Error("durable webhook driver failed to terminalize an over-budget delivery",
+			"driver", driverID, "delivery_id", event.DeliveryID, "event", event.Event,
+			"repo", event.Repository, "pr", event.PullRequest, "error", err)
+		return
+	}
+	metrics.RecordWebhookEvent(finishCtx, h.metricAppForRepo(event.Repository), event.Event, event.Action, event.Repository, "durable_dispatch_failed")
+	h.logger.Error("durable webhook delivery terminalized without processing after exhausting its attempt budget",
+		"driver", driverID, "delivery_id", event.DeliveryID, "event", event.Event,
+		"action", event.Action, "repo", event.Repository, "pr", event.PullRequest, "attempts", event.Attempts)
+}
+
+// driveClaimedDurableWebhook runs the process → heartbeat → finish lifecycle for
+// a freshly claimed delivery.
+func (h *Handler) driveClaimedDurableWebhook(ctx context.Context, driverID int, store storage.WebhookEventStore, event *storage.WebhookEvent) {
 	runCtx, cancelRun := context.WithCancel(ctx)
 	stopHeartbeat := h.startDurableWebhookHeartbeat(runCtx, driverID, event, cancelRun)
 	process := h.processDurableWebhookEvent
@@ -289,6 +360,11 @@ func (h *Handler) metricAppForRepo(repo string) string {
 	}
 	app, err := cfg.ResolveGitHubAppForRepo(repo)
 	if err != nil {
+		// A multi-App deployment that cannot map the repo to an App still needs a
+		// metric label; fall back to the default rather than dropping the metric,
+		// but log so a misconfigured mapping does not silently mislabel telemetry.
+		h.logger.Warn("could not resolve owning GitHub App for durable webhook metrics; using default app label",
+			"repo", repo, "error", err)
 		return metricAppName("")
 	}
 	return app.Name
@@ -321,6 +397,8 @@ func (h *Handler) startDurableWebhookHeartbeat(ctx context.Context, driverID int
 					if hbCtx.Err() != nil {
 						// The heartbeat was stopped intentionally mid-call; the
 						// interrupted call is not a lease failure.
+						h.logger.Debug("durable webhook heartbeat interrupted by intentional stop; not a lease failure",
+							"driver", driverID, "delivery_id", event.DeliveryID)
 						return
 					}
 					if errors.Is(err, storage.ErrWebhookEventLeaseLost) || errors.Is(err, storage.ErrWebhookEventNotFound) {
@@ -393,8 +471,24 @@ func (h *Handler) processDurablePullRequest(ctx context.Context, event *storage.
 		return false, nil
 	}
 
-	installationID, err := strconv.ParseInt(event.TenantID, 10, 64)
-	if err != nil || installationID == 0 {
+	installationID, parseErr := strconv.ParseInt(event.TenantID, 10, 64)
+	if parseErr != nil {
+		// A non-numeric TenantID is a corrupted/enqueue-side bug, distinct from a
+		// legitimately empty tenant; surface it rather than silently folding it
+		// into the payload fallback below.
+		h.logger.Warn("durable pull_request delivery has an unparseable tenant ID; falling back to the payload installation",
+			"delivery_id", event.DeliveryID, "tenant_id", event.TenantID,
+			"repo", event.Repository, "pr", event.PullRequest, "error", parseErr)
+	}
+	if parseErr != nil || installationID == 0 {
+		// Fallback for rows without a stored tenant. Today the only producer
+		// (enqueueDurablePullRequest) always stores a resolved non-zero
+		// installation ID, so this only matters for replay or future producers.
+		// The payload carries an installation ID only for org/user App installs;
+		// repo-level deliveries have none, so a future producer that synthesizes
+		// such rows (WH-6b) must persist a resolved installation ID in TenantID
+		// rather than relying on this fallback, or repo-level deliveries will
+		// terminally fail here.
 		installationID = h.effectiveInstallationID(ctx, payload.Installation.ID)
 	}
 	if installationID == 0 {

--- a/pkg/webhook/durable_dispatch.go
+++ b/pkg/webhook/durable_dispatch.go
@@ -22,8 +22,8 @@ const (
 	// before a retryable failure is recorded as terminal. Attempts increment on
 	// claim, so an unclassified permanent error (e.g. a misconfigured GitHub
 	// App) cannot retry forever. It aliases the store's claim ceiling so the
-	// driver terminalizes a delivery on the same attempt at which FindNext
-	// would stop handing it out.
+	// driver records a retryable failure as terminal on the same attempt at
+	// which FindNext would stop handing the delivery out.
 	maxDurableWebhookAttempts = storage.MaxWebhookEventAttempts
 )
 
@@ -190,45 +190,8 @@ func (h *Handler) driveNextDurableWebhook(ctx context.Context, driverID int, own
 		"head_sha", event.HeadSHA,
 		"attempts", event.Attempts)
 
-	// A delivery reclaimed beyond the processing attempt budget was abandoned on
-	// its final attempt before recording a terminal state (e.g. a hard kill the
-	// panic recovery cannot catch) and its lease later expired. Terminalize it
-	// without processing — replaying a deterministic poison payload would just
-	// re-abandon it — so it lands in a terminal failed state that GitHub
-	// Redeliver and reconciliation can recover, instead of wedging unclaimable
-	// forever at the cap.
-	if event.Attempts > maxDurableWebhookAttempts {
-		h.terminalizeOverBudgetDelivery(ctx, driverID, store, event)
-		return true
-	}
-
 	h.driveClaimedDurableWebhook(ctx, driverID, store, event)
 	return true
-}
-
-// terminalizeOverBudgetDelivery records a terminal failure for a delivery that
-// was reclaimed after exhausting its processing attempt budget, without running
-// the (possibly poison) work again.
-func (h *Handler) terminalizeOverBudgetDelivery(ctx context.Context, driverID int, store storage.WebhookEventStore, event *storage.WebhookEvent) {
-	finishCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
-	defer cancel()
-	termErr := fmt.Sprintf("durable webhook delivery %s reclaimed after exhausting its processing attempt budget (%d attempts)", event.DeliveryID, event.Attempts)
-	if err := store.MarkFailed(finishCtx, event.ID, event.LeaseToken, termErr, nil); err != nil {
-		if errors.Is(err, storage.ErrWebhookEventLeaseLost) || errors.Is(err, storage.ErrWebhookEventNotFound) {
-			h.logger.Warn("durable webhook driver lost the lease before terminalizing an over-budget delivery; another driver owns it or the row is gone",
-				"driver", driverID, "delivery_id", event.DeliveryID, "event", event.Event,
-				"repo", event.Repository, "pr", event.PullRequest)
-			return
-		}
-		h.logger.Error("durable webhook driver failed to terminalize an over-budget delivery",
-			"driver", driverID, "delivery_id", event.DeliveryID, "event", event.Event,
-			"repo", event.Repository, "pr", event.PullRequest, "error", err)
-		return
-	}
-	metrics.RecordWebhookEvent(finishCtx, h.metricAppForRepo(event.Repository), event.Event, event.Action, event.Repository, "durable_dispatch_failed")
-	h.logger.Error("durable webhook delivery terminalized without processing after exhausting its attempt budget",
-		"driver", driverID, "delivery_id", event.DeliveryID, "event", event.Event,
-		"action", event.Action, "repo", event.Repository, "pr", event.PullRequest, "attempts", event.Attempts)
 }
 
 // driveClaimedDurableWebhook runs the process → heartbeat → finish lifecycle for

--- a/pkg/webhook/durable_dispatch.go
+++ b/pkg/webhook/durable_dispatch.go
@@ -37,7 +37,11 @@ func (h *Handler) StartDurableWebhookDispatch(ctx context.Context) {
 	}
 	store := h.webhookEventStore()
 	if store == nil {
-		h.logger.Warn("durable webhook dispatch disabled because webhook event storage is unavailable")
+		// Only the driver pool is skipped here — durable dispatch stays enabled,
+		// so the ingest path still routes deliveries through the durable branch
+		// and rejects them with 500 until storage recovers. This is not a
+		// fallback to in-process handling.
+		h.logger.Warn("durable webhook driver pool not started: webhook event storage is unavailable; incoming deliveries will be rejected with 500 until storage recovers")
 		return
 	}
 

--- a/pkg/webhook/durable_dispatch_test.go
+++ b/pkg/webhook/durable_dispatch_test.go
@@ -392,39 +392,6 @@ func TestDurableWebhookDriverStopsRetryingAtAttemptCap(t *testing.T) {
 	require.Empty(t, store.completed)
 }
 
-// A delivery that is reclaimed after its lease expired on the final attempt —
-// e.g. a hard kill the panic recovery can't catch left it in processing at the
-// attempt cap — is terminalized without being processed again, so it lands in a
-// terminal state that redelivery and reconciliation can recover instead of
-// wedging unclaimable forever.
-func TestDurableWebhookDriverTerminalizesOverBudgetDelivery(t *testing.T) {
-	event := durablePullRequestEvent(t)
-	event.Attempts = maxDurableWebhookAttempts // FindNext claim increments past the cap
-	store := newScriptedWebhookEventStore(event)
-	factory := &fakeClientFactory{forInstallationStarted: make(chan struct{})}
-	h := newDurableDriverHandler(t, store, nil, factory)
-	h.durableWebhookProcessOverride = func(context.Context, *storage.WebhookEvent) (bool, error) {
-		t.Fatal("over-budget delivery must not be processed again")
-		return false, nil
-	}
-
-	require.True(t, h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0"))
-
-	select {
-	case failure := <-store.failed:
-		require.Nil(t, failure.retryAfter, "an over-budget delivery must fail terminally")
-		require.Contains(t, failure.errMsg, "exhausting its processing attempt budget")
-	default:
-		t.Fatal("expected over-budget delivery to be marked failed")
-	}
-	require.Empty(t, store.completed)
-	select {
-	case <-factory.forInstallationStarted:
-		t.Fatal("over-budget delivery must not create a GitHub client")
-	default:
-	}
-}
-
 // A single wake drains the whole backlog rather than one delivery per signal, so
 // a burst of queued deliveries is worked down without waiting for the next tick.
 func TestDurableWebhookDrainProcessesBacklogInOnePass(t *testing.T) {

--- a/pkg/webhook/durable_dispatch_test.go
+++ b/pkg/webhook/durable_dispatch_test.go
@@ -18,6 +18,10 @@ import (
 	"github.com/block/schemabot/pkg/storage"
 )
 
+// durableWebhookTestDeadline bounds waits for async driver work in these
+// unit tests so a hang fails fast instead of stalling the suite.
+const durableWebhookTestDeadline = 5 * time.Second
+
 type durableWebhookTestStorage struct {
 	emptyStorage
 	webhookEvents storage.WebhookEventStore
@@ -256,7 +260,7 @@ func TestDurableWebhookDriverCompletesUnsupportedEvent(t *testing.T) {
 	})
 	h := newDurableDriverHandler(t, store, nil, nil)
 
-	h.driveNextDurableWebhook(t.Context(), 0)
+	h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
 
 	select {
 	case outcome := <-store.completed:
@@ -277,7 +281,7 @@ func TestDurableWebhookDriverFailsMalformedPullRequestTerminally(t *testing.T) {
 	})
 	h := newDurableDriverHandler(t, store, nil, nil)
 
-	h.driveNextDurableWebhook(t.Context(), 0)
+	h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
 
 	select {
 	case failure := <-store.failed:
@@ -295,7 +299,7 @@ func TestDurableWebhookDriverRetriesBootstrapFailure(t *testing.T) {
 	h := newDurableDriverHandler(t, store, nil, factory)
 
 	before := time.Now()
-	h.driveNextDurableWebhook(t.Context(), 0)
+	h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
 
 	select {
 	case failure := <-store.failed:
@@ -314,7 +318,7 @@ func TestDurableWebhookDriverCompletesUnregisteredRepo(t *testing.T) {
 	factory := &fakeClientFactory{forInstallationStarted: make(chan struct{})}
 	h := newDurableDriverHandler(t, store, config, factory)
 
-	h.driveNextDurableWebhook(t.Context(), 0)
+	h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
 
 	select {
 	case <-store.completed:
@@ -345,7 +349,7 @@ func TestDurableWebhookHeartbeatLossCancelsRun(t *testing.T) {
 
 	select {
 	case <-runCtx.Done():
-	case <-time.After(5 * time.Second):
+	case <-time.After(durableWebhookTestDeadline):
 		t.Fatal("expected heartbeat lease loss to cancel the run context")
 	}
 	require.ErrorIs(t, stop(), storage.ErrWebhookEventLeaseLost)
@@ -363,7 +367,7 @@ func TestDurableWebhookHeartbeatLossSkipsCompletion(t *testing.T) {
 		return false, nil
 	}
 
-	h.driveNextDurableWebhook(t.Context(), 0)
+	h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
 
 	require.Empty(t, store.completed, "lease-lost delivery must not be marked completed")
 	require.Empty(t, store.failed, "delivery must be left processing so lease expiry hands it to another driver")
@@ -376,7 +380,7 @@ func TestDurableWebhookDriverStopsRetryingAtAttemptCap(t *testing.T) {
 	factory := &fakeClientFactory{forInstallationErr: errors.New("installation token unavailable")}
 	h := newDurableDriverHandler(t, store, nil, factory)
 
-	h.driveNextDurableWebhook(t.Context(), 0)
+	h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
 
 	select {
 	case failure := <-store.failed:
@@ -388,6 +392,61 @@ func TestDurableWebhookDriverStopsRetryingAtAttemptCap(t *testing.T) {
 	require.Empty(t, store.completed)
 }
 
+// A delivery that is reclaimed after its lease expired on the final attempt —
+// e.g. a hard kill the panic recovery can't catch left it in processing at the
+// attempt cap — is terminalized without being processed again, so it lands in a
+// terminal state that redelivery and reconciliation can recover instead of
+// wedging unclaimable forever.
+func TestDurableWebhookDriverTerminalizesOverBudgetDelivery(t *testing.T) {
+	event := durablePullRequestEvent(t)
+	event.Attempts = maxDurableWebhookAttempts // FindNext claim increments past the cap
+	store := newScriptedWebhookEventStore(event)
+	factory := &fakeClientFactory{forInstallationStarted: make(chan struct{})}
+	h := newDurableDriverHandler(t, store, nil, factory)
+	h.durableWebhookProcessOverride = func(context.Context, *storage.WebhookEvent) (bool, error) {
+		t.Fatal("over-budget delivery must not be processed again")
+		return false, nil
+	}
+
+	require.True(t, h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0"))
+
+	select {
+	case failure := <-store.failed:
+		require.Nil(t, failure.retryAfter, "an over-budget delivery must fail terminally")
+		require.Contains(t, failure.errMsg, "exhausting its processing attempt budget")
+	default:
+		t.Fatal("expected over-budget delivery to be marked failed")
+	}
+	require.Empty(t, store.completed)
+	select {
+	case <-factory.forInstallationStarted:
+		t.Fatal("over-budget delivery must not create a GitHub client")
+	default:
+	}
+}
+
+// A single wake drains the whole backlog rather than one delivery per signal, so
+// a burst of queued deliveries is worked down without waiting for the next tick.
+func TestDurableWebhookDrainProcessesBacklogInOnePass(t *testing.T) {
+	store := newScriptedWebhookEventStore(
+		&storage.WebhookEvent{Provider: storage.WebhookProviderGitHub, DeliveryID: "d1", Event: "push", Payload: []byte(`{}`)},
+		&storage.WebhookEvent{Provider: storage.WebhookProviderGitHub, DeliveryID: "d2", Event: "push", Payload: []byte(`{}`)},
+		&storage.WebhookEvent{Provider: storage.WebhookProviderGitHub, DeliveryID: "d3", Event: "push", Payload: []byte(`{}`)},
+	)
+	h := newDurableDriverHandler(t, store, nil, nil)
+
+	h.drainDurableWebhooks(t.Context(), 0, "test-host/1/webhook-driver-0")
+
+	for i := range 3 {
+		select {
+		case <-store.completed:
+		default:
+			t.Fatalf("expected delivery %d of 3 to be drained in a single pass", i+1)
+		}
+	}
+	require.Empty(t, store.failed)
+}
+
 func TestDurableWebhookDriverRecoversPanic(t *testing.T) {
 	store := newScriptedWebhookEventStore(durablePullRequestEvent(t))
 	h := newDurableDriverHandler(t, store, nil, nil)
@@ -397,7 +456,7 @@ func TestDurableWebhookDriverRecoversPanic(t *testing.T) {
 
 	// Must not crash the process: a panicking delivery stays claimable after
 	// lease expiry, so an unrecovered panic would crash-loop every replica.
-	h.driveNextDurableWebhook(t.Context(), 0)
+	h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
 
 	select {
 	case failure := <-store.failed:
@@ -424,7 +483,7 @@ func TestDurableWebhookShutdownReleasesClaim(t *testing.T) {
 		return true, fmt.Errorf("auto-plan interrupted: %w", ctx.Err())
 	}
 
-	h.driveNextDurableWebhook(driverCtx, 0)
+	h.driveNextDurableWebhook(driverCtx, 0, "test-host/1/webhook-driver-0")
 
 	select {
 	case released := <-store.released:
@@ -457,7 +516,7 @@ func TestDurableWebhookHeartbeatTransientErrorKeepsRunAlive(t *testing.T) {
 		}
 	}
 
-	h.driveNextDurableWebhook(t.Context(), 0)
+	h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
 
 	select {
 	case <-store.completed:
@@ -482,7 +541,7 @@ func TestDurableWebhookDispatchLifecycleDrainsQueuedEvent(t *testing.T) {
 	select {
 	case outcome := <-store.completed:
 		require.Equal(t, "token-1", outcome.leaseToken)
-	case <-time.After(5 * time.Second):
+	case <-time.After(durableWebhookTestDeadline):
 		t.Fatal("expected driver pool to drain the queued event")
 	}
 

--- a/pkg/webhook/durable_dispatch_test.go
+++ b/pkg/webhook/durable_dispatch_test.go
@@ -79,6 +79,10 @@ func (s *recordingWebhookEventStore) MarkFailed(context.Context, int64, string, 
 	return errors.New("MarkFailed not implemented by recordingWebhookEventStore")
 }
 
+func (s *recordingWebhookEventStore) Release(context.Context, int64, string) error {
+	return errors.New("Release not implemented by recordingWebhookEventStore")
+}
+
 func TestDurablePullRequestWebhookQueuesAndAcks(t *testing.T) {
 	events := newRecordingWebhookEventStore()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -145,6 +149,7 @@ type scriptedWebhookEventStore struct {
 
 	completed chan scriptedWebhookOutcome
 	failed    chan scriptedWebhookFailure
+	released  chan scriptedWebhookOutcome
 }
 
 type scriptedWebhookOutcome struct {
@@ -165,6 +170,7 @@ func newScriptedWebhookEventStore(queue ...*storage.WebhookEvent) *scriptedWebho
 		queue:                      queue,
 		completed:                  make(chan scriptedWebhookOutcome, 8),
 		failed:                     make(chan scriptedWebhookFailure, 8),
+		released:                   make(chan scriptedWebhookOutcome, 8),
 	}
 }
 
@@ -199,6 +205,11 @@ func (s *scriptedWebhookEventStore) MarkCompleted(_ context.Context, id int64, l
 
 func (s *scriptedWebhookEventStore) MarkFailed(_ context.Context, id int64, leaseToken string, errMsg string, retryAfter *time.Time) error {
 	s.failed <- scriptedWebhookFailure{id: id, leaseToken: leaseToken, errMsg: errMsg, retryAfter: retryAfter}
+	return nil
+}
+
+func (s *scriptedWebhookEventStore) Release(_ context.Context, id int64, leaseToken string) error {
+	s.released <- scriptedWebhookOutcome{id: id, leaseToken: leaseToken}
 	return nil
 }
 
@@ -375,6 +386,85 @@ func TestDurableWebhookDriverStopsRetryingAtAttemptCap(t *testing.T) {
 		t.Fatal("expected exhausted delivery to be marked failed")
 	}
 	require.Empty(t, store.completed)
+}
+
+func TestDurableWebhookDriverRecoversPanic(t *testing.T) {
+	store := newScriptedWebhookEventStore(durablePullRequestEvent(t))
+	h := newDurableDriverHandler(t, store, nil, nil)
+	h.durableWebhookProcessOverride = func(context.Context, *storage.WebhookEvent) (bool, error) {
+		panic("poison payload")
+	}
+
+	// Must not crash the process: a panicking delivery stays claimable after
+	// lease expiry, so an unrecovered panic would crash-loop every replica.
+	h.driveNextDurableWebhook(t.Context(), 0)
+
+	select {
+	case failure := <-store.failed:
+		require.NotNil(t, failure.retryAfter, "recovered panic must consume the normal retry budget")
+		require.Contains(t, failure.errMsg, "panic processing durable webhook delivery")
+		require.Contains(t, failure.errMsg, "poison payload")
+	default:
+		t.Fatal("expected recovered panic to be recorded as a delivery failure")
+	}
+	require.Empty(t, store.completed)
+}
+
+func TestDurableWebhookShutdownReleasesClaim(t *testing.T) {
+	store := newScriptedWebhookEventStore(durablePullRequestEvent(t))
+	h := newDurableDriverHandler(t, store, nil, nil)
+
+	driverCtx, cancelDriver := context.WithCancel(t.Context())
+	defer cancelDriver()
+	h.durableWebhookProcessOverride = func(ctx context.Context, _ *storage.WebhookEvent) (bool, error) {
+		// Simulate shutdown arriving mid-run: the driver context is cancelled
+		// while the delivery is being processed.
+		cancelDriver()
+		<-ctx.Done()
+		return true, fmt.Errorf("auto-plan interrupted: %w", ctx.Err())
+	}
+
+	h.driveNextDurableWebhook(driverCtx, 0)
+
+	select {
+	case released := <-store.released:
+		require.Equal(t, "token-1", released.leaseToken)
+	default:
+		t.Fatal("expected shutdown-cancelled claim to be released")
+	}
+	require.Empty(t, store.failed, "shutdown cancellation must not consume the attempt budget")
+	require.Empty(t, store.completed)
+}
+
+func TestDurableWebhookHeartbeatTransientErrorKeepsRunAlive(t *testing.T) {
+	store := newScriptedWebhookEventStore(&storage.WebhookEvent{
+		Provider:   storage.WebhookProviderGitHub,
+		DeliveryID: "delivery-transient-heartbeat",
+		Event:      "push",
+		Payload:    []byte(`{}`),
+	})
+	store.heartbeatErr = errors.New("transient store blip")
+	h := newDurableDriverHandler(t, store, nil, nil)
+	h.durableWebhookLeaseDuration = 30 * time.Millisecond
+	h.durableWebhookProcessOverride = func(ctx context.Context, _ *storage.WebhookEvent) (bool, error) {
+		// Outlast several failing heartbeats; a transient heartbeat error must
+		// not cancel the run or block completion.
+		select {
+		case <-ctx.Done():
+			return true, fmt.Errorf("run cancelled by transient heartbeat error: %w", ctx.Err())
+		case <-time.After(100 * time.Millisecond):
+			return false, nil
+		}
+	}
+
+	h.driveNextDurableWebhook(t.Context(), 0)
+
+	select {
+	case <-store.completed:
+	default:
+		t.Fatal("expected delivery to complete despite transient heartbeat errors")
+	}
+	require.Empty(t, store.failed)
 }
 
 func TestDurableWebhookDispatchLifecycleDrainsQueuedEvent(t *testing.T) {

--- a/pkg/webhook/durable_dispatch_test.go
+++ b/pkg/webhook/durable_dispatch_test.go
@@ -1,0 +1,402 @@
+package webhook
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/api"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+type durableWebhookTestStorage struct {
+	emptyStorage
+	webhookEvents storage.WebhookEventStore
+}
+
+func (s *durableWebhookTestStorage) WebhookEvents() storage.WebhookEventStore {
+	return s.webhookEvents
+}
+
+type recordingWebhookEventStore struct {
+	mu     sync.Mutex
+	events map[string]*storage.WebhookEvent
+}
+
+func newRecordingWebhookEventStore() *recordingWebhookEventStore {
+	return &recordingWebhookEventStore{events: make(map[string]*storage.WebhookEvent)}
+}
+
+func (s *recordingWebhookEventStore) Create(_ context.Context, event *storage.WebhookEvent) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := event.Provider + ":" + event.DeliveryID
+	if _, ok := s.events[key]; ok {
+		return false, nil
+	}
+	copy := *event
+	copy.Payload = append([]byte(nil), event.Payload...)
+	s.events[key] = &copy
+	return true, nil
+}
+
+func (s *recordingWebhookEventStore) GetByDeliveryID(_ context.Context, provider, deliveryID string) (*storage.WebhookEvent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	event := s.events[provider+":"+deliveryID]
+	if event == nil {
+		return nil, nil
+	}
+	copy := *event
+	copy.Payload = append([]byte(nil), event.Payload...)
+	return &copy, nil
+}
+
+func (s *recordingWebhookEventStore) FindNext(context.Context, string, time.Duration) (*storage.WebhookEvent, error) {
+	return nil, errors.New("FindNext not implemented by recordingWebhookEventStore")
+}
+
+func (s *recordingWebhookEventStore) Heartbeat(context.Context, int64, string, time.Duration) error {
+	return errors.New("Heartbeat not implemented by recordingWebhookEventStore")
+}
+
+func (s *recordingWebhookEventStore) MarkCompleted(context.Context, int64, string) error {
+	return errors.New("MarkCompleted not implemented by recordingWebhookEventStore")
+}
+
+func (s *recordingWebhookEventStore) MarkFailed(context.Context, int64, string, string, *time.Time) error {
+	return errors.New("MarkFailed not implemented by recordingWebhookEventStore")
+}
+
+func TestDurablePullRequestWebhookQueuesAndAcks(t *testing.T) {
+	events := newRecordingWebhookEventStore()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	service := api.New(&durableWebhookTestStorage{webhookEvents: events}, &api.ServerConfig{}, nil, logger)
+	clientFactory := &fakeClientFactory{forInstallationStarted: make(chan struct{})}
+	h := NewHandler(service, clientFactory, nil, logger, WithDurableWebhookDispatch())
+
+	req := buildPRWebhookRequest(t, prWebhookPayloadOpts{action: "opened", headSHA: "head-sha"}, nil)
+	req.Header.Set(headerDeliveryID, "delivery-1")
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.JSONEq(t, `{"message":"auto-plan queued"}`, rr.Body.String())
+	event, err := events.GetByDeliveryID(t.Context(), storage.WebhookProviderGitHub, "delivery-1")
+	require.NoError(t, err)
+	require.NotNil(t, event)
+	require.Equal(t, "pull_request", event.Event)
+	require.Equal(t, "opened", event.Action)
+	require.Equal(t, "octocat/hello-world", event.Repository)
+	require.Equal(t, 1, event.PullRequest)
+	require.Equal(t, "head-sha", event.HeadSHA)
+	require.Equal(t, "12345", event.TenantID)
+	require.NotEmpty(t, event.Payload)
+
+	select {
+	case <-clientFactory.forInstallationStarted:
+		t.Fatal("durable request path should not create a GitHub client")
+	default:
+	}
+}
+
+func TestDurablePullRequestWebhookDeduplicatesDelivery(t *testing.T) {
+	events := newRecordingWebhookEventStore()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	service := api.New(&durableWebhookTestStorage{webhookEvents: events}, &api.ServerConfig{}, nil, logger)
+	h := NewHandler(service, &fakeClientFactory{}, nil, logger, WithDurableWebhookDispatch())
+
+	for range 2 {
+		req := buildPRWebhookRequest(t, prWebhookPayloadOpts{action: "synchronize"}, nil)
+		req.Header.Set(headerDeliveryID, "delivery-1")
+		rr := httptest.NewRecorder()
+
+		h.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+	}
+
+	events.mu.Lock()
+	defer events.mu.Unlock()
+	require.Len(t, events.events, 1)
+}
+
+// scriptedWebhookEventStore feeds queued events to the driver claim path and
+// records terminal outcomes so tests can assert on MarkCompleted/MarkFailed.
+type scriptedWebhookEventStore struct {
+	recordingWebhookEventStore
+
+	queueMu      sync.Mutex
+	queue        []*storage.WebhookEvent
+	nextID       int64
+	heartbeatErr error
+
+	completed chan scriptedWebhookOutcome
+	failed    chan scriptedWebhookFailure
+}
+
+type scriptedWebhookOutcome struct {
+	id         int64
+	leaseToken string
+}
+
+type scriptedWebhookFailure struct {
+	id         int64
+	leaseToken string
+	errMsg     string
+	retryAfter *time.Time
+}
+
+func newScriptedWebhookEventStore(queue ...*storage.WebhookEvent) *scriptedWebhookEventStore {
+	return &scriptedWebhookEventStore{
+		recordingWebhookEventStore: *newRecordingWebhookEventStore(),
+		queue:                      queue,
+		completed:                  make(chan scriptedWebhookOutcome, 8),
+		failed:                     make(chan scriptedWebhookFailure, 8),
+	}
+}
+
+func (s *scriptedWebhookEventStore) FindNext(_ context.Context, owner string, _ time.Duration) (*storage.WebhookEvent, error) {
+	s.queueMu.Lock()
+	defer s.queueMu.Unlock()
+
+	if len(s.queue) == 0 {
+		return nil, nil
+	}
+	event := s.queue[0]
+	s.queue = s.queue[1:]
+	s.nextID++
+	claimed := *event
+	if claimed.ID == 0 {
+		claimed.ID = s.nextID
+	}
+	claimed.LeaseOwner = owner
+	claimed.LeaseToken = fmt.Sprintf("token-%d", claimed.ID)
+	claimed.Attempts = event.Attempts + 1
+	return &claimed, nil
+}
+
+func (s *scriptedWebhookEventStore) Heartbeat(context.Context, int64, string, time.Duration) error {
+	return s.heartbeatErr
+}
+
+func (s *scriptedWebhookEventStore) MarkCompleted(_ context.Context, id int64, leaseToken string) error {
+	s.completed <- scriptedWebhookOutcome{id: id, leaseToken: leaseToken}
+	return nil
+}
+
+func (s *scriptedWebhookEventStore) MarkFailed(_ context.Context, id int64, leaseToken string, errMsg string, retryAfter *time.Time) error {
+	s.failed <- scriptedWebhookFailure{id: id, leaseToken: leaseToken, errMsg: errMsg, retryAfter: retryAfter}
+	return nil
+}
+
+func newDurableDriverHandler(t *testing.T, store storage.WebhookEventStore, config *api.ServerConfig, factory *fakeClientFactory) *Handler {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	if config == nil {
+		config = &api.ServerConfig{}
+	}
+	service := api.New(&durableWebhookTestStorage{webhookEvents: store}, config, nil, logger)
+	if factory == nil {
+		factory = &fakeClientFactory{}
+	}
+	return NewHandler(service, factory, nil, logger, WithDurableWebhookDispatch())
+}
+
+func durablePullRequestEvent(t *testing.T) *storage.WebhookEvent {
+	t.Helper()
+	payload := []byte(`{
+		"action": "opened",
+		"pull_request": {"number": 7, "head": {"sha": "head-sha", "ref": "feature"}},
+		"repository": {"full_name": "octocat/hello-world"},
+		"installation": {"id": 12345}
+	}`)
+	return &storage.WebhookEvent{
+		Provider:    storage.WebhookProviderGitHub,
+		DeliveryID:  "delivery-driver-1",
+		Event:       "pull_request",
+		Action:      "opened",
+		Repository:  "octocat/hello-world",
+		PullRequest: 7,
+		HeadSHA:     "head-sha",
+		TenantID:    "12345",
+		Payload:     payload,
+	}
+}
+
+func TestDurableWebhookDriverCompletesUnsupportedEvent(t *testing.T) {
+	store := newScriptedWebhookEventStore(&storage.WebhookEvent{
+		Provider:   storage.WebhookProviderGitHub,
+		DeliveryID: "delivery-unsupported",
+		Event:      "push",
+		Payload:    []byte(`{}`),
+	})
+	h := newDurableDriverHandler(t, store, nil, nil)
+
+	h.driveNextDurableWebhook(t.Context(), 0)
+
+	select {
+	case outcome := <-store.completed:
+		require.Equal(t, int64(1), outcome.id)
+		require.Equal(t, "token-1", outcome.leaseToken)
+	default:
+		t.Fatal("expected unsupported event to be marked completed")
+	}
+	require.Empty(t, store.failed)
+}
+
+func TestDurableWebhookDriverFailsMalformedPullRequestTerminally(t *testing.T) {
+	store := newScriptedWebhookEventStore(&storage.WebhookEvent{
+		Provider:   storage.WebhookProviderGitHub,
+		DeliveryID: "delivery-malformed",
+		Event:      "pull_request",
+		Payload:    []byte(`{not json`),
+	})
+	h := newDurableDriverHandler(t, store, nil, nil)
+
+	h.driveNextDurableWebhook(t.Context(), 0)
+
+	select {
+	case failure := <-store.failed:
+		require.Nil(t, failure.retryAfter, "malformed payload must not be retried")
+		require.Contains(t, failure.errMsg, "decode durable pull_request delivery")
+	default:
+		t.Fatal("expected malformed event to be marked failed")
+	}
+	require.Empty(t, store.completed)
+}
+
+func TestDurableWebhookDriverRetriesBootstrapFailure(t *testing.T) {
+	store := newScriptedWebhookEventStore(durablePullRequestEvent(t))
+	factory := &fakeClientFactory{forInstallationErr: errors.New("installation token unavailable")}
+	h := newDurableDriverHandler(t, store, nil, factory)
+
+	before := time.Now()
+	h.driveNextDurableWebhook(t.Context(), 0)
+
+	select {
+	case failure := <-store.failed:
+		require.NotNil(t, failure.retryAfter, "bootstrap failure must stay retryable")
+		require.True(t, failure.retryAfter.After(before), "retry must be scheduled in the future")
+		require.Contains(t, failure.errMsg, "installation token unavailable")
+	default:
+		t.Fatal("expected bootstrap failure to be marked failed")
+	}
+	require.Empty(t, store.completed)
+}
+
+func TestDurableWebhookDriverCompletesUnregisteredRepo(t *testing.T) {
+	store := newScriptedWebhookEventStore(durablePullRequestEvent(t))
+	config := &api.ServerConfig{Repos: map[string]api.RepoConfig{"other/repo": {}}}
+	factory := &fakeClientFactory{forInstallationStarted: make(chan struct{})}
+	h := newDurableDriverHandler(t, store, config, factory)
+
+	h.driveNextDurableWebhook(t.Context(), 0)
+
+	select {
+	case <-store.completed:
+	default:
+		t.Fatal("expected unregistered-repo event to be marked completed")
+	}
+	require.Empty(t, store.failed)
+	select {
+	case <-factory.forInstallationStarted:
+		t.Fatal("unregistered repo must not create a GitHub client")
+	default:
+	}
+}
+
+func TestDurableWebhookHeartbeatLossCancelsRun(t *testing.T) {
+	store := newScriptedWebhookEventStore()
+	store.heartbeatErr = storage.ErrWebhookEventLeaseLost
+	h := newDurableDriverHandler(t, store, nil, nil)
+	h.durableWebhookLeaseDuration = 30 * time.Millisecond
+
+	runCtx, cancelRun := context.WithCancel(t.Context())
+	defer cancelRun()
+	event := durablePullRequestEvent(t)
+	event.ID = 1
+	event.LeaseToken = "token-1"
+
+	stop := h.startDurableWebhookHeartbeat(runCtx, 0, event, cancelRun)
+
+	select {
+	case <-runCtx.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected heartbeat lease loss to cancel the run context")
+	}
+	require.ErrorIs(t, stop(), storage.ErrWebhookEventLeaseLost)
+}
+
+func TestDurableWebhookHeartbeatLossSkipsCompletion(t *testing.T) {
+	store := newScriptedWebhookEventStore(durablePullRequestEvent(t))
+	store.heartbeatErr = storage.ErrWebhookEventLeaseLost
+	h := newDurableDriverHandler(t, store, nil, nil)
+	h.durableWebhookLeaseDuration = 30 * time.Millisecond
+	h.durableWebhookProcessOverride = func(ctx context.Context, _ *storage.WebhookEvent) (bool, error) {
+		// Simulate work that finishes successfully just as the lease is lost:
+		// wait for the failed heartbeat to cancel the run, then report success.
+		<-ctx.Done()
+		return false, nil
+	}
+
+	h.driveNextDurableWebhook(t.Context(), 0)
+
+	require.Empty(t, store.completed, "lease-lost delivery must not be marked completed")
+	require.Empty(t, store.failed, "delivery must be left processing so lease expiry hands it to another driver")
+}
+
+func TestDurableWebhookDriverStopsRetryingAtAttemptCap(t *testing.T) {
+	event := durablePullRequestEvent(t)
+	event.Attempts = maxDurableWebhookAttempts - 1 // FindNext claim increments to the cap
+	store := newScriptedWebhookEventStore(event)
+	factory := &fakeClientFactory{forInstallationErr: errors.New("installation token unavailable")}
+	h := newDurableDriverHandler(t, store, nil, factory)
+
+	h.driveNextDurableWebhook(t.Context(), 0)
+
+	select {
+	case failure := <-store.failed:
+		require.Nil(t, failure.retryAfter, "delivery at the attempt cap must fail terminally")
+		require.Contains(t, failure.errMsg, "installation token unavailable")
+	default:
+		t.Fatal("expected exhausted delivery to be marked failed")
+	}
+	require.Empty(t, store.completed)
+}
+
+func TestDurableWebhookDispatchLifecycleDrainsQueuedEvent(t *testing.T) {
+	store := newScriptedWebhookEventStore(&storage.WebhookEvent{
+		Provider:   storage.WebhookProviderGitHub,
+		DeliveryID: "delivery-lifecycle",
+		Event:      "push",
+		Payload:    []byte(`{}`),
+	})
+	h := newDurableDriverHandler(t, store, nil, nil)
+	h.durableWebhookPollInterval = 10 * time.Millisecond
+
+	h.StartDurableWebhookDispatch(t.Context())
+
+	select {
+	case outcome := <-store.completed:
+		require.Equal(t, "token-1", outcome.leaseToken)
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected driver pool to drain the queued event")
+	}
+
+	h.StopDurableWebhookDispatch()
+	// Stop must be idempotent.
+	h.StopDurableWebhookDispatch()
+}

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -555,22 +555,33 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ctx = withResolvedInstallationID(ctx, installationID)
 	}
 
+	// Capture the handler's HTTP status so "processed" is only recorded when the
+	// delivery actually succeeded. A handler that fails closed with a 5xx has
+	// already emitted a specific failure status; recording "processed" too would
+	// double-count the same delivery under contradictory labels.
+	sw := &statusCapturingResponseWriter{ResponseWriter: w}
+	recordProcessed := func() {
+		if sw.statusCode() >= http.StatusInternalServerError {
+			return
+		}
+		metrics.RecordWebhookEvent(ctx, metricApp, eventType, action, repo, "processed")
+	}
 	switch eventType {
 	case "issue_comment":
-		h.handleIssueComment(ctx, metricApp, w, body)
-		metrics.RecordWebhookEvent(ctx, metricApp, eventType, action, repo, "processed")
+		h.handleIssueComment(ctx, metricApp, sw, body)
+		recordProcessed()
 	case "check_run":
-		h.handleCheckRun(ctx, w, body)
-		metrics.RecordWebhookEvent(ctx, metricApp, eventType, action, repo, "processed")
+		h.handleCheckRun(ctx, sw, body)
+		recordProcessed()
 	case "pull_request":
-		h.handlePullRequest(ctx, metricApp, w, body, r.Header.Get(headerDeliveryID))
-		metrics.RecordWebhookEvent(ctx, metricApp, eventType, action, repo, "processed")
+		h.handlePullRequest(ctx, metricApp, sw, body, r.Header.Get(headerDeliveryID))
+		recordProcessed()
 	case "merge_group":
-		h.handleMergeGroup(ctx, metricApp, w, body)
-		metrics.RecordWebhookEvent(ctx, metricApp, eventType, action, repo, "processed")
+		h.handleMergeGroup(ctx, metricApp, sw, body)
+		recordProcessed()
 	case "push":
-		h.handlePush(ctx, metricApp, w, body)
-		metrics.RecordWebhookEvent(ctx, metricApp, eventType, action, repo, "processed")
+		h.handlePush(ctx, metricApp, sw, body)
+		recordProcessed()
 	default:
 		h.logger.Info("webhook ignored",
 			"reason", "unsupported_event_type",
@@ -798,6 +809,30 @@ func (h *Handler) goSafe(repo string, pr int, installationID int64, fn func()) {
 		defer h.recoverPanic(repo, pr, installationID)
 		fn()
 	}()
+}
+
+// statusCapturingResponseWriter records the HTTP status a handler wrote so the
+// dispatcher can tell a successful delivery from one that failed closed with a
+// 5xx. Without it the dispatcher records "processed" unconditionally, which
+// double-counts a failed delivery alongside the specific failure status the
+// handler already emitted (e.g. durable_enqueue_failed).
+type statusCapturingResponseWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (w *statusCapturingResponseWriter) WriteHeader(status int) {
+	w.status = status
+	w.ResponseWriter.WriteHeader(status)
+}
+
+// statusCode returns the status the handler wrote, defaulting to 200 for
+// handlers that write a body without an explicit WriteHeader.
+func (w *statusCapturingResponseWriter) statusCode() int {
+	if w.status == 0 {
+		return http.StatusOK
+	}
+	return w.status
 }
 
 func (h *Handler) writeJSON(w http.ResponseWriter, status int, v any) {

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -69,6 +69,9 @@ const (
 	hookTargetTypeApp    = "integration"
 	hookTargetTypeRepo   = "repository"
 	maxWebhookBodyBytes  = 10 << 20
+
+	defaultDurableWebhookPollInterval  = 1 * time.Second
+	defaultDurableWebhookLeaseDuration = 1 * time.Minute
 )
 
 // Handler processes GitHub webhook events.
@@ -121,6 +124,21 @@ type Handler struct {
 	// (single- and multi-App) unchanged.
 	repoWebhookSecret []byte
 
+	durableWebhookDispatch      bool
+	durableWebhookDriverCount   int
+	durableWebhookPollInterval  time.Duration
+	durableWebhookLeaseDuration time.Duration
+	durableWebhookMu            sync.Mutex
+	durableWebhookStop          chan struct{}
+	durableWebhookCancel        context.CancelFunc
+	durableWebhookWake          chan struct{}
+	durableWebhookWg            sync.WaitGroup
+	// durableWebhookProcessOverride is a test seam that replaces
+	// processDurableWebhookEvent so driver finish-path behavior (for example
+	// refusing to complete a delivery after lease loss) can be exercised
+	// deterministically. Production code never sets it.
+	durableWebhookProcessOverride func(ctx context.Context, event *storage.WebhookEvent) (retry bool, err error)
+
 	logger                     *slog.Logger
 	priorEnvCheckMaxAttempts   int
 	priorEnvCheckRetryInterval time.Duration
@@ -138,6 +156,15 @@ func WithRepoWebhookSecret(secret []byte) HandlerOption {
 		if len(secret) > 0 {
 			h.repoWebhookSecret = secret
 		}
+	}
+}
+
+// WithDurableWebhookDispatch enables the durable webhook inbox path for events
+// that have been moved out of the request path. Unsupported events keep using
+// their existing synchronous or fire-and-forget handlers.
+func WithDurableWebhookDispatch() HandlerOption {
+	return func(h *Handler) {
+		h.durableWebhookDispatch = true
 	}
 }
 
@@ -172,13 +199,15 @@ func NewHandlerWithClientSet(service *api.Service, ghClients github.ClientSet, w
 // for legacy single-secret behavior (used internally by NewHandler).
 func NewHandlerWithDispatch(service *api.Service, ghClients github.ClientSet, webhookSecretsByApp map[string][]byte, webhookAppByID map[int64]string, logger *slog.Logger, opts ...HandlerOption) *Handler {
 	h := &Handler{
-		service:                    service,
-		ghClients:                  ghClients,
-		webhookSecretsByApp:        maps.Clone(webhookSecretsByApp),
-		webhookAppByID:             maps.Clone(webhookAppByID),
-		logger:                     logger,
-		priorEnvCheckMaxAttempts:   defaultPriorEnvCheckMaxAttempts,
-		priorEnvCheckRetryInterval: defaultPriorEnvCheckRetryInterval,
+		service:                     service,
+		ghClients:                   ghClients,
+		webhookSecretsByApp:         maps.Clone(webhookSecretsByApp),
+		webhookAppByID:              maps.Clone(webhookAppByID),
+		logger:                      logger,
+		durableWebhookPollInterval:  defaultDurableWebhookPollInterval,
+		durableWebhookLeaseDuration: defaultDurableWebhookLeaseDuration,
+		priorEnvCheckMaxAttempts:    defaultPriorEnvCheckMaxAttempts,
+		priorEnvCheckRetryInterval:  defaultPriorEnvCheckRetryInterval,
 	}
 	for _, opt := range opts {
 		opt(h)

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -36,6 +36,19 @@ type pullRequestPayload struct {
 	} `json:"installation"`
 }
 
+// isAutoPlannablePullRequestAction reports whether a pull_request action
+// triggers auto-plan. The HTTP enqueue path and the durable dispatcher must
+// share this predicate: the dispatcher re-validates fail-closed, so an action
+// added to only one side would either never enqueue or — worse — enqueue rows
+// the dispatcher silently completes without planning.
+func isAutoPlannablePullRequestAction(action string) bool {
+	switch action {
+	case "opened", "synchronize", "reopened":
+		return true
+	}
+	return false
+}
+
 // handlePullRequest processes GitHub pull_request webhook events.
 // On PR open/synchronize/reopen, it auto-plans all databases with schema changes.
 func (h *Handler) handlePullRequest(ctx context.Context, metricApp string, w http.ResponseWriter, body []byte, deliveryID string) {
@@ -50,10 +63,10 @@ func (h *Handler) handlePullRequest(ctx context.Context, metricApp string, w htt
 	installationID := h.effectiveInstallationID(ctx, payload.Installation.ID)
 
 	// Route PR actions
-	switch payload.Action {
-	case "opened", "synchronize", "reopened":
+	switch {
+	case isAutoPlannablePullRequestAction(payload.Action):
 		// proceed to auto-plan below
-	case "closed":
+	case payload.Action == "closed":
 		h.goSafe(payload.Repository.FullName, payload.PullRequest.Number, installationID, func() {
 			h.handlePRClosed(payload.Repository.FullName, payload.PullRequest.Number, installationID, payload.PullRequest.Merged)
 		})
@@ -99,6 +112,11 @@ func (h *Handler) handlePullRequest(ctx context.Context, metricApp string, w htt
 	)
 
 	if h.durableWebhookDispatch {
+		// Enqueue failure is a deliberate 500 with no in-process fallback: it
+		// fails loudly (metric below + a red delivery in GitHub's webhook UI)
+		// rather than silently, but GitHub never auto-retries, so the delivery
+		// stays lost until an operator hits "Redeliver" (which re-opens a
+		// terminally failed row) or a new push arrives.
 		inserted, err := h.enqueueDurablePullRequest(ctx, payload, body, deliveryID, installationID)
 		if err != nil {
 			h.logger.Error("failed to enqueue durable pull_request auto-plan",

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -98,15 +98,55 @@ func (h *Handler) handlePullRequest(ctx context.Context, metricApp string, w htt
 		"delivery_id", deliveryID,
 	)
 
+	if h.durableWebhookDispatch {
+		inserted, err := h.enqueueDurablePullRequest(ctx, payload, body, deliveryID, installationID)
+		if err != nil {
+			h.logger.Error("failed to enqueue durable pull_request auto-plan",
+				"action", payload.Action,
+				"repo", repo,
+				"pr", pr,
+				"head_sha", headSHA,
+				"delivery_id", deliveryID,
+				"error", err,
+			)
+			metrics.RecordWebhookEvent(ctx, metricApp, "pull_request", payload.Action, repo, "durable_enqueue_failed")
+			h.writeError(w, http.StatusInternalServerError, "failed to enqueue webhook delivery")
+			return
+		}
+		if !inserted {
+			h.logger.Info("durable pull_request delivery already queued",
+				"action", payload.Action,
+				"repo", repo,
+				"pr", pr,
+				"head_sha", headSHA,
+				"delivery_id", deliveryID,
+			)
+			h.writeJSON(w, http.StatusOK, map[string]string{"message": "auto-plan already queued"})
+			return
+		}
+		h.logger.Info("durable pull_request auto-plan queued",
+			"action", payload.Action,
+			"repo", repo,
+			"pr", pr,
+			"head_sha", headSHA,
+			"delivery_id", deliveryID,
+		)
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "auto-plan queued"})
+		return
+	}
+
 	h.goSafe(repo, pr, installationID, func() {
-		ctx, cancel, client, err := h.autoPlanBootstrap(repo, installationID)
+		ctx, cancel, client, err := h.autoPlanBootstrap(context.Background(), repo, installationID)
 		if err != nil {
 			metrics.RecordWebhookEvent(context.Background(), metricApp, "pull_request", payload.Action, repo, "auto_plan_bootstrap_failed")
 			h.logger.Error("failed to bootstrap auto-plan", "repo", repo, "pr", pr, "head_sha", headSHA, "delivery_id", deliveryID, "error", err)
 			return
 		}
 		defer cancel()
-		message := h.runAutoPlanForPR(ctx, client, repo, pr, headSHA, installationID, "pull_request", payload.Action, payload.Before, deliveryID)
+		// The discovery error is already logged and posted as a failing check
+		// inside runAutoPlanForPR; the fire-and-forget request path has no
+		// durable row to retry, so the error is intentionally dropped here.
+		message, _ := h.runAutoPlanForPR(ctx, client, repo, pr, headSHA, installationID, "pull_request", payload.Action, payload.Before, deliveryID)
 		h.logger.Info("auto-plan dispatched",
 			"action", payload.Action,
 			"repo", repo,
@@ -119,8 +159,12 @@ func (h *Handler) handlePullRequest(ctx context.Context, metricApp string, w htt
 	h.writeJSON(w, http.StatusOK, map[string]string{"message": "auto-plan started"})
 }
 
-func (h *Handler) autoPlanBootstrap(repo string, installationID int64) (context.Context, context.CancelFunc, *ghclient.InstallationClient, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+// autoPlanBootstrap derives a bounded work context from parent and resolves the
+// GitHub client for repo. Request-path callers pass context.Background() so the
+// work is detached from the HTTP request lifetime; the durable webhook driver
+// passes its run context so lease loss and shutdown cancel in-flight work.
+func (h *Handler) autoPlanBootstrap(parent context.Context, repo string, installationID int64) (context.Context, context.CancelFunc, *ghclient.InstallationClient, error) {
+	ctx, cancel := context.WithTimeout(parent, 30*time.Second)
 	// Dedupe FetchPullRequest calls within this webhook delivery.
 	ctx = ghclient.WithPRInfoCache(ctx)
 
@@ -155,14 +199,20 @@ func (h *Handler) shouldPostAutoPlanComment(ctx context.Context, client *ghclien
 	return false
 }
 
-func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA string, installationID int64, source string, action string, beforeSHA string, deliveryID string) string {
+// runAutoPlanForPR discovers schema configs for the PR and launches auto-plan
+// work. The returned message describes the dispatch outcome. The returned error
+// is non-nil only for discovery failures (typically transient GitHub API
+// errors), so durable callers can retry the delivery; request-path callers may
+// ignore it because the failure is already logged and posted as a failing
+// check here.
+func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA string, installationID int64, source string, action string, beforeSHA string, deliveryID string) (string, error) {
 	// Fetch the changed files once so the same list drives both config discovery
 	// and the server-managed-directory safety check below.
 	files, err := client.FetchPRFiles(ctx, repo, pr)
 	if err != nil {
 		h.logger.Error("failed to fetch PR files for auto-plan", "repo", repo, "pr", pr, "head_sha", headSHA, "source", source, "delivery_id", deliveryID, "error", err)
 		h.postConfigDiscoveryFailure(ctx, client, repo, pr, headSHA, err)
-		return "config discovery failed"
+		return "config discovery failed", fmt.Errorf("fetch PR files for %s#%d: %w", repo, pr, err)
 	}
 
 	// Discover all configs matching changed schema files in this PR
@@ -170,7 +220,7 @@ func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.Install
 	if err != nil {
 		h.logger.Error("failed to discover configs for PR", "repo", repo, "pr", pr, "head_sha", headSHA, "source", source, "delivery_id", deliveryID, "error", err)
 		h.postConfigDiscoveryFailure(ctx, client, repo, pr, headSHA, err)
-		return "config discovery failed"
+		return "config discovery failed", fmt.Errorf("discover configs for %s#%d: %w", repo, pr, err)
 	}
 
 	// Fail closed when the PR changes schema files under a directory the server
@@ -179,7 +229,7 @@ func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.Install
 	// not silently unmanage a server-owned schema directory.
 	if unmanaged := h.unmanagedServerManagedSchemaChanges(repo, files, configs); len(unmanaged) > 0 {
 		h.failClosedOnUnmanagedSchemaDir(ctx, client, repo, pr, headSHA, source, unmanaged)
-		return "schema change under managed directory has no config"
+		return "schema change under managed directory has no config", nil
 	}
 
 	configs = h.filterManagedDiscoveredConfigs(ctx, repo, pr, headSHA, source, configs)
@@ -219,7 +269,7 @@ func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.Install
 				Repository: repo,
 				Status:     "skipped",
 			})
-			return "no schema files in PR (aggregate participant, staying silent)"
+			return "no schema files in PR (aggregate participant, staying silent)", nil
 		}
 		// A PR with no leader-managed schema can still touch schema owned by
 		// expected participant deployments. The leader's aggregate is the
@@ -242,7 +292,7 @@ func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.Install
 				}
 				h.updateAggregateCheck(ctx, c, repo, pr, headSHA)
 			})
-			return "no schema files in PR (aggregate folds expected participants)"
+			return "no schema files in PR (aggregate folds expected participants)", nil
 		}
 		// Post passing aggregates on the current HEAD SHA so branch protection
 		// isn't blocked on PRs that don't touch schema files. Always post —
@@ -260,7 +310,7 @@ func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.Install
 			}
 			h.postPassingAggregates(ctx, c, repo, pr, headSHA)
 		})
-		return "no schema files in PR"
+		return "no schema files in PR", nil
 	}
 	postPlanComment := h.shouldPostAutoPlanComment(ctx, client, action, repo, pr, beforeSHA, headSHA)
 
@@ -276,7 +326,7 @@ func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.Install
 		})
 	}
 
-	return "auto-plan started"
+	return "auto-plan started", nil
 }
 
 func (h *Handler) filterManagedDiscoveredConfigs(ctx context.Context, repo string, pr int, headSHA, source string, configs []ghclient.DiscoveredConfig) []ghclient.DiscoveredConfig {

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -116,7 +116,7 @@ func (h *Handler) handlePullRequest(ctx context.Context, metricApp string, w htt
 		// fails loudly (metric below + a red delivery in GitHub's webhook UI)
 		// rather than silently, but GitHub never auto-retries, so the delivery
 		// stays lost until an operator hits "Redeliver" (which re-opens a
-		// terminally failed row) or a new push arrives.
+		// terminal row — failed or completed) or a new push arrives.
 		inserted, err := h.enqueueDurablePullRequest(ctx, payload, body, deliveryID, installationID)
 		if err != nil {
 			h.logger.Error("failed to enqueue durable pull_request auto-plan",
@@ -161,9 +161,10 @@ func (h *Handler) handlePullRequest(ctx context.Context, metricApp string, w htt
 			return
 		}
 		defer cancel()
-		// The discovery error is already logged and posted as a failing check
-		// inside runAutoPlanForPR; the fire-and-forget request path has no
-		// durable row to retry, so the error is intentionally dropped here.
+		// The discovery error is logged and best-effort posted as a failing check
+		// inside runAutoPlanForPR (the post itself re-verifies the head SHA and
+		// can no-op during a GitHub outage); the fire-and-forget request path has
+		// no durable row to retry, so the error is intentionally dropped here.
 		message, _ := h.runAutoPlanForPR(ctx, client, repo, pr, headSHA, installationID, "pull_request", payload.Action, payload.Before, deliveryID)
 		h.logger.Info("auto-plan dispatched",
 			"action", payload.Action,
@@ -221,8 +222,9 @@ func (h *Handler) shouldPostAutoPlanComment(ctx context.Context, client *ghclien
 // work. The returned message describes the dispatch outcome. The returned error
 // is non-nil only for discovery failures (typically transient GitHub API
 // errors), so durable callers can retry the delivery; request-path callers may
-// ignore it because the failure is already logged and posted as a failing
-// check here.
+// ignore it because the failure is logged and best-effort posted as a failing
+// check here (the post re-verifies the head SHA and can no-op during a GitHub
+// outage).
 func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA string, installationID int64, source string, action string, beforeSHA string, deliveryID string) (string, error) {
 	// Fetch the changed files once so the same list drives both config discovery
 	// and the server-managed-directory safety check below.


### PR DESCRIPTION
## Summary

Drains the durable webhook inbox (#703) with a leased driver pool so `pull_request` auto-plans survive restarts. The request path now enqueues the delivery and acks 200 immediately; drivers claim rows, run config discovery and plan dispatch, and record completion or failure durably.

## What

- `pull_request` webhook handler enqueues into `webhook_events` (dedup by delivery GUID) and acks, instead of firing a detached goroutine.
- A driver pool claims rows with time-boxed leases, heartbeats while processing, and is started/stopped from the server lifecycle so shutdown drains in-flight work.
- Transient failures (bootstrap/discovery) retry with a capped attempt budget; malformed payloads and non-auto-plannable actions resolve terminally; a driver that loses its lease refuses to mark the row completed so lease expiry hands it to another driver.
- A duplicate delivery GUID re-opens a terminal row (failed **or** completed): completion is recorded before the detached plan goroutines persist their work, so a crash in that window can lose the auto-plan while leaving the row completed — re-running auto-plan on the same head SHA is idempotent, so GitHub "Redeliver" is a safe recovery lever.
- An over-budget reclaim (attempts past the cap, e.g. a hard-killed final attempt) is terminalized without re-processing so it can't wedge a `processing` row unclaimable forever.
- `runAutoPlanForPR` now reports discovery errors to callers so the durable path can retry; request-path callers keep prior behavior.

## Why

After #701 a 200 ack still relied on an in-process goroutine — a crash or deploy between ack and check publication lost the work with no recovery signal. With the inbox as source of truth, any replica can reclaim and finish acked deliveries.

```
Before:
╭────────╮   ╭──────────────╮   ╭────────────────────────────╮
│ GitHub │──▶│ validate+ack │──▶│ goroutine: discover + plan │── lost on crash
╰────────╯   ╰──────────────╯   ╰────────────────────────────╯

After:
╭────────╮   ╭──────────────╮   ╭────────────────╮  claim   ╭─────────────────────╮
│ GitHub │──▶│ validate+ack │──▶│ webhook_events │◀────────▶│ leased driver pool  │
╰────────╯   │ enqueue      │   │ inbox + dedup  │ complete │ heartbeat + retries │
             ╰──────────────╯   ╰────────────────╯          │ lease-expiry reclaim│
                                                            ╰─────────────────────╯
```
## Follow-ups (intentionally out of scope — tracked in the webhook reliability plan)

This PR is the durable-dispatch phase of a larger phased effort. The following are known and deliberately deferred, so reviewers don't need to flag them here:

- **Shared driver-pool primitive.** The pool/heartbeat/lease-owner loop is now the third hand-rolled lease loop (applies, control requests, webhook events). Extraction is deferred until a fourth appears; the extraction should carry this PR's stricter behavior (refuse completion after lease loss) back to the operator pool, which can still complete after lease loss.
- **Poll-interval tuning.** Drivers poll every 1s; the enqueue wake channel already gives sub-millisecond pickup, so the ticker is recovery-only and can move to a 15–30s interval with per-driver jitter once queue-depth/throughput metrics exist (observability phase).
- **Claim-query cost.** The inbox claim query filesorts across three state ranges under `FOR UPDATE SKIP LOCKED`; an ordered/`claimable_at`-style index is deferred to the observability phase to tune against real metrics.
- **Repo-level installation fallback.** The driver-context installation-ID fallback only resolves org/user-App payloads (repo-level deliveries carry no installation ID). Today's sole producer always stores a resolved non-zero ID; a future producer that synthesizes rows must persist a resolved installation ID rather than rely on this fallback (comment left in code).
- **Reconciliation/backfill** is the automatic safety net for "200 ack but missing checks" and is a separate phase; the redeliver-reopen above is the manual complement, not a replacement.
