### PR TITLE
feat(github): post a fresh progress comment when a volume change takes effect

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -3046,6 +3046,45 @@ The `-v` flag is required and must be a number between 1 (slowest) and 11 (faste
 </details>
 
 <details>
+<summary><a name="volume-changed-superseded-progress-comment"></a><strong>Volume Changed: Superseded Progress Comment</strong></summary>
+
+
+⏩ Volume changed to **8/11** — progress continues in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
+
+<details>
+<summary>Progress before the volume change</summary>
+
+## Schema Change Status — Staging
+
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
+
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: In Progress | Volume: 3/11
+
+**`users`**: 🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 32%
+
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+```
+Rows: 2,300,000 / 7,200,000 · ETA: 13m 0s
+
+
+---
+
+To stop this schema change:
+```
+schemabot stop apply-a1b2c3d4e5f6 -e staging
+```
+
+_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
+
+
+</details>
+
+</details>
+
+<details>
 <summary><a name="summary-completed"></a><strong>Summary: Completed</strong></summary>
 
 
@@ -5548,6 +5587,46 @@ Volume change to 8 requested. SchemaBot will adjust the speed of this schema cha
 Usage: `schemabot volume <apply-id> -e <environment> -v <level>`
 
 The `-v` flag is required and must be a number between 1 (slowest) and 11 (fastest).
+
+</details>
+
+<details>
+<summary><a name="volume-changed-superseded-progress-comment"></a><strong>Volume Changed: Superseded Progress Comment</strong></summary>
+
+
+⏩ Volume changed to **8/11** — progress continues in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
+
+<details>
+<summary>Progress before the volume change</summary>
+
+## Schema Change Status — Staging
+
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
+
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: In Progress | Volume: 3/11
+
+**`users`**: 🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 32%
+
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+```
+Rows: 2,300,000 / 7,200,000 · ETA: 13m 0s
+
+
+---
+
+To stop this schema change:
+```
+schemabot stop apply-a1b2c3d4e5f6 -e staging
+```
+
+_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
+
+
+</details>
+
 
 </details>
 

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -3030,7 +3030,7 @@ Cutover is already in progress. SchemaBot will keep reporting progress from the 
 **Environment**: `staging`
 **Requested by**: @alice
 
-Volume change to 8 requested. SchemaBot will adjust the speed of this schema change shortly; the progress comment on this PR shows the current level.
+Volume change to 8 requested. SchemaBot will adjust the speed of this schema change shortly; once the new level takes effect, a fresh progress comment will track the schema change at the new volume.
 
 </details>
 
@@ -5534,7 +5534,7 @@ Cutover is already in progress. SchemaBot will keep reporting progress from the 
 **Environment**: `staging`
 **Requested by**: @alice
 
-Volume change to 8 requested. SchemaBot will adjust the speed of this schema change shortly; the progress comment on this PR shows the current level.
+Volume change to 8 requested. SchemaBot will adjust the speed of this schema change shortly; once the new level takes effect, a fresh progress comment will track the schema change at the new volume.
 
 
 </details>

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -78,6 +78,7 @@ func previewCommentAllOutput() {
 		{"CUTOVER COMMAND ALREADY IN PROGRESS", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAlreadyInProgress()) }},
 		{"VOLUME COMMAND ACCEPTED", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeCommandAccepted()) }},
 		{"VOLUME COMMAND INVALID LEVEL", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeInvalidLevel()) }},
+		{"VOLUME CHANGED: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeSupersededProgress()) }},
 		{"SUMMARY: COMPLETED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryCompleted()) }},
 		{"SUMMARY: FAILED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryFailed()) }},
 		{"SUMMARY: STOPPED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryStopped()) }},
@@ -128,6 +129,7 @@ func previewApplyCommandAllOutput() {
 		{"CUTOVER COMMAND ALREADY IN PROGRESS", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAlreadyInProgress()) }},
 		{"VOLUME COMMAND ACCEPTED", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeCommandAccepted()) }},
 		{"VOLUME COMMAND INVALID LEVEL", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeInvalidLevel()) }},
