### PR TITLE
fix(github): mirror the remote volume level onto control-plane apply options

### DIFF
--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -1404,6 +1404,34 @@ func (c *GRPCClient) mirrorRemoteDisplayMetadata(ctx context.Context, apply *sto
 	return blob
 }
 
+// mirrorRemoteVolume copies the volume level the data plane reports on a
+// progress response onto the in-memory apply options, so the poll's regular
+// parent-apply persistence records it. Volume changes are applied by the
+// data-plane driver against its own apply row, and the control plane only
+// learns the resulting level from progress responses — the PR comment and the
+// control-plane progress API both read the level from the control-plane apply
+// options. Returns true when the stored level changed so the caller can log
+// the transition.
+func mirrorRemoteVolume(apply *storage.Apply, remoteVolume int32) bool {
+	if remoteVolume == 0 {
+		// The data plane reports 0 when no volume level was ever set on the
+		// apply; there is nothing to mirror.
+		return false
+	}
+	if remoteVolume < storage.MinVolume || remoteVolume > storage.MaxVolume {
+		slog.Warn("remote progress reported an out-of-range volume level; keeping the stored level",
+			append(apply.LogAttrs(), "remote_volume", remoteVolume)...)
+		return false
+	}
+	opts := apply.GetOptions()
+	if opts.Volume == int(remoteVolume) {
+		return false
+	}
+	opts.Volume = int(remoteVolume)
+	apply.SetOptions(opts)
+	return true
+}
+
 // operationForDisplayMirror loads the apply_operation whose
 // engine_resume_metadata should carry the display projection. An
 // operation-scoped drive already knows its operation id; a whole-apply
@@ -3231,6 +3259,10 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 			apply.State = newState
 			apply.ErrorMessage = remoteProgressErrorMessage(apply.State, resp.ErrorMessage, apply.ErrorMessage)
 			apply.UpdatedAt = now
