### PR TITLE
fix(github): converge stale checks left behind by an unclaimed rollback

### DIFF
--- a/pkg/storage/mysqlstore/checks.go
+++ b/pkg/storage/mysqlstore/checks.go
@@ -378,8 +378,13 @@ func (s *checkStore) CompleteForApply(ctx context.Context, check *storage.Check,
 }
 
 // MarkActionRequiredForApply marks stored check state action_required after a
-// rollback only if it still belongs to that rollback apply and no newer apply
-// exists for the same PR/environment/database.
+// rollback only if no apply newer than the rollback exists for the same
+// PR/environment/database. Unlike CompleteForApply, the write does not require
+// the row to be owned by the rollback apply: a rollback that never claimed the
+// row (its claim failed or the driver crashed before it landed) must still be
+// able to block a stale successful check left over from the apply it reverted.
+// Rows owned by an older apply or with no owner qualify; the newer-apply guard
+// is what protects a re-apply that started after the rollback.
 func (s *checkStore) MarkActionRequiredForApply(ctx context.Context, check *storage.Check, apply *storage.Apply) (bool, error) {
 	var checkRunID any
 	if check.CheckRunID != 0 {
@@ -413,7 +418,7 @@ func (s *checkStore) MarkActionRequiredForApply(ctx context.Context, check *stor
 		    change_summary = COALESCE(NULLIF(?, ''), change_summary)
 		WHERE repository = ? AND pull_request = ?
 		  AND environment = ? AND database_type = ? AND database_name = ?
-		  AND apply_id = ?
+		  AND (apply_id IS NULL OR apply_id <= ?)
 		  AND NOT EXISTS (
 		    SELECT 1
 		    FROM applies newer

--- a/pkg/storage/mysqlstore/checks_test.go
+++ b/pkg/storage/mysqlstore/checks_test.go
@@ -1555,6 +1555,86 @@ func TestCheckStore_MarkActionRequiredForApply(t *testing.T) {
 	require.Equal(t, int64(0), retrieved.ApplyID)
 }
 
+// A rollback that never claimed the stored check row (its claim failed or the
+// driver crashed before it landed) must still be able to block the stale
+// successful row left over from the apply it reverted; only a newer apply
+// protects the row from the rollback's terminal write.
+func TestCheckStore_MarkActionRequiredForApplyConvergesPriorApplyOwnedCheck(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	priorApply := createCheckStoreApply(t, store, "apply-succeeded", state.Apply.Completed)
+	rollbackApply := createCheckStoreApply(t, store, "rollback-unclaimed", state.Apply.Completed)
+	require.Greater(t, rollbackApply.ID, priorApply.ID)
+
+	check := &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "abc123",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		ApplyID:      priorApply.ID,
+		HasChanges:   false,
+		Status:       "completed",
+		Conclusion:   "success",
+	}
+	require.NoError(t, store.Checks().Upsert(ctx, check))
+
+	check.HasChanges = true
+	check.Conclusion = "action_required"
+	updated, err := store.Checks().MarkActionRequiredForApply(ctx, check, rollbackApply)
+	require.NoError(t, err)
+	require.True(t, updated)
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	assert.Equal(t, "completed", retrieved.Status)
+	assert.Equal(t, "action_required", retrieved.Conclusion)
+	assert.True(t, retrieved.HasChanges)
+	assert.Equal(t, int64(0), retrieved.ApplyID, "the rollback's terminal write releases check ownership")
+}
+
+// An unowned successful row (for example after a deliberate stale-cleanup
+// unblock) still yields to a completed rollback's terminal write when the
+// rollback is the newest apply for the target.
+func TestCheckStore_MarkActionRequiredForApplyConvergesUnownedCheck(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	rollbackApply := createCheckStoreApply(t, store, "rollback-unclaimed", state.Apply.Completed)
+
+	check := &storage.Check{
+		Repository:   "org/repo",
+		PullRequest:  123,
+		HeadSHA:      "abc123",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: "testdb",
+		HasChanges:   false,
+		Status:       "completed",
+		Conclusion:   "success",
+	}
+	require.NoError(t, store.Checks().Upsert(ctx, check))
+
+	check.HasChanges = true
+	check.Conclusion = "action_required"
+	updated, err := store.Checks().MarkActionRequiredForApply(ctx, check, rollbackApply)
+	require.NoError(t, err)
+	require.True(t, updated)
+
+	retrieved, err := store.Checks().Get(ctx, "org/repo", 123, "staging", "mysql", "testdb")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	assert.Equal(t, "completed", retrieved.Status)
+	assert.Equal(t, "action_required", retrieved.Conclusion)
+	assert.True(t, retrieved.HasChanges)
+	assert.Equal(t, int64(0), retrieved.ApplyID)
+}
+
 func TestCheckStore_MarkActionRequiredForApplyLeaseGuard(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -132,7 +132,8 @@ type CheckStore interface {
 	// PR/environment/database. Rows owned by the rollback, by an older apply, or
 	// unowned all qualify: a rollback that never claimed the row must still be
 	// able to block the stale successful check left over from the apply it
-	// reverted. Returns false when a newer apply owns the target.
+	// reverted. Returns false when any apply newer than the rollback exists for
+	// the target, whether or not it has claimed the row.
 	MarkActionRequiredForApply(ctx context.Context, check *Check, apply *Apply) (bool, error)
 
 	// Get returns stored check state by its unique key (PR + env + database), or nil if not found.

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -128,9 +128,11 @@ type CheckStore interface {
 	CompleteForApply(ctx context.Context, check *Check, apply *Apply) (bool, error)
 
 	// MarkActionRequiredForApply marks stored check state action_required after
-	// a rollback only if it still belongs to that rollback apply and no newer
-	// apply exists for the same PR/environment/database. Returns false when
-	// another driver changed the stored state first.
+	// a rollback only if no apply newer than the rollback exists for the same
+	// PR/environment/database. Rows owned by the rollback, by an older apply, or
+	// unowned all qualify: a rollback that never claimed the row must still be
+	// able to block the stale successful check left over from the apply it
+	// reverted. Returns false when a newer apply owns the target.
 	MarkActionRequiredForApply(ctx context.Context, check *Check, apply *Apply) (bool, error)
 
 	// Get returns stored check state by its unique key (PR + env + database), or nil if not found.

--- a/pkg/webhook/check_cleanup_integration_test.go
+++ b/pkg/webhook/check_cleanup_integration_test.go
@@ -384,6 +384,86 @@ func TestE2EReconcileStaleInProgressCheckFailure(t *testing.T) {
 	}
 }
 
+// TestE2EReconcileRollbackThatNeverClaimedCheck verifies reconciliation for a
+// rollback that completed without ever claiming the stored check row: the
+// rollback was queued, but the claim failed (or the driver crashed before it
+// landed), so the row still says success and is owned by the apply the
+// rollback reverted. The reverted change is gone from the environment, so the
+// next plan or apply command must converge the row to action_required — the PR
+// must not stay mergeable on the strength of the pre-rollback success.
+func TestE2EReconcileRollbackThatNeverClaimedCheck(t *testing.T) {
+	dbName := "webhook_rollback_unclaimed"
+	svc := setupE2EService(t, dbName)
+	ctx := t.Context()
+
+	// The original apply completed and its terminal update recorded success while
+	// retaining ownership of the row.
+	priorApply := &storage.Apply{
+		ApplyIdentifier: "apply-before-rollback",
+		Database:        dbName,
+		DatabaseType:    "mysql",
+		Environment:     "staging",
+		Repository:      "octocat/hello-world",
+		PullRequest:     1,
+		State:           state.Apply.Completed,
+		Engine:          "spirit",
+	}
+	priorApplyID, err := svc.Storage().Applies().Create(ctx, priorApply)
+	require.NoError(t, err)
+
+	// The rollback reached Completed, but no check row points at it.
+	rollbackApply := &storage.Apply{
+		ApplyIdentifier: "rollback-unclaimed",
+		Database:        dbName,
+		DatabaseType:    "mysql",
+		Environment:     "staging",
+		Repository:      "octocat/hello-world",
+		PullRequest:     1,
+		State:           state.Apply.Completed,
+		Engine:          "spirit",
+		Options:         storage.MarshalApplyOptions(storage.ApplyOptions{AllowUnsafe: true, Rollback: true}),
+	}
+	rollbackApplyID, err := svc.Storage().Applies().Create(ctx, rollbackApply)
+	require.NoError(t, err)
+	require.Greater(t, rollbackApplyID, priorApplyID)
+
+	require.NoError(t, svc.Storage().Checks().Upsert(ctx, &storage.Check{
+		Repository:   "octocat/hello-world",
+		PullRequest:  1,
+		HeadSHA:      "oldsha999",
+		Environment:  "staging",
+		DatabaseType: "mysql",
+		DatabaseName: dbName,
+		CheckRunID:   42,
+		ApplyID:      priorApplyID,
+		HasChanges:   false,
+		Status:       checkStatusCompleted,
+		Conclusion:   checkConclusionSuccess,
+	}))
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	setupFakeGitHubForPlan(t, mux, nil, "", dbName)
+	h := newE2EHandler(t, svc, client)
+	installClient := ghclient.NewInstallationClient(client, h.logger)
+
+	require.NoError(t, h.reconcileStaleChecks(ctx, installClient, "octocat/hello-world", 1))
+
+	check, err := svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1, "staging", "mysql", dbName)
+	require.NoError(t, err)
+	require.NotNil(t, check)
+	assert.Equal(t, checkStatusCompleted, check.Status)
+	assert.Equal(t, checkConclusionActionRequired, check.Conclusion, "the pre-rollback success must not keep the PR mergeable")
+	assert.Equal(t, rollbackCompletedBlock.blockingReason, check.BlockingReason)
+	assert.True(t, check.HasChanges, "the PR's reverted change is still outstanding")
+	assert.Zero(t, check.ApplyID, "rollback finalization releases check ownership so a re-apply can take over")
+}
+
 // TestE2EPRCloseReopenRetainsStartedApplyBlock verifies that closing and
 // reopening a PR cannot bypass a block that requires operator reconciliation.
 // Scenario: an apply for the PR completes, then a later commit removes the

--- a/pkg/webhook/check_records.go
+++ b/pkg/webhook/check_records.go
@@ -264,6 +264,32 @@ func isApplyNewer(candidate, existing *storage.Apply) bool {
 	return candidate.ID > existing.ID
 }
 
+// checkNeedsTerminalReconcile reports whether stored check state is stale
+// relative to the newest apply for its target and must be repaired from that
+// apply's terminal outcome. Two stale shapes exist:
+//
+//   - an in_progress row whose newest apply is already terminal: the driver
+//     died between finishing the apply and updating stored check state;
+//   - an apply-owned successful row whose newest apply is a completed
+//     rollback: the rollback never claimed the row (its claim failed or the
+//     driver crashed before the claim landed), so the row's success predates
+//     the revert and would let the PR merge with the change missing.
+//
+// Successful rows without apply ownership are left alone: releasing ownership
+// is how a deliberate stale-cleanup unblock records its decision, and
+// re-blocking such a row here would fight the operator.
+func checkNeedsTerminalReconcile(check *storage.Check, apply *storage.Apply) bool {
+	if !state.IsTerminalApplyState(apply.State) {
+		return false
+	}
+	if check.Status == checkStatusInProgress {
+		return true
+	}
+	return check.ApplyID != 0 &&
+		check.Conclusion == checkConclusionSuccess &&
+		isCompletedRollback(apply)
+}
+
 // reconcileStaleChecks repairs stored check state from authoritative apply
 // state. The visible GitHub Check Run is the PR merge gate, but the apply row is
 // the source of truth for whether a schema change is still running. If a driver
@@ -295,9 +321,6 @@ func (h *Handler) reconcileStaleChecks(ctx context.Context, client *ghclient.Ins
 
 	reconciled := false
 	for _, check := range checks {
-		if check.Status != checkStatusInProgress {
-			continue
-		}
 		if isAggregateCheck(check) {
 			continue
 		}
@@ -309,30 +332,41 @@ func (h *Handler) reconcileStaleChecks(ctx context.Context, client *ghclient.Ins
 		}
 		apply := latestApplies[key]
 		if apply == nil {
-			h.logger.Debug("skipping in_progress check without matching apply",
-				"repo", repo, "pr", pr,
-				"database", check.DatabaseName, "database_type", check.DatabaseType,
-				"environment", check.Environment, "check_apply_id", check.ApplyID,
-				"check_head_sha", check.HeadSHA)
+			// A row with no apply for its target is normal for plan-only checks;
+			// only an in_progress row with no apply is worth a trace.
+			if check.Status == checkStatusInProgress {
+				h.logger.Debug("skipping in_progress check without matching apply",
+					"repo", repo, "pr", pr,
+					"database", check.DatabaseName, "database_type", check.DatabaseType,
+					"environment", check.Environment, "check_apply_id", check.ApplyID,
+					"check_head_sha", check.HeadSHA)
+			}
 			continue
 		}
-		if !state.IsTerminalApplyState(apply.State) {
-			h.logger.Debug("skipping in_progress check because latest apply is not terminal",
-				"repo", repo, "pr", pr,
-				"database", check.DatabaseName, "database_type", check.DatabaseType,
-				"environment", check.Environment,
-				"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,
-				"apply_state", apply.State, "check_apply_id", check.ApplyID,
-				"check_head_sha", check.HeadSHA)
+		if !checkNeedsTerminalReconcile(check, apply) {
+			// The common case: the stored row already reflects the newest apply's
+			// outcome (or that apply is still running and will write its own
+			// terminal update). An in_progress row that stays behind is the one
+			// worth a trace.
+			if check.Status == checkStatusInProgress {
+				h.logger.Debug("skipping in_progress check because latest apply is not terminal",
+					"repo", repo, "pr", pr,
+					"database", check.DatabaseName, "database_type", check.DatabaseType,
+					"environment", check.Environment,
+					"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,
+					"apply_state", apply.State, "check_apply_id", check.ApplyID,
+					"check_head_sha", check.HeadSHA)
+			}
 			continue
 		}
 
-		h.logger.Info("reconciling stale in_progress check",
+		h.logger.Info("reconciling stale check from the latest apply's terminal outcome",
 			"repo", repo, "pr", pr,
 			"database", check.DatabaseName, "database_type", check.DatabaseType,
 			"environment", check.Environment,
 			"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,
 			"apply_state", apply.State, "check_apply_id", check.ApplyID,
+			"check_status", check.Status, "check_conclusion", check.Conclusion,
 			"check_head_sha", check.HeadSHA)
 
 		updated, err := h.updateCheckRecordForApplyResult(ctx, repo, pr, apply)

--- a/pkg/webhook/check_records.go
+++ b/pkg/webhook/check_records.go
@@ -3,7 +3,6 @@ package webhook
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/block/schemabot/pkg/apitypes"
 	ghclient "github.com/block/schemabot/pkg/github"
@@ -336,30 +335,6 @@ func (h *Handler) reconcileStaleChecks(ctx context.Context, client *ghclient.Ins
 			"apply_state", apply.State, "check_apply_id", check.ApplyID,
 			"check_head_sha", check.HeadSHA)
 
-		// A completed rollback must reconcile to action_required, not success: its
-		// success is a reverted PR change that must not merge as-is. Route it to the
-		// rollback finalizer instead of the ordinary apply-result update, which
-		// would mark the check successful.
-		if apply.IsRollback() && state.IsState(apply.State, state.Apply.Completed) {
-			// setCheckActionRequired emits its own rollback_finished
-			// success/skipped/error metric; only count the reconciliation as a
-			// success here when the stored check was actually updated, so an
-			// ownership-miss skip does not inflate the stale-reconcile success
-			// count or trigger a spurious aggregate refresh.
-			if h.setCheckActionRequired(repo, pr, apply.InstallationID, apply) {
-				metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
-					Operation:    "stale_check_reconciliation",
-					Repository:   repo,
-					Database:     check.DatabaseName,
-					DatabaseType: check.DatabaseType,
-					Environment:  check.Environment,
-					Status:       "success",
-				})
-				reconciled = true
-			}
-			continue
-		}
-
 		updated, err := h.updateCheckRecordForApplyResult(ctx, repo, pr, apply)
 		if err != nil {
 			metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
@@ -409,32 +384,47 @@ func (h *Handler) reconcileStaleChecks(ctx context.Context, client *ghclient.Ins
 	return nil
 }
 
+// isCompletedRollback reports whether the apply is a rollback that reached
+// Completed. A completed rollback reverted the PR's schema change from the
+// target environment, so its stored check must land action_required rather
+// than success — the PR must not merge with the change missing.
+func isCompletedRollback(a *storage.Apply) bool {
+	return a.IsRollback() && state.IsState(a.State, state.Apply.Completed)
+}
+
 // updateCheckRecordForApplyResult updates stored check state after an apply
-// reaches a terminal state. The aggregate check is updated separately to reflect
+// reaches a terminal state. A completed rollback lands action_required; other
+// terminal states map to success or failure. The rollback routing lives here —
+// not in callers — because every terminal path (observer, operator-driven
+// drive, recovery, stale reconciliation) must honor the rollback intent from
+// the durable apply row. The aggregate check is updated separately to reflect
 // the new status on the PR.
 func (h *Handler) updateCheckRecordForApplyResult(ctx context.Context, repo string, pr int, apply *storage.Apply) (bool, error) {
-	check, err := h.service.Storage().Checks().Get(ctx, repo, pr, apply.Environment, apply.DatabaseType, apply.Database)
-	if err != nil {
+	// Metrics keep rollback finalization distinct from ordinary apply completion
+	// so operators can alert on the two outcomes separately.
+	operation := "apply_finished"
+	if isCompletedRollback(apply) {
+		operation = "rollback_finished"
+	}
+	recordOutcome := func(status string) {
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
-			Operation:    "apply_finished",
+			Operation:    operation,
 			Repository:   repo,
 			Database:     apply.Database,
 			DatabaseType: apply.DatabaseType,
 			Environment:  apply.Environment,
-			Status:       "error",
+			Status:       status,
 		})
+	}
+
+	check, err := h.service.Storage().Checks().Get(ctx, repo, pr, apply.Environment, apply.DatabaseType, apply.Database)
+	if err != nil {
+		recordOutcome("error")
 		return false, fmt.Errorf("look up check for apply result repo %s pr %d environment %s database_type %s database %s: %w",
 			repo, pr, apply.Environment, apply.DatabaseType, apply.Database, err)
 	}
 	if check == nil {
-		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
-			Operation:    "apply_finished",
-			Repository:   repo,
-			Database:     apply.Database,
-			DatabaseType: apply.DatabaseType,
-			Environment:  apply.Environment,
-			Status:       "error",
-		})
+		recordOutcome("error")
 		return false, fmt.Errorf("no stored check state found to update after apply repo %s pr %d environment %s database_type %s database %s",
 			repo, pr, apply.Environment, apply.DatabaseType, apply.Database)
 	}
@@ -446,14 +436,7 @@ func (h *Handler) updateCheckRecordForApplyResult(ctx context.Context, repo stri
 	// apply's success can never update it. Leave the check in_progress so the PR
 	// stays blocked while paused and a later resume can complete it.
 	if state.IsState(apply.State, state.Apply.Stopped) {
-		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
-			Operation:    "apply_finished",
-			Repository:   repo,
-			Database:     apply.Database,
-			DatabaseType: apply.DatabaseType,
-			Environment:  apply.Environment,
-			Status:       "noop",
-		})
+		recordOutcome("noop")
 		h.logger.Info("apply stopped; leaving check in_progress so a resume can complete it",
 			"repo", repo, "pr", pr, "database", apply.Database,
 			"database_type", apply.DatabaseType, "environment", apply.Environment,
@@ -462,48 +445,53 @@ func (h *Handler) updateCheckRecordForApplyResult(ctx context.Context, repo stri
 		return false, nil
 	}
 
-	var conclusion string
-	switch {
-	case state.IsState(apply.State, state.Apply.Completed) && checkBlockedByRemovedSchemaAfterApply(check):
-		conclusion = checkConclusionActionRequired
-	case state.IsState(apply.State, state.Apply.Completed):
-		conclusion = checkConclusionSuccess
-	case state.IsState(apply.State, state.Apply.Failed):
-		conclusion = checkConclusionFailure
-	default:
-		conclusion = checkConclusionFailure
+	var updated bool
+	if isCompletedRollback(apply) {
+		check.Status = checkStatusCompleted
+		check.Conclusion = checkConclusionActionRequired
+		check.HasChanges = true
+		check.BlockingReason = rollbackCompletedBlock.blockingReason
+		check.ErrorMessage = rollbackCompletedBlock.message
+		// MarkActionRequiredForApply releases check ownership (unlike
+		// CompleteForApply, which retains it) so a re-apply of the reverted
+		// change can claim the row.
+		updated, err = h.service.Storage().Checks().MarkActionRequiredForApply(ctx, check, apply)
+		if err != nil {
+			recordOutcome("error")
+			return false, fmt.Errorf("mark stored check state action_required after rollback repo %s pr %d environment %s database_type %s database %s: %w",
+				repo, pr, apply.Environment, apply.DatabaseType, apply.Database, err)
+		}
+	} else {
+		var conclusion string
+		switch {
+		case state.IsState(apply.State, state.Apply.Completed) && checkBlockedByRemovedSchemaAfterApply(check):
+			conclusion = checkConclusionActionRequired
+		case state.IsState(apply.State, state.Apply.Completed):
+			conclusion = checkConclusionSuccess
+		case state.IsState(apply.State, state.Apply.Failed):
+			conclusion = checkConclusionFailure
+		default:
+			conclusion = checkConclusionFailure
+		}
+
+		check.Status = checkStatusCompleted
+		check.Conclusion = conclusion
+		check.HasChanges = conclusion != checkConclusionSuccess
+		if conclusion == checkConclusionSuccess {
+			check.BlockingReason = ""
+			check.ErrorMessage = ""
+		}
+		updated, err = h.service.Storage().Checks().CompleteForApply(ctx, check, apply)
+		if err != nil {
+			recordOutcome("error")
+			return false, fmt.Errorf("update stored check state after apply repo %s pr %d environment %s database_type %s database %s: %w",
+				repo, pr, apply.Environment, apply.DatabaseType, apply.Database, err)
+		}
 	}
 
-	check.Status = checkStatusCompleted
-	check.Conclusion = conclusion
-	check.HasChanges = conclusion != checkConclusionSuccess
-	if conclusion == checkConclusionSuccess {
-		check.BlockingReason = ""
-		check.ErrorMessage = ""
-	}
-	updated, err := h.service.Storage().Checks().CompleteForApply(ctx, check, apply)
-	if err != nil {
-		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
-			Operation:    "apply_finished",
-			Repository:   repo,
-			Database:     apply.Database,
-			DatabaseType: apply.DatabaseType,
-			Environment:  apply.Environment,
-			Status:       "error",
-		})
-		return false, fmt.Errorf("update stored check state after apply repo %s pr %d environment %s database_type %s database %s: %w",
-			repo, pr, apply.Environment, apply.DatabaseType, apply.Database, err)
-	}
 	if !updated {
-		metrics.RecordCheckOwnershipMiss(ctx, "apply_finished", repo, apply.Database, apply.DatabaseType, apply.Deployment, apply.Environment)
-		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
-			Operation:    "apply_finished",
-			Repository:   repo,
-			Database:     apply.Database,
-			DatabaseType: apply.DatabaseType,
-			Environment:  apply.Environment,
-			Status:       "skipped",
-		})
+		metrics.RecordCheckOwnershipMiss(ctx, operation, repo, apply.Database, apply.DatabaseType, apply.Deployment, apply.Environment)
+		recordOutcome("skipped")
 		h.logger.Warn("skipping check state update because stored state no longer belongs to apply",
 			"repo", repo, "pr", pr, "database", apply.Database,
 			"database_type", apply.DatabaseType, "environment", apply.Environment,
@@ -517,127 +505,8 @@ func (h *Handler) updateCheckRecordForApplyResult(ctx context.Context, repo stri
 		"repo", repo, "pr", pr, "database", apply.Database,
 		"database_type", apply.DatabaseType, "environment", apply.Environment,
 		"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,
-		"apply_state", apply.State, "conclusion", conclusion,
+		"apply_state", apply.State, "conclusion", check.Conclusion,
 		"blocking_reason", check.BlockingReason)
-	metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
-		Operation:    "apply_finished",
-		Repository:   repo,
-		Database:     apply.Database,
-		DatabaseType: apply.DatabaseType,
-		Environment:  apply.Environment,
-		Status:       "success",
-	})
+	recordOutcome("success")
 	return true, nil
-}
-
-// setCheckActionRequired sets the rollback apply's check back to action_required.
-// Used after a rollback completes because the PR's schema changes need to be re-applied.
-// It reports whether the stored check was actually updated; callers that count
-// their own reconciliation outcome should not record success on a skip (this
-// function already emits its own skipped/ownership-miss metric). It emits its own
-// rollback_finished success/skipped/error metrics regardless.
-func (h *Handler) setCheckActionRequired(repo string, pr int, installationID int64, apply *storage.Apply) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	check, err := h.service.Storage().Checks().Get(ctx, repo, pr, apply.Environment, apply.DatabaseType, apply.Database)
-	if err != nil {
-		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
-			Operation:    "rollback_finished",
-			Repository:   repo,
-			Database:     apply.Database,
-			DatabaseType: apply.DatabaseType,
-			Environment:  apply.Environment,
-			Status:       "error",
-		})
-		h.logger.Error("failed to look up stored check state after rollback",
-			"repo", repo, "pr", pr, "database", apply.Database,
-			"database_type", apply.DatabaseType, "environment", apply.Environment,
-			"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,
-			"error", err)
-		return false
-	}
-	if check == nil {
-		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
-			Operation:    "rollback_finished",
-			Repository:   repo,
-			Database:     apply.Database,
-			DatabaseType: apply.DatabaseType,
-			Environment:  apply.Environment,
-			Status:       "error",
-		})
-		h.logger.Warn("no stored check state to update after rollback",
-			"repo", repo, "pr", pr, "database", apply.Database,
-			"database_type", apply.DatabaseType, "environment", apply.Environment,
-			"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier)
-		return false
-	}
-
-	check.Status = checkStatusCompleted
-	check.Conclusion = checkConclusionActionRequired
-	check.HasChanges = true
-	check.BlockingReason = rollbackCompletedBlock.blockingReason
-	check.ErrorMessage = rollbackCompletedBlock.message
-	updated, err := h.service.Storage().Checks().MarkActionRequiredForApply(ctx, check, apply)
-	if err != nil {
-		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
-			Operation:    "rollback_finished",
-			Repository:   repo,
-			Database:     apply.Database,
-			DatabaseType: apply.DatabaseType,
-			Environment:  apply.Environment,
-			Status:       "error",
-		})
-		h.logger.Error("failed to set check to action_required after rollback",
-			"repo", repo, "pr", pr, "database", apply.Database,
-			"database_type", apply.DatabaseType, "environment", apply.Environment,
-			"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,
-			"check_apply_id", check.ApplyID, "check_status", check.Status,
-			"check_head_sha", check.HeadSHA, "error", err)
-		return false
-	}
-	if !updated {
-		metrics.RecordCheckOwnershipMiss(ctx, "rollback_finished", repo, apply.Database, apply.DatabaseType, apply.Deployment, apply.Environment)
-		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
-			Operation:    "rollback_finished",
-			Repository:   repo,
-			Database:     apply.Database,
-			DatabaseType: apply.DatabaseType,
-			Environment:  apply.Environment,
-			Status:       "skipped",
-		})
-		h.logger.Warn("skipping rollback action_required update because check no longer belongs to apply",
-			"repo", repo, "pr", pr, "database", apply.Database,
-			"database_type", apply.DatabaseType, "environment", apply.Environment,
-			"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,
-			"apply_state", apply.State, "check_apply_id", check.ApplyID,
-			"check_status", check.Status, "check_head_sha", check.HeadSHA)
-		return false
-	}
-
-	h.logger.Info("check set to action_required after rollback",
-		"repo", repo, "pr", pr, "database", apply.Database,
-		"database_type", apply.DatabaseType, "environment", apply.Environment,
-		"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,
-		"apply_state", apply.State)
-	metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
-		Operation:    "rollback_finished",
-		Repository:   repo,
-		Database:     apply.Database,
-		DatabaseType: apply.DatabaseType,
-		Environment:  apply.Environment,
-		Status:       "success",
-	})
-
-	// Update the aggregate check to reflect the rollback
-	if aggClient, err := h.clientForRepo(repo, installationID); err == nil {
-		h.updateAggregateCheck(ctx, aggClient, repo, pr, check.HeadSHA)
-	} else {
-		h.logger.Error("failed to create GitHub client for rollback aggregate update",
-			"repo", repo, "pr", pr, "database", apply.Database,
-			"database_type", apply.DatabaseType, "environment", apply.Environment,
-			"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,
-			"error", err)
-	}
-	return true
 }

--- a/pkg/webhook/check_records.go
+++ b/pkg/webhook/check_records.go
@@ -526,7 +526,14 @@ func (h *Handler) updateCheckRecordForApplyResult(ctx context.Context, repo stri
 	if !updated {
 		metrics.RecordCheckOwnershipMiss(ctx, operation, repo, apply.Database, apply.DatabaseType, apply.Deployment, apply.Environment)
 		recordOutcome("skipped")
-		h.logger.Warn("skipping check state update because stored state no longer belongs to apply",
+		// The two writes skip for different reasons: the rollback write yields
+		// only to an apply newer than the rollback, while the ordinary completion
+		// requires the row to still be owned by this apply.
+		msg := "skipping check state update because stored state no longer belongs to apply"
+		if isCompletedRollback(apply) {
+			msg = "skipping rollback action_required update because a newer apply supersedes the rollback"
+		}
+		h.logger.Warn(msg,
 			"repo", repo, "pr", pr, "database", apply.Database,
 			"database_type", apply.DatabaseType, "environment", apply.Environment,
 			"apply_id", apply.ID, "apply_identifier", apply.ApplyIdentifier,

--- a/pkg/webhook/check_records_rollback_test.go
+++ b/pkg/webhook/check_records_rollback_test.go
@@ -58,7 +58,7 @@ func TestRefreshChecksForTerminalApply_CompletedRollbackIsActionRequired(t *test
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	svc := api.New(st, &api.ServerConfig{}, nil, logger)
 
-	// setCheckActionRequired resolves a GitHub client to refresh the aggregate
+	// The terminal refresh resolves a GitHub client to update the aggregate
 	// Check Run after writing stored state. Point it at an unrouted test server:
 	// the stored update (the behavior under test) lands first, and the GitHub
 	// refresh fails gracefully without a real installation.

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -279,17 +279,6 @@ func (h *Handler) refreshChecksForTerminalApply(ctx context.Context, a *storage.
 			"context", logCtx,
 		}
 	}
-	// A completed rollback reverted the PR's schema change, so its required check
-	// must land action_required, not success — otherwise the PR could merge with
-	// the change missing. The rollback command registers an observer that does
-	// this, but an operator-driven (multi-operation) or recovery terminal
-	// suppresses that per-driver observer and routes here instead, so the
-	// rollback intent must be honored from the durable apply.
-	if a.IsRollback() && state.IsState(a.State, state.Apply.Completed) {
-		h.logger.Info("refreshing check to action_required for completed rollback", checkFields()...)
-		h.setCheckActionRequired(a.Repository, a.PullRequest, a.InstallationID, a)
-		return
-	}
 	updated, err := h.updateCheckRecordForApplyResult(ctx, a.Repository, a.PullRequest, a)
 	if err != nil {
 		h.logger.Error("observer: failed to update check record for terminal apply",


### PR DESCRIPTION
Follow-up to #640, addressing the two review findings deferred there: the completed-rollback routing was duplicated in callers instead of living in the terminal check update, and a rollback that never claimed the stored check row could leave a stale successful check blocking nothing — forever.

**Why this matters.** A rollback claims the stored check row only after it has been queued. If that claim fails (or the driver crashes before it lands), the row keeps saying `success`, owned by the apply the rollback reverted. The rollback's terminal write required row ownership, so it matched nothing — and no reconcile path looked at completed rows. The PR stayed mergeable while its schema change was gone from the environment: a fail-open window with no convergence.

```
before                                          after
──────                                          ─────
rollback queued ──► claim fails/crash           rollback queued ──► claim fails/crash
        │                                               │
rollback completes                              rollback completes
        │                                               │
terminal write: WHERE apply_id = rollback       terminal write: owner is NULL or older
        │            (0 rows — skipped)                 │        (newer-apply guard holds)
        ▼                                               ▼
row stays success/owned-by-prior-apply          row → action_required, ownership released
reconcile skips completed rows  ⇒ stuck         reconcile also repairs apply-owned success
                                                rows whose newest apply is a completed
                                                rollback  ⇒ next plan/apply converges it
```

**What it does.**
- `updateCheckRecordForApplyResult` now owns the completed-rollback → `action_required` routing, so every terminal path (observer, operator-driven drive, recovery, stale reconciliation) honors the rollback intent from the durable apply row. The duplicated caller guards and the rollback-only `setCheckActionRequired` helper are gone; metrics keep the `rollback_finished` / `apply_finished` operation labels on every outcome, including ownership misses.
- `MarkActionRequiredForApply` no longer requires the row to be owned by the rollback apply — unowned rows and rows owned by an older apply qualify. The existing newer-apply guard still protects a re-apply that started after the rollback, and this write only moves a check in the blocking direction.
- Stale-check reconciliation (`checkNeedsTerminalReconcile`) now also repairs apply-owned successful rows whose newest apply is a completed rollback. Unowned successful rows are deliberately left alone: releasing ownership is how a stale-cleanup unblock records its decision, and re-blocking it would fight the operator.

**How it moves toward the northstar.** Check state converges to the durable apply row from every path, including crash windows — the merge gate can be trusted without an operator hand-editing stored check state after a partial rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