+		{"VOLUME CHANGED: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeSupersededProgress()) }},
 		{"CHECKS GATE: NOT PASSING", func() {
 			fmt.Print(webhooktemplates.RenderApplyBlockedByNonPassingChecks("staging", []webhooktemplates.BlockingCheck{
 				{Name: "CI / unit-tests", State: "failure"},
@@ -262,6 +264,7 @@ func previewCommentApplyFlowAllOutput() {
 		{"CUTOVER COMMAND ALREADY IN PROGRESS", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAlreadyInProgress()) }},
 		{"VOLUME COMMAND ACCEPTED", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeCommandAccepted()) }},
 		{"VOLUME COMMAND INVALID LEVEL", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeInvalidLevel()) }},
+		{"VOLUME CHANGED: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeSupersededProgress()) }},
 		// Summaries
 		{"SUMMARY: COMPLETED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryCompleted()) }},
 		{"SUMMARY: FAILED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryFailed()) }},

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -555,6 +555,16 @@ func (ic *InstallationClient) CreateIssueComment(ctx context.Context, repo strin
 	return comment.GetID(), nil
 }
 
+// GetIssueComment returns the current body of an existing PR/issue comment.
+func (ic *InstallationClient) GetIssueComment(ctx context.Context, repo string, commentID int64) (string, error) {
+	owner, repoName := splitRepo(repo)
+	comment, _, err := ic.client.Issues.GetComment(ctx, owner, repoName, commentID)
+	if err != nil {
+		return "", fmt.Errorf("get issue comment %d: %w", commentID, err)
+	}
+	return comment.GetBody(), nil
+}
+
 // EditIssueComment edits an existing PR/issue comment.
 func (ic *InstallationClient) EditIssueComment(ctx context.Context, repo string, commentID int64, body string) error {
 	owner, repoName := splitRepo(repo)

--- a/pkg/schema/mysql/apply_comments.sql
+++ b/pkg/schema/mysql/apply_comments.sql
@@ -4,6 +4,7 @@ CREATE TABLE `apply_comments` (
   `comment_state` varchar(50) NOT NULL,
   `github_comment_id` bigint NOT NULL,
   `posted_volume` int DEFAULT NULL,
+  `pending_freeze_github_comment_id` bigint DEFAULT NULL,
   `edit_count` int NOT NULL DEFAULT '0',
   `last_edited_at` datetime DEFAULT NULL,
   `superseded_at` datetime DEFAULT NULL,

--- a/pkg/schema/mysql/apply_comments.sql
+++ b/pkg/schema/mysql/apply_comments.sql
@@ -3,6 +3,7 @@ CREATE TABLE `apply_comments` (
   `apply_id` bigint unsigned NOT NULL,
   `comment_state` varchar(50) NOT NULL,
   `github_comment_id` bigint NOT NULL,
+  `posted_volume` int DEFAULT NULL,
   `edit_count` int NOT NULL DEFAULT '0',
   `last_edited_at` datetime DEFAULT NULL,
   `superseded_at` datetime DEFAULT NULL,

--- a/pkg/storage/mysqlstore/apply_comments.go
+++ b/pkg/storage/mysqlstore/apply_comments.go
@@ -13,7 +13,7 @@ import (
 )
 
 // applyCommentColumns lists all columns for SELECT queries.
-const applyCommentColumns = `id, apply_id, comment_state, github_comment_id, posted_volume, edit_count, last_edited_at, superseded_at, created_at, updated_at`
+const applyCommentColumns = `id, apply_id, comment_state, github_comment_id, posted_volume, pending_freeze_github_comment_id, edit_count, last_edited_at, superseded_at, created_at, updated_at`
 
 // applyCommentStore implements storage.ApplyCommentStore using MySQL.
 type applyCommentStore struct {
@@ -21,8 +21,9 @@ type applyCommentStore struct {
 }
 
 // Upsert creates or updates a comment record.
-// On conflict (same apply_id + comment_state), updates the github_comment_id
-// and posted_volume so the row always describes the currently tracked comment.
+// On conflict (same apply_id + comment_state), updates the github_comment_id,
+// posted_volume, and pending_freeze_github_comment_id so the row always
+// describes the currently tracked comment and the freeze it may still owe.
 func (s *applyCommentStore) Upsert(ctx context.Context, comment *storage.ApplyComment) error {
 	lease, hasLease, err := applyLeaseFromContext(ctx, comment.ApplyID)
 	if err != nil {
@@ -30,25 +31,27 @@ func (s *applyCommentStore) Upsert(ctx context.Context, comment *storage.ApplyCo
 	}
 	if !hasLease {
 		_, err := s.db.ExecContext(ctx, `
-			INSERT INTO apply_comments (apply_id, comment_state, github_comment_id, posted_volume)
-			VALUES (?, ?, ?, ?)
+			INSERT INTO apply_comments (apply_id, comment_state, github_comment_id, posted_volume, pending_freeze_github_comment_id)
+			VALUES (?, ?, ?, ?, ?)
 			ON DUPLICATE KEY UPDATE
 				github_comment_id = VALUES(github_comment_id),
 				posted_volume = VALUES(posted_volume),
+				pending_freeze_github_comment_id = VALUES(pending_freeze_github_comment_id),
 				superseded_at = NULL
-		`, comment.ApplyID, comment.CommentState, comment.GitHubCommentID, comment.PostedVolume)
+		`, comment.ApplyID, comment.CommentState, comment.GitHubCommentID, comment.PostedVolume, comment.PendingFreezeCommentID)
 		return err
 	}
 
 	result, err := s.db.ExecContext(ctx, `
-		INSERT INTO apply_comments (apply_id, comment_state, github_comment_id, posted_volume)
-		SELECT ?, ?, ?, ? FROM applies a
+		INSERT INTO apply_comments (apply_id, comment_state, github_comment_id, posted_volume, pending_freeze_github_comment_id)
+		SELECT ?, ?, ?, ?, ? FROM applies a
 		WHERE a.id = ? AND a.lease_token = ?
 		ON DUPLICATE KEY UPDATE
 			github_comment_id = VALUES(github_comment_id),
 			posted_volume = VALUES(posted_volume),
+			pending_freeze_github_comment_id = VALUES(pending_freeze_github_comment_id),
 			superseded_at = NULL
-	`, comment.ApplyID, comment.CommentState, comment.GitHubCommentID, comment.PostedVolume, comment.ApplyID, lease.Token)
+	`, comment.ApplyID, comment.CommentState, comment.GitHubCommentID, comment.PostedVolume, comment.PendingFreezeCommentID, comment.ApplyID, lease.Token)
 	if err != nil {
 		return err
 	}
@@ -175,6 +178,46 @@ func (s *applyCommentStore) Supersede(ctx context.Context, applyID int64, commen
 	return nil
 }
 
+// ClearPendingFreeze removes the pending-freeze marker for a single
+// (apply_id, comment_state) once the superseded comment's frozen rendering has
+// landed on GitHub. A missing row or an already-clear marker is not an error;
+// with a lease in context, a zero-row update surfaces a lost lease.
+func (s *applyCommentStore) ClearPendingFreeze(ctx context.Context, applyID int64, commentState string) error {
+	lease, hasLease, err := applyLeaseFromContext(ctx, applyID)
+	if err != nil {
+		return err
+	}
+	if !hasLease {
+		_, err := s.db.ExecContext(ctx, `
+			UPDATE apply_comments SET pending_freeze_github_comment_id = NULL
+			WHERE apply_id = ? AND comment_state = ? AND pending_freeze_github_comment_id IS NOT NULL
+		`, applyID, commentState)
+		return err
+	}
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE apply_comments c
+		JOIN applies a ON a.id = c.apply_id
+		SET c.pending_freeze_github_comment_id = NULL
+		WHERE c.apply_id = ? AND c.comment_state = ? AND c.pending_freeze_github_comment_id IS NOT NULL AND a.lease_token = ?
+	`, applyID, commentState, lease.Token)
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read apply comment pending-freeze clear rows affected for apply %d state %s: %w", applyID, commentState, err)
+	}
+	if rows == 0 {
+		// Zero rows can mean the row was missing, the marker was already clear,
+		// or the lease was lost. The first two are benign; surface only a lost
+		// lease.
+		if err := ensureApplyLeaseStillOwned(ctx, s.db, lease); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // scanApplyComment scans a single apply comment row, returning nil if not found.
 func scanApplyComment(row *sql.Row) (*storage.ApplyComment, error) {
 	comment, err := scanApplyCommentInto(row)
@@ -202,7 +245,7 @@ func scanApplyCommentInto(s scanner) (*storage.ApplyComment, error) {
 	var comment storage.ApplyComment
 	err := s.Scan(
 		&comment.ID, &comment.ApplyID, &comment.CommentState,
-		&comment.GitHubCommentID, &comment.PostedVolume, &comment.EditCount,
+		&comment.GitHubCommentID, &comment.PostedVolume, &comment.PendingFreezeCommentID, &comment.EditCount,
 		&comment.LastEditedAt, &comment.SupersededAt, &comment.CreatedAt, &comment.UpdatedAt,
 	)
 	if err != nil {

--- a/pkg/storage/mysqlstore/apply_comments.go
+++ b/pkg/storage/mysqlstore/apply_comments.go
@@ -13,7 +13,7 @@ import (
 )
 
 // applyCommentColumns lists all columns for SELECT queries.
-const applyCommentColumns = `id, apply_id, comment_state, github_comment_id, edit_count, last_edited_at, superseded_at, created_at, updated_at`
+const applyCommentColumns = `id, apply_id, comment_state, github_comment_id, posted_volume, edit_count, last_edited_at, superseded_at, created_at, updated_at`
 
 // applyCommentStore implements storage.ApplyCommentStore using MySQL.
 type applyCommentStore struct {
@@ -21,7 +21,8 @@ type applyCommentStore struct {
 }
 
 // Upsert creates or updates a comment record.
-// On conflict (same apply_id + comment_state), updates the github_comment_id.
+// On conflict (same apply_id + comment_state), updates the github_comment_id
+// and posted_volume so the row always describes the currently tracked comment.
 func (s *applyCommentStore) Upsert(ctx context.Context, comment *storage.ApplyComment) error {
 	lease, hasLease, err := applyLeaseFromContext(ctx, comment.ApplyID)
 	if err != nil {
@@ -29,23 +30,25 @@ func (s *applyCommentStore) Upsert(ctx context.Context, comment *storage.ApplyCo
 	}
 	if !hasLease {
 		_, err := s.db.ExecContext(ctx, `
-			INSERT INTO apply_comments (apply_id, comment_state, github_comment_id)
-			VALUES (?, ?, ?)
+			INSERT INTO apply_comments (apply_id, comment_state, github_comment_id, posted_volume)
+			VALUES (?, ?, ?, ?)
 			ON DUPLICATE KEY UPDATE
 				github_comment_id = VALUES(github_comment_id),
+				posted_volume = VALUES(posted_volume),
 				superseded_at = NULL
-		`, comment.ApplyID, comment.CommentState, comment.GitHubCommentID)
+		`, comment.ApplyID, comment.CommentState, comment.GitHubCommentID, comment.PostedVolume)
 		return err
 	}
 
 	result, err := s.db.ExecContext(ctx, `
-		INSERT INTO apply_comments (apply_id, comment_state, github_comment_id)
-		SELECT ?, ?, ? FROM applies a
+		INSERT INTO apply_comments (apply_id, comment_state, github_comment_id, posted_volume)
+		SELECT ?, ?, ?, ? FROM applies a
 		WHERE a.id = ? AND a.lease_token = ?
 		ON DUPLICATE KEY UPDATE
 			github_comment_id = VALUES(github_comment_id),
+			posted_volume = VALUES(posted_volume),
 			superseded_at = NULL
-	`, comment.ApplyID, comment.CommentState, comment.GitHubCommentID, comment.ApplyID, lease.Token)
+	`, comment.ApplyID, comment.CommentState, comment.GitHubCommentID, comment.PostedVolume, comment.ApplyID, lease.Token)
 	if err != nil {
 		return err
 	}
@@ -199,8 +202,8 @@ func scanApplyCommentInto(s scanner) (*storage.ApplyComment, error) {
 	var comment storage.ApplyComment
 	err := s.Scan(
 		&comment.ID, &comment.ApplyID, &comment.CommentState,
-		&comment.GitHubCommentID, &comment.EditCount, &comment.LastEditedAt,
-		&comment.SupersededAt, &comment.CreatedAt, &comment.UpdatedAt,
+		&comment.GitHubCommentID, &comment.PostedVolume, &comment.EditCount,
+		&comment.LastEditedAt, &comment.SupersededAt, &comment.CreatedAt, &comment.UpdatedAt,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/mysqlstore/apply_comments_test.go
+++ b/pkg/storage/mysqlstore/apply_comments_test.go
@@ -21,10 +21,12 @@ func TestApplyCommentStore_Upsert(t *testing.T) {
 	lock := createTestLock(t, store, "testdb", "mysql", "staging")
 	apply := createTestApply(t, store, lock, "apply_comment_upsert", 1)
 
+	postedVolume := 3
 	comment := &storage.ApplyComment{
 		ApplyID:         apply.ID,
 		CommentState:    state.Comment.Progress,
 		GitHubCommentID: 111222333,
+		PostedVolume:    &postedVolume,
 	}
 
 	// Insert
@@ -37,19 +39,37 @@ func TestApplyCommentStore_Upsert(t *testing.T) {
 	assert.Equal(t, apply.ID, retrieved.ApplyID)
 	assert.Equal(t, state.Comment.Progress, retrieved.CommentState)
 	assert.Equal(t, int64(111222333), retrieved.GitHubCommentID)
+	require.NotNil(t, retrieved.PostedVolume)
+	assert.Equal(t, 3, *retrieved.PostedVolume)
 	assert.NotZero(t, retrieved.ID)
 	assert.NotZero(t, retrieved.CreatedAt)
 	assert.NotZero(t, retrieved.UpdatedAt)
 
-	// Upsert with new comment ID (simulates Start/resume)
+	// Upsert with new comment ID and level (simulates a volume-change rotation)
 	comment.GitHubCommentID = 444555666
+	newVolume := 5
+	comment.PostedVolume = &newVolume
 	require.NoError(t, store.ApplyComments().Upsert(ctx, comment))
 
-	// Verify upsert updated the comment ID
+	// Verify upsert updated the comment ID and recorded level
 	retrieved, err = store.ApplyComments().Get(ctx, apply.ID, state.Comment.Progress)
 	require.NoError(t, err)
 	require.NotNil(t, retrieved)
 	assert.Equal(t, int64(444555666), retrieved.GitHubCommentID)
+	require.NotNil(t, retrieved.PostedVolume)
+	assert.Equal(t, 5, *retrieved.PostedVolume)
+
+	// A summary comment carries no level; the column stays NULL and reads back nil.
+	summary := &storage.ApplyComment{
+		ApplyID:         apply.ID,
+		CommentState:    state.Comment.Summary,
+		GitHubCommentID: 777888999,
+	}
+	require.NoError(t, store.ApplyComments().Upsert(ctx, summary))
+	retrieved, err = store.ApplyComments().Get(ctx, apply.ID, state.Comment.Summary)
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	assert.Nil(t, retrieved.PostedVolume)
 }
 
 func TestApplyCommentStore_Get(t *testing.T) {

--- a/pkg/storage/mysqlstore/apply_comments_test.go
+++ b/pkg/storage/mysqlstore/apply_comments_test.go
@@ -237,6 +237,58 @@ func TestApplyCommentStore_Supersede(t *testing.T) {
 	require.NoError(t, store.ApplyComments().Supersede(ctx, 99999, state.Comment.Progress))
 }
 
+func TestApplyCommentStore_PendingFreeze(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_comment_pending_freeze", 1)
+
+	// A volume-change rotation records the freeze owed to the superseded
+	// comment in the same write that tracks its successor.
+	postedVolume := 5
+	supersededID := int64(100)
+	require.NoError(t, store.ApplyComments().Upsert(ctx, &storage.ApplyComment{
+		ApplyID:                apply.ID,
+		CommentState:           state.Comment.Progress,
+		GitHubCommentID:        200,
+		PostedVolume:           &postedVolume,
+		PendingFreezeCommentID: &supersededID,
+	}))
+
+	retrieved, err := store.ApplyComments().Get(ctx, apply.ID, state.Comment.Progress)
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	assert.Equal(t, int64(200), retrieved.GitHubCommentID)
+	require.NotNil(t, retrieved.PendingFreezeCommentID)
+	assert.Equal(t, supersededID, *retrieved.PendingFreezeCommentID)
+
+	// Once the frozen rendering lands on GitHub, the marker is cleared; the
+	// rest of the row is untouched.
+	require.NoError(t, store.ApplyComments().ClearPendingFreeze(ctx, apply.ID, state.Comment.Progress))
+	retrieved, err = store.ApplyComments().Get(ctx, apply.ID, state.Comment.Progress)
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	assert.Nil(t, retrieved.PendingFreezeCommentID)
+	assert.Equal(t, int64(200), retrieved.GitHubCommentID)
+	require.NotNil(t, retrieved.PostedVolume)
+	assert.Equal(t, 5, *retrieved.PostedVolume)
+
+	// Clearing an already-clear marker or a missing row is a no-op, not an error.
+	require.NoError(t, store.ApplyComments().ClearPendingFreeze(ctx, apply.ID, state.Comment.Progress))
+	require.NoError(t, store.ApplyComments().ClearPendingFreeze(ctx, 99999, state.Comment.Progress))
+
+	// A post that supersedes nothing leaves the marker NULL.
+	require.NoError(t, store.ApplyComments().Upsert(ctx, &storage.ApplyComment{
+		ApplyID: apply.ID, CommentState: state.Comment.Summary, GitHubCommentID: 300,
+	}))
+	summary, err := store.ApplyComments().Get(ctx, apply.ID, state.Comment.Summary)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.Nil(t, summary.PendingFreezeCommentID)
+}
+
 func TestApplyCommentStore_UniqueConstraint(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
@@ -315,6 +367,24 @@ func TestApplyCommentStore_LeaseGuardsWrites(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, retrieved)
 	assert.Equal(t, 1, retrieved.EditCount)
+
+	// ClearPendingFreeze is a lease-guarded write like the others: a stale
+	// lease fails closed, the current lease clears the marker.
+	pendingFreezeID := int64(50)
+	comment.PendingFreezeCommentID = &pendingFreezeID
+	require.NoError(t, store.ApplyComments().Upsert(currentCtx, comment))
+	require.ErrorIs(t, store.ApplyComments().ClearPendingFreeze(staleCtx, apply.ID, state.Comment.Progress), storage.ErrApplyLeaseLost)
+
+	retrieved, err = store.ApplyComments().Get(ctx, apply.ID, state.Comment.Progress)
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	require.NotNil(t, retrieved.PendingFreezeCommentID, "a stale lease must not clear the marker")
+
+	require.NoError(t, store.ApplyComments().ClearPendingFreeze(currentCtx, apply.ID, state.Comment.Progress))
+	retrieved, err = store.ApplyComments().Get(ctx, apply.ID, state.Comment.Progress)
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	assert.Nil(t, retrieved.PendingFreezeCommentID)
 }
 
 // DB error tests

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -495,6 +495,12 @@ type ApplyCommentStore interface {
 	// Upsert for the same state clears superseded_at. A missing or already-
 	// superseded row is not an error.
 	Supersede(ctx context.Context, applyID int64, commentState string) error
+
+	// ClearPendingFreeze removes the pending-freeze marker for a single
+	// (apply_id, comment_state) once the superseded comment's frozen rendering
+	// has landed on GitHub. A missing row or an already-clear marker is not an
+	// error.
+	ClearPendingFreeze(ctx context.Context, applyID int64, commentState string) error
 }
 
 // ApplyOperationStore manages per-(apply, deployment, operation_key) child rows

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -1099,6 +1099,13 @@ type ApplyComment struct {
 	// GitHubCommentID is the GitHub comment ID for editing.
 	GitHubCommentID int64
 
+	// PostedVolume records the apply's volume level at the moment a progress
+	// comment was posted. The observer compares it against the apply's current
+	// level to detect an applied volume change and rotate in a fresh progress
+	// comment. Nil for comment states where the level is not meaningful and
+	// for rows that predate volume tracking — nil never triggers a rotation.
+	PostedVolume *int
+
 	// EditCount tracks how many times this comment was edited.
 	EditCount int
 

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -1106,6 +1106,14 @@ type ApplyComment struct {
 	// for rows that predate volume tracking — nil never triggers a rotation.
 	PostedVolume *int
 
+	// PendingFreezeCommentID records the GitHub comment ID of a progress
+	// comment this row's comment superseded whose frozen rendering has not yet
+	// landed on GitHub. It is written in the same upsert that tracks the
+	// successor, so a failed freeze edit (or a pod dying before it) leaves a
+	// durable marker any later observer can reconcile; it is cleared once the
+	// freeze lands. Nil means no freeze is owed.
+	PendingFreezeCommentID *int64
+
 	// EditCount tracks how many times this comment was edited.
 	EditCount int
 

--- a/pkg/webhook/apply_comment_integration_test.go
+++ b/pkg/webhook/apply_comment_integration_test.go
@@ -3,8 +3,10 @@
 package webhook
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -543,7 +545,10 @@ func TestE2EVolumeChangeRotatesProgressComment(t *testing.T) {
 
 	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
 	require.NoError(t, err)
-	t.Cleanup(func() { utils.CloseAndLog(schemabotDB) })
+	// svc.Close below owns closing the store's DB; this early-failure safety
+	// close is redundant once svc exists, so discard its guaranteed
+	// already-closed error.
+	t.Cleanup(func() { _ = schemabotDB.Close() })
 
 	st := mysqlstore.New(schemabotDB)
 
@@ -711,6 +716,180 @@ func TestE2EVolumeChangeRotatesProgressComment(t *testing.T) {
 		t.Fatalf("a volume change must rotate exactly once; got another new comment %d", created.ID)
 	case <-time.After(5 * time.Second):
 		t.Fatal("expected an in-place edit of the new progress comment on the next tick")
+	}
+}
+
+// failingCommentUpsertStore wraps an ApplyCommentStore so every Upsert fails,
+// modeling a storage outage between posting a comment and recording its ID.
+type failingCommentUpsertStore struct {
+	storage.ApplyCommentStore
+}
+
+func (s *failingCommentUpsertStore) Upsert(context.Context, *storage.ApplyComment) error {
+	return errors.New("injected comment upsert failure")
+}
+
+// failingCommentUpsertStorage serves the failing comment store while passing
+// every other store through to the real storage.
+type failingCommentUpsertStorage struct {
+	storage.Storage
+}
+
+func (s *failingCommentUpsertStorage) ApplyComments() storage.ApplyCommentStore {
+	return &failingCommentUpsertStore{s.Storage.ApplyComments()}
+}
+
+// A volume-change rotation whose fresh comment posts to the PR but fails to be
+// recorded as the tracked comment must not freeze the prior comment: the
+// tracked row still points at the prior comment, so later progress edits land
+// there, and a frozen "superseded" body would fight those edits. The fresh
+// comment stays a point-in-time snapshot, the prior comment stays live, and no
+// further duplicate comments are posted for the same level.
+func TestE2EVolumeRotationUntrackedFreshCommentLeavesPriorCommentLive(t *testing.T) {
+	ctx := t.Context()
+
+	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
+	require.NoError(t, err)
+	// svc.Close below owns closing the store's DB; this early-failure safety
+	// close is redundant once svc exists, so discard its guaranteed
+	// already-closed error.
+	t.Cleanup(func() { _ = schemabotDB.Close() })
+
+	st := mysqlstore.New(schemabotDB)
+
+	for _, stmt := range []string{
+		"DELETE FROM apply_comments",
+		"DELETE FROM tasks WHERE repository = 'org/repo-volume-untracked'",
+		"DELETE FROM applies WHERE repository = 'org/repo-volume-untracked'",
+		"DELETE FROM locks WHERE repository = 'org/repo-volume-untracked'",
+	} {
+		_, err = schemabotDB.ExecContext(ctx, stmt)
+		require.NoError(t, err)
+	}
+
+	lock := &storage.Lock{
+		DatabaseName: "e2e_volume_untracked_db",
+		DatabaseType: "mysql",
+		Repository:   "org/repo-volume-untracked",
+		PullRequest:  144,
+		Owner:        "org/repo-volume-untracked#144",
+	}
+	require.NoError(t, st.Locks().Acquire(ctx, lock))
+	lock, err = st.Locks().Get(ctx, "e2e_volume_untracked_db", "mysql")
+	require.NoError(t, err)
+
+	apply := &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply_e2e_volume_untracked_%d", time.Now().UnixNano()),
+		LockID:          lock.ID,
+		PlanID:          1,
+		Database:        "e2e_volume_untracked_db",
+		DatabaseType:    "mysql",
+		Repository:      "org/repo-volume-untracked",
+		PullRequest:     144,
+		Environment:     "staging",
+		InstallationID:  12345,
+		Engine:          "spirit",
+		State:           state.Apply.Running,
+	}
+	apply.SetOptions(storage.ApplyOptions{Volume: 3})
+	applyID, err := st.Applies().Create(ctx, apply)
+	require.NoError(t, err)
+	apply.ID = applyID
+	apply.LeaseOwner = "volume-untracked-test-driver"
+	apply.LeaseToken = "volume-untracked-test-token"
+	leaseAcquiredAt := time.Now()
+	apply.LeaseAcquiredAt = &leaseAcquiredAt
+	_, err = schemabotDB.ExecContext(ctx, `
+		UPDATE applies
+		SET lease_owner = ?, lease_token = ?, lease_acquired_at = ?
+		WHERE id = ?
+	`, apply.LeaseOwner, apply.LeaseToken, leaseAcquiredAt, applyID)
+	require.NoError(t, err)
+
+	now := time.Now()
+	task := &storage.Task{
+		TaskIdentifier:  fmt.Sprintf("task_e2e_volume_untracked_%d", now.UnixNano()),
+		ApplyID:         applyID,
+		PlanID:          1,
+		Database:        "e2e_volume_untracked_db",
+		DatabaseType:    "mysql",
+		Engine:          "spirit",
+		Repository:      "org/repo-volume-untracked",
+		PullRequest:     144,
+		Environment:     "staging",
+		State:           state.Task.Running,
+		TableName:       "users",
+		DDL:             "ALTER TABLE users ADD INDEX idx_email (email)",
+		DDLAction:       "alter",
+		RowsCopied:      500,
+		RowsTotal:       1000,
+		ProgressPercent: 50,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	_, err = st.Tasks().Create(ctx, task)
+	require.NoError(t, err)
+
+	installClient, capture := setupFakeGitHubForComments(t)
+	factory := &fakeClientFactory{client: installClient}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := api.New(st, &api.ServerConfig{}, map[string]tern.Client{}, logger)
+	t.Cleanup(func() { _ = svc.Close() })
+	h := NewHandler(svc, factory, nil, logger)
+
+	// Seed the tracked progress comment at the starting level through the real
+	// store, the way the accepted-apply handler does.
+	startingVolume := 3
+	h.postAndTrackComment(ctx, "org/repo-volume-untracked", 144, 12345, applyID, state.Comment.Progress, "Copying at volume 3", &startingVolume)
+	initialProgressID := requireCommentCreate(t, capture)
+
+	// The observer's comment-tracking writes hit the failing store; reads and
+	// every other store pass through.
+	fake := clock.NewFake(now)
+	obs := NewCommentObserver(CommentObserverConfig{
+		GHClient:       factory,
+		Storage:        &failingCommentUpsertStorage{Storage: st},
+		Repo:           "org/repo-volume-untracked",
+		PR:             144,
+		InstallationID: 12345,
+		ApplyID:        applyID,
+		Logger:         logger,
+		Clock:          fake,
+	})
+
+	// The level change posts the fresh comment, but recording it as the tracked
+	// comment fails — the prior comment must not be frozen.
+	apply.SetOptions(storage.ApplyOptions{Volume: 5})
+	fake.Advance(activeInterval + time.Second)
+	obs.OnProgress(apply, []*storage.Task{task})
+
+	select {
+	case created := <-capture.creates:
+		assert.Contains(t, created.Body, "Volume: 5/11", "the fresh comment renders the new level")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the volume change to post a fresh progress comment")
+	}
+	select {
+	case edited := <-capture.edits:
+		t.Fatalf("no comment may be edited when the fresh comment was not tracked; got an edit of %d: %s", edited.CommentID, edited.Body)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// A later tick does not post a duplicate for the same level, and its
+	// progress edit lands on the prior comment — still the tracked one.
+	task.RowsCopied = 700
+	task.ProgressPercent = 70
+	fake.Advance(activeInterval + time.Second)
+	obs.OnProgress(apply, []*storage.Task{task})
+
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, initialProgressID, edited.CommentID, "progress edits continue on the prior tracked comment")
+		assert.Contains(t, edited.Body, "70%")
+	case created := <-capture.creates:
+		t.Fatalf("an untracked rotation must not repost for the same level; got another new comment %d", created.ID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected an in-place edit of the prior tracked comment")
 	}
 }
 

--- a/pkg/webhook/apply_comment_integration_test.go
+++ b/pkg/webhook/apply_comment_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -31,11 +32,28 @@ import (
 	"github.com/block/schemabot/pkg/tern"
 )
 
-// commentCapture records all GitHub comment API calls (creates and edits).
+// commentCapture records all GitHub comment API calls (creates and edits) and
+// remembers the latest body per comment ID so GET reads return what was written.
 type commentCapture struct {
 	creates chan commentCreate
 	edits   chan commentEdit
 	nextID  atomic.Int64
+
+	mu     sync.Mutex
+	bodies map[int64]string
+}
+
+func (c *commentCapture) setBody(commentID int64, body string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.bodies[commentID] = body
+}
+
+func (c *commentCapture) body(commentID int64) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	body, ok := c.bodies[commentID]
+	return body, ok
 }
 
 type commentCreate struct {
@@ -56,6 +74,7 @@ func setupFakeGitHubForComments(t *testing.T) (*ghclient.InstallationClient, *co
 	capture := &commentCapture{
 		creates: make(chan commentCreate, 20),
 		edits:   make(chan commentEdit, 20),
+		bodies:  make(map[int64]string),
 	}
 	capture.nextID.Store(1000)
 
@@ -70,9 +89,27 @@ func setupFakeGitHubForComments(t *testing.T) (*ghclient.InstallationClient, *co
 		}
 		_ = json.NewDecoder(r.Body).Decode(&body)
 		id := capture.nextID.Add(1) - 1
+		capture.setBody(id, body.Body)
 		capture.creates <- commentCreate{Body: body.Body, ID: id}
 		w.WriteHeader(http.StatusCreated)
 		_ = json.NewEncoder(w).Encode(map[string]any{"id": id})
+	})
+
+	// Read comment — the observer loads a superseded comment's body before
+	// freezing it into a collapsed details block.
+	mux.HandleFunc("GET /repos/", func(w http.ResponseWriter, r *http.Request) {
+		var commentID int64
+		parts := splitPath(r.URL.Path)
+		if len(parts) >= 6 {
+			_, _ = fmt.Sscanf(parts[5], "%d", &commentID)
+		}
+		body, ok := capture.body(commentID)
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": commentID, "body": body})
 	})
 
 	// Edit comment — match any repo/comment ID via prefix
@@ -89,6 +126,7 @@ func setupFakeGitHubForComments(t *testing.T) (*ghclient.InstallationClient, *co
 			Body string `json:"body"`
 		}
 		_ = json.NewDecoder(r.Body).Decode(&body)
+		capture.setBody(commentID, body.Body)
 		capture.edits <- commentEdit{CommentID: commentID, Body: body.Body}
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(map[string]any{"id": commentID})
@@ -207,7 +245,7 @@ func TestE2EApplyCommentLifecycle(t *testing.T) {
 	h := NewHandler(svc, factory, nil, logger)
 
 	// Step 1: Post initial progress comment
-	h.postAndTrackComment(ctx, "org/repo", 42, 12345, applyID, state.Comment.Progress, "Initial progress")
+	h.postAndTrackComment(ctx, "org/repo", 42, 12345, applyID, state.Comment.Progress, "Initial progress", nil)
 
 	// Verify create was captured
 	var progressCommentID int64
@@ -257,7 +295,7 @@ func TestE2EApplyCommentLifecycle(t *testing.T) {
 	assert.Equal(t, progressCommentID, active.GitHubCommentID)
 
 	// Step 4: Post cutover comment (simulating defer_cutover)
-	h.postAndTrackComment(ctx, "org/repo", 42, 12345, applyID, state.Comment.Cutover, "Cutover ready")
+	h.postAndTrackComment(ctx, "org/repo", 42, 12345, applyID, state.Comment.Cutover, "Cutover ready", nil)
 
 	var cutoverCommentID int64
 	select {
@@ -287,7 +325,7 @@ func TestE2EApplyCommentLifecycle(t *testing.T) {
 	}
 
 	// Step 7: Post summary comment (terminal state)
-	h.postAndTrackComment(ctx, "org/repo", 42, 12345, applyID, state.Comment.Summary, "Schema change completed")
+	h.postAndTrackComment(ctx, "org/repo", 42, 12345, applyID, state.Comment.Summary, "Schema change completed", nil)
 
 	var summaryCommentID int64
 	select {
@@ -412,9 +450,9 @@ func TestE2EResumeRotatesProgressComment(t *testing.T) {
 
 	// Seed the pre-resume comments left by the stop: the progress comment frozen at
 	// "Stopped" and the stopped summary marker that signals a resume is in progress.
-	h.postAndTrackComment(ctx, "org/repo-rotate", 142, 12345, applyID, state.Comment.Progress, "Stopped at 21%")
+	h.postAndTrackComment(ctx, "org/repo-rotate", 142, 12345, applyID, state.Comment.Progress, "Stopped at 21%", nil)
 	stoppedProgressID := requireCommentCreate(t, capture)
-	h.postAndTrackComment(ctx, "org/repo-rotate", 142, 12345, applyID, state.Comment.Summary, "Schema Change Stopped")
+	h.postAndTrackComment(ctx, "org/repo-rotate", 142, 12345, applyID, state.Comment.Summary, "Schema Change Stopped", nil)
 	requireCommentCreate(t, capture)
 
 	fake := clock.NewFake(now)
@@ -490,6 +528,189 @@ func requireCommentCreate(t *testing.T, capture *commentCapture) int64 {
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for comment create")
 		return 0
+	}
+}
+
+// When an operator's volume change takes effect on a running apply, the
+// observer posts a fresh progress comment tracking the new level — a new
+// comment at the bottom of the PR timeline is where the operator looks for the
+// effect of the command they just issued. The prior progress comment is frozen
+// into a collapsed details block pointing at its successor, later progress
+// edits land on the new comment, and a tick without a level change does not
+// rotate again.
+func TestE2EVolumeChangeRotatesProgressComment(t *testing.T) {
+	ctx := t.Context()
+
+	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
+	require.NoError(t, err)
+	t.Cleanup(func() { utils.CloseAndLog(schemabotDB) })
+
+	st := mysqlstore.New(schemabotDB)
+
+	for _, stmt := range []string{
+		"DELETE FROM apply_comments",
+		"DELETE FROM tasks WHERE repository = 'org/repo-volume'",
+		"DELETE FROM applies WHERE repository = 'org/repo-volume'",
+		"DELETE FROM locks WHERE repository = 'org/repo-volume'",
+	} {
+		_, err = schemabotDB.ExecContext(ctx, stmt)
+		require.NoError(t, err)
+	}
+
+	lock := &storage.Lock{
+		DatabaseName: "e2e_volume_db",
+		DatabaseType: "mysql",
+		Repository:   "org/repo-volume",
+		PullRequest:  143,
+		Owner:        "org/repo-volume#143",
+	}
+	require.NoError(t, st.Locks().Acquire(ctx, lock))
+	lock, err = st.Locks().Get(ctx, "e2e_volume_db", "mysql")
+	require.NoError(t, err)
+
+	apply := &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply_e2e_volume_%d", time.Now().UnixNano()),
+		LockID:          lock.ID,
+		PlanID:          1,
+		Database:        "e2e_volume_db",
+		DatabaseType:    "mysql",
+		Repository:      "org/repo-volume",
+		PullRequest:     143,
+		Environment:     "staging",
+		InstallationID:  12345,
+		Engine:          "spirit",
+		State:           state.Apply.Running,
+	}
+	apply.SetOptions(storage.ApplyOptions{Volume: 3})
+	applyID, err := st.Applies().Create(ctx, apply)
+	require.NoError(t, err)
+	apply.ID = applyID
+	apply.LeaseOwner = "volume-test-driver"
+	apply.LeaseToken = "volume-test-token"
+	leaseAcquiredAt := time.Now()
+	apply.LeaseAcquiredAt = &leaseAcquiredAt
+	_, err = schemabotDB.ExecContext(ctx, `
+		UPDATE applies
+		SET lease_owner = ?, lease_token = ?, lease_acquired_at = ?
+		WHERE id = ?
+	`, apply.LeaseOwner, apply.LeaseToken, leaseAcquiredAt, applyID)
+	require.NoError(t, err)
+
+	now := time.Now()
+	task := &storage.Task{
+		TaskIdentifier:  fmt.Sprintf("task_e2e_volume_%d", now.UnixNano()),
+		ApplyID:         applyID,
+		PlanID:          1,
+		Database:        "e2e_volume_db",
+		DatabaseType:    "mysql",
+		Engine:          "spirit",
+		Repository:      "org/repo-volume",
+		PullRequest:     143,
+		Environment:     "staging",
+		State:           state.Task.Running,
+		TableName:       "users",
+		DDL:             "ALTER TABLE users ADD INDEX idx_email (email)",
+		DDLAction:       "alter",
+		RowsCopied:      500,
+		RowsTotal:       1000,
+		ProgressPercent: 50,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	_, err = st.Tasks().Create(ctx, task)
+	require.NoError(t, err)
+
+	installClient, capture := setupFakeGitHubForComments(t)
+	factory := &fakeClientFactory{client: installClient}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	serverConfig := &api.ServerConfig{}
+	svc := api.New(st, serverConfig, map[string]tern.Client{}, logger)
+	t.Cleanup(func() { _ = svc.Close() })
+	h := NewHandler(svc, factory, nil, logger)
+
+	// Seed the tracked progress comment the apply started with, recording the
+	// starting level the way the accepted-apply handler does.
+	startingVolume := 3
+	h.postAndTrackComment(ctx, "org/repo-volume", 143, 12345, applyID, state.Comment.Progress, "Copying at volume 3", &startingVolume)
+	initialProgressID := requireCommentCreate(t, capture)
+
+	fake := clock.NewFake(now)
+	obs := NewCommentObserver(CommentObserverConfig{
+		GHClient:       factory,
+		Storage:        st,
+		Repo:           "org/repo-volume",
+		PR:             143,
+		InstallationID: 12345,
+		ApplyID:        applyID,
+		Logger:         logger,
+		Clock:          fake,
+	})
+
+	// A tick at the level the comment was posted with edits in place.
+	fake.Advance(activeInterval + time.Second)
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, initialProgressID, edited.CommentID, "same-level ticks edit the tracked comment in place")
+		assert.Contains(t, edited.Body, "Volume: 3/11")
+	case created := <-capture.creates:
+		t.Fatalf("a tick without a volume change must not post a new comment, got %d", created.ID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected an in-place edit of the tracked progress comment")
+	}
+
+	// The driver applied a volume change and recorded the new level on the
+	// apply options. The next tick rotates: a fresh progress comment tracks
+	// the new level.
+	apply.SetOptions(storage.ApplyOptions{Volume: 5})
+	task.RowsCopied = 600
+	fake.Advance(activeInterval + time.Second)
+	obs.OnProgress(apply, []*storage.Task{task})
+
+	var newProgressID int64
+	select {
+	case created := <-capture.creates:
+		newProgressID = created.ID
+		assert.Contains(t, created.Body, "Volume: 5/11", "the fresh comment tracks the new level")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected a new progress comment after the volume change")
+	}
+	assert.NotEqual(t, initialProgressID, newProgressID, "the volume change must post a new comment, not reuse the old one")
+
+	// The prior comment is frozen into a collapsed details block pointing at
+	// its successor, with the pre-change body preserved inside the fold.
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, initialProgressID, edited.CommentID, "the freeze edit lands on the superseded comment")
+		assert.Contains(t, edited.Body, "Volume changed to **5/11**")
+		assert.Contains(t, edited.Body, fmt.Sprintf("#issuecomment-%d", newProgressID), "the frozen comment links to its successor")
+		assert.Contains(t, edited.Body, "<details>")
+		assert.Contains(t, edited.Body, "Volume: 3/11", "the pre-change body is preserved inside the fold")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the superseded progress comment to be frozen")
+	}
+
+	// The progress row tracks the new comment at the new level.
+	prog, err := st.ApplyComments().Get(ctx, applyID, state.Comment.Progress)
+	require.NoError(t, err)
+	require.NotNil(t, prog)
+	assert.Equal(t, newProgressID, prog.GitHubCommentID)
+	require.NotNil(t, prog.PostedVolume)
+	assert.Equal(t, 5, *prog.PostedVolume)
+
+	// A later tick without another level change edits the new comment in place.
+	task.RowsCopied = 700
+	task.ProgressPercent = 70
+	fake.Advance(activeInterval + time.Second)
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, newProgressID, edited.CommentID, "later edits land on the new comment")
+		assert.Contains(t, edited.Body, "70%")
+	case created := <-capture.creates:
+		t.Fatalf("a volume change must rotate exactly once; got another new comment %d", created.ID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected an in-place edit of the new progress comment on the next tick")
 	}
 }
 
@@ -679,7 +900,7 @@ func TestE2EApplyCommentUpsertOnResume(t *testing.T) {
 	h := NewHandler(svc, factory, nil, logger)
 
 	// Resume: post new progress comment (upsert should replace old ID)
-	h.postAndTrackComment(ctx, "org/repo-resume", 43, 12345, applyID, state.Comment.Progress, "Resumed progress")
+	h.postAndTrackComment(ctx, "org/repo-resume", 43, 12345, applyID, state.Comment.Progress, "Resumed progress", nil)
 
 	var newProgressID int64
 	select {
@@ -698,7 +919,7 @@ func TestE2EApplyCommentUpsertOnResume(t *testing.T) {
 	assert.NotEqual(t, int64(111), comment.GitHubCommentID, "old comment ID should be replaced")
 
 	// Post new summary (upsert replaces old ID)
-	h.postAndTrackComment(ctx, "org/repo-resume", 43, 12345, applyID, state.Comment.Summary, "Resumed summary")
+	h.postAndTrackComment(ctx, "org/repo-resume", 43, 12345, applyID, state.Comment.Summary, "Resumed summary", nil)
 
 	var newSummaryID int64
 	select {
@@ -952,7 +1173,7 @@ func TestE2EInitialProgressCommentFinalizedForFastApply(t *testing.T) {
 
 		pending := *apply
 		pending.State = state.Apply.Pending
-		h.postInitialProgressComment(ctx, apply.Repository, apply.PullRequest, apply.InstallationID, apply.ID,
+		h.postInitialProgressComment(ctx, apply.Repository, apply.PullRequest, apply.InstallationID, apply,
 			formatProgressComment(&pending, nil, nil, ""))
 
 		var created commentCreate
@@ -990,7 +1211,7 @@ func TestE2EInitialProgressCommentFinalizedForFastApply(t *testing.T) {
 		}))
 		require.NoError(t, st.ApplyComments().IncrementEditCount(ctx, apply.ID, state.Comment.Progress))
 
-		h.postInitialProgressComment(ctx, apply.Repository, apply.PullRequest, apply.InstallationID, apply.ID,
+		h.postInitialProgressComment(ctx, apply.Repository, apply.PullRequest, apply.InstallationID, apply,
 			formatProgressComment(apply, nil, nil, ""))
 
 		select {
@@ -1011,7 +1232,7 @@ func TestE2EInitialProgressCommentFinalizedForFastApply(t *testing.T) {
 		apply := newApply(t, state.Apply.Running)
 		h, capture := newHandler(t)
 
-		h.postInitialProgressComment(ctx, apply.Repository, apply.PullRequest, apply.InstallationID, apply.ID,
+		h.postInitialProgressComment(ctx, apply.Repository, apply.PullRequest, apply.InstallationID, apply,
 			formatProgressComment(apply, nil, nil, ""))
 
 		select {

--- a/pkg/webhook/apply_comment_integration_test.go
+++ b/pkg/webhook/apply_comment_integration_test.go
@@ -247,7 +247,7 @@ func TestE2EApplyCommentLifecycle(t *testing.T) {
 	h := NewHandler(svc, factory, nil, logger)
 
 	// Step 1: Post initial progress comment
-	h.postAndTrackComment(ctx, "org/repo", 42, 12345, applyID, state.Comment.Progress, "Initial progress", nil)
+	h.postAndTrackComment(ctx, "org/repo", 42, 12345, apply, state.Comment.Progress, "Initial progress")
 
 	// Verify create was captured
 	var progressCommentID int64
@@ -297,7 +297,7 @@ func TestE2EApplyCommentLifecycle(t *testing.T) {
 	assert.Equal(t, progressCommentID, active.GitHubCommentID)
 
 	// Step 4: Post cutover comment (simulating defer_cutover)
-	h.postAndTrackComment(ctx, "org/repo", 42, 12345, applyID, state.Comment.Cutover, "Cutover ready", nil)
+	h.postAndTrackComment(ctx, "org/repo", 42, 12345, apply, state.Comment.Cutover, "Cutover ready")
 
 	var cutoverCommentID int64
 	select {
@@ -327,7 +327,7 @@ func TestE2EApplyCommentLifecycle(t *testing.T) {
 	}
 
 	// Step 7: Post summary comment (terminal state)
-	h.postAndTrackComment(ctx, "org/repo", 42, 12345, applyID, state.Comment.Summary, "Schema change completed", nil)
+	h.postAndTrackComment(ctx, "org/repo", 42, 12345, apply, state.Comment.Summary, "Schema change completed")
 
 	var summaryCommentID int64
 	select {
@@ -360,114 +360,27 @@ func TestE2EApplyCommentLifecycle(t *testing.T) {
 func TestE2EResumeRotatesProgressComment(t *testing.T) {
 	ctx := t.Context()
 
-	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
-	require.NoError(t, err)
-	t.Cleanup(func() { utils.CloseAndLog(schemabotDB) })
-
-	st := mysqlstore.New(schemabotDB)
-
-	for _, stmt := range []string{
-		"DELETE FROM apply_comments",
-		"DELETE FROM tasks WHERE repository = 'org/repo-rotate'",
-		"DELETE FROM applies WHERE repository = 'org/repo-rotate'",
-		"DELETE FROM locks WHERE repository = 'org/repo-rotate'",
-	} {
-		_, err = schemabotDB.ExecContext(ctx, stmt)
-		require.NoError(t, err)
-	}
-
-	lock := &storage.Lock{
-		DatabaseName: "e2e_rotate_db",
-		DatabaseType: "mysql",
-		Repository:   "org/repo-rotate",
-		PullRequest:  142,
-		Owner:        "org/repo-rotate#142",
-	}
-	require.NoError(t, st.Locks().Acquire(ctx, lock))
-	lock, err = st.Locks().Get(ctx, "e2e_rotate_db", "mysql")
-	require.NoError(t, err)
-
 	// The apply has just been started again after a stop: the data plane accepted
 	// the start, so the apply is in the Resuming window (it may still report stopped
-	// briefly) before it transitions to Running.
-	apply := &storage.Apply{
-		ApplyIdentifier: fmt.Sprintf("apply_e2e_rotate_%d", time.Now().UnixNano()),
-		LockID:          lock.ID,
-		PlanID:          1,
-		Database:        "e2e_rotate_db",
-		DatabaseType:    "mysql",
-		Repository:      "org/repo-rotate",
-		PullRequest:     142,
-		Environment:     "staging",
-		InstallationID:  12345,
-		Engine:          "spirit",
-		State:           state.Apply.Resuming,
-	}
-	applyID, err := st.Applies().Create(ctx, apply)
-	require.NoError(t, err)
-	apply.ID = applyID
-	apply.LeaseOwner = "resume-test-driver"
-	apply.LeaseToken = "resume-test-token"
-	leaseAcquiredAt := time.Now()
-	apply.LeaseAcquiredAt = &leaseAcquiredAt
-	_, err = schemabotDB.ExecContext(ctx, `
-		UPDATE applies
-		SET lease_owner = ?, lease_token = ?, lease_acquired_at = ?, state = ?
-		WHERE id = ?
-	`, apply.LeaseOwner, apply.LeaseToken, leaseAcquiredAt, state.Apply.Resuming, applyID)
-	require.NoError(t, err)
-
-	// The task is copying again after resume.
-	now := time.Now()
-	task := &storage.Task{
-		TaskIdentifier:  fmt.Sprintf("task_e2e_rotate_%d", now.UnixNano()),
-		ApplyID:         applyID,
-		PlanID:          1,
-		Database:        "e2e_rotate_db",
-		DatabaseType:    "mysql",
-		Engine:          "spirit",
-		Repository:      "org/repo-rotate",
-		PullRequest:     142,
-		Environment:     "staging",
-		State:           state.Task.Running,
-		TableName:       "users",
-		DDL:             "ALTER TABLE users ADD INDEX idx_email (email)",
-		DDLAction:       "alter",
-		RowsCopied:      500,
-		RowsTotal:       1000,
-		ProgressPercent: 50,
-		CreatedAt:       now,
-		UpdatedAt:       now,
-	}
-	_, err = st.Tasks().Create(ctx, task)
-	require.NoError(t, err)
-
-	installClient, capture := setupFakeGitHubForComments(t)
-	factory := &fakeClientFactory{client: installClient}
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
-	serverConfig := &api.ServerConfig{}
-	svc := api.New(st, serverConfig, map[string]tern.Client{}, logger)
-	t.Cleanup(func() { _ = svc.Close() })
-	h := NewHandler(svc, factory, nil, logger)
+	// briefly) before it transitions to Running. The task is copying again after
+	// resume.
+	f := setupApplyCommentFixture(t, applyCommentFixtureParams{
+		repo:       "org/repo-rotate",
+		pr:         142,
+		database:   "e2e_rotate_db",
+		applyState: state.Apply.Resuming,
+	})
+	st, apply, task, capture, h := f.st, f.apply, f.task, f.capture, f.handler
 
 	// Seed the pre-resume comments left by the stop: the progress comment frozen at
 	// "Stopped" and the stopped summary marker that signals a resume is in progress.
-	h.postAndTrackComment(ctx, "org/repo-rotate", 142, 12345, applyID, state.Comment.Progress, "Stopped at 21%", nil)
+	h.postAndTrackComment(ctx, "org/repo-rotate", 142, 12345, apply, state.Comment.Progress, "Stopped at 21%")
 	stoppedProgressID := requireCommentCreate(t, capture)
-	h.postAndTrackComment(ctx, "org/repo-rotate", 142, 12345, applyID, state.Comment.Summary, "Schema Change Stopped", nil)
+	h.postAndTrackComment(ctx, "org/repo-rotate", 142, 12345, apply, state.Comment.Summary, "Schema Change Stopped")
 	requireCommentCreate(t, capture)
 
-	fake := clock.NewFake(now)
-	obs := NewCommentObserver(CommentObserverConfig{
-		GHClient:       factory,
-		Storage:        st,
-		Repo:           "org/repo-rotate",
-		PR:             142,
-		InstallationID: 12345,
-		ApplyID:        applyID,
-		Logger:         logger,
-		Clock:          fake,
-	})
+	fake := clock.NewFake(task.CreatedAt)
+	obs := f.newObserver(st, fake)
 
 	// First progress tick after resume rotates the progress comment. While the
 	// apply is in the Resuming window the comment keeps the stable in-progress
@@ -492,11 +405,11 @@ func TestE2EResumeRotatesProgressComment(t *testing.T) {
 	// The progress row now tracks the new comment; the stopped-summary marker is
 	// consumed by being superseded — the row and its GitHub comment are kept, not
 	// deleted.
-	prog, err := st.ApplyComments().Get(ctx, applyID, state.Comment.Progress)
+	prog, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Progress)
 	require.NoError(t, err)
 	require.NotNil(t, prog)
 	assert.Equal(t, newProgressID, prog.GitHubCommentID)
-	summary, err := st.ApplyComments().Get(ctx, applyID, state.Comment.Summary)
+	summary, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Summary)
 	require.NoError(t, err)
 	require.NotNil(t, summary, "the stopped-summary row is retired, not deleted")
 	assert.NotNil(t, summary.SupersededAt, "the stopped-summary marker is superseded after rotation")
@@ -533,14 +446,34 @@ func requireCommentCreate(t *testing.T, capture *commentCapture) int64 {
 	}
 }
 
-// When an operator's volume change takes effect on a running apply, the
-// observer posts a fresh progress comment tracking the new level — a new
-// comment at the bottom of the PR timeline is where the operator looks for the
-// effect of the command they just issued. The prior progress comment is frozen
-// into a collapsed details block pointing at its successor, later progress
-// edits land on the new comment, and a tick without a level change does not
-// rotate again.
-func TestE2EVolumeChangeRotatesProgressComment(t *testing.T) {
+// applyCommentFixtureParams names the per-test identity of a comment-rotation
+// fixture. A zero volume seeds the apply without volume options.
+type applyCommentFixtureParams struct {
+	repo       string
+	pr         int
+	database   string
+	applyState string
+	volume     int
+}
+
+// applyCommentFixture bundles the storage seeding and fake-GitHub plumbing the
+// comment-rotation tests share: a leased apply mid-copy with one running task,
+// and a webhook handler wired to a capturing fake GitHub.
+type applyCommentFixture struct {
+	st      storage.Storage
+	apply   *storage.Apply
+	task    *storage.Task
+	capture *commentCapture
+	factory *fakeClientFactory
+	logger  *slog.Logger
+	handler *Handler
+}
+
+// setupApplyCommentFixture cleans up any prior rows for the fixture's repo,
+// seeds a lock, a leased apply, and a running copy task at 50%, and returns
+// the handler and fake-GitHub capture the test drives comments through.
+func setupApplyCommentFixture(t *testing.T, p applyCommentFixtureParams) *applyCommentFixture {
+	t.Helper()
 	ctx := t.Context()
 
 	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
@@ -552,65 +485,64 @@ func TestE2EVolumeChangeRotatesProgressComment(t *testing.T) {
 
 	st := mysqlstore.New(schemabotDB)
 
-	for _, stmt := range []string{
-		"DELETE FROM apply_comments",
-		"DELETE FROM tasks WHERE repository = 'org/repo-volume'",
-		"DELETE FROM applies WHERE repository = 'org/repo-volume'",
-		"DELETE FROM locks WHERE repository = 'org/repo-volume'",
-	} {
-		_, err = schemabotDB.ExecContext(ctx, stmt)
+	_, err = schemabotDB.ExecContext(ctx, "DELETE FROM apply_comments")
+	require.NoError(t, err)
+	for _, table := range []string{"tasks", "applies", "locks"} {
+		_, err = schemabotDB.ExecContext(ctx, "DELETE FROM `"+table+"` WHERE repository = ?", p.repo)
 		require.NoError(t, err)
 	}
 
 	lock := &storage.Lock{
-		DatabaseName: "e2e_volume_db",
+		DatabaseName: p.database,
 		DatabaseType: "mysql",
-		Repository:   "org/repo-volume",
-		PullRequest:  143,
-		Owner:        "org/repo-volume#143",
+		Repository:   p.repo,
+		PullRequest:  p.pr,
+		Owner:        fmt.Sprintf("%s#%d", p.repo, p.pr),
 	}
 	require.NoError(t, st.Locks().Acquire(ctx, lock))
-	lock, err = st.Locks().Get(ctx, "e2e_volume_db", "mysql")
+	lock, err = st.Locks().Get(ctx, p.database, "mysql")
 	require.NoError(t, err)
 
 	apply := &storage.Apply{
-		ApplyIdentifier: fmt.Sprintf("apply_e2e_volume_%d", time.Now().UnixNano()),
+		ApplyIdentifier: fmt.Sprintf("apply_%s_%d", p.database, time.Now().UnixNano()),
 		LockID:          lock.ID,
 		PlanID:          1,
-		Database:        "e2e_volume_db",
+		Database:        p.database,
 		DatabaseType:    "mysql",
-		Repository:      "org/repo-volume",
-		PullRequest:     143,
+		Repository:      p.repo,
+		PullRequest:     p.pr,
 		Environment:     "staging",
 		InstallationID:  12345,
 		Engine:          "spirit",
-		State:           state.Apply.Running,
+		State:           p.applyState,
 	}
-	apply.SetOptions(storage.ApplyOptions{Volume: 3})
+	if p.volume != 0 {
+		apply.SetOptions(storage.ApplyOptions{Volume: p.volume})
+	}
 	applyID, err := st.Applies().Create(ctx, apply)
 	require.NoError(t, err)
 	apply.ID = applyID
-	apply.LeaseOwner = "volume-test-driver"
-	apply.LeaseToken = "volume-test-token"
+	apply.LeaseOwner = p.database + "-test-driver"
+	apply.LeaseToken = p.database + "-test-token"
 	leaseAcquiredAt := time.Now()
 	apply.LeaseAcquiredAt = &leaseAcquiredAt
 	_, err = schemabotDB.ExecContext(ctx, `
 		UPDATE applies
-		SET lease_owner = ?, lease_token = ?, lease_acquired_at = ?
+		SET lease_owner = ?, lease_token = ?, lease_acquired_at = ?, state = ?
 		WHERE id = ?
-	`, apply.LeaseOwner, apply.LeaseToken, leaseAcquiredAt, applyID)
+	`, apply.LeaseOwner, apply.LeaseToken, leaseAcquiredAt, p.applyState, applyID)
 	require.NoError(t, err)
 
 	now := time.Now()
 	task := &storage.Task{
-		TaskIdentifier:  fmt.Sprintf("task_e2e_volume_%d", now.UnixNano()),
+		TaskIdentifier:  fmt.Sprintf("task_%s_%d", p.database, now.UnixNano()),
 		ApplyID:         applyID,
 		PlanID:          1,
-		Database:        "e2e_volume_db",
+		Database:        p.database,
 		DatabaseType:    "mysql",
 		Engine:          "spirit",
-		Repository:      "org/repo-volume",
-		PullRequest:     143,
+		Repository:      p.repo,
+		PullRequest:     p.pr,
 		Environment:     "staging",
 		State:           state.Task.Running,
 		TableName:       "users",
@@ -628,28 +560,62 @@ func TestE2EVolumeChangeRotatesProgressComment(t *testing.T) {
 	installClient, capture := setupFakeGitHubForComments(t)
 	factory := &fakeClientFactory{client: installClient}
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
-	serverConfig := &api.ServerConfig{}
-	svc := api.New(st, serverConfig, map[string]tern.Client{}, logger)
+	svc := api.New(st, &api.ServerConfig{}, map[string]tern.Client{}, logger)
 	t.Cleanup(func() { _ = svc.Close() })
-	h := NewHandler(svc, factory, nil, logger)
 
-	// Seed the tracked progress comment the apply started with, recording the
-	// starting level the way the accepted-apply handler does.
-	startingVolume := 3
-	h.postAndTrackComment(ctx, "org/repo-volume", 143, 12345, applyID, state.Comment.Progress, "Copying at volume 3", &startingVolume)
+	return &applyCommentFixture{
+		st:      st,
+		apply:   apply,
+		task:    task,
+		capture: capture,
+		factory: factory,
+		logger:  logger,
+		handler: NewHandler(svc, factory, nil, logger),
+	}
+}
+
+// newObserver builds a comment observer over the fixture's apply. Tests pass
+// the fixture's real storage, or a wrapper injecting failures, and their fake
+// clock.
+func (f *applyCommentFixture) newObserver(stor storage.Storage, clk clock.Clock) *CommentObserver {
+	return NewCommentObserver(CommentObserverConfig{
+		GHClient:       f.factory,
+		Storage:        stor,
+		Repo:           f.apply.Repository,
+		PR:             f.apply.PullRequest,
+		InstallationID: f.apply.InstallationID,
+		ApplyID:        f.apply.ID,
+		Logger:         f.logger,
+		Clock:          clk,
+	})
+}
+
+// When an operator's volume change takes effect on a running apply, the
+// observer posts a fresh progress comment tracking the new level — a new
+// comment at the bottom of the PR timeline is where the operator looks for the
+// effect of the command they just issued. The prior progress comment is frozen
+// into a collapsed details block pointing at its successor, later progress
+// edits land on the new comment, and a tick without a level change does not
+// rotate again.
+func TestE2EVolumeChangeRotatesProgressComment(t *testing.T) {
+	ctx := t.Context()
+
+	f := setupApplyCommentFixture(t, applyCommentFixtureParams{
+		repo:       "org/repo-volume",
+		pr:         143,
+		database:   "e2e_volume_db",
+		applyState: state.Apply.Running,
+		volume:     3,
+	})
+	st, apply, task, capture, h := f.st, f.apply, f.task, f.capture, f.handler
+
+	// Seed the tracked progress comment the apply started with; the handler
+	// records the starting level from the apply's options.
+	h.postAndTrackComment(ctx, "org/repo-volume", 143, 12345, apply, state.Comment.Progress, "Copying at volume 3")
 	initialProgressID := requireCommentCreate(t, capture)
 
-	fake := clock.NewFake(now)
-	obs := NewCommentObserver(CommentObserverConfig{
-		GHClient:       factory,
-		Storage:        st,
-		Repo:           "org/repo-volume",
-		PR:             143,
-		InstallationID: 12345,
-		ApplyID:        applyID,
-		Logger:         logger,
-		Clock:          fake,
-	})
+	fake := clock.NewFake(task.CreatedAt)
+	obs := f.newObserver(st, fake)
 
 	// A tick at the level the comment was posted with edits in place.
 	fake.Advance(activeInterval + time.Second)
@@ -696,7 +662,7 @@ func TestE2EVolumeChangeRotatesProgressComment(t *testing.T) {
 	}
 
 	// The progress row tracks the new comment at the new level.
-	prog, err := st.ApplyComments().Get(ctx, applyID, state.Comment.Progress)
+	prog, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Progress)
 	require.NoError(t, err)
 	require.NotNil(t, prog)
 	assert.Equal(t, newProgressID, prog.GitHubCommentID)
@@ -719,143 +685,70 @@ func TestE2EVolumeChangeRotatesProgressComment(t *testing.T) {
 	}
 }
 
-// failingCommentUpsertStore wraps an ApplyCommentStore so every Upsert fails,
-// modeling a storage outage between posting a comment and recording its ID.
+// failingCommentUpsertStore wraps an ApplyCommentStore so every Upsert fails
+// until the outage is healed, modeling a storage outage between posting a
+// comment and recording its ID. Reads and every other write pass through.
 type failingCommentUpsertStore struct {
 	storage.ApplyCommentStore
+	healed *atomic.Bool
 }
 
-func (s *failingCommentUpsertStore) Upsert(context.Context, *storage.ApplyComment) error {
+func (s *failingCommentUpsertStore) Upsert(ctx context.Context, comment *storage.ApplyComment) error {
+	if s.healed.Load() {
+		return s.ApplyCommentStore.Upsert(ctx, comment)
+	}
 	return errors.New("injected comment upsert failure")
 }
 
 // failingCommentUpsertStorage serves the failing comment store while passing
-// every other store through to the real storage.
+// every other store through to the real storage. heal ends the outage so
+// later Upserts land.
 type failingCommentUpsertStorage struct {
 	storage.Storage
+	healed atomic.Bool
 }
 
 func (s *failingCommentUpsertStorage) ApplyComments() storage.ApplyCommentStore {
-	return &failingCommentUpsertStore{s.Storage.ApplyComments()}
+	return &failingCommentUpsertStore{ApplyCommentStore: s.Storage.ApplyComments(), healed: &s.healed}
 }
+
+func (s *failingCommentUpsertStorage) heal() { s.healed.Store(true) }
 
 // A volume-change rotation whose fresh comment posts to the PR but fails to be
 // recorded as the tracked comment must not freeze the prior comment: the
 // tracked row still points at the prior comment, so later progress edits land
-// there, and a frozen "superseded" body would fight those edits. The fresh
-// comment stays a point-in-time snapshot, the prior comment stays live, and no
-// further duplicate comments are posted for the same level.
-func TestE2EVolumeRotationUntrackedFreshCommentLeavesPriorCommentLive(t *testing.T) {
+// there, and a frozen "superseded" body would fight those edits. While the
+// outage lasts, later ticks retry only the tracking write (adoption) — never
+// another post — so duplicates stay bounded at one. Once storage heals, the
+// next tick adopts the already-live fresh comment: the tracked row (and the
+// freeze owed to the prior comment, recorded in the same write) points at it,
+// the prior comment is frozen with a link to its successor, and progress edits
+// move to the adopted comment. A volume revert after adoption rotates again
+// off the adopted comment, so an operator's revert always gets its own fresh
+// comment.
+func TestE2EVolumeRotationUntrackedFreshCommentAdoptedWhenStorageHeals(t *testing.T) {
 	ctx := t.Context()
 
-	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
-	require.NoError(t, err)
-	// svc.Close below owns closing the store's DB; this early-failure safety
-	// close is redundant once svc exists, so discard its guaranteed
-	// already-closed error.
-	t.Cleanup(func() { _ = schemabotDB.Close() })
-
-	st := mysqlstore.New(schemabotDB)
-
-	for _, stmt := range []string{
-		"DELETE FROM apply_comments",
-		"DELETE FROM tasks WHERE repository = 'org/repo-volume-untracked'",
-		"DELETE FROM applies WHERE repository = 'org/repo-volume-untracked'",
-		"DELETE FROM locks WHERE repository = 'org/repo-volume-untracked'",
-	} {
-		_, err = schemabotDB.ExecContext(ctx, stmt)
-		require.NoError(t, err)
-	}
-
-	lock := &storage.Lock{
-		DatabaseName: "e2e_volume_untracked_db",
-		DatabaseType: "mysql",
-		Repository:   "org/repo-volume-untracked",
-		PullRequest:  144,
-		Owner:        "org/repo-volume-untracked#144",
-	}
-	require.NoError(t, st.Locks().Acquire(ctx, lock))
-	lock, err = st.Locks().Get(ctx, "e2e_volume_untracked_db", "mysql")
-	require.NoError(t, err)
-
-	apply := &storage.Apply{
-		ApplyIdentifier: fmt.Sprintf("apply_e2e_volume_untracked_%d", time.Now().UnixNano()),
-		LockID:          lock.ID,
-		PlanID:          1,
-		Database:        "e2e_volume_untracked_db",
-		DatabaseType:    "mysql",
-		Repository:      "org/repo-volume-untracked",
-		PullRequest:     144,
-		Environment:     "staging",
-		InstallationID:  12345,
-		Engine:          "spirit",
-		State:           state.Apply.Running,
-	}
-	apply.SetOptions(storage.ApplyOptions{Volume: 3})
-	applyID, err := st.Applies().Create(ctx, apply)
-	require.NoError(t, err)
-	apply.ID = applyID
-	apply.LeaseOwner = "volume-untracked-test-driver"
-	apply.LeaseToken = "volume-untracked-test-token"
-	leaseAcquiredAt := time.Now()
-	apply.LeaseAcquiredAt = &leaseAcquiredAt
-	_, err = schemabotDB.ExecContext(ctx, `
-		UPDATE applies
-		SET lease_owner = ?, lease_token = ?, lease_acquired_at = ?
-		WHERE id = ?
-	`, apply.LeaseOwner, apply.LeaseToken, leaseAcquiredAt, applyID)
-	require.NoError(t, err)
-
-	now := time.Now()
-	task := &storage.Task{
-		TaskIdentifier:  fmt.Sprintf("task_e2e_volume_untracked_%d", now.UnixNano()),
-		ApplyID:         applyID,
-		PlanID:          1,
-		Database:        "e2e_volume_untracked_db",
-		DatabaseType:    "mysql",
-		Engine:          "spirit",
-		Repository:      "org/repo-volume-untracked",
-		PullRequest:     144,
-		Environment:     "staging",
-		State:           state.Task.Running,
-		TableName:       "users",
-		DDL:             "ALTER TABLE users ADD INDEX idx_email (email)",
-		DDLAction:       "alter",
-		RowsCopied:      500,
-		RowsTotal:       1000,
-		ProgressPercent: 50,
-		CreatedAt:       now,
-		UpdatedAt:       now,
-	}
-	_, err = st.Tasks().Create(ctx, task)
-	require.NoError(t, err)
-
-	installClient, capture := setupFakeGitHubForComments(t)
-	factory := &fakeClientFactory{client: installClient}
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
-	svc := api.New(st, &api.ServerConfig{}, map[string]tern.Client{}, logger)
-	t.Cleanup(func() { _ = svc.Close() })
-	h := NewHandler(svc, factory, nil, logger)
+	f := setupApplyCommentFixture(t, applyCommentFixtureParams{
+		repo:       "org/repo-volume-untracked",
+		pr:         144,
+		database:   "e2e_volume_untracked_db",
+		applyState: state.Apply.Running,
+		volume:     3,
+	})
+	st, apply, task, capture, h := f.st, f.apply, f.task, f.capture, f.handler
 
 	// Seed the tracked progress comment at the starting level through the real
-	// store, the way the accepted-apply handler does.
-	startingVolume := 3
-	h.postAndTrackComment(ctx, "org/repo-volume-untracked", 144, 12345, applyID, state.Comment.Progress, "Copying at volume 3", &startingVolume)
+	// store, the way the accepted-apply handler does (recording the level from
+	// the apply's options).
+	h.postAndTrackComment(ctx, "org/repo-volume-untracked", 144, 12345, apply, state.Comment.Progress, "Copying at volume 3")
 	initialProgressID := requireCommentCreate(t, capture)
 
 	// The observer's comment-tracking writes hit the failing store; reads and
 	// every other store pass through.
-	fake := clock.NewFake(now)
-	obs := NewCommentObserver(CommentObserverConfig{
-		GHClient:       factory,
-		Storage:        &failingCommentUpsertStorage{Storage: st},
-		Repo:           "org/repo-volume-untracked",
-		PR:             144,
-		InstallationID: 12345,
-		ApplyID:        applyID,
-		Logger:         logger,
-		Clock:          fake,
-	})
+	failingStorage := &failingCommentUpsertStorage{Storage: st}
+	fake := clock.NewFake(task.CreatedAt)
+	obs := f.newObserver(failingStorage, fake)
 
 	// The level change posts the fresh comment, but recording it as the tracked
 	// comment fails — the prior comment must not be frozen.
@@ -863,8 +756,10 @@ func TestE2EVolumeRotationUntrackedFreshCommentLeavesPriorCommentLive(t *testing
 	fake.Advance(activeInterval + time.Second)
 	obs.OnProgress(apply, []*storage.Task{task})
 
+	var freshProgressID int64
 	select {
 	case created := <-capture.creates:
+		freshProgressID = created.ID
 		assert.Contains(t, created.Body, "Volume: 5/11", "the fresh comment renders the new level")
 	case <-time.After(5 * time.Second):
 		t.Fatal("expected the volume change to post a fresh progress comment")
@@ -875,8 +770,9 @@ func TestE2EVolumeRotationUntrackedFreshCommentLeavesPriorCommentLive(t *testing
 	case <-time.After(100 * time.Millisecond):
 	}
 
-	// A later tick does not post a duplicate for the same level, and its
-	// progress edit lands on the prior comment — still the tracked one.
+	// While the outage lasts, a later tick retries only the tracking write — it
+	// does not post a duplicate for the same level — and its progress edit
+	// lands on the prior comment, still the tracked one.
 	task.RowsCopied = 700
 	task.ProgressPercent = 70
 	fake.Advance(activeInterval + time.Second)
@@ -890,6 +786,139 @@ func TestE2EVolumeRotationUntrackedFreshCommentLeavesPriorCommentLive(t *testing
 		t.Fatalf("an untracked rotation must not repost for the same level; got another new comment %d", created.ID)
 	case <-time.After(5 * time.Second):
 		t.Fatal("expected an in-place edit of the prior tracked comment")
+	}
+
+	// Once storage heals, the next tick adopts the already-live fresh comment
+	// instead of posting another: the prior comment is frozen pointing at its
+	// successor, and the tick's progress edit lands on the adopted comment.
+	failingStorage.heal()
+	task.RowsCopied = 800
+	task.ProgressPercent = 80
+	fake.Advance(activeInterval + time.Second)
+	obs.OnProgress(apply, []*storage.Task{task})
+
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, initialProgressID, edited.CommentID, "the freeze edit lands on the superseded comment")
+		assert.Contains(t, edited.Body, "Volume changed to **5/11**")
+		assert.Contains(t, edited.Body, fmt.Sprintf("#issuecomment-%d", freshProgressID), "the frozen comment links to its adopted successor")
+		assert.Contains(t, edited.Body, "<details>")
+	case created := <-capture.creates:
+		t.Fatalf("adoption must not post another comment; got %d", created.ID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the superseded progress comment to be frozen after adoption")
+	}
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, freshProgressID, edited.CommentID, "progress edits move to the adopted comment")
+		assert.Contains(t, edited.Body, "80%")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected a progress edit on the adopted comment")
+	}
+
+	// The tracked row now points at the adopted comment at the new level, with
+	// no freeze left owing.
+	prog, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Progress)
+	require.NoError(t, err)
+	require.NotNil(t, prog)
+	assert.Equal(t, freshProgressID, prog.GitHubCommentID)
+	require.NotNil(t, prog.PostedVolume)
+	assert.Equal(t, 5, *prog.PostedVolume)
+	assert.Nil(t, prog.PendingFreezeCommentID)
+
+	// An operator reverting the volume after adoption rotates again: a fresh
+	// comment at the reverted level, with the adopted comment frozen in turn.
+	apply.SetOptions(storage.ApplyOptions{Volume: 3})
+	fake.Advance(activeInterval + time.Second)
+	obs.OnProgress(apply, []*storage.Task{task})
+
+	var revertedProgressID int64
+	select {
+	case created := <-capture.creates:
+		revertedProgressID = created.ID
+		assert.Contains(t, created.Body, "Volume: 3/11", "the revert posts a fresh comment at the reverted level")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected a volume revert after adoption to rotate again")
+	}
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, freshProgressID, edited.CommentID, "the adopted comment is frozen in turn")
+		assert.Contains(t, edited.Body, "Volume changed to **3/11**")
+		assert.Contains(t, edited.Body, fmt.Sprintf("#issuecomment-%d", revertedProgressID), "the frozen comment links to the revert's fresh comment")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the adopted comment to be frozen after the revert")
+	}
+}
+
+// A rotation that tracked its fresh comment but died before the freeze edit
+// landed leaves the pending-freeze marker on the tracked row. A later drive's
+// observer — with no in-memory state from the rotation — reconciles it on its
+// first volume check: the superseded comment is frozen pointing at its
+// successor and the marker is cleared, without posting anything new.
+func TestE2EVolumeRotationReconcilesPendingFreezeFromPriorDrive(t *testing.T) {
+	ctx := t.Context()
+
+	f := setupApplyCommentFixture(t, applyCommentFixtureParams{
+		repo:       "org/repo-volume-freeze",
+		pr:         145,
+		database:   "e2e_volume_freeze_db",
+		applyState: state.Apply.Running,
+		volume:     5,
+	})
+	st, apply, task, capture, h := f.st, f.apply, f.task, f.capture, f.handler
+
+	// Seed the two comments the prior drive left on the PR: the superseded
+	// comment still showing live progress, and the fresh comment it rotated to.
+	h.postAndTrackComment(ctx, "org/repo-volume-freeze", 145, 12345, apply, state.Comment.Progress, "Copying at volume 3")
+	supersededID := requireCommentCreate(t, capture)
+	h.postAndTrackComment(ctx, "org/repo-volume-freeze", 145, 12345, apply, state.Comment.Progress, "Copying at volume 5")
+	freshID := requireCommentCreate(t, capture)
+
+	// The prior drive recorded the freeze it owed in the same write that
+	// tracked the fresh comment, then died before the freeze edit landed.
+	postedVolume := 5
+	require.NoError(t, st.ApplyComments().Upsert(ctx, &storage.ApplyComment{
+		ApplyID:                apply.ID,
+		CommentState:           state.Comment.Progress,
+		GitHubCommentID:        freshID,
+		PostedVolume:           &postedVolume,
+		PendingFreezeCommentID: &supersededID,
+	}))
+
+	fake := clock.NewFake(task.CreatedAt)
+	obs := f.newObserver(st, fake)
+
+	// The new drive's first tick reconciles the owed freeze even though the
+	// levels already match — no rotation, no new comment.
+	fake.Advance(activeInterval + time.Second)
+	obs.OnProgress(apply, []*storage.Task{task})
+
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, supersededID, edited.CommentID, "the reconciled freeze lands on the superseded comment")
+		assert.Contains(t, edited.Body, "Volume changed to **5/11**")
+		assert.Contains(t, edited.Body, fmt.Sprintf("#issuecomment-%d", freshID), "the frozen comment links to its successor")
+		assert.Contains(t, edited.Body, "Copying at volume 3", "the superseded body is preserved inside the fold")
+	case created := <-capture.creates:
+		t.Fatalf("reconciling a pending freeze must not post a new comment; got %d", created.ID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the pending freeze to be reconciled on the first tick")
+	}
+
+	// The marker is cleared once the freeze lands; the row still tracks the
+	// fresh comment.
+	prog, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Progress)
+	require.NoError(t, err)
+	require.NotNil(t, prog)
+	assert.Nil(t, prog.PendingFreezeCommentID)
+	assert.Equal(t, freshID, prog.GitHubCommentID)
+
+	// The same tick's progress edit lands on the tracked fresh comment.
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, freshID, edited.CommentID, "the tick's progress edit lands on the tracked comment")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the tick's progress edit on the tracked comment")
 	}
 }
 
@@ -1058,6 +1087,7 @@ func TestE2EApplyCommentUpsertOnResume(t *testing.T) {
 	}
 	applyID, err := st.Applies().Create(ctx, apply)
 	require.NoError(t, err)
+	apply.ID = applyID
 
 	// Simulate old comment IDs from previous run
 	require.NoError(t, st.ApplyComments().Upsert(ctx, &storage.ApplyComment{
@@ -1079,7 +1109,7 @@ func TestE2EApplyCommentUpsertOnResume(t *testing.T) {
 	h := NewHandler(svc, factory, nil, logger)
 
 	// Resume: post new progress comment (upsert should replace old ID)
-	h.postAndTrackComment(ctx, "org/repo-resume", 43, 12345, applyID, state.Comment.Progress, "Resumed progress", nil)
+	h.postAndTrackComment(ctx, "org/repo-resume", 43, 12345, apply, state.Comment.Progress, "Resumed progress")
 
 	var newProgressID int64
 	select {
@@ -1098,7 +1128,7 @@ func TestE2EApplyCommentUpsertOnResume(t *testing.T) {
 	assert.NotEqual(t, int64(111), comment.GitHubCommentID, "old comment ID should be replaced")
 
 	// Post new summary (upsert replaces old ID)
-	h.postAndTrackComment(ctx, "org/repo-resume", 43, 12345, applyID, state.Comment.Summary, "Resumed summary", nil)
+	h.postAndTrackComment(ctx, "org/repo-resume", 43, 12345, apply, state.Comment.Summary, "Resumed summary")
 
 	var newSummaryID int64
 	select {

--- a/pkg/webhook/apply_execute.go
+++ b/pkg/webhook/apply_execute.go
@@ -204,7 +204,7 @@ func (h *Handler) executeApply(
 		State:       apply.State,
 		Engine:      schemaResult.Type,
 	})
-	h.postInitialProgressComment(ctx, repo, pr, installationID, applyID, progressBody)
+	h.postInitialProgressComment(ctx, repo, pr, installationID, apply, progressBody)
 
 	// Update stored check state to in_progress (transitions action_required to in_progress).
 	if err := h.updateCheckRecordForApplyStart(ctx, client, repo, pr, schemaResult, environment, applyID); err != nil {

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -72,6 +72,26 @@ type CommentObserver struct {
 	// be posting the initial progress comment concurrently with early ticks.
 	trackedPostedVolume      int
 	trackedPostedVolumeKnown bool
+
+	// pendingRotation remembers a fresh progress comment that is live on the PR
+	// but whose tracking write failed, so later ticks adopt it (retry the write
+	// with the known comment ID) instead of posting a duplicate.
+	pendingRotation *pendingProgressRotation
+}
+
+// pendingProgressRotation identifies a volume-rotation progress comment that
+// was posted but not tracked: the comment exists on the PR while the stored
+// row still points at its predecessor. Adoption retries only the tracking
+// write — never another post — so duplicates stay bounded, and a level change
+// while the comment was untracked (an operator reverting the volume) is
+// re-detected against the adopted level on the same tick.
+type pendingProgressRotation struct {
+	// commentID is the posted comment's GitHub ID.
+	commentID int64
+	// volume is the level the comment was posted at.
+	volume int
+	// supersededCommentID is the prior tracked comment, still owed its freeze.
+	supersededCommentID int64
 }
 
 const (
@@ -213,11 +233,14 @@ func (o *CommentObserver) OnProgress(apply *storage.Apply, tasks []*storage.Task
 	}
 
 	// Post cutover comment when entering cutting_over with defer_cutover,
-	// but only if one hasn't been posted already.
+	// but only if one hasn't been posted already. A failed post leaves
+	// hasCutoverComment unset so the next tick retries, instead of muting the
+	// observer for the rest of the drive over one transient GitHub error.
 	if currentState == state.Apply.CuttingOver && o.shouldDeferCutover(apply) && !o.hasCutoverComment {
 		body := o.formatStatusComment(apply, tasks)
-		o.postAndTrackComment(apply, state.Comment.Cutover, body)
-		o.hasCutoverComment = true
+		if _, posted, _ := o.postAndTrackComment(apply, state.Comment.Cutover, body, nil); posted {
+			o.hasCutoverComment = true
+		}
 		o.lastState = currentState
 		return
 	}
@@ -342,7 +365,7 @@ func (o *CommentObserver) OnTerminal(apply *storage.Apply, tasks []*storage.Task
 		// to it rather than post a duplicate, partial summary.
 		if o.shouldPublishSeparateSummary(apply, ops, opsErr) {
 			summaryBody := o.summaryCommentFromOps(ctx, apply, ops, opsErr, tasks, shardsByTable)
-			o.postAndTrackComment(apply, state.Comment.Summary, summaryBody)
+			o.postAndTrackComment(apply, state.Comment.Summary, summaryBody, nil)
 		}
 	}
 
@@ -639,7 +662,13 @@ func (o *CommentObserver) rotateProgressCommentForResume(apply *storage.Apply, t
 	}
 
 	body := o.formatStatusComment(apply, tasks)
-	o.postAndTrackComment(apply, state.Comment.Progress, body)
+	if _, posted, _ := o.postAndTrackComment(apply, state.Comment.Progress, body, nil); !posted {
+		// postAndTrackComment logged the failure. The summary marker is left in
+		// place — it is the durable signal that a resume rotation is owed — so
+		// the next tick retries instead of consuming the marker for a comment
+		// that never landed.
+		return false
+	}
 	o.resumeRotated = true
 
 	if err := o.stor.ApplyComments().Supersede(o.contextWithApplyLease(ctx, apply), o.applyID, state.Comment.Summary); err != nil {
@@ -654,22 +683,30 @@ func (o *CommentObserver) rotateProgressCommentForResume(apply *storage.Apply, t
 // rotateProgressCommentForVolumeChange posts a fresh progress comment when the
 // apply's volume level no longer matches the level the tracked progress comment
 // was posted at — the durable sign that a requested volume change has been
-// applied. The fresh comment records the new level via postAndTrackComment, so
-// a later tick sees matching levels and does not rotate again; the prior
-// comment is frozen with a note pointing at its successor. Returns true when it
-// rotated.
+// applied. The fresh comment is posted and tracked (with the freeze it owes its
+// predecessor recorded in the same write), so a later tick sees matching levels
+// and does not rotate again; the prior comment is frozen with a note pointing
+// at its successor. Returns true when it rotated.
 func (o *CommentObserver) rotateProgressCommentForVolumeChange(apply *storage.Apply, tasks []*storage.Task) bool {
 	currentVolume := apply.GetOptions().Volume
 	if currentVolume == 0 {
 		// The apply has no explicit volume level to compare — nothing changed.
 		return false
 	}
+	if o.pendingRotation != nil {
+		// A prior tick's fresh comment is live on the PR but untracked. Adopt
+		// it before considering another rotation so the tracking write is
+		// retried with the known comment ID instead of posting a duplicate.
+		if !o.adoptPendingRotationComment(apply) {
+			return false
+		}
+		// Fall through: the adopted level may already mismatch again (an
+		// operator changed the volume while the comment was untracked), which
+		// the checks below re-detect against the adopted level.
+	}
 	if o.volumeRotatedTo == currentVolume {
-		// This observer already rotated for this level. Guard against posting
-		// duplicate fresh comments on later ticks if the tracked-row update
-		// failed to land after the post; a fresh observer on a later drive
-		// claim starts with this unset, bounding any duplicate to one per
-		// drive rather than one per tick.
+		// This observer already rotated for this level — answered from memory
+		// without a storage read.
 		return false
 	}
 	if o.trackedPostedVolumeKnown && o.trackedPostedVolume == currentVolume {
@@ -687,11 +724,41 @@ func (o *CommentObserver) rotateProgressCommentForVolumeChange(apply *storage.Ap
 		o.logError(apply, "observer: failed to load tracked progress comment before volume rotation", "error", err)
 		return false
 	}
-	if tracked == nil || tracked.PostedVolume == nil {
-		// No tracked progress comment yet, or the row predates volume tracking:
-		// there is no recorded level to compare, so keep editing in place. The
-		// next posted comment records the current level.
+	if tracked == nil {
+		// No tracked progress comment yet — the handler may still be posting
+		// the initial one. Nothing to rotate away from; the next posted comment
+		// records the current level.
+		o.logInfo(apply, "observer: no tracked progress comment yet; skipping volume-rotation check",
+			"volume", currentVolume)
 		return false
+	}
+	if tracked.PostedVolume == nil {
+		// The row predates volume tracking, so there is no recorded level to
+		// compare. Backfill the current level so the next applied volume change
+		// rotates (and so this check answers from the cache instead of
+		// re-reading storage every tick for the apply's remaining lifetime).
+		backfill := &storage.ApplyComment{
+			ApplyID:         o.applyID,
+			CommentState:    state.Comment.Progress,
+			GitHubCommentID: tracked.GitHubCommentID,
+			PostedVolume:    &currentVolume,
+		}
+		if err := o.stor.ApplyComments().Upsert(o.contextWithApplyLease(ctx, apply), backfill); err != nil {
+			o.logError(apply, "observer: failed to backfill tracked progress comment volume; volume rotation stays disabled for this apply until the backfill lands",
+				"volume", currentVolume, "error", err)
+			return false
+		}
+		o.trackedPostedVolume = currentVolume
+		o.trackedPostedVolumeKnown = true
+		o.logInfo(apply, "observer: backfilled tracked progress comment volume for a row predating volume tracking; the next applied volume change rotates",
+			"volume", currentVolume)
+		return false
+	}
+	if tracked.PendingFreezeCommentID != nil {
+		// A superseded comment from an earlier rotation is still owed its
+		// frozen rendering — the freeze edit failed or the pod died before it
+		// landed. Retry it now; on success the marker is cleared.
+		o.freezeSupersededProgressComment(apply, *tracked.PendingFreezeCommentID, tracked.GitHubCommentID, *tracked.PostedVolume)
 	}
 	o.trackedPostedVolume = *tracked.PostedVolume
 	o.trackedPostedVolumeKnown = true
@@ -702,27 +769,62 @@ func (o *CommentObserver) rotateProgressCommentForVolumeChange(apply *storage.Ap
 	}
 
 	body := o.formatStatusComment(apply, tasks)
-	newCommentID, posted, trackedNew := o.postAndTrackComment(apply, state.Comment.Progress, body)
+	newCommentID, posted, trackedNew := o.postAndTrackComment(apply, state.Comment.Progress, body, &tracked.GitHubCommentID)
 	if !posted {
 		// postAndTrackComment logged the failure; the level mismatch persists,
 		// so the next tick retries the rotation.
 		return false
 	}
-	o.volumeRotatedTo = currentVolume
 	if !trackedNew {
 		// The fresh comment is on the PR, but the tracked row still points at
-		// the prior comment, so later edits continue to land there. Freezing
-		// the prior comment would fight those edits with a stale "superseded"
-		// body, so leave it live; the fresh comment stays a point-in-time
-		// snapshot, and a later drive's observer re-detects the level mismatch
-		// and rotates again.
-		o.logError(apply, "observer: fresh progress comment posted for volume change but not tracked; progress edits continue on the prior comment",
+		// the prior comment. Remember it so later ticks retry only the tracking
+		// write — adoption — instead of posting a duplicate; until it lands,
+		// progress edits continue on the prior comment.
+		o.pendingRotation = &pendingProgressRotation{
+			commentID:           newCommentID,
+			volume:              currentVolume,
+			supersededCommentID: tracked.GitHubCommentID,
+		}
+		o.logError(apply, "observer: fresh progress comment posted for volume change but not tracked; progress edits continue on the prior comment until the next tick adopts it",
 			"volume", currentVolume, "github_comment_id", newCommentID)
 		return true
 	}
+	o.volumeRotatedTo = currentVolume
 	o.logInfo(apply, "observer: posted fresh progress comment for volume change",
 		"previous_volume", *tracked.PostedVolume, "volume", currentVolume)
 	o.freezeSupersededProgressComment(apply, tracked.GitHubCommentID, newCommentID, currentVolume)
+	return true
+}
+
+// adoptPendingRotationComment retries the tracking write for a fresh progress
+// comment that was posted but never recorded, pointing the tracked row (and
+// the freeze owed to its predecessor) at the already-live comment. Returns
+// true when the row now tracks the pending comment; on failure the pending
+// record is kept so the next tick retries — no path posts another comment.
+func (o *CommentObserver) adoptPendingRotationComment(apply *storage.Apply) bool {
+	p := o.pendingRotation
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	comment := &storage.ApplyComment{
+		ApplyID:                o.applyID,
+		CommentState:           state.Comment.Progress,
+		GitHubCommentID:        p.commentID,
+		PostedVolume:           &p.volume,
+		PendingFreezeCommentID: &p.supersededCommentID,
+	}
+	if err := o.stor.ApplyComments().Upsert(o.contextWithApplyLease(ctx, apply), comment); err != nil {
+		o.logError(apply, "observer: failed to adopt posted-but-untracked progress comment; progress edits continue on the prior comment until a retry lands",
+			"github_comment_id", p.commentID, "volume", p.volume, "error", err)
+		return false
+	}
+	o.pendingRotation = nil
+	o.trackedPostedVolume = p.volume
+	o.trackedPostedVolumeKnown = true
+	o.volumeRotatedTo = p.volume
+	o.logInfo(apply, "observer: adopted posted-but-untracked progress comment; progress edits now land on it",
+		"github_comment_id", p.commentID, "volume", p.volume)
+	o.freezeSupersededProgressComment(apply, p.supersededCommentID, p.commentID, p.volume)
 	return true
 }
 
@@ -731,9 +833,10 @@ func (o *CommentObserver) rotateProgressCommentForVolumeChange(apply *storage.Ap
 // the comment that replaced it. Collapsing rather than deleting keeps the
 // pre-change progress on the PR as a record while decluttering the timeline;
 // without the fold a reader has no way to tell a frozen comment from a live
-// one. Best-effort: on failure the old comment simply stops receiving edits,
-// which the fold would only have made explicit, so errors are logged and
-// progress continues on the new comment.
+// one. A failure leaves the tracked row's pending-freeze marker in place (it
+// is written alongside the successor's tracking), so a later tick or a later
+// drive's observer retries; the marker is cleared only once the frozen
+// rendering is on GitHub.
 func (o *CommentObserver) freezeSupersededProgressComment(apply *storage.Apply, oldCommentID, newCommentID int64, volume int) {
 	if !o.leaseStillOwnsObserver(apply, "create GitHub client before freezing superseded comment") {
 		return
@@ -752,29 +855,40 @@ func (o *CommentObserver) freezeSupersededProgressComment(apply *storage.Apply, 
 			"error", err, "github_comment_id", oldCommentID)
 		return
 	}
-	if !o.leaseStillOwnsObserver(apply, "freeze superseded progress comment") {
-		return
+	if !templates.IsVolumeSupersededProgressComment(oldBody) {
+		// A retry after a failed marker clear sees the frozen body already on
+		// GitHub; re-rendering would fold the frozen body inside another fold.
+		if !o.leaseStillOwnsObserver(apply, "freeze superseded progress comment") {
+			return
+		}
+		frozen := templates.RenderVolumeSupersededProgressComment(templates.VolumeSupersededProgressData{
+			Volume:       volume,
+			Repo:         o.repo,
+			PR:           o.pr,
+			NewCommentID: newCommentID,
+			PreviousBody: oldBody,
+		})
+		if err := client.EditIssueComment(ctx, o.repo, oldCommentID, frozen); err != nil {
+			o.logError(apply, "observer: failed to freeze superseded progress comment; the pending-freeze marker stays set and the next observer pass that reads the tracked row retries",
+				"error", err, "github_comment_id", oldCommentID)
+			return
+		}
 	}
-	frozen := templates.RenderVolumeSupersededProgressComment(templates.VolumeSupersededProgressData{
-		Volume:       volume,
-		Repo:         o.repo,
-		PR:           o.pr,
-		NewCommentID: newCommentID,
-		PreviousBody: oldBody,
-	})
-	if err := client.EditIssueComment(ctx, o.repo, oldCommentID, frozen); err != nil {
-		o.logError(apply, "observer: failed to freeze superseded progress comment",
+	if err := o.stor.ApplyComments().ClearPendingFreeze(o.contextWithApplyLease(ctx, apply), o.applyID, state.Comment.Progress); err != nil {
+		o.logError(apply, "observer: failed to clear pending-freeze marker after freezing superseded progress comment; a later retry finds the comment already frozen and clears the marker",
 			"error", err, "github_comment_id", oldCommentID)
 	}
 }
 
 // postAndTrackComment creates a comment and stores its ID, recording the
 // apply's volume level on progress comments so a later applied volume change
-// is detectable. Returns the GitHub comment ID, whether the post landed on the
-// PR, and whether the tracking row was updated to point at it — a posted but
-// untracked comment exists on the PR while later edits still target the prior
-// comment.
-func (o *CommentObserver) postAndTrackComment(apply *storage.Apply, commentState string, body string) (commentID int64, posted, tracked bool) {
+// is detectable. pendingFreezeCommentID, when non-nil, records in the same
+// tracking write that the named predecessor comment is still owed its frozen
+// rendering; pass nil for posts that supersede nothing. Returns the GitHub
+// comment ID, whether the post landed on the PR, and whether the tracking row
+// was updated to point at it — a posted but untracked comment exists on the PR
+// while later edits still target the prior comment.
+func (o *CommentObserver) postAndTrackComment(apply *storage.Apply, commentState string, body string, pendingFreezeCommentID *int64) (commentID int64, posted, tracked bool) {
 	if !o.leaseStillOwnsObserver(apply, "create GitHub client before post") {
 		return 0, false, false
 	}
@@ -796,13 +910,17 @@ func (o *CommentObserver) postAndTrackComment(apply *storage.Apply, commentState
 		return 0, false, false
 	}
 	if !o.leaseStillOwnsObserver(apply, "record posted GitHub comment") {
-		return 0, false, false
+		// The comment is live on the PR; only the tracking write is being
+		// skipped. Report it posted-but-untracked — the contract callers use to
+		// bound duplicates — rather than pretending the post never happened.
+		return commentID, true, false
 	}
 
 	comment := &storage.ApplyComment{
-		ApplyID:         o.applyID,
-		CommentState:    commentState,
-		GitHubCommentID: commentID,
+		ApplyID:                o.applyID,
+		CommentState:           commentState,
+		GitHubCommentID:        commentID,
+		PendingFreezeCommentID: pendingFreezeCommentID,
 	}
 	if commentState == state.Comment.Progress {
 		level := apply.GetOptions().Volume

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -2,7 +2,6 @@ package webhook
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/webhook/templates"
 )
 
 // CommentObserver implements tern.ProgressObserver by posting PR comments.
@@ -726,10 +726,13 @@ func (o *CommentObserver) freezeSupersededProgressComment(apply *storage.Apply, 
 	if !o.leaseStillOwnsObserver(apply, "freeze superseded progress comment") {
 		return
 	}
-	frozen := fmt.Sprintf(
-		"⏩ Volume changed to **%d/%d** — progress continues in [a new progress comment](https://github.com/%s/pull/%d#issuecomment-%d).\n\n"+
-			"<details>\n<summary>Progress before the volume change</summary>\n\n%s\n\n</details>\n",
-		volume, storage.MaxVolume, o.repo, o.pr, newCommentID, oldBody)
+	frozen := templates.RenderVolumeSupersededProgressComment(templates.VolumeSupersededProgressData{
+		Volume:       volume,
+		Repo:         o.repo,
+		PR:           o.pr,
+		NewCommentID: newCommentID,
+		PreviousBody: oldBody,
+	})
 	if err := client.EditIssueComment(ctx, o.repo, oldCommentID, frozen); err != nil {
 		o.logError(apply, "observer: failed to freeze superseded progress comment",
 			"error", err, "github_comment_id", oldCommentID)

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -60,6 +61,7 @@ type CommentObserver struct {
 	stagnantTicks     int
 	hasCutoverComment bool
 	resumeRotated     bool
+	volumeRotatedTo   int
 }
 
 const (
@@ -222,6 +224,17 @@ func (o *CommentObserver) OnProgress(apply *storage.Apply, tasks []*storage.Task
 	// copy and leave the prior comment frozen at "Stopped" as the record of where
 	// the apply paused.
 	if !state.IsTerminalApplyState(apply.State) && o.rotateProgressCommentForResume(apply, tasks) {
+		o.lastState = currentState
+		o.lastProgressPost = now
+		o.stagnantTicks = 0
+		return
+	}
+
+	// An applied volume change likewise gets a fresh progress comment: a new
+	// comment at the bottom of the PR timeline is where operators look for the
+	// effect of a command they just issued, rather than re-reading an older
+	// comment for an edited level.
+	if !state.IsTerminalApplyState(apply.State) && o.rotateProgressCommentForVolumeChange(apply, tasks) {
 		o.lastState = currentState
 		o.lastProgressPost = now
 		o.stagnantTicks = 0
@@ -628,9 +641,72 @@ func (o *CommentObserver) rotateProgressCommentForResume(apply *storage.Apply, t
 	return true
 }
 
-// postAndTrackComment creates a comment and stores its ID.
-func (o *CommentObserver) postAndTrackComment(apply *storage.Apply, commentState string, body string) {
-	if !o.leaseStillOwnsObserver(apply, "create GitHub client before post") {
+// rotateProgressCommentForVolumeChange posts a fresh progress comment when the
+// apply's volume level no longer matches the level the tracked progress comment
+// was posted at — the durable sign that a requested volume change has been
+// applied. The fresh comment records the new level via postAndTrackComment, so
+// a later tick sees matching levels and does not rotate again; the prior
+// comment is frozen with a note pointing at its successor. Returns true when it
+// rotated.
+func (o *CommentObserver) rotateProgressCommentForVolumeChange(apply *storage.Apply, tasks []*storage.Task) bool {
+	currentVolume := apply.GetOptions().Volume
+	if currentVolume == 0 {
+		// The apply has no explicit volume level to compare — nothing changed.
+		return false
+	}
+	if o.volumeRotatedTo == currentVolume {
+		// This observer already rotated for this level. Guard against posting
+		// duplicate fresh comments on later ticks if the tracked-row update
+		// failed to land after the post; a fresh observer on a later drive
+		// claim starts with this unset, bounding any duplicate to one per
+		// drive rather than one per tick.
+		return false
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tracked, err := o.stor.ApplyComments().Get(ctx, o.applyID, state.Comment.Progress)
+	if err != nil {
+		o.logError(apply, "observer: failed to load tracked progress comment before volume rotation", "error", err)
+		return false
+	}
+	if tracked == nil || tracked.PostedVolume == nil {
+		// No tracked progress comment yet, or the row predates volume tracking:
+		// there is no recorded level to compare, so keep editing in place. The
+		// next posted comment records the current level.
+		return false
+	}
+	if *tracked.PostedVolume == currentVolume {
+		// The level is unchanged since the comment was posted — the common
+		// path on every progress tick.
+		return false
+	}
+
+	body := o.formatStatusComment(apply, tasks)
+	newCommentID, posted := o.postAndTrackComment(apply, state.Comment.Progress, body)
+	if !posted {
+		// postAndTrackComment logged the failure; the level mismatch persists,
+		// so the next tick retries the rotation.
+		return false
+	}
+	o.volumeRotatedTo = currentVolume
+	o.logInfo(apply, "observer: posted fresh progress comment for volume change",
+		"previous_volume", *tracked.PostedVolume, "volume", currentVolume)
+	o.freezeSupersededProgressComment(apply, tracked.GitHubCommentID, newCommentID, currentVolume)
+	return true
+}
+
+// freezeSupersededProgressComment collapses a progress comment that is no
+// longer tracked into a folded details block whose summary points readers at
+// the comment that replaced it. Collapsing rather than deleting keeps the
+// pre-change progress on the PR as a record while decluttering the timeline;
+// without the fold a reader has no way to tell a frozen comment from a live
+// one. Best-effort: on failure the old comment simply stops receiving edits,
+// which the fold would only have made explicit, so errors are logged and
+// progress continues on the new comment.
+func (o *CommentObserver) freezeSupersededProgressComment(apply *storage.Apply, oldCommentID, newCommentID int64, volume int) {
+	if !o.leaseStillOwnsObserver(apply, "create GitHub client before freezing superseded comment") {
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -638,20 +714,54 @@ func (o *CommentObserver) postAndTrackComment(apply *storage.Apply, commentState
 
 	client, err := o.ghClient.ForInstallation(o.installationID)
 	if err != nil {
-		o.logError(apply, "observer: failed to create GitHub client", "error", err)
+		o.logError(apply, "observer: failed to create GitHub client to freeze superseded progress comment", "error", err)
 		return
 	}
-	if !o.leaseStillOwnsObserver(apply, "post GitHub comment") {
+	oldBody, err := client.GetIssueComment(ctx, o.repo, oldCommentID)
+	if err != nil {
+		o.logError(apply, "observer: failed to load superseded progress comment before freezing it",
+			"error", err, "github_comment_id", oldCommentID)
 		return
+	}
+	if !o.leaseStillOwnsObserver(apply, "freeze superseded progress comment") {
+		return
+	}
+	frozen := fmt.Sprintf(
+		"⏩ Volume changed to **%d/%d** — progress continues in [a new progress comment](https://github.com/%s/pull/%d#issuecomment-%d).\n\n"+
+			"<details>\n<summary>Progress before the volume change</summary>\n\n%s\n\n</details>\n",
+		volume, storage.MaxVolume, o.repo, o.pr, newCommentID, oldBody)
+	if err := client.EditIssueComment(ctx, o.repo, oldCommentID, frozen); err != nil {
+		o.logError(apply, "observer: failed to freeze superseded progress comment",
+			"error", err, "github_comment_id", oldCommentID)
+	}
+}
+
+// postAndTrackComment creates a comment and stores its ID, recording the
+// apply's volume level on progress comments so a later applied volume change
+// is detectable. Returns the GitHub comment ID and whether the post succeeded.
+func (o *CommentObserver) postAndTrackComment(apply *storage.Apply, commentState string, body string) (int64, bool) {
+	if !o.leaseStillOwnsObserver(apply, "create GitHub client before post") {
+		return 0, false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	client, err := o.ghClient.ForInstallation(o.installationID)
+	if err != nil {
+		o.logError(apply, "observer: failed to create GitHub client", "error", err)
+		return 0, false
+	}
+	if !o.leaseStillOwnsObserver(apply, "post GitHub comment") {
+		return 0, false
 	}
 
 	commentID, err := client.CreateIssueComment(ctx, o.repo, o.pr, o.renderPRComment(body))
 	if err != nil {
 		o.logError(apply, "observer: failed to post comment", "error", err, "comment_state", commentState)
-		return
+		return 0, false
 	}
 	if !o.leaseStillOwnsObserver(apply, "record posted GitHub comment") {
-		return
+		return 0, false
 	}
 
 	comment := &storage.ApplyComment{
@@ -659,9 +769,14 @@ func (o *CommentObserver) postAndTrackComment(apply *storage.Apply, commentState
 		CommentState:    commentState,
 		GitHubCommentID: commentID,
 	}
+	if commentState == state.Comment.Progress {
+		level := apply.GetOptions().Volume
+		comment.PostedVolume = &level
+	}
 	if err := o.stor.ApplyComments().Upsert(o.contextWithApplyLease(ctx, apply), comment); err != nil {
 		o.logError(apply, "observer: failed to store comment ID", "error", err, "comment_state", commentState)
 	}
+	return commentID, true
 }
 
 func (o *CommentObserver) renderPRComment(body string) string {

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -62,6 +62,16 @@ type CommentObserver struct {
 	hasCutoverComment bool
 	resumeRotated     bool
 	volumeRotatedTo   int
+
+	// trackedPostedVolume caches the tracked progress comment's recorded level
+	// (valid only when trackedPostedVolumeKnown) so the per-tick volume-change
+	// check answers from memory instead of a storage read under the mutex. The
+	// cache is safe for the duration of a drive: while this observer's apply
+	// holds its lease, the observer is the only writer of the tracked progress
+	// row. A missing row or nil level is never cached — the handler may still
+	// be posting the initial progress comment concurrently with early ticks.
+	trackedPostedVolume      int
+	trackedPostedVolumeKnown bool
 }
 
 const (
@@ -662,6 +672,12 @@ func (o *CommentObserver) rotateProgressCommentForVolumeChange(apply *storage.Ap
 		// drive rather than one per tick.
 		return false
 	}
+	if o.trackedPostedVolumeKnown && o.trackedPostedVolume == currentVolume {
+		// The tracked comment already records the current level — the common
+		// path on every progress tick, answered from the cache without a
+		// storage read.
+		return false
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -677,20 +693,33 @@ func (o *CommentObserver) rotateProgressCommentForVolumeChange(apply *storage.Ap
 		// next posted comment records the current level.
 		return false
 	}
+	o.trackedPostedVolume = *tracked.PostedVolume
+	o.trackedPostedVolumeKnown = true
 	if *tracked.PostedVolume == currentVolume {
 		// The level is unchanged since the comment was posted — the common
-		// path on every progress tick.
+		// path on the first tick of a drive, before the cache is primed.
 		return false
 	}
 
 	body := o.formatStatusComment(apply, tasks)
-	newCommentID, posted := o.postAndTrackComment(apply, state.Comment.Progress, body)
+	newCommentID, posted, trackedNew := o.postAndTrackComment(apply, state.Comment.Progress, body)
 	if !posted {
 		// postAndTrackComment logged the failure; the level mismatch persists,
 		// so the next tick retries the rotation.
 		return false
 	}
 	o.volumeRotatedTo = currentVolume
+	if !trackedNew {
+		// The fresh comment is on the PR, but the tracked row still points at
+		// the prior comment, so later edits continue to land there. Freezing
+		// the prior comment would fight those edits with a stale "superseded"
+		// body, so leave it live; the fresh comment stays a point-in-time
+		// snapshot, and a later drive's observer re-detects the level mismatch
+		// and rotates again.
+		o.logError(apply, "observer: fresh progress comment posted for volume change but not tracked; progress edits continue on the prior comment",
+			"volume", currentVolume, "github_comment_id", newCommentID)
+		return true
+	}
 	o.logInfo(apply, "observer: posted fresh progress comment for volume change",
 		"previous_volume", *tracked.PostedVolume, "volume", currentVolume)
 	o.freezeSupersededProgressComment(apply, tracked.GitHubCommentID, newCommentID, currentVolume)
@@ -741,10 +770,13 @@ func (o *CommentObserver) freezeSupersededProgressComment(apply *storage.Apply, 
 
 // postAndTrackComment creates a comment and stores its ID, recording the
 // apply's volume level on progress comments so a later applied volume change
-// is detectable. Returns the GitHub comment ID and whether the post succeeded.
-func (o *CommentObserver) postAndTrackComment(apply *storage.Apply, commentState string, body string) (int64, bool) {
+// is detectable. Returns the GitHub comment ID, whether the post landed on the
+// PR, and whether the tracking row was updated to point at it — a posted but
+// untracked comment exists on the PR while later edits still target the prior
+// comment.
+func (o *CommentObserver) postAndTrackComment(apply *storage.Apply, commentState string, body string) (commentID int64, posted, tracked bool) {
 	if !o.leaseStillOwnsObserver(apply, "create GitHub client before post") {
-		return 0, false
+		return 0, false, false
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -752,19 +784,19 @@ func (o *CommentObserver) postAndTrackComment(apply *storage.Apply, commentState
 	client, err := o.ghClient.ForInstallation(o.installationID)
 	if err != nil {
 		o.logError(apply, "observer: failed to create GitHub client", "error", err)
-		return 0, false
+		return 0, false, false
 	}
 	if !o.leaseStillOwnsObserver(apply, "post GitHub comment") {
-		return 0, false
+		return 0, false, false
 	}
 
-	commentID, err := client.CreateIssueComment(ctx, o.repo, o.pr, o.renderPRComment(body))
+	commentID, err = client.CreateIssueComment(ctx, o.repo, o.pr, o.renderPRComment(body))
 	if err != nil {
 		o.logError(apply, "observer: failed to post comment", "error", err, "comment_state", commentState)
-		return 0, false
+		return 0, false, false
 	}
 	if !o.leaseStillOwnsObserver(apply, "record posted GitHub comment") {
-		return 0, false
+		return 0, false, false
 	}
 
 	comment := &storage.ApplyComment{
@@ -778,8 +810,18 @@ func (o *CommentObserver) postAndTrackComment(apply *storage.Apply, commentState
 	}
 	if err := o.stor.ApplyComments().Upsert(o.contextWithApplyLease(ctx, apply), comment); err != nil {
 		o.logError(apply, "observer: failed to store comment ID", "error", err, "comment_state", commentState)
+		if commentState == state.Comment.Progress {
+			// The tracked row still describes the prior comment; drop the
+			// cached level so the next volume check re-reads storage.
+			o.trackedPostedVolumeKnown = false
+		}
+		return commentID, true, false
 	}
-	return commentID, true
+	if commentState == state.Comment.Progress {
+		o.trackedPostedVolume = *comment.PostedVolume
+		o.trackedPostedVolumeKnown = true
+	}
+	return commentID, true, true
 }
 
 func (o *CommentObserver) renderPRComment(body string) string {

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -420,7 +420,7 @@ func (h *Handler) ReconcileMissingSummaryComments(ctx context.Context) {
 		released := releasedForApply(ctx, h.service.Storage(), apply, ops, h.logger)
 		summaryBase := formatApplySummaryComment(apply, ops, released, tasks, resolveDisplayByOperation(ctx, h.service.Storage(), apply, ops), nil, h.deploymentTenant())
 		summaryBody := summaryBase + failureLogsSection(ctx, h.service.Storage(), h.logger, apply, summaryBase)
-		h.postAndTrackComment(ctx, apply.Repository, apply.PullRequest, apply.InstallationID, apply.ID, state.Comment.Summary, summaryBody)
+		h.postAndTrackComment(ctx, apply.Repository, apply.PullRequest, apply.InstallationID, apply.ID, state.Comment.Summary, summaryBody, nil)
 	}
 }
 

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -420,7 +420,7 @@ func (h *Handler) ReconcileMissingSummaryComments(ctx context.Context) {
 		released := releasedForApply(ctx, h.service.Storage(), apply, ops, h.logger)
 		summaryBase := formatApplySummaryComment(apply, ops, released, tasks, resolveDisplayByOperation(ctx, h.service.Storage(), apply, ops), nil, h.deploymentTenant())
 		summaryBody := summaryBase + failureLogsSection(ctx, h.service.Storage(), h.logger, apply, summaryBase)
-		h.postAndTrackComment(ctx, apply.Repository, apply.PullRequest, apply.InstallationID, apply.ID, state.Comment.Summary, summaryBody, nil)
+		h.postAndTrackComment(ctx, apply.Repository, apply.PullRequest, apply.InstallationID, apply, state.Comment.Summary, summaryBody)
 	}
 }
 

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -435,9 +435,12 @@ func (h *Handler) postComment(repo string, pr int, installationID int64, body st
 }
 
 // postAndTrackComment creates a PR comment and stores its ID in apply_comments.
+// postedVolume records the apply's volume level on progress comments so the
+// observer can detect a later applied volume change; pass nil for comment
+// states where the level is not meaningful.
 func (h *Handler) postAndTrackComment(
 	ctx context.Context, repo string, pr int, installationID int64,
-	applyID int64, commentState string, body string,
+	applyID int64, commentState string, body string, postedVolume *int,
 ) {
 	client, err := h.clientForRepo(repo, installationID)
 	if err != nil {
@@ -456,6 +459,7 @@ func (h *Handler) postAndTrackComment(
 		ApplyID:         applyID,
 		CommentState:    commentState,
 		GitHubCommentID: commentID,
+		PostedVolume:    postedVolume,
 	}
 	if err := h.service.Storage().ApplyComments().Upsert(ctx, comment); err != nil {
 		h.logger.Error("failed to store comment ID",
@@ -473,8 +477,10 @@ func (h *Handler) postAndTrackComment(
 // apply after the post closes that window from this side — whichever of the
 // observer's terminal edit and this finalize runs last converges the comment
 // on the terminal rendering.
-func (h *Handler) postInitialProgressComment(ctx context.Context, repo string, pr int, installationID int64, applyID int64, body string) {
-	h.postAndTrackComment(ctx, repo, pr, installationID, applyID, state.Comment.Progress, body)
+func (h *Handler) postInitialProgressComment(ctx context.Context, repo string, pr int, installationID int64, apply *storage.Apply, body string) {
+	applyID := apply.ID
+	startingVolume := apply.GetOptions().Volume
+	h.postAndTrackComment(ctx, repo, pr, installationID, applyID, state.Comment.Progress, body, &startingVolume)
 
 	apply, err := h.service.Storage().Applies().Get(ctx, applyID)
 	if err != nil {

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -435,12 +435,13 @@ func (h *Handler) postComment(repo string, pr int, installationID int64, body st
 }
 
 // postAndTrackComment creates a PR comment and stores its ID in apply_comments.
-// postedVolume records the apply's volume level on progress comments so the
-// observer can detect a later applied volume change; pass nil for comment
-// states where the level is not meaningful.
+// Progress comments record the apply's volume level at post time — derived
+// here, matching the observer's variant, so no caller can post a progress
+// comment that silently disables volume-rotation detection — and other comment
+// states carry no level.
 func (h *Handler) postAndTrackComment(
 	ctx context.Context, repo string, pr int, installationID int64,
-	applyID int64, commentState string, body string, postedVolume *int,
+	apply *storage.Apply, commentState string, body string,
 ) {
 	client, err := h.clientForRepo(repo, installationID)
 	if err != nil {
@@ -456,14 +457,17 @@ func (h *Handler) postAndTrackComment(
 	}
 
 	comment := &storage.ApplyComment{
-		ApplyID:         applyID,
+		ApplyID:         apply.ID,
 		CommentState:    commentState,
 		GitHubCommentID: commentID,
-		PostedVolume:    postedVolume,
+	}
+	if commentState == state.Comment.Progress {
+		level := apply.GetOptions().Volume
+		comment.PostedVolume = &level
 	}
 	if err := h.service.Storage().ApplyComments().Upsert(ctx, comment); err != nil {
 		h.logger.Error("failed to store comment ID",
-			"applyID", applyID, "commentState", commentState, "commentID", commentID, "error", err)
+			"applyID", apply.ID, "commentState", commentState, "commentID", commentID, "error", err)
 	}
 }
 
@@ -479,8 +483,7 @@ func (h *Handler) postAndTrackComment(
 // on the terminal rendering.
 func (h *Handler) postInitialProgressComment(ctx context.Context, repo string, pr int, installationID int64, apply *storage.Apply, body string) {
 	applyID := apply.ID
-	startingVolume := apply.GetOptions().Volume
-	h.postAndTrackComment(ctx, repo, pr, installationID, applyID, state.Comment.Progress, body, &startingVolume)
+	h.postAndTrackComment(ctx, repo, pr, installationID, apply, state.Comment.Progress, body)
 
 	apply, err := h.service.Storage().Applies().Get(ctx, applyID)
 	if err != nil {

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -455,7 +455,7 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment 
 	// omitted on this first comment — the observer refreshes it from engine
 	// display metadata on the next progress tick.
 	progressBody := formatProgressComment(apply, nil, nil, h.deploymentTenant())
-	h.postInitialProgressComment(ctx, repo, pr, installationID, applyID, progressBody)
+	h.postInitialProgressComment(ctx, repo, pr, installationID, apply, progressBody)
 }
 
 func (h *Handler) rollbackConfirmPlanForPR(ctx context.Context, repo string, pr int, environment, lockOwner string) (*storage.Lock, *storage.Plan, error) {

--- a/pkg/webhook/templates/issue_comment.go
+++ b/pkg/webhook/templates/issue_comment.go
@@ -271,7 +271,7 @@ func RenderVolumeCommandAccepted(data VolumeCommandAcceptedData) string {
 	if data.RequestedBy != "" {
 		body += fmt.Sprintf("**Requested by**: @%s\n", data.RequestedBy)
 	}
-	body += fmt.Sprintf("\nVolume change to %d requested. SchemaBot will adjust the speed of this schema change shortly; the progress comment on this PR shows the current level.\n", data.Volume)
+	body += fmt.Sprintf("\nVolume change to %d requested. SchemaBot will adjust the speed of this schema change shortly; once the new level takes effect, a fresh progress comment will track the schema change at the new volume.\n", data.Volume)
 	return body
 }
 

--- a/pkg/webhook/templates/issue_comment.go
+++ b/pkg/webhook/templates/issue_comment.go
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/storage"
@@ -309,15 +310,27 @@ type VolumeSupersededProgressData struct {
 	PreviousBody string
 }
 
+// volumeSupersededPrefix opens every frozen superseded-progress body;
+// IsVolumeSupersededProgressComment keys on it so a freeze retry can tell an
+// already-frozen comment from a live one.
+const volumeSupersededPrefix = "⏩ Volume changed to"
+
 // RenderVolumeSupersededProgressComment renders the frozen body written over a
 // progress comment once a volume change rotates in a fresh one. The old
 // comment's final progress stays on the PR as a record, collapsed into a
 // details block, with a pointer to the comment where progress continues.
 func RenderVolumeSupersededProgressComment(data VolumeSupersededProgressData) string {
 	return fmt.Sprintf(
-		"⏩ Volume changed to **%d/%d** — progress continues in [a new progress comment](https://github.com/%s/pull/%d#issuecomment-%d).\n\n"+
+		volumeSupersededPrefix+" **%d/%d** — progress continues in [a new progress comment](https://github.com/%s/pull/%d#issuecomment-%d).\n\n"+
 			"<details>\n<summary>Progress before the volume change</summary>\n\n%s\n\n</details>\n",
 		data.Volume, storage.MaxVolume, data.Repo, data.PR, data.NewCommentID, data.PreviousBody)
+}
+
+// IsVolumeSupersededProgressComment reports whether a comment body is already
+// the frozen rendering written by RenderVolumeSupersededProgressComment, so a
+// freeze retry does not wrap a frozen body in a second fold.
+func IsVolumeSupersededProgressComment(body string) bool {
+	return strings.HasPrefix(body, volumeSupersededPrefix)
 }
 
 // RenderCutoverCommandAccepted renders the acknowledgement posted when a PR

--- a/pkg/webhook/templates/issue_comment.go
+++ b/pkg/webhook/templates/issue_comment.go
@@ -292,6 +292,34 @@ func PreviewCommentVolumeInvalidLevel() string {
 	return RenderVolumeInvalidLevel()
 }
 
+// VolumeSupersededProgressData contains data for freezing a progress comment
+// that a volume change has superseded.
+type VolumeSupersededProgressData struct {
+	// Volume is the new level (1=slowest, 11=fastest) that took effect.
+	Volume int
+	// Repo is the "owner/name" repository, used to link the successor comment.
+	Repo string
+	// PR is the pull request number, used to link the successor comment.
+	PR int
+	// NewCommentID is the GitHub comment ID of the fresh progress comment now
+	// tracking the schema change.
+	NewCommentID int64
+	// PreviousBody is the superseded comment's last rendered body, preserved
+	// inside the folded details block.
+	PreviousBody string
+}
+
+// RenderVolumeSupersededProgressComment renders the frozen body written over a
+// progress comment once a volume change rotates in a fresh one. The old
+// comment's final progress stays on the PR as a record, collapsed into a
+// details block, with a pointer to the comment where progress continues.
+func RenderVolumeSupersededProgressComment(data VolumeSupersededProgressData) string {
+	return fmt.Sprintf(
+		"⏩ Volume changed to **%d/%d** — progress continues in [a new progress comment](https://github.com/%s/pull/%d#issuecomment-%d).\n\n"+
+			"<details>\n<summary>Progress before the volume change</summary>\n\n%s\n\n</details>\n",
+		data.Volume, storage.MaxVolume, data.Repo, data.PR, data.NewCommentID, data.PreviousBody)
+}
+
 // RenderCutoverCommandAccepted renders the acknowledgement posted when a PR
 // comment cutover command records durable cutover intent.
 func RenderCutoverCommandAccepted(data CutoverCommandAcceptedData) string {

--- a/pkg/webhook/templates/issue_comment_test.go
+++ b/pkg/webhook/templates/issue_comment_test.go
@@ -176,6 +176,8 @@ func TestRenderVolumeCommandAccepted(t *testing.T) {
 	assert.Contains(t, rendered, "`staging`")
 	assert.Contains(t, rendered, "@alice")
 	assert.Contains(t, rendered, "Volume change to 8 requested. SchemaBot will adjust the speed of this schema change shortly")
+	assert.Contains(t, rendered, "a fresh progress comment will track the schema change at the new volume",
+		"the acknowledgement points the operator at the new comment that appears once the level takes effect")
 }
 
 // TestRenderVolumeInvalidLevel verifies the rejection posted for a missing,

--- a/pkg/webhook/templates/issue_comment_test.go
+++ b/pkg/webhook/templates/issue_comment_test.go
@@ -190,6 +190,26 @@ func TestRenderVolumeInvalidLevel(t *testing.T) {
 	assert.Contains(t, rendered, "between 1 (slowest) and 11 (fastest)")
 }
 
+// TestRenderVolumeSupersededProgressComment verifies the frozen body written
+// over an old progress comment after a volume change: it names the new level,
+// links the successor comment, and folds the final pre-change progress into a
+// details block so the record stays on the PR without looking live.
+func TestRenderVolumeSupersededProgressComment(t *testing.T) {
+	rendered := RenderVolumeSupersededProgressComment(VolumeSupersededProgressData{
+		Volume:       8,
+		Repo:         "acme/testapp",
+		PR:           42,
+		NewCommentID: 2222222222,
+		PreviousBody: "## Schema Change Progress\n\nVolume: 3/11",
+	})
+	assert.Contains(t, rendered, "Volume changed to **8/11**")
+	assert.Contains(t, rendered, "https://github.com/acme/testapp/pull/42#issuecomment-2222222222")
+	assert.Contains(t, rendered, "<details>")
+	assert.Contains(t, rendered, "<summary>Progress before the volume change</summary>")
+	assert.Contains(t, rendered, "Volume: 3/11",
+		"the superseded body is preserved inside the fold")
+}
+
 func TestRenderRevertCommandAccepted(t *testing.T) {
 	rendered := RenderRevertCommandAccepted(RevertCommandAcceptedData{
 		ApplyID:     "apply-957642f96d634694",

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -1425,6 +1425,27 @@ func PreviewCommentApplySingleProgressVolume() string {
 	return RenderApplyStatusComment(data)
 }
 
+// PreviewCommentVolumeSupersededProgress renders an old progress comment after
+// a volume change froze it: the final pre-change progress collapses into a
+// details block under a pointer to the fresh comment now tracking the apply.
+func PreviewCommentVolumeSupersededProgress() string {
+	table := sampleSingleTable()
+	table.Status = state.Task.Running
+	table.RowsCopied = 2300000
+	table.RowsTotal = 7200000
+	table.PercentComplete = 32
+	table.ETASeconds = 780
+	data := sampleSingleApplyData(state.Apply.Running, table)
+	data.Volume = 3
+	return RenderVolumeSupersededProgressComment(VolumeSupersededProgressData{
+		Volume:       8,
+		Repo:         "acme/testapp",
+		PR:           42,
+		NewCommentID: 2222222222,
+		PreviousBody: RenderApplyStatusComment(data),
+	})
+}
+
 // PreviewCommentApplySingleCompleted renders a single-table apply completed.
 func PreviewCommentApplySingleCompleted() string {
 	table := sampleSingleTable()


### PR DESCRIPTION
**Why this matters:** After `schemabot volume` was accepted, the only place the new level showed up was an edit to the existing progress comment — operators had to scroll back up and re-read an old comment to confirm the change took effect. Operators look at the bottom of the PR timeline for the effect of a command they just issued.

**What it does:** When an applied volume change takes effect, the observer rotates the progress comment the same way a stop→resume does:

```
[progress comment]  Volume: 3/11        ── frozen: collapsed <details>,
        │                                  "⏩ Volume changed to 5/11 —
        │  schemabot volume -v 5 …          progress continues in a new
        ▼                                   progress comment" (linked)
[volume accepted]
        ▼
[new progress comment]  Volume: 5/11    ── live: tracked for all further edits
```

Progress comments now record the apply's volume level at post time (`apply_comments.posted_volume`), so the observer detects an applied change durably and across pods by comparing the stored level against the apply options — the same options the local driver records applied volumes on and the remote progress sync mirrors. Rows predating the column are backfilled at the apply's current level on the first check, so they rotate on the next applied change. The collapsed old comment keeps the pre-change progress on the PR as a record instead of deleting it. The accepted reply's wording now points at the fresh comment, and the frozen comment renders from the templates package so TEMPLATES.md previews it.

The rotation is durable at each seam. The freeze owed to the prior comment is recorded in the same storage write that tracks the fresh one (`apply_comments.pending_freeze_github_comment_id`), so a failed freeze edit — or a pod dying before it — is reconciled by any later observer pass that reads the tracked row; the marker is cleared only once the frozen rendering lands. If the post lands but the tracking write fails, the prior comment stays live (a frozen body would fight its edits) and later ticks retry only the tracking write, adopting the already-posted comment instead of posting a duplicate — so duplicates stay bounded at one and a volume revert while the comment was untracked still converges.

**How it moves toward the northstar:** Every control command issued from the PR should have its effect visible where the operator issued it — the volume boundary now reads like any other lifecycle boundary on the PR timeline.

The regression tests drive the observer through a real progress sequence: same-level ticks edit in place, the level change posts the fresh comment and freezes the old one with a link to its successor, a later tick edits only the new comment, a tracking-write outage is adopted once storage heals (including a revert after adoption), and a pending freeze left by a dead pod is reconciled by the next drive's observer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