+			if mirrorRemoteVolume(apply, resp.Volume) {
+				slog.Info("mirrored remote volume level onto control-plane apply options",
+					append(apply.LogAttrs(), "volume", resp.Volume)...)
+			}
 
 			terminal := isTerminalProtoState(resp.State)
 			if terminal {

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -519,6 +519,7 @@ type capturingTernServer struct {
 	progressStateSet  bool
 	progressStates    []ternv1.State
 	progressTables    []*ternv1.TableProgress
+	progressVolume    int32
 	progressError     string
 	progressErr       error
 	startErr          error
@@ -615,6 +616,7 @@ func (s *capturingTernServer) Progress(_ context.Context, req *ternv1.ProgressRe
 		psSet = true
 	}
 	tables := s.progressTables
+	volume := s.progressVolume
 	errorMessage := s.progressError
 	err := s.progressErr
 	s.mu.Unlock()
@@ -624,7 +626,7 @@ func (s *capturingTernServer) Progress(_ context.Context, req *ternv1.ProgressRe
 	if !psSet {
 		ps = ternv1.State_STATE_COMPLETED
 	}
-	return &ternv1.ProgressResponse{State: ps, Tables: tables, ErrorMessage: errorMessage}, nil
+	return &ternv1.ProgressResponse{State: ps, Tables: tables, Volume: volume, ErrorMessage: errorMessage}, nil
 }
 
 func (s *capturingTernServer) getStartApplyID() string {
@@ -2999,6 +3001,100 @@ func TestGRPCClient_PollForCompletionReleasesAtCutoverBarrier(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, state.Apply.WaitingForCutover, apply.State)
 	assert.Equal(t, state.Task.WaitingForCutover, task.State)
+}
+
+// A remote apply's volume changes are applied by the data-plane driver against
+// its own apply row, so the control plane only learns the resulting level from
+// progress responses. The copy drive must mirror the reported level onto the
+// control-plane apply options — the PR comment and the control-plane progress
+// API read the level from there — and persist it with the regular progress
+// sync.
+func TestGRPCClient_PollForCompletionMirrorsRemoteVolume(t *testing.T) {
+	server := &capturingTernServer{
+		progressState:    ternv1.State_STATE_RUNNING,
+		progressStateSet: true,
+		progressVolume:   5,
+		progressTables: []*ternv1.TableProgress{{
+			Namespace:       "default",
+			TableName:       "users",
+			Status:          state.Task.Running,
+			PercentComplete: 40,
+		}},
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              70,
+		ApplyIdentifier: "apply-volume-mirror",
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+		ExternalID:      "remote-volume-mirror",
+		State:           state.Apply.Running,
+	}
+	storedApply := *apply
+	task := &storage.Task{
+		ID:             71,
+		TaskIdentifier: "task-volume-mirror",
+		ApplyID:        apply.ID,
+		Namespace:      "default",
+		TableName:      "users",
+		State:          state.Task.Running,
+	}
+	applies := &mockApplyStore{apply: &storedApply}
+	client.storage = &mockStorage{
+		applies: applies,
+		tasks:   &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:    &mockApplyLogStore{},
+	}
+
+	// The drive keeps polling a running remote; the deadline only bounds the
+	// test — the level must be mirrored on the first progress sync.
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	err := client.pollForCompletion(ctx, apply, false, wholeApplyTaskScope(), false)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 5, apply.GetOptions().Volume)
+	require.NotNil(t, applies.apply)
+	assert.Equal(t, 5, applies.apply.GetOptions().Volume,
+		"the mirrored level must be persisted so the PR comment and progress API can render it")
+}
+
+// mirrorRemoteVolume edge cases: a zero level means the apply never had a
+// volume set and mirrors nothing, an out-of-range level never lands on the
+// stored options, and an unchanged level reports no transition so the drive
+// does not log one every poll.
+func TestMirrorRemoteVolume(t *testing.T) {
+	t.Run("reported level lands on the apply options", func(t *testing.T) {
+		apply := &storage.Apply{ApplyIdentifier: "apply-x"}
+		require.True(t, mirrorRemoteVolume(apply, 5))
+		assert.Equal(t, 5, apply.GetOptions().Volume)
+	})
+
+	t.Run("level change overwrites the stored level", func(t *testing.T) {
+		apply := &storage.Apply{ApplyIdentifier: "apply-x", Options: storage.MarshalApplyOptions(storage.ApplyOptions{Volume: 3})}
+		require.True(t, mirrorRemoteVolume(apply, 5))
+		assert.Equal(t, 5, apply.GetOptions().Volume)
+	})
+
+	t.Run("unchanged level reports no transition", func(t *testing.T) {
+		apply := &storage.Apply{ApplyIdentifier: "apply-x", Options: storage.MarshalApplyOptions(storage.ApplyOptions{Volume: 5})}
+		assert.False(t, mirrorRemoteVolume(apply, 5))
+		assert.Equal(t, 5, apply.GetOptions().Volume)
+	})
+
+	t.Run("zero level mirrors nothing", func(t *testing.T) {
+		apply := &storage.Apply{ApplyIdentifier: "apply-x", Options: storage.MarshalApplyOptions(storage.ApplyOptions{Volume: 3})}
+		assert.False(t, mirrorRemoteVolume(apply, 0))
+		assert.Equal(t, 3, apply.GetOptions().Volume)
+	})
+
+	t.Run("out-of-range level keeps the stored level", func(t *testing.T) {
+		apply := &storage.Apply{ApplyIdentifier: "apply-x", Options: storage.MarshalApplyOptions(storage.ApplyOptions{Volume: 3})}
+		assert.False(t, mirrorRemoteVolume(apply, 12))
+		assert.Equal(t, 3, apply.GetOptions().Volume)
+	})
 }
 
 // The cutover drive (and any non-barrier drive) must NOT release at the barrier:


### PR DESCRIPTION
**Why this matters:** After a `schemabot volume` command against a remote (gRPC) apply is accepted, the progress comment on the PR and the control-plane progress API kept showing the level the apply started with. Operators had no confirmation the change took effect — the accepted reply points at the progress comment as the place to watch the new level.

**What it does:** A volume change is applied by the data-plane driver against its own apply row, so the control plane only learns the resulting level from progress responses — which the remote progress sync was dropping. This mirrors the reported level onto the in-memory apply options during the sync, and the poll's regular parent-apply persistence records it. Out-of-range reported levels are logged and ignored, keeping the stored level.

```
PR comment: schemabot volume -v 5 <apply>
        │
        ▼
control plane ── Volume RPC ──► data plane queues control request
        │                              │ driver applies level 5
        │                              ▼
        └── progress poll ◄── ProgressResponse{volume: 5}
                │ mirror onto apply options   ◄── (this fix)
                ▼
    progress comment / API show Volume: 5/11
```

**How it moves toward the northstar:** Remote applies should be operable entirely from the PR — a control command's effect has to be visible where the operator issued it, without shelling into the data plane to confirm.

The regression test drives a real progress poll against a mock data plane and asserts the persisted apply carries the reported level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)