### PR TITLE
fix(inventory): honor caller context in per-request secret resolution

### DIFF
--- a/pkg/inventory/credentials.go
+++ b/pkg/inventory/credentials.go
@@ -58,13 +58,15 @@ type SecretRefCredentialResolver struct {
 
 var _ CredentialResolver = SecretRefCredentialResolver{}
 
-// ResolveCredentials resolves the password reference fresh on every call.
-func (r SecretRefCredentialResolver) ResolveCredentials(_ context.Context, req Request, _ map[string]string) (*Credentials, error) {
+// ResolveCredentials resolves the password reference fresh on every call. The
+// resolution is bounded by ctx, so a per-request secret fetch honors the
+// caller's deadline.
+func (r SecretRefCredentialResolver) ResolveCredentials(ctx context.Context, req Request, _ map[string]string) (*Credentials, error) {
 	if r.PasswordRef == "" {
 		return nil, fmt.Errorf("password reference is required for target %q", req.Target)
 	}
 	ref := strings.ReplaceAll(r.PasswordRef, "{target}", req.Target)
-	password, err := secrets.Resolve(ref, "")
+	password, err := secrets.ResolveContext(ctx, ref, "")
 	if err != nil {
 		return nil, fmt.Errorf("resolve password for target %q: %w", req.Target, err)
 	}

--- a/pkg/inventory/static.go
+++ b/pkg/inventory/static.go
@@ -245,7 +245,7 @@ func (c *StaticDSNFromConfig) validate(target string) error {
 // MySQL assembler and the fail-closed secret-ref credential resolver so a rotated
 // password or empty secret is handled identically to the Etre data-plane path.
 func (c *StaticDSNFromConfig) assemble(ctx context.Context, req Request, databaseType string) (string, error) {
-	host, port, err := c.resolveEndpoint(req.Target)
+	host, port, err := c.resolveEndpoint(ctx, req.Target)
 	if err != nil {
 		return "", err
 	}
@@ -264,9 +264,9 @@ func (c *StaticDSNFromConfig) assemble(ctx context.Context, req Request, databas
 // resolveEndpoint resolves the config document and reads the target host and
 // port from it. The port defaults to 3306 when absent; the database name in the
 // document, if any, is ignored (static target DSNs are namespace-free).
-func (c *StaticDSNFromConfig) resolveEndpoint(target string) (host, port string, err error) {
+func (c *StaticDSNFromConfig) resolveEndpoint(ctx context.Context, target string) (host, port string, err error) {
 	ref := strings.ReplaceAll(c.ConfigRef, "{target}", target)
-	document, err := secrets.Resolve(ref, "")
+	document, err := secrets.ResolveContext(ctx, ref, "")
 	if err != nil {
 		return "", "", fmt.Errorf("resolve config reference for target %q: %w", target, err)
 	}

--- a/pkg/secrets/resolve.go
+++ b/pkg/secrets/resolve.go
@@ -78,18 +78,20 @@ func Unregister(prefix string) {
 //
 // If value is empty, falls back to the fallbackEnvVar environment variable.
 //
-// Resolve uses a background context for any network-backed lookup. Callers on a
-// request path that want the resolution bounded by the request deadline should
-// use ResolveContext.
+// Resolve uses a background context for the built-in AWS Secrets Manager lookup.
+// Callers on a request path that want that lookup bounded by the request deadline
+// should use ResolveContext. Custom resolvers never receive a context (see
+// ResolverFunc), so their I/O is not bounded either way.
 func Resolve(value string, fallbackEnvVar string) (string, error) {
 	return ResolveContext(context.Background(), value, fallbackEnvVar)
 }
 
 // ResolveContext is Resolve with a caller-supplied context. The context bounds
-// network-backed lookups (AWS Secrets Manager) so a per-request resolution is
+// the built-in AWS Secrets Manager lookup so a per-request resolution is
 // cancelled by the caller's deadline instead of only a fixed background timeout.
-// The env:, file:, literal, and custom-resolver paths do no cancellable I/O and
-// ignore the context.
+// The env:, file:, and literal paths do only local, non-cancellable work and
+// ignore the context. Custom resolvers may perform network I/O, but ResolverFunc
+// takes no context, so that I/O is not cancelled by ctx either.
 func ResolveContext(ctx context.Context, value string, fallbackEnvVar string) (string, error) {
 	if value == "" {
 		return os.Getenv(fallbackEnvVar), nil

--- a/pkg/secrets/resolve.go
+++ b/pkg/secrets/resolve.go
@@ -77,7 +77,20 @@ func Unregister(prefix string) {
 //   - Direct value is returned as-is
 //
 // If value is empty, falls back to the fallbackEnvVar environment variable.
+//
+// Resolve uses a background context for any network-backed lookup. Callers on a
+// request path that want the resolution bounded by the request deadline should
+// use ResolveContext.
 func Resolve(value string, fallbackEnvVar string) (string, error) {
+	return ResolveContext(context.Background(), value, fallbackEnvVar)
+}
+
+// ResolveContext is Resolve with a caller-supplied context. The context bounds
+// network-backed lookups (AWS Secrets Manager) so a per-request resolution is
+// cancelled by the caller's deadline instead of only a fixed background timeout.
+// The env:, file:, literal, and custom-resolver paths do no cancellable I/O and
+// ignore the context.
+func ResolveContext(ctx context.Context, value string, fallbackEnvVar string) (string, error) {
 	if value == "" {
 		return os.Getenv(fallbackEnvVar), nil
 	}
@@ -105,7 +118,7 @@ func Resolve(value string, fallbackEnvVar string) (string, error) {
 
 	// Check for "secretsmanager:" prefix
 	if strings.HasPrefix(value, "secretsmanager:") {
-		return resolveSecretsManager(value[15:])
+		return resolveSecretsManager(ctx, value[15:])
 	}
 
 	return value, nil
@@ -123,12 +136,16 @@ func resolveFile(path string) (string, error) {
 
 // resolveSecretsManager fetches a secret from AWS Secrets Manager.
 // Format: "secret-name" or "secret-name#json-key"
-func resolveSecretsManager(ref string) (string, error) {
+//
+// The fetch is bounded by the caller's context and a 10s cap, whichever is
+// sooner, so a per-request resolution honors the request deadline instead of
+// always waiting the full background timeout.
+func resolveSecretsManager(ctx context.Context, ref string) (string, error) {
 	// Parse secret name and optional JSON key
 	secretName, jsonKey, _ := strings.Cut(ref, "#")
 
 	// Create AWS config (uses default credential chain: env vars, IAM role, etc.)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	cfg, err := config.LoadDefaultConfig(ctx)

--- a/pkg/secrets/resolve_integration_test.go
+++ b/pkg/secrets/resolve_integration_test.go
@@ -3,6 +3,7 @@
 package secrets
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -145,5 +146,15 @@ func TestResolve_SecretsManager_Integration(t *testing.T) {
 	t.Run("nonexistent secret", func(t *testing.T) {
 		_, err := Resolve("secretsmanager:does-not-exist", "")
 		require.Error(t, err)
+	})
+
+	// A per-request resolution is bounded by the caller's context: a cancelled
+	// context fails the Secrets Manager fetch instead of waiting the background
+	// timeout.
+	t.Run("context cancellation is honored", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		_, err := ResolveContext(ctx, "secretsmanager:test-plain-secret", "")
+		require.ErrorIs(t, err, context.Canceled)
 	})
 }


### PR DESCRIPTION
## Summary

Threads the caller's `context.Context` through the per-request secret-resolution path so AWS Secrets Manager lookups are cancelled by the request deadline instead of always using a fixed background timeout. Startup-time call sites are unchanged.

## What

- Added `secrets.ResolveContext(ctx, ...)`; `secrets.Resolve(...)` is now a `context.Background()` wrapper.
- The Secrets Manager resolver derives its timeout from the caller context (capped at 10s).
- The two per-request inventory surfaces (`credentials.go`, `static.go`) pass `ctx` into secret resolution.

## Why

On the request path, a slow or hung Secrets Manager lookup was bounded only by a fixed background timeout, so it could outlive the caller's own deadline and hold the request open. Honoring the caller context lets a cancelled/expired request abort the lookup promptly.

## Before / after

BEFORE — request deadline ignored by the SM lookup
```
request(ctx, deadline=2s)
│
▼
inventory (credentials / static)
│  Resolve(value)                 ← ctx dropped here
▼
ResolveContext(context.Background(), …)
│
▼
Secrets Manager lookup
timeout = fixed 10s background        ← can outlive the 2s request
```
AFTER — SM lookup bounded by caller deadline
```
request(ctx, deadline=2s)
│  ctx
▼
inventory (credentials / static)
│  ResolveContext(ctx, value)      ← ctx threaded through
▼
Secrets Manager lookup
timeout = min(caller deadline, 10s)   ← cancelled at 2s

env: / file: / literal → local, non-cancellable (unchanged)
custom resolvers        → ResolverFunc has no ctx (unchanged)
```