### PR TITLE
fix(github): carry the tenant flag in apply lifecycle command hints

### DIFF
--- a/pkg/webhook/apply.go
+++ b/pkg/webhook/apply.go
@@ -19,8 +19,9 @@ import (
 // the PlanetScale deploy-request URL), resolved from engine resume metadata by
 // resolveDisplayByOperation (zero value when there is none). shardsByTable holds
 // the per-shard detail rows grouped by table (nil for unsharded engines); it is
-// attached to each table's progress for the compact per-shard summary.
-func buildApplyCommentData(apply *storage.Apply, tasks []*storage.Task, display operationDisplay, shardsByTable map[string][]*storage.Task) templates.ApplyStatusCommentData {
+// attached to each table's progress for the compact per-shard summary. tenant is
+// the deployment's tenant identity, carried into every pasteable command hint.
+func buildApplyCommentData(apply *storage.Apply, tasks []*storage.Task, display operationDisplay, shardsByTable map[string][]*storage.Task, tenant string) templates.ApplyStatusCommentData {
 	data := templates.ApplyStatusCommentData{
 		ApplyID:          apply.ApplyIdentifier,
 		Database:         apply.Database,
@@ -33,6 +34,7 @@ func buildApplyCommentData(apply *storage.Apply, tasks []*storage.Task, display 
 		DeployRequestURL: display.DeployRequestURL,
 		RevertExpiresAt:  display.RevertExpiresAt,
 		Volume:           apply.GetOptions().Volume,
+		Tenant:           tenant,
 	}
 	if apply.StartedAt != nil {
 		data.StartedAt = apply.StartedAt.Format(time.RFC3339)
@@ -176,13 +178,13 @@ func shardCommentTableKey(applyOperationID *int64, namespace, table string) stri
 // formatProgressComment renders the progress comment using the template system.
 // It is the no-operations fallback (load error, or the initial rollback comment),
 // so it carries no VSchema — the observer refreshes VSchema once operations load.
-func formatProgressComment(apply *storage.Apply, tasks []*storage.Task, shardsByTable map[string][]*storage.Task) string {
-	return templates.RenderApplyStatusComment(buildApplyCommentData(apply, tasks, operationDisplay{}, shardsByTable))
+func formatProgressComment(apply *storage.Apply, tasks []*storage.Task, shardsByTable map[string][]*storage.Task, tenant string) string {
+	return templates.RenderApplyStatusComment(buildApplyCommentData(apply, tasks, operationDisplay{}, shardsByTable, tenant))
 }
 
 // formatSummaryComment renders the final summary comment for a terminal apply
 // state. Like formatProgressComment it is the no-operations fallback and carries
 // no VSchema.
-func formatSummaryComment(apply *storage.Apply, tasks []*storage.Task, shardsByTable map[string][]*storage.Task) string {
-	return templates.RenderApplySummaryComment(buildApplyCommentData(apply, tasks, operationDisplay{}, shardsByTable))
+func formatSummaryComment(apply *storage.Apply, tasks []*storage.Task, shardsByTable map[string][]*storage.Task, tenant string) string {
+	return templates.RenderApplySummaryComment(buildApplyCommentData(apply, tasks, operationDisplay{}, shardsByTable, tenant))
 }

--- a/pkg/webhook/apply_comment_integration_test.go
+++ b/pkg/webhook/apply_comment_integration_test.go
@@ -953,7 +953,7 @@ func TestE2EInitialProgressCommentFinalizedForFastApply(t *testing.T) {
 		pending := *apply
 		pending.State = state.Apply.Pending
 		h.postInitialProgressComment(ctx, apply.Repository, apply.PullRequest, apply.InstallationID, apply.ID,
-			formatProgressComment(&pending, nil, nil))
+			formatProgressComment(&pending, nil, nil, ""))
 
 		var created commentCreate
 		select {
@@ -991,7 +991,7 @@ func TestE2EInitialProgressCommentFinalizedForFastApply(t *testing.T) {
 		require.NoError(t, st.ApplyComments().IncrementEditCount(ctx, apply.ID, state.Comment.Progress))
 
 		h.postInitialProgressComment(ctx, apply.Repository, apply.PullRequest, apply.InstallationID, apply.ID,
-			formatProgressComment(apply, nil, nil))
+			formatProgressComment(apply, nil, nil, ""))
 
 		select {
 		case <-capture.creates:
@@ -1012,7 +1012,7 @@ func TestE2EInitialProgressCommentFinalizedForFastApply(t *testing.T) {
 		h, capture := newHandler(t)
 
 		h.postInitialProgressComment(ctx, apply.Repository, apply.PullRequest, apply.InstallationID, apply.ID,
-			formatProgressComment(apply, nil, nil))
+			formatProgressComment(apply, nil, nil, ""))
 
 		select {
 		case <-capture.creates:

--- a/pkg/webhook/apply_execute.go
+++ b/pkg/webhook/apply_execute.go
@@ -128,6 +128,7 @@ func (h *Handler) executeApply(
 		InstallationID: installationID,
 		DeferCutover:   options["defer_cutover"] == "true",
 		SupportChannel: h.supportChannel(),
+		Tenant:         h.deploymentTenant(),
 		Logger:         h.logger,
 		OnTerminalHook: func(apply *storage.Apply) {
 			updated, err := h.updateCheckRecordForApplyResult(context.Background(), repo, pr, apply)

--- a/pkg/webhook/apply_test.go
+++ b/pkg/webhook/apply_test.go
@@ -35,7 +35,7 @@ func TestFormatProgressComment(t *testing.T) {
 		},
 	}
 
-	body := formatProgressComment(apply, tasks, nil)
+	body := formatProgressComment(apply, tasks, nil, "")
 
 	// Template renders rich progress bars instead of a table
 	assert.Contains(t, body, "testdb")
@@ -59,7 +59,7 @@ func TestFormatProgressComment_NoTasks(t *testing.T) {
 		State:       state.Apply.Pending,
 	}
 
-	body := formatProgressComment(apply, nil, nil)
+	body := formatProgressComment(apply, nil, nil, "")
 
 	assert.Contains(t, body, "testdb")
 	assert.Contains(t, body, "Starting")
@@ -74,7 +74,7 @@ func TestFormatProgressComment_WithError(t *testing.T) {
 		ErrorMessage: "connection refused",
 	}
 
-	body := formatProgressComment(apply, nil, nil)
+	body := formatProgressComment(apply, nil, nil, "")
 
 	assert.Contains(t, body, "connection refused")
 	assert.Contains(t, body, "Failed")
@@ -102,7 +102,7 @@ func TestFormatProgressCommentCutoverState(t *testing.T) {
 		{TableName: "orders", State: state.Task.WaitingForCutover, ReadyToComplete: true},
 	}
 
-	body := formatProgressComment(apply, tasks, nil)
+	body := formatProgressComment(apply, tasks, nil, "")
 
 	assert.Contains(t, body, "Cutover")
 	assert.Contains(t, body, "testdb")
@@ -122,7 +122,7 @@ func TestFormatSummaryComment(t *testing.T) {
 		{TableName: "orders", State: state.Task.Completed},
 	}
 
-	body := formatSummaryComment(apply, tasks, nil)
+	body := formatSummaryComment(apply, tasks, nil, "")
 
 	assert.Contains(t, body, "Schema Change Applied")
 	assert.Contains(t, body, "`users`")
@@ -142,7 +142,7 @@ func TestFormatSummaryComment_Failed(t *testing.T) {
 		{TableName: "users", State: state.Task.Failed},
 	}
 
-	body := formatSummaryComment(apply, tasks, nil)
+	body := formatSummaryComment(apply, tasks, nil, "")
 
 	assert.Contains(t, body, "duplicate column")
 	assert.Contains(t, body, "Failed")
@@ -178,7 +178,7 @@ func TestBuildApplyCommentData(t *testing.T) {
 		},
 	}
 
-	data := buildApplyCommentData(apply, tasks, operationDisplay{}, nil)
+	data := buildApplyCommentData(apply, tasks, operationDisplay{}, nil, "")
 
 	assert.Equal(t, "apply-abc123", data.ApplyID)
 	assert.Equal(t, "testdb", data.Database)
@@ -200,7 +200,7 @@ func TestBuildApplyCommentData_DefaultNamespace(t *testing.T) {
 		{TableName: "users", State: state.Task.Running},
 	}
 
-	data := buildApplyCommentData(apply, tasks, operationDisplay{}, nil)
+	data := buildApplyCommentData(apply, tasks, operationDisplay{}, nil, "")
 
 	assert.Equal(t, "testdb", data.Tables[0].Namespace, "empty namespace should default to database name")
 }

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -29,6 +29,7 @@ type CommentObserver struct {
 	applyLease     storage.ApplyLease
 	deferCutover   bool
 	supportChannel api.SupportChannelConfig
+	tenant         string
 	logger         interface {
 		Info(msg string, args ...any)
 		Error(msg string, args ...any)
@@ -79,7 +80,13 @@ type CommentObserverConfig struct {
 	ApplyLease     storage.ApplyLease
 	DeferCutover   bool
 	SupportChannel api.SupportChannelConfig
-	Logger         interface {
+
+	// Tenant is the deployment's tenant identity, carried into every pasteable
+	// command hint the observer's comments render. Empty on single-tenant
+	// deployments.
+	Tenant string
+
+	Logger interface {
 		Info(msg string, args ...any)
 		Error(msg string, args ...any)
 	}
@@ -148,6 +155,7 @@ func NewCommentObserver(cfg CommentObserverConfig) *CommentObserver {
 		applyLease:     cfg.ApplyLease,
 		deferCutover:   cfg.DeferCutover,
 		supportChannel: cfg.SupportChannel,
+		tenant:         cfg.Tenant,
 		logger:         cfg.Logger,
 		OnTerminalHook: cfg.OnTerminalHook,
 		clock:          clk,
@@ -406,9 +414,9 @@ func (o *CommentObserver) statusCommentFromOps(apply *storage.Apply, ops []*stor
 	if opsErr != nil {
 		o.logger.Error("observer: failed to load apply operations for comment dispatch; rendering single-deployment layout",
 			"apply_id", o.applyID, "error", opsErr)
-		return formatProgressComment(apply, tasks, shardsByTable)
+		return formatProgressComment(apply, tasks, shardsByTable, o.tenant)
 	}
-	return formatApplyStatusComment(apply, ops, o.resolveReleased(apply, ops), tasks, o.resolveDisplay(apply, ops), shardsByTable)
+	return formatApplyStatusComment(apply, ops, o.resolveReleased(apply, ops), tasks, o.resolveDisplay(apply, ops), shardsByTable, o.tenant)
 }
 
 // resolveDisplay projects the apply's per-operation engine display state (VSchema
@@ -455,9 +463,9 @@ func (o *CommentObserver) summaryCommentFromOps(apply *storage.Apply, ops []*sto
 	if opsErr != nil {
 		o.logger.Error("observer: failed to load apply operations for summary comment dispatch; rendering single-deployment layout",
 			"apply_id", o.applyID, "error", opsErr)
-		return formatSummaryComment(apply, tasks, shardsByTable)
+		return formatSummaryComment(apply, tasks, shardsByTable, o.tenant)
 	}
-	return formatApplySummaryComment(apply, ops, o.resolveReleased(apply, ops), tasks, o.resolveDisplay(apply, ops), shardsByTable)
+	return formatApplySummaryComment(apply, ops, o.resolveReleased(apply, ops), tasks, o.resolveDisplay(apply, ops), shardsByTable, o.tenant)
 }
 
 func (o *CommentObserver) shouldDeferCutover(apply *storage.Apply) bool {

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -214,6 +214,7 @@ func NewHandlerWithDispatch(service *api.Service, ghClients github.ClientSet, we
 					ApplyID:        apply.ID,
 					ApplyLease:     apply.Lease(),
 					SupportChannel: h.supportChannel(),
+					Tenant:         h.deploymentTenant(),
 					Logger:         logger,
 					OnTerminalHook: func(a *storage.Apply) {
 						h.refreshChecksForTerminalApply(context.Background(), a, "recovered apply")
@@ -250,6 +251,7 @@ func NewHandlerWithDispatch(service *api.Service, ghClients github.ClientSet, we
 				InstallationID: apply.InstallationID,
 				ApplyID:        apply.ID,
 				SupportChannel: h.supportChannel(),
+				Tenant:         h.deploymentTenant(),
 				Logger:         logger,
 				OnTerminalHook: func(a *storage.Apply) {
 					h.refreshChecksForTerminalApply(context.Background(), a, "aggregate terminal apply")
@@ -427,7 +429,7 @@ func (h *Handler) ReconcileMissingSummaryComments(ctx context.Context) {
 			ops = nil
 		}
 		released := releasedForApply(ctx, h.service.Storage(), apply, ops, h.logger)
-		summaryBody := formatApplySummaryComment(apply, ops, released, tasks, resolveDisplayByOperation(ctx, h.service.Storage(), apply, ops), nil)
+		summaryBody := formatApplySummaryComment(apply, ops, released, tasks, resolveDisplayByOperation(ctx, h.service.Storage(), apply, ops), nil, h.deploymentTenant())
 		h.postAndTrackComment(ctx, apply.Repository, apply.PullRequest, apply.InstallationID, apply.ID, state.Comment.Summary, summaryBody)
 	}
 }

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -527,7 +527,7 @@ func (h *Handler) postInitialProgressComment(ctx context.Context, repo string, p
 			append(apply.LogAttrs(), "error", err)...)
 		return
 	}
-	finalBody := formatProgressComment(apply, nil, nil)
+	finalBody := formatProgressComment(apply, nil, nil, h.deploymentTenant())
 	if err := client.EditIssueComment(ctx, repo, comment.GitHubCommentID, h.renderPRComment(finalBody)); err != nil {
 		h.logger.Error("failed to finalize progress comment for already-terminal apply",
 			append(apply.LogAttrs(), "github_comment_id", comment.GitHubCommentID, "error", err)...)

--- a/pkg/webhook/multi_apply.go
+++ b/pkg/webhook/multi_apply.go
@@ -37,17 +37,17 @@ func releasedForApply(ctx context.Context, stor storage.Storage, apply *storage.
 // ops must be in resolved deployment order (as returned by
 // ApplyOperations().ListByApply); tasks are the apply's tasks across all
 // deployments, regrouped per operation for the multi-deployment layout.
-func formatApplyStatusComment(apply *storage.Apply, ops []*storage.ApplyOperation, released bool, tasks []*storage.Task, displayByOp map[int64]operationDisplay, shardsByTable map[string][]*storage.Task) string {
+func formatApplyStatusComment(apply *storage.Apply, ops []*storage.ApplyOperation, released bool, tasks []*storage.Task, displayByOp map[int64]operationDisplay, shardsByTable map[string][]*storage.Task, tenant string) string {
 	// A sharded apply fans out across the shards of one keyspace within a single
 	// deployment, so it gets the shard-unit layout rather than the deployment-unit
 	// one — its operations differ by shard, not deployment.
 	if isShardedApply(ops) {
-		return templates.RenderShardedApplyComment(buildShardedApplyData(apply, ops, released, tasks))
+		return templates.RenderShardedApplyComment(buildShardedApplyData(apply, ops, released, tasks, tenant))
 	}
 	if len(ops) <= 1 {
-		return templates.RenderApplyStatusComment(buildApplyCommentData(apply, tasks, singleOpDisplay(ops, displayByOp), shardsByTable))
+		return templates.RenderApplyStatusComment(buildApplyCommentData(apply, tasks, singleOpDisplay(ops, displayByOp), shardsByTable, tenant))
 	}
-	return templates.RenderMultiDeploymentApplyComment(buildMultiApplyData(apply, ops, released, tasks, displayByOp, shardsByTable))
+	return templates.RenderMultiDeploymentApplyComment(buildMultiApplyData(apply, ops, released, tasks, displayByOp, shardsByTable, tenant))
 }
 
 // formatApplySummaryComment renders the terminal summary PR comment for an apply,
@@ -60,17 +60,17 @@ func formatApplyStatusComment(apply *storage.Apply, ops []*storage.ApplyOperatio
 // ops must be in resolved deployment order (as returned by
 // ApplyOperations().ListByApply); tasks are the apply's tasks across all
 // deployments, regrouped per operation for the multi-deployment layout.
-func formatApplySummaryComment(apply *storage.Apply, ops []*storage.ApplyOperation, released bool, tasks []*storage.Task, displayByOp map[int64]operationDisplay, shardsByTable map[string][]*storage.Task) string {
+func formatApplySummaryComment(apply *storage.Apply, ops []*storage.ApplyOperation, released bool, tasks []*storage.Task, displayByOp map[int64]operationDisplay, shardsByTable map[string][]*storage.Task, tenant string) string {
 	// The sharded layout is terminal-aware (header, footer, no last-updated line),
 	// so the same renderer serves the terminal summary; only the deployment-unit
 	// path has a distinct summary renderer.
 	if isShardedApply(ops) {
-		return templates.RenderShardedApplyComment(buildShardedApplyData(apply, ops, released, tasks))
+		return templates.RenderShardedApplyComment(buildShardedApplyData(apply, ops, released, tasks, tenant))
 	}
 	if len(ops) <= 1 {
-		return templates.RenderApplySummaryComment(buildApplyCommentData(apply, tasks, singleOpDisplay(ops, displayByOp), shardsByTable))
+		return templates.RenderApplySummaryComment(buildApplyCommentData(apply, tasks, singleOpDisplay(ops, displayByOp), shardsByTable, tenant))
 	}
-	return templates.RenderMultiDeploymentApplySummaryComment(buildMultiApplyData(apply, ops, released, tasks, displayByOp, shardsByTable))
+	return templates.RenderMultiDeploymentApplySummaryComment(buildMultiApplyData(apply, ops, released, tasks, displayByOp, shardsByTable, tenant))
 }
 
 // singleOpDisplay returns the engine display projection for a zero/one-operation
@@ -86,13 +86,13 @@ func singleOpDisplay(ops []*storage.ApplyOperation, displayByOp map[int64]operat
 // buildMultiApplyData assembles the multi-deployment comment input: the derived
 // rollup plus each deployment's own single-deployment comment data, so each
 // deployment's section reuses the existing per-table renderer.
-func buildMultiApplyData(apply *storage.Apply, ops []*storage.ApplyOperation, released bool, tasks []*storage.Task, displayByOp map[int64]operationDisplay, shardsByTable map[string][]*storage.Task) templates.MultiDeploymentApplyData {
+func buildMultiApplyData(apply *storage.Apply, ops []*storage.ApplyOperation, released bool, tasks []*storage.Task, displayByOp map[int64]operationDisplay, shardsByTable map[string][]*storage.Task, tenant string) templates.MultiDeploymentApplyData {
 	tasksByOp := groupTasksByOperation(tasks)
 
 	model := deriveApplyPresentation(ops, released)
 	details := make(map[string]templates.ApplyStatusCommentData, len(ops))
 	for _, op := range ops {
-		details[op.Deployment] = buildDeploymentDetail(apply, op, tasksByOp[op.ID], displayByOp[op.ID], shardsByTable)
+		details[op.Deployment] = buildDeploymentDetail(apply, op, tasksByOp[op.ID], displayByOp[op.ID], shardsByTable, tenant)
 	}
 
 	data := templates.MultiDeploymentApplyData{
@@ -100,6 +100,7 @@ func buildMultiApplyData(apply *storage.Apply, ops []*storage.ApplyOperation, re
 		ApplyID:     apply.ApplyIdentifier,
 		Environment: apply.Environment,
 		Details:     details,
+		Tenant:      tenant,
 	}
 	if apply.StartedAt != nil {
 		data.StartedAt = apply.StartedAt.Format(time.RFC3339)
@@ -149,7 +150,7 @@ func applyOperationToPresentation(op *storage.ApplyOperation, released bool) pre
 // identity and timing, and the deployment's own tasks. The deployment's database
 // target is shown via the section's deployment name; the per-table rows fall back
 // to the apply database for namespace, matching the single-deployment renderer.
-func buildDeploymentDetail(apply *storage.Apply, op *storage.ApplyOperation, tasks []*storage.Task, display operationDisplay, shardsByTable map[string][]*storage.Task) templates.ApplyStatusCommentData {
+func buildDeploymentDetail(apply *storage.Apply, op *storage.ApplyOperation, tasks []*storage.Task, display operationDisplay, shardsByTable map[string][]*storage.Task, tenant string) templates.ApplyStatusCommentData {
 	data := templates.ApplyStatusCommentData{
 		ApplyID:          apply.ApplyIdentifier,
 		Database:         apply.Database,
@@ -162,6 +163,7 @@ func buildDeploymentDetail(apply *storage.Apply, op *storage.ApplyOperation, tas
 		VSchemaChanges:   display.VSchema,
 		DeployRequestURL: display.DeployRequestURL,
 		RevertExpiresAt:  display.RevertExpiresAt,
+		Tenant:           tenant,
 	}
 	if apply.StartedAt != nil {
 		data.StartedAt = apply.StartedAt.Format(time.RFC3339)

--- a/pkg/webhook/multi_apply_test.go
+++ b/pkg/webhook/multi_apply_test.go
@@ -22,7 +22,7 @@ func runningApply() *storage.Apply {
 // An apply with no operation rows (legacy, predating apply_operations) renders
 // the single-deployment comment unchanged — no aggregate header.
 func TestFormatApplyStatusComment_NoOperationsRendersSingle(t *testing.T) {
-	out := formatApplyStatusComment(runningApply(), nil, false, nil, nil, nil)
+	out := formatApplyStatusComment(runningApply(), nil, false, nil, nil, nil, "")
 	assert.Contains(t, out, "## Schema Change Status")
 	assert.NotContains(t, out, "**Deployments**:")
 }
@@ -33,7 +33,7 @@ func TestFormatApplyStatusComment_OneOperationRendersSingle(t *testing.T) {
 	ops := []*storage.ApplyOperation{
 		{ID: 1, Deployment: "eu", State: state.ApplyOperation.Running},
 	}
-	out := formatApplyStatusComment(runningApply(), ops, false, nil, nil, nil)
+	out := formatApplyStatusComment(runningApply(), ops, false, nil, nil, nil, "")
 	assert.NotContains(t, out, "**Deployments**:")
 	assert.NotContains(t, out, "- 🔄 eu")
 }
@@ -45,7 +45,7 @@ func TestFormatApplyStatusComment_MultipleOperationsRendersMulti(t *testing.T) {
 		{ID: 1, Deployment: "eu", State: state.ApplyOperation.Completed, CutoverPolicy: storage.CutoverPolicyBarrier},
 		{ID: 2, Deployment: "us", State: state.ApplyOperation.Running, CutoverPolicy: storage.CutoverPolicyBarrier},
 	}
-	out := formatApplyStatusComment(runningApply(), ops, false, nil, nil, nil)
+	out := formatApplyStatusComment(runningApply(), ops, false, nil, nil, nil, "")
 	assert.Contains(t, out, "## Schema Change Status")
 	assert.Contains(t, out, "**Deployments**: 1 completed, 1 running")
 	assert.Contains(t, out, "- ✅ eu — completed")
@@ -62,10 +62,10 @@ func TestFormatApplyStatusComment_ReleasedPauseRendersDegradedNotPaused(t *testi
 		{ID: 2, Deployment: "us", State: state.ApplyOperation.Pending, OnFailure: storage.OnFailurePause},
 	}
 
-	paused := formatApplyStatusComment(runningApply(), ops, false, nil, nil, nil)
+	paused := formatApplyStatusComment(runningApply(), ops, false, nil, nil, nil, "")
 	assert.Contains(t, paused, "paused — eu failed; release or stop")
 
-	released := formatApplyStatusComment(runningApply(), ops, true, nil, nil, nil)
+	released := formatApplyStatusComment(runningApply(), ops, true, nil, nil, nil, "")
 	assert.NotContains(t, released, "paused — eu failed; release or stop")
 }
 
@@ -78,7 +78,7 @@ func completedApply() *storage.Apply {
 // An apply with no operation rows (legacy) renders the single-deployment summary
 // unchanged — no aggregate header.
 func TestFormatApplySummaryComment_NoOperationsRendersSingle(t *testing.T) {
-	out := formatApplySummaryComment(completedApply(), nil, false, nil, nil, nil)
+	out := formatApplySummaryComment(completedApply(), nil, false, nil, nil, nil, "")
 	assert.Contains(t, out, "## ✅ Schema Change Applied")
 	assert.NotContains(t, out, "**Deployments**:")
 }
@@ -89,7 +89,7 @@ func TestFormatApplySummaryComment_OneOperationRendersSingle(t *testing.T) {
 	ops := []*storage.ApplyOperation{
 		{ID: 1, Deployment: "eu", State: state.ApplyOperation.Completed},
 	}
-	out := formatApplySummaryComment(completedApply(), ops, false, nil, nil, nil)
+	out := formatApplySummaryComment(completedApply(), ops, false, nil, nil, nil, "")
 	assert.NotContains(t, out, "**Deployments**:")
 	assert.NotContains(t, out, "- ✅ eu")
 }
@@ -102,7 +102,7 @@ func TestFormatApplySummaryComment_MultipleOperationsRendersMulti(t *testing.T) 
 		{ID: 1, Deployment: "eu", State: state.ApplyOperation.Completed},
 		{ID: 2, Deployment: "us", State: state.ApplyOperation.Completed},
 	}
-	out := formatApplySummaryComment(completedApply(), ops, false, nil, nil, nil)
+	out := formatApplySummaryComment(completedApply(), ops, false, nil, nil, nil, "")
 	assert.Contains(t, out, "## ✅ Schema Change Applied")
 	assert.Contains(t, out, "**Deployments**: 2 completed")
 	assert.Contains(t, out, "- ✅ eu — completed")
@@ -120,7 +120,7 @@ func TestBuildMultiApplyData_RoutesTasksByOperation(t *testing.T) {
 		{ApplyOperationID: new(int64(2)), TableName: "orders", State: state.Task.Running},
 		{ApplyOperationID: new(int64(1)), TableName: "customers", State: state.Task.Running},
 	}
-	data := buildMultiApplyData(runningApply(), ops, false, tasks, nil, nil)
+	data := buildMultiApplyData(runningApply(), ops, false, tasks, nil, nil, "")
 
 	require.Len(t, data.Details["eu"].Tables, 1)
 	assert.Equal(t, "customers", data.Details["eu"].Tables[0].TableName)
@@ -150,7 +150,7 @@ func TestBuildMultiApplyData_ScopesShardsByOperation(t *testing.T) {
 		},
 	}
 
-	data := buildMultiApplyData(runningApply(), ops, false, tasks, nil, shardsByTable)
+	data := buildMultiApplyData(runningApply(), ops, false, tasks, nil, shardsByTable, "")
 
 	require.Len(t, data.Details["eu"].Tables, 1)
 	require.Len(t, data.Details["eu"].Tables[0].Shards, 1)
@@ -167,7 +167,7 @@ func TestBuildDeploymentDetail_UsesOperationStateAndError(t *testing.T) {
 	op := &storage.ApplyOperation{ID: 1, Deployment: "us", State: state.ApplyOperation.Failed, ErrorMessage: "lock wait timeout"}
 	apply := runningApply()
 	apply.Attempt = 3
-	detail := buildDeploymentDetail(apply, op, nil, operationDisplay{}, nil)
+	detail := buildDeploymentDetail(apply, op, nil, operationDisplay{}, nil, "")
 	assert.Equal(t, state.Apply.Failed, detail.State)
 	assert.Equal(t, "lock wait timeout", detail.ErrorMessage)
 	assert.Equal(t, "payments", detail.Database)

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -380,6 +380,7 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment 
 		InstallationID: installationID,
 		DeferCutover:   options["defer_cutover"] == "true",
 		SupportChannel: h.supportChannel(),
+		Tenant:         h.deploymentTenant(),
 		Logger:         h.logger,
 		OnTerminalHook: func(a *storage.Apply) {
 			updated, err := h.updateCheckRecordForApplyResult(context.Background(), repo, pr, a)
@@ -497,7 +498,7 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment 
 	// Post initial progress comment for the observer to edit. VSchema status is
 	// omitted on this first comment — the observer refreshes it from engine
 	// display metadata on the next progress tick.
-	progressBody := formatProgressComment(apply, nil, nil)
+	progressBody := formatProgressComment(apply, nil, nil, h.deploymentTenant())
 	h.postInitialProgressComment(ctx, repo, pr, installationID, applyID, progressBody)
 }
 

--- a/pkg/webhook/sharded_apply.go
+++ b/pkg/webhook/sharded_apply.go
@@ -76,7 +76,7 @@ func isShardedApply(ops []*storage.ApplyOperation) bool {
 // ("waiting for `-40`", "halted — `-40` failed") reference shards. Finalizer
 // (VSchema) operations are not shard work and are omitted from the shard view;
 // their outcome is still reflected in the aggregate headline state.
-func buildShardedApplyData(apply *storage.Apply, ops []*storage.ApplyOperation, released bool, tasks []*storage.Task) templates.ShardedApplyData {
+func buildShardedApplyData(apply *storage.Apply, ops []*storage.ApplyOperation, released bool, tasks []*storage.Task, tenant string) templates.ShardedApplyData {
 	tasksByOp := groupTasksByOperation(tasks)
 	// Tasks arrive in created_at DESC order with no id tiebreaker. Sort each
 	// operation's tasks by id so the joined DDL (and the change signature derived
@@ -128,6 +128,7 @@ func buildShardedApplyData(apply *storage.Apply, ops []*storage.ApplyOperation, 
 		RequestedBy: actorFromCaller(apply.Caller),
 		Shards:      shardStatuses(shardOrder, opsByShard, released, tasksByOp),
 		Cells:       cells,
+		Tenant:      tenant,
 	}
 	if apply.StartedAt != nil {
 		data.StartedAt = apply.StartedAt.Format(time.RFC3339)

--- a/pkg/webhook/sharded_apply_test.go
+++ b/pkg/webhook/sharded_apply_test.go
@@ -22,7 +22,7 @@ func TestFormatApplyStatusComment_ShardedAttributionFromCaller(t *testing.T) {
 	oid := int64(1)
 	tasks := []*storage.Task{{ID: 1, ApplyID: 1, ApplyOperationID: &oid, Namespace: "cdb_resolute_sharded", TableName: "mutes", Shard: "-40", DDL: "ALTER TABLE `mutes` ADD INDEX a"}}
 
-	out := formatApplyStatusComment(apply, []*storage.ApplyOperation{op}, false, tasks, nil, nil)
+	out := formatApplyStatusComment(apply, []*storage.ApplyOperation{op}, false, tasks, nil, nil, "")
 
 	assert.Contains(t, out, "by @morgo at", "attribution shows the clean username")
 	assert.NotContains(t, out, "github:", "the raw structured caller is not rendered")
@@ -100,7 +100,7 @@ func TestFormatApplyStatusComment_ShardedFailedSurfacesError(t *testing.T) {
 	}
 	tasks := []*storage.Task{task(1, 1, "-40"), task(2, 2, "40-80"), task(3, 3, "80-c0"), task(4, 4, "c0-")}
 
-	out := formatApplyStatusComment(apply, ops, false, tasks, nil, nil)
+	out := formatApplyStatusComment(apply, ops, false, tasks, nil, nil, "")
 
 	assert.Contains(t, out, "## Schema Change Status", "uses the stable in-place status headline")
 	assert.Contains(t, out, "**Shards**:", "counts shards, not deployments")
@@ -127,7 +127,7 @@ func TestFormatApplyStatusComment_ShardedFailureFallsBackToTaskError(t *testing.
 	oid := int64(1)
 	tasks := []*storage.Task{{ID: 1, ApplyID: 1, ApplyOperationID: &oid, Namespace: "cdb_resolute_sharded", TableName: "mutes", Shard: "-40", DDL: "ALTER ...", ErrorMessage: gotZero}}
 
-	out := formatApplyStatusComment(apply, []*storage.ApplyOperation{op}, false, tasks, nil, nil)
+	out := formatApplyStatusComment(apply, []*storage.ApplyOperation{op}, false, tasks, nil, nil, "")
 
 	assert.Contains(t, out, gotZero, "the task error is surfaced when the operation row has none")
 }
@@ -150,7 +150,7 @@ func TestBuildShardedApplyData_DivergentGroupsByTable(t *testing.T) {
 	}
 	tasks := []*storage.Task{tk(1, 1, "mutes"), tk(2, 2, "mutes"), tk(3, 3, "blocks")}
 
-	data := buildShardedApplyData(apply, ops, false, tasks)
+	data := buildShardedApplyData(apply, ops, false, tasks, "")
 
 	assert.Equal(t, "ks", data.Keyspace)
 	require.Len(t, data.Cells, 3)
@@ -173,7 +173,7 @@ func TestBuildShardedApplyData_JoinsMultiTaskDDL(t *testing.T) {
 		{ID: 3, ApplyID: 1, ApplyOperationID: &oid, Namespace: "ks", TableName: "mutes", DDL: "ALTER TABLE `mutes` ADD INDEX b"},
 	}
 
-	data := buildShardedApplyData(apply, []*storage.ApplyOperation{op}, false, tasks)
+	data := buildShardedApplyData(apply, []*storage.ApplyOperation{op}, false, tasks, "")
 
 	require.Len(t, data.Cells, 1)
 	assert.Equal(t, "ALTER TABLE `mutes` ADD INDEX a\nALTER TABLE `mutes` ADD INDEX b", data.Cells[0].DDL,

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -90,6 +90,11 @@ type ApplyStatusCommentData struct {
 	// its stored options. Zero means the engine default is in effect and the
 	// comment renders no volume.
 	Volume int
+
+	// Tenant is the deployment's tenant identity, appended as --tenant to every
+	// pasteable command hint so copied commands address this deployment in
+	// tenant mode. Empty on single-tenant deployments, leaving hints unchanged.
+	Tenant string
 }
 
 // RenderApplyStatusComment renders a PR comment for the current apply status.
@@ -297,7 +302,7 @@ func writeStopOrCancelFooterAction(sb *strings.Builder, data ApplyStatusCommentD
 	if command == "cancel" {
 		prefix = cancelPrefix
 	}
-	writeFooterAction(sb, prefix, fmt.Sprintf("schemabot %s %s -e %s", command, data.ApplyID, data.Environment))
+	writeFooterAction(sb, prefix, appendTenantFlag(fmt.Sprintf("schemabot %s %s -e %s", command, data.ApplyID, data.Environment), data.Tenant))
 }
 
 // revertWindowCountdown returns the time remaining before the revert window
@@ -895,9 +900,9 @@ func writeRowsAndETA(sb *strings.Builder, table TableProgressData) {
 func writeApplyFooter(sb *strings.Builder, data ApplyStatusCommentData) {
 	switch data.State {
 	case state.Apply.WaitingForDeploy:
-		writeFooterAction(sb, "To deploy:", fmt.Sprintf("schemabot cutover %s -e %s", data.ApplyID, data.Environment))
+		writeFooterAction(sb, "To deploy:", appendTenantFlag(fmt.Sprintf("schemabot cutover %s -e %s", data.ApplyID, data.Environment), data.Tenant))
 	case state.Apply.WaitingForCutover:
-		writeFooterAction(sb, "To proceed with cutover:", fmt.Sprintf("schemabot cutover %s -e %s", data.ApplyID, data.Environment))
+		writeFooterAction(sb, "To proceed with cutover:", appendTenantFlag(fmt.Sprintf("schemabot cutover %s -e %s", data.ApplyID, data.Environment), data.Tenant))
 	case state.Apply.Recovering:
 		sb.WriteString("\n---\n\n")
 		if pct, ok := recoveringCopyPercent(data.Tables); ok {
@@ -921,16 +926,16 @@ func writeApplyFooter(sb *strings.Builder, data ApplyStatusCommentData) {
 			"An error interrupted this schema change. SchemaBot retries automatically and marks it failed if retries are exhausted. To stop retrying:",
 			"An error interrupted this schema change. SchemaBot retries automatically and marks it failed if retries are exhausted. To cancel it:")
 	case state.Apply.Stopped:
-		writeFooterAction(sb, "Paused — to resume from where it stopped:", fmt.Sprintf("schemabot start %s -e %s", data.ApplyID, data.Environment))
+		writeFooterAction(sb, "Paused — to resume from where it stopped:", appendTenantFlag(fmt.Sprintf("schemabot start %s -e %s", data.ApplyID, data.Environment), data.Tenant))
 	case state.Apply.Cancelled:
 		sb.WriteString("\n---\n\n")
 		sb.WriteString("This schema change was cancelled and cannot be resumed. Open a new schema change to apply it again.\n")
 	case state.Apply.Failed:
-		writeFooterAction(sb, "To retry:", fmt.Sprintf("schemabot apply -e %s", data.Environment))
+		writeFooterAction(sb, "To retry:", appendTenantFlag(fmt.Sprintf("schemabot apply -e %s", data.Environment), data.Tenant))
 	case state.Apply.RevertWindow:
 		// Skip-revert (finalize) is the common path, so it leads; revert (undo) follows.
-		writeFooterAction(sb, "To skip revert and keep changes:", fmt.Sprintf("schemabot skip-revert %s -e %s", data.ApplyID, data.Environment))
-		fmt.Fprintf(sb, "\nTo revert:\n```\nschemabot revert %s -e %s\n```\n", data.ApplyID, data.Environment)
+		writeFooterAction(sb, "To skip revert and keep changes:", appendTenantFlag(fmt.Sprintf("schemabot skip-revert %s -e %s", data.ApplyID, data.Environment), data.Tenant))
+		fmt.Fprintf(sb, "\nTo revert:\n```\n%s\n```\n", appendTenantFlag(fmt.Sprintf("schemabot revert %s -e %s", data.ApplyID, data.Environment), data.Tenant))
 	case state.Apply.SkippingRevert:
 		sb.WriteString("\n---\n\n")
 		sb.WriteString("Skip-revert was requested — closing the revert window and making this schema change permanent. This can no longer be reverted.\n")
@@ -1016,7 +1021,7 @@ func writeSummaryFailed(sb *strings.Builder, data ApplyStatusCommentData, comple
 	}
 
 	writeSummaryTableList(sb, data)
-	writeFooterAction(sb, "To retry:", fmt.Sprintf("schemabot apply -e %s", data.Environment))
+	writeFooterAction(sb, "To retry:", appendTenantFlag(fmt.Sprintf("schemabot apply -e %s", data.Environment), data.Tenant))
 }
 
 func writeSummaryStopped(sb *strings.Builder, data ApplyStatusCommentData, completedCount int, totalTables int) {
@@ -1028,7 +1033,7 @@ func writeSummaryStopped(sb *strings.Builder, data ApplyStatusCommentData, compl
 	}
 
 	writeSummaryTableList(sb, data)
-	writeFooterAction(sb, "Paused — to resume from where it stopped:", fmt.Sprintf("schemabot start %s -e %s", data.ApplyID, data.Environment))
+	writeFooterAction(sb, "Paused — to resume from where it stopped:", appendTenantFlag(fmt.Sprintf("schemabot start %s -e %s", data.ApplyID, data.Environment), data.Tenant))
 }
 
 // writeSummaryCancelled renders the terminal summary for a cancelled schema

--- a/pkg/webhook/templates/apply_tenant_test.go
+++ b/pkg/webhook/templates/apply_tenant_test.go
@@ -1,0 +1,88 @@
+package templates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// Every pasteable lifecycle hint in the apply status comment addresses a
+// specific deployment, so on a tenant deployment each carries the --tenant
+// flag; single-tenant deployments render the same command unchanged.
+func TestApplyStatusCommentHintsCarryTenant(t *testing.T) {
+	cases := []struct {
+		name     string
+		state    string
+		engine   string
+		commands []string
+	}{
+		{name: "waiting_for_deploy cutover", state: state.Apply.WaitingForDeploy, commands: []string{"schemabot cutover apply-x -e production"}},
+		{name: "waiting_for_cutover cutover", state: state.Apply.WaitingForCutover, commands: []string{"schemabot cutover apply-x -e production"}},
+		{name: "running stop", state: state.Apply.Running, commands: []string{"schemabot stop apply-x -e production"}},
+		{name: "running planetscale cancel", state: state.Apply.Running, engine: storage.EnginePlanetScale, commands: []string{"schemabot cancel apply-x -e production"}},
+		{name: "failed_retryable stop", state: state.Apply.FailedRetryable, commands: []string{"schemabot stop apply-x -e production"}},
+		{name: "stopped start", state: state.Apply.Stopped, commands: []string{"schemabot start apply-x -e production"}},
+		{name: "failed retry", state: state.Apply.Failed, commands: []string{"schemabot apply -e production"}},
+		{name: "revert window skip-revert and revert", state: state.Apply.RevertWindow, engine: storage.EnginePlanetScale, commands: []string{
+			"schemabot skip-revert apply-x -e production",
+			"schemabot revert apply-x -e production",
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data := ApplyStatusCommentData{
+				ApplyID:     "apply-x",
+				Database:    "orders",
+				Environment: "production",
+				State:       tc.state,
+				Engine:      tc.engine,
+			}
+
+			untenanted := RenderApplyStatusComment(data)
+			assert.NotContains(t, untenanted, "--tenant")
+			for _, cmd := range tc.commands {
+				assert.Contains(t, untenanted, cmd+"\n", "single-tenant hint must be the bare command")
+			}
+
+			data.Tenant = "acme"
+			tenanted := RenderApplyStatusComment(data)
+			for _, cmd := range tc.commands {
+				assert.Contains(t, tenanted, cmd+" --tenant acme", "tenant hint must carry the deployment's tenant")
+			}
+		})
+	}
+}
+
+// The terminal summary comment's retry and resume hints carry the tenant flag
+// on tenant deployments and stay unchanged on single-tenant ones.
+func TestApplySummaryCommentHintsCarryTenant(t *testing.T) {
+	cases := []struct {
+		name    string
+		state   string
+		command string
+	}{
+		{name: "failed retry", state: state.Apply.Failed, command: "schemabot apply -e production"},
+		{name: "stopped start", state: state.Apply.Stopped, command: "schemabot start apply-x -e production"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data := ApplyStatusCommentData{
+				ApplyID:     "apply-x",
+				Database:    "orders",
+				Environment: "production",
+				State:       tc.state,
+			}
+
+			untenanted := RenderApplySummaryComment(data)
+			assert.NotContains(t, untenanted, "--tenant")
+			assert.Contains(t, untenanted, tc.command+"\n", "single-tenant hint must be the bare command")
+
+			data.Tenant = "acme"
+			tenanted := RenderApplySummaryComment(data)
+			assert.Contains(t, tenanted, tc.command+" --tenant acme", "tenant hint must carry the deployment's tenant")
+		})
+	}
+}

--- a/pkg/webhook/templates/multi_apply.go
+++ b/pkg/webhook/templates/multi_apply.go
@@ -41,6 +41,11 @@ type MultiDeploymentApplyData struct {
 	// comment data (its tables, error, timing, database). Each deployment's
 	// <details> body is rendered from its entry via RenderApplyStatusComment.
 	Details map[string]ApplyStatusCommentData
+
+	// Tenant is the deployment's tenant identity, appended as --tenant to every
+	// pasteable command hint so copied commands address this deployment in
+	// tenant mode. Empty on single-tenant deployments, leaving hints unchanged.
+	Tenant string
 }
 
 // RenderMultiDeploymentApplyComment renders the PR comment for an apply that
@@ -168,14 +173,14 @@ func writeAggregateNextAction(sb *strings.Builder, data MultiDeploymentApplyData
 	case presentation.NextActionCutover:
 		writeFooterAction(sb,
 			fmt.Sprintf("To cut over `%s`:", na.Deployment),
-			fmt.Sprintf("schemabot cutover %s -e %s", data.ApplyID, data.Environment))
+			appendTenantFlag(fmt.Sprintf("schemabot cutover %s -e %s", data.ApplyID, data.Environment), data.Tenant))
 	case presentation.NextActionResume:
-		writeFooterAction(sb, "Paused — to resume from where it stopped:", fmt.Sprintf("schemabot start %s -e %s", data.ApplyID, data.Environment))
+		writeFooterAction(sb, "Paused — to resume from where it stopped:", appendTenantFlag(fmt.Sprintf("schemabot start %s -e %s", data.ApplyID, data.Environment), data.Tenant))
 	case presentation.NextActionReviewFailure:
 		// revert applies only to a deployment still in its post-cutover revert
 		// window, not to a failure; the recovery path for a failed apply is a
 		// retry, matching the single-deployment failed footer.
-		writeFooterAction(sb, "To retry:", fmt.Sprintf("schemabot apply -e %s", data.Environment))
+		writeFooterAction(sb, "To retry:", appendTenantFlag(fmt.Sprintf("schemabot apply -e %s", data.Environment), data.Tenant))
 	case presentation.NextActionNone:
 		// No operator action is pending; nothing to render.
 	}

--- a/pkg/webhook/templates/multi_apply_tenant_test.go
+++ b/pkg/webhook/templates/multi_apply_tenant_test.go
@@ -1,0 +1,72 @@
+package templates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/block/schemabot/pkg/presentation"
+	"github.com/block/schemabot/pkg/state"
+)
+
+// The multi-deployment comment's aggregate next-action hint addresses a
+// specific deployment, so on a tenant deployment it carries the --tenant flag;
+// single-tenant deployments render the same command unchanged.
+func TestMultiDeploymentApplyHintsCarryTenant(t *testing.T) {
+	cases := []struct {
+		name    string
+		ops     []presentation.Operation
+		command string
+	}{
+		{
+			name:    "cutover next action",
+			ops:     []presentation.Operation{barrierOp("eu", so.WaitingForCutover), barrierOp("us", so.Running)},
+			command: "schemabot cutover apply-123 -e production",
+		},
+		{
+			name:    "resume next action",
+			ops:     []presentation.Operation{rollingOp("eu", so.Stopped), rollingOp("us", so.Completed)},
+			command: "schemabot start apply-123 -e production",
+		},
+		{
+			name:    "retry next action",
+			ops:     []presentation.Operation{rollingOp("eu", so.Completed), rollingOp("us", so.Failed)},
+			command: "schemabot apply -e production",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data := MultiDeploymentApplyData{
+				Model:       presentation.Derive(tc.ops),
+				ApplyID:     "apply-123",
+				Environment: "production",
+			}
+
+			untenanted := RenderMultiDeploymentApplyComment(data)
+			assert.NotContains(t, untenanted, "--tenant")
+			assert.Contains(t, untenanted, tc.command+"\n", "single-tenant hint must be the bare command")
+
+			data.Tenant = "acme"
+			tenanted := RenderMultiDeploymentApplyComment(data)
+			assert.Contains(t, tenanted, tc.command+" --tenant acme", "tenant hint must carry the deployment's tenant")
+		})
+	}
+}
+
+// Each deployment's <details> body is rendered by the single-deployment
+// renderer including its lifecycle footer, so its hints carry the tenant flag
+// from the deployment's own detail data.
+func TestMultiDeploymentApplyDetailHintsCarryTenant(t *testing.T) {
+	data := MultiDeploymentApplyData{
+		Model:       presentation.Derive([]presentation.Operation{rollingOp("eu", so.Stopped), rollingOp("us", so.Completed)}),
+		ApplyID:     "apply-123",
+		Environment: "production",
+		Tenant:      "acme",
+		Details: map[string]ApplyStatusCommentData{
+			"eu": {ApplyID: "apply-123", Environment: "production", State: state.Apply.Stopped, Tenant: "acme"},
+		},
+	}
+
+	out := RenderMultiDeploymentApplyComment(data)
+	assert.Contains(t, out, "schemabot start apply-123 -e production --tenant acme")
+}

--- a/pkg/webhook/templates/reconciliation.go
+++ b/pkg/webhook/templates/reconciliation.go
@@ -10,8 +10,8 @@ import (
 type SchemaChangeReconciliationData struct {
 	RequestedBy string
 	Timestamp   string
-	// Tenant is the deployment's own tenant; when set, the pasteable stop and
-	// rollback hints carry it so the command addresses this deployment.
+	// Tenant is the deployment's own tenant; when set, the pasteable stop,
+	// plan, and rollback hints carry it so the command addresses this deployment.
 	Tenant string
 	Items  []SchemaChangeReconciliationItem
 }
@@ -149,7 +149,7 @@ func writeInProgressReconciliation(sb *strings.Builder, tenant string, items []S
 	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", stopCommand(tenant, items))
 	sb.WriteString("\n2. Then reconcile the final live schema:\n")
 	sb.WriteString("   - If the live schema change should remain, add the schema change back to the PR, then comment:\n")
-	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", planCommand(items))
+	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", planCommand(tenant, items))
 	sb.WriteString("   - If the live schema change should not remain, roll it back:\n")
 	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", rollbackCommand(tenant, items))
 	sb.WriteString("     After rollback: push a no-op `schemabot.yaml` edit to trigger a fresh plan.\n")
@@ -163,23 +163,23 @@ func writeCompletedReconciliation(sb *strings.Builder, tenant string, items []Sc
 	sb.WriteString("1. Keep the live schema change:\n")
 	sb.WriteString("   - add the schema change back to the PR\n")
 	sb.WriteString("   - comment:\n")
-	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", planCommand(items))
+	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", planCommand(tenant, items))
 	sb.WriteString("\n2. Undo the live schema change:\n")
 	sb.WriteString("   - comment:\n")
 	fmt.Fprintf(sb, "     ```\n     %s\n     ```\n", rollbackCommand(tenant, items))
 	sb.WriteString("   - after rollback: push a no-op `schemabot.yaml` edit to trigger a fresh plan\n")
 }
 
-func planCommand(items []SchemaChangeReconciliationItem) string {
+func planCommand(tenant string, items []SchemaChangeReconciliationItem) string {
 	item, ok := singleCommandItem(items)
 	if !ok {
-		return "schemabot plan -e <environment> -d <database>"
+		return appendTenantFlag("schemabot plan -e <environment> -d <database>", tenant)
 	}
 	cmd := fmt.Sprintf("schemabot plan -e %s", item.Environment)
 	if item.Database != "" {
 		cmd += fmt.Sprintf(" -d %s", item.Database)
 	}
-	return cmd
+	return appendTenantFlag(cmd, tenant)
 }
 
 func stopCommand(tenant string, items []SchemaChangeReconciliationItem) string {

--- a/pkg/webhook/templates/reconciliation_tenant_test.go
+++ b/pkg/webhook/templates/reconciliation_tenant_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// The reconciliation comment's pasteable stop/rollback hints address a
+// The reconciliation comment's pasteable stop/plan/rollback hints address a
 // specific deployment, so on a tenant deployment they carry its tenant flag.
 func TestReconciliationHintsCarryTenant(t *testing.T) {
 	out := RenderSchemaChangeReconciliationRequired(SchemaChangeReconciliationData{
@@ -14,10 +14,12 @@ func TestReconciliationHintsCarryTenant(t *testing.T) {
 		Items:  []SchemaChangeReconciliationItem{{Database: "orders", Environment: "staging", ApplyID: "apply_abc123", State: "completed"}},
 	})
 	require.Contains(t, out, "schemabot rollback apply_abc123 -e staging --tenant acme")
+	require.Contains(t, out, "schemabot plan -e staging -d orders --tenant acme")
 
 	untenanted := RenderSchemaChangeReconciliationRequired(SchemaChangeReconciliationData{
 		Items: []SchemaChangeReconciliationItem{{Database: "orders", Environment: "staging", ApplyID: "apply_abc123", State: "completed"}},
 	})
 	require.Contains(t, untenanted, "schemabot rollback apply_abc123 -e staging")
+	require.Contains(t, untenanted, "schemabot plan -e staging -d orders")
 	require.NotContains(t, untenanted, "--tenant")
 }

--- a/pkg/webhook/templates/sharded_apply.go
+++ b/pkg/webhook/templates/sharded_apply.go
@@ -37,6 +37,11 @@ type ShardedApplyData struct {
 	// Cells is one entry per (shard, table) operation — the unit that carries the
 	// DDL and defines a shard's change signature for grouping.
 	Cells []ShardCell
+
+	// Tenant is the deployment's tenant identity, appended as --tenant to every
+	// pasteable command hint so copied commands address this deployment in
+	// tenant mode. Empty on single-tenant deployments, leaving hints unchanged.
+	Tenant string
 }
 
 // ShardStatus is one shard's aggregate status. Emoji/Label come from the same
@@ -270,10 +275,10 @@ func shardStatusCell(s ShardStatus) string {
 func writeShardedFooter(sb *strings.Builder, data ShardedApplyData) {
 	switch {
 	case state.IsState(data.State, state.Apply.Failed):
-		writeFooterAction(sb, "To retry:", fmt.Sprintf("schemabot apply -e %s", data.Environment))
+		writeFooterAction(sb, "To retry:", appendTenantFlag(fmt.Sprintf("schemabot apply -e %s", data.Environment), data.Tenant))
 	case state.IsState(data.State, state.Apply.FailedRetryable):
-		writeFooterAction(sb, "An error interrupted this schema change. SchemaBot retries automatically and marks it failed if retries are exhausted. To stop retrying:", fmt.Sprintf("schemabot stop %s -e %s", data.ApplyID, data.Environment))
+		writeFooterAction(sb, "An error interrupted this schema change. SchemaBot retries automatically and marks it failed if retries are exhausted. To stop retrying:", appendTenantFlag(fmt.Sprintf("schemabot stop %s -e %s", data.ApplyID, data.Environment), data.Tenant))
 	case state.IsState(data.State, state.Apply.Stopped):
-		writeFooterAction(sb, "Paused — to resume from where it stopped:", fmt.Sprintf("schemabot start %s -e %s", data.ApplyID, data.Environment))
+		writeFooterAction(sb, "Paused — to resume from where it stopped:", appendTenantFlag(fmt.Sprintf("schemabot start %s -e %s", data.ApplyID, data.Environment), data.Tenant))
 	}
 }

--- a/pkg/webhook/templates/sharded_apply_tenant_test.go
+++ b/pkg/webhook/templates/sharded_apply_tenant_test.go
@@ -1,0 +1,48 @@
+package templates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/block/schemabot/pkg/state"
+)
+
+// The sharded-apply comment's lifecycle footer addresses a specific deployment,
+// so on a tenant deployment its hint carries the --tenant flag; single-tenant
+// deployments render the same command unchanged.
+func TestShardedApplyHintsCarryTenant(t *testing.T) {
+	cases := []struct {
+		name    string
+		state   string
+		command string
+	}{
+		{name: "failed retry", state: state.Apply.Failed, command: "schemabot apply -e staging"},
+		{name: "failed_retryable stop", state: state.Apply.FailedRetryable, command: "schemabot stop apply-x -e staging"},
+		{name: "stopped start", state: state.Apply.Stopped, command: "schemabot start apply-x -e staging"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data := ShardedApplyData{
+				State:       tc.state,
+				Environment: "staging",
+				Database:    "cdb_resolute",
+				Keyspace:    "cdb_resolute_sharded",
+				ApplyID:     "apply-x",
+				Shards: []ShardStatus{
+					{Shard: "-40", Emoji: "⏸", Label: "stopped", State: state.ApplyOperation.Stopped},
+					{Shard: "80-", Emoji: "⏸", Label: "stopped", State: state.ApplyOperation.Stopped},
+				},
+				Cells: []ShardCell{mutesCell("-40"), mutesCell("80-")},
+			}
+
+			untenanted := RenderShardedApplyComment(data)
+			assert.NotContains(t, untenanted, "--tenant")
+			assert.Contains(t, untenanted, tc.command+"\n", "single-tenant hint must be the bare command")
+
+			data.Tenant = "acme"
+			tenanted := RenderShardedApplyComment(data)
+			assert.Contains(t, tenanted, tc.command+" --tenant acme", "tenant hint must carry the deployment's tenant")
+		})
+	}
+}


### PR DESCRIPTION
## Why this matters

On tenant deployments, lifecycle commands (`cutover`, `start`, `stop`, `cancel`, `skip-revert`, `revert`, retry `apply`) do not fan out — a command without `--tenant` is silently ignored. But the apply progress, summary, multi-deployment, and sharded PR comments rendered their pasteable hints without the flag, so a user who copied a hint verbatim posted a command that did nothing, with no feedback.

## What it does

- Routes every lifecycle hint in `templates/apply.go`, `templates/multi_apply.go`, and `templates/sharded_apply.go` through the existing `appendTenantFlag` helper the plan and apply-gate comments already use: tenant deployments append `--tenant <tenant>`, single-tenant deployments render byte-identical hints to before.
- Fixes the same gap found in audit: the reconciliation comment's plan hint was missing the flag while its sibling stop/rollback hints already carried it.
- Threads the tenant from the deployment config through a new `CommentObserverConfig.Tenant` field and the direct render paths (summary reconciliation, progress finalize, rollback initial progress), including the multi-deployment `<details>` bodies, which render the full single-deployment footer.
- Adds template tests asserting both renderings for every footer state across all three comment layouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)