### PR TITLE
fix(github): mark tables parked at the cutover barrier as ready in apply comments

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -2748,25 +2748,25 @@ This schema change was cancelled and cannot be resumed. Open a new schema change
 
 **Status**: Waiting for Cutover
 
-**0/3** table(s) ready for cutover — waiting on 3
+**3/3** table(s) ready for cutover
 
 📊 3 waiting for cutover
 
 **Schema `testapp`**
 
-**`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Waiting for cutover
+**`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✅ Ready for cutover
 
 ```sql
 ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
 ```
 
-**`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Waiting for cutover
+**`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✅ Ready for cutover
 
 ```sql
 ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
 ```
 
-**`products`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Waiting for cutover
+**`products`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✅ Ready for cutover
 
 ```sql
 ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
@@ -5594,25 +5594,25 @@ schemabot cutover apply-a1b2c3d4e5f6 -e production
 
 **Status**: Waiting for Cutover
 
-**0/3** table(s) ready for cutover — waiting on 3
+**3/3** table(s) ready for cutover
 
 📊 3 waiting for cutover
 
 **Schema `testapp`**
 
-**`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Waiting for cutover
+**`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✅ Ready for cutover
 
 ```sql
 ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
 ```
 
-**`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Waiting for cutover
+**`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✅ Ready for cutover
 
 ```sql
 ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
 ```
 
-**`products`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Waiting for cutover
+**`products`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✅ Ready for cutover
 
 ```sql
 ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -2750,7 +2750,7 @@ This schema change was cancelled and cannot be resumed. Open a new schema change
 
 **3/3** table(s) ready for cutover
 
-📊 3 waiting for cutover
+📊 3 ready for cutover
 
 **Schema `testapp`**
 
@@ -2795,8 +2795,6 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 **Status**: Cutting Over
-
-**0/3** table(s) ready for cutover — waiting on 3
 
 📊 3 cutting over
 
@@ -5596,7 +5594,7 @@ schemabot cutover apply-a1b2c3d4e5f6 -e production
 
 **3/3** table(s) ready for cutover
 
-📊 3 waiting for cutover
+📊 3 ready for cutover
 
 **Schema `testapp`**
 

--- a/pkg/webhook/apply.go
+++ b/pkg/webhook/apply.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/block/schemabot/pkg/apitypes"
+	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/tern"
 	"github.com/block/schemabot/pkg/webhook/templates"
@@ -130,12 +131,21 @@ func tableProgressFromTasks(databaseFallback string, tasks []*storage.Task, shar
 			ChecksumRowsChecked: t.ChecksumRowsChecked,
 			ChecksumRowsTotal:   t.ChecksumRowsTotal,
 			IsInstant:           t.IsInstant,
-			ReadyToComplete:     t.ReadyToComplete,
+			ReadyToComplete:     taskReadyForCutover(t),
 			ErrorMessage:        t.ErrorMessage,
 			Shards:              shardProgressForTable(shardsByTable, t.ApplyOperationID, t.Namespace, t.TableName),
 		})
 	}
 	return out
+}
+
+// taskReadyForCutover reports whether a table's task is ready for the operator
+// to cut over. A task parked at the cutover barrier has finished its copy and
+// verification phases — the remaining binlog catch-up happens under cutover
+// itself — so the barrier state is what makes the table ready. Engines report
+// no separate per-task readiness signal.
+func taskReadyForCutover(t *storage.Task) bool {
+	return state.IsState(t.State, state.Task.WaitingForCutover)
 }
 
 // shardProgressForTable returns the per-shard summary rows for a table, sorted by

--- a/pkg/webhook/apply_test.go
+++ b/pkg/webhook/apply_test.go
@@ -89,6 +89,11 @@ func TestCommentObserverShouldDeferCutoverUsesPersistedApplyOption(t *testing.T)
 	assert.True(t, observer.shouldDeferCutover(apply))
 }
 
+// A defer-cutover apply parks its tasks at the cutover barrier with only the
+// task state to show for it — the driver persists no separate readiness flag.
+// The barrier state alone must mark every parked table ready, so the readiness
+// count agrees with the header and the cutover hint instead of telling the
+// operator the apply is still waiting.
 func TestFormatProgressCommentCutoverState(t *testing.T) {
 	apply := &storage.Apply{
 		ApplyIdentifier: "apply-abc123",
@@ -98,8 +103,8 @@ func TestFormatProgressCommentCutoverState(t *testing.T) {
 	}
 
 	tasks := []*storage.Task{
-		{TableName: "users", State: state.Task.WaitingForCutover, ReadyToComplete: true},
-		{TableName: "orders", State: state.Task.WaitingForCutover, ReadyToComplete: true},
+		{TableName: "users", State: state.Task.WaitingForCutover},
+		{TableName: "orders", State: state.Task.WaitingForCutover},
 	}
 
 	body := formatProgressComment(apply, tasks, nil)
@@ -108,6 +113,36 @@ func TestFormatProgressCommentCutoverState(t *testing.T) {
 	assert.Contains(t, body, "testdb")
 	assert.Contains(t, body, "`users`")
 	assert.Contains(t, body, "`orders`")
+	assert.Contains(t, body, "**2/2** table(s) ready for cutover")
+	assert.NotContains(t, body, "waiting on")
+	assert.Contains(t, body, "✅ Ready for cutover")
+	assert.NotContains(t, body, "Waiting for cutover", "a parked table must render as ready, not waiting")
+	assert.Contains(t, body, "📊 2 ready for cutover", "the progress summary must agree with the per-table rows")
+	assert.NotContains(t, body, "waiting for cutover", "no line on the comment may call a parked table waiting")
+}
+
+// While one table is still copying, the readiness summary counts only the
+// tables parked at the barrier so the operator can see what the cutover is
+// still waiting on.
+func TestFormatProgressCommentCutoverReadinessCountsOnlyParkedTables(t *testing.T) {
+	apply := &storage.Apply{
+		ApplyIdentifier: "apply-abc123",
+		Database:        "testdb",
+		Environment:     "production",
+		State:           state.Apply.WaitingForCutover,
+	}
+
+	tasks := []*storage.Task{
+		{TableName: "users", State: state.Task.WaitingForCutover},
+		{TableName: "orders", State: state.Task.Running},
+	}
+
+	body := formatProgressComment(apply, tasks, nil)
+
+	assert.Contains(t, body, "**1/2** table(s) ready for cutover — waiting on 1")
+	assert.Contains(t, body, "✅ Ready for cutover")
+	assert.Contains(t, body, "1 ready for cutover", "the progress summary must count the parked table as ready")
+	assert.Contains(t, body, "1 running", "the progress summary must show the table the cutover is waiting on")
 }
 
 func TestFormatSummaryComment(t *testing.T) {

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -117,8 +117,10 @@ func renderApplyStatusComment(data ApplyStatusCommentData, includeLastUpdated bo
 	// deploy request's own progress, which the comment does not otherwise surface.
 	writeDeployRequestLink(&sb, data)
 
-	// Cutover readiness summary
-	if data.State == state.Apply.WaitingForCutover || data.State == state.Apply.CuttingOver {
+	// Cutover readiness summary. Only while the apply is parked at the barrier —
+	// readiness answers "can I cut over yet?", a question that no longer exists
+	// once cutover is running, when the per-table rows carry the state.
+	if data.State == state.Apply.WaitingForCutover {
 		writeCutoverSummary(&sb, data.Tables)
 	}
 
@@ -350,7 +352,7 @@ func writeProgressSummary(sb *strings.Builder, tables []TableProgressData) {
 		return
 	}
 
-	var completed, running, checksumming, queued, failed, retrying, stopped, waiting, recovering, cutting, cancelled int
+	var completed, running, checksumming, queued, failed, retrying, stopped, readyForCutover, waiting, recovering, cutting, cancelled int
 	var runningPct int
 	var runningEstimateExceeded bool
 
@@ -370,7 +372,14 @@ func writeProgressSummary(sb *strings.Builder, tables []TableProgressData) {
 		case state.Task.Pending:
 			queued++
 		case state.Task.WaitingForCutover:
-			waiting++
+			// The summary must agree with the per-table rows: a task the
+			// projection marks ready renders as "Ready for cutover", so it
+			// counts as ready here, not as still waiting.
+			if t.ReadyToComplete {
+				readyForCutover++
+			} else {
+				waiting++
+			}
 		case state.Task.Recovering:
 			recovering++
 		case state.Task.CuttingOver:
@@ -415,6 +424,13 @@ func writeProgressSummary(sb *strings.Builder, tables []TableProgressData) {
 	}
 	if queued > 0 && multi {
 		parts = append(parts, fmt.Sprintf("%d queued", queued))
+	}
+	if readyForCutover > 0 {
+		if multi {
+			parts = append(parts, fmt.Sprintf("%d ready for cutover", readyForCutover))
+		} else {
+			parts = append(parts, "ready for cutover")
+		}
 	}
 	if waiting > 0 {
 		if multi {

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -1114,6 +1114,7 @@ func PreviewCommentApplyWaitingForCutover() string {
 	tables := sampleApplyTables()
 	for i := range tables {
 		tables[i].Status = state.Task.WaitingForCutover
+		tables[i].ReadyToComplete = true
 	}
 	return RenderApplyStatusComment(sampleApplyData(state.Apply.WaitingForCutover, tables))
 }
@@ -1207,6 +1208,7 @@ func PreviewCommentMultiDeploymentApplyInProgress() string {
 	euTables := sampleApplyTables()
 	for i := range euTables {
 		euTables[i].Status = state.Task.WaitingForCutover
+		euTables[i].ReadyToComplete = true
 	}
 
 	usTables := sampleApplyTables()


### PR DESCRIPTION
**Why this matters:** A defer-cutover apply parked at *Waiting for Cutover* told the operator two contradictory things on the same comment: the header and cutover hint said the apply was ready to cut over, while the readiness summary said "**0/N** table(s) ready for cutover — waiting on N" with every table row stuck at "Waiting for cutover". Operators reasonably concluded `--defer-cutover` was broken.

**What it does:** The comment projection copied `storage.Task.ReadyToComplete`, a field no engine path ever writes, so the readiness count could never move. This derives readiness from the task state instead: a task parked at the cutover barrier has finished its copy and verification phases (the remaining binlog catch-up happens under cutover itself), so the barrier state is what makes the table ready — for both Spirit and Vitess, whose ready states both map to `waiting_for_cutover`.

The 📊 progress summary line agrees too: a ready task counts as "N ready for cutover" instead of "N waiting for cutover", so no line on the comment contradicts another. And the readiness summary now renders only while the apply is parked at the barrier — during *Cutting Over* it used to claim "0/N ready — waiting on N" about tables that were actively cutting over.

```
before:  Status: Waiting for Cutover          after:  Status: Waiting for Cutover
         0/2 ready — waiting on 2                     2/2 table(s) ready for cutover
         📊 2 waiting for cutover                     📊 2 ready for cutover
         `users`  Waiting for cutover                 `users`  ✅ Ready for cutover
         `orders` Waiting for cutover                 `orders` ✅ Ready for cutover
         ▶️ cutover hint                              ▶️ cutover hint
```

The regression tests build tasks exactly as the driver persists them (state only, no hand-set readiness flag) so the rendering is proven through the real projection — the previous tests set `ReadyToComplete` on fixtures directly, which masked the bug. A second test covers mixed readiness (one table still copying → "1/2 … waiting on 1" + "📊 1 running · 1 ready for cutover").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
