### PR TITLE
feat(github): show collapsed logs in the failed-apply summary comment

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -3126,7 +3126,7 @@ schemabot apply -e staging
 ```
 
 <details>
-<summary>Logs (5)</summary>
+<summary>Show logs (5 entries)</summary>
 
 ```text
 2026-03-15 14:22:00 UTC [INF] Apply claimed by driver [queued -> running]
@@ -3391,7 +3391,7 @@ schemabot apply -e staging
 ```
 
 <details>
-<summary>Logs (5)</summary>
+<summary>Show logs (5 entries)</summary>
 
 ```text
 2026-03-15 14:22:00 UTC [INF] Apply claimed by driver [queued -> running]
@@ -3461,7 +3461,7 @@ schemabot apply -e staging
 ```
 
 <details>
-<summary>Logs (5)</summary>
+<summary>Show logs (5 entries)</summary>
 
 ```text
 2026-03-15 14:22:00 UTC [INF] Apply claimed by driver [queued -> running]

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -3126,7 +3126,7 @@ schemabot apply -e staging
 ```
 
 <details>
-<summary>Recent logs (5)</summary>
+<summary>Logs (5)</summary>
 
 ```text
 2026-03-15 14:22:00 UTC [INF] Apply claimed by driver [queued -> running]
@@ -3391,7 +3391,7 @@ schemabot apply -e staging
 ```
 
 <details>
-<summary>Recent logs (5)</summary>
+<summary>Logs (5)</summary>
 
 ```text
 2026-03-15 14:22:00 UTC [INF] Apply claimed by driver [queued -> running]
@@ -3461,7 +3461,7 @@ schemabot apply -e staging
 ```
 
 <details>
-<summary>Recent logs (5)</summary>
+<summary>Logs (5)</summary>
 
 ```text
 2026-03-15 14:22:00 UTC [INF] Apply claimed by driver [queued -> running]

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -3125,6 +3125,19 @@ To retry:
 schemabot apply -e staging
 ```
 
+<details>
+<summary>Recent logs (5)</summary>
+
+```text
+2026-03-15 14:22:00 UTC [INF] Apply claimed by driver [queued -> running]
+2026-03-15 14:22:15 UTC [INF] Task started: schema change on `users`
+2026-03-15 14:25:00 UTC [WRN] Copy throttled by replication lag (1.2s)
+2026-03-15 14:28:00 UTC [ERR] Task failed: unsafe warning: Field 'name' doesn't have a default value
+2026-03-15 14:29:00 UTC [ERR] Apply failed [running -> failed]
+```
+
+</details>
+
 </details>
 
 <details>
@@ -3377,6 +3390,19 @@ To retry:
 schemabot apply -e staging
 ```
 
+<details>
+<summary>Recent logs (5)</summary>
+
+```text
+2026-03-15 14:22:00 UTC [INF] Apply claimed by driver [queued -> running]
+2026-03-15 14:22:15 UTC [INF] Task started: schema change on `addresses`
+2026-03-15 14:25:00 UTC [WRN] Copy throttled by replication lag (1.2s)
+2026-03-15 14:28:00 UTC [ERR] Task failed: Error 1062: Duplicate entry '12345' for key 'addresses.idx_user_id'
+2026-03-15 14:29:00 UTC [ERR] Apply failed [running -> failed]
+```
+
+</details>
+
 </details>
 
 <details>
@@ -3433,6 +3459,19 @@ To retry:
 ```
 schemabot apply -e staging
 ```
+
+<details>
+<summary>Recent logs (5)</summary>
+
+```text
+2026-03-15 14:22:00 UTC [INF] Apply claimed by driver [queued -> running]
+2026-03-15 14:22:15 UTC [INF] Task started: schema change on `addresses`
+2026-03-15 14:25:00 UTC [WRN] Copy throttled by replication lag (1.2s)
+2026-03-15 14:28:00 UTC [ERR] Task failed: Error 1205: Lock wait timeout exceeded
+2026-03-15 14:29:00 UTC [ERR] Apply failed [running -> failed]
+```
+
+</details>
 
 </details>
 

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -1164,9 +1164,24 @@ func (f *ForwardAuthSettings) validate() error {
 	return nil
 }
 
+// Comment renderers reserve a fixed amount of headroom under GitHub's comment
+// size cap for the support-channel footer, so its two free-text fields must be
+// bounded — an unbounded footer could push an otherwise budget-fitting comment
+// over the cap and GitHub would reject it outright.
+const (
+	maxSupportChannelNameChars = 100
+	maxSupportChannelURLChars  = 500
+)
+
 func validateSupportChannel(c SupportChannelConfig) error {
 	if c.Name == "" && c.URL == "" {
 		return nil
+	}
+	if len(c.Name) > maxSupportChannelNameChars {
+		return fmt.Errorf("support_channel.name must be at most %d characters (got %d)", maxSupportChannelNameChars, len(c.Name))
+	}
+	if len(c.URL) > maxSupportChannelURLChars {
+		return fmt.Errorf("support_channel.url must be at most %d characters (got %d)", maxSupportChannelURLChars, len(c.URL))
 	}
 	if strings.TrimSpace(c.Name) != c.Name {
 		return fmt.Errorf("support_channel.name contains leading or trailing whitespace")

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -3273,6 +3274,20 @@ func TestSupportChannelConfig(t *testing.T) {
 		cfg.SupportChannel = SupportChannelConfig{Name: "#schema-help", URL: "https://example.com/schema-help)"}
 		err := cfg.Validate()
 		assert.ErrorContains(t, err, "support_channel.url contains characters that are unsafe in Markdown links")
+	})
+
+	t.Run("name must fit the comment footer reservation", func(t *testing.T) {
+		cfg := validConfig()
+		cfg.SupportChannel = SupportChannelConfig{Name: strings.Repeat("a", maxSupportChannelNameChars+1), URL: "https://example.com/schema-help"}
+		err := cfg.Validate()
+		assert.ErrorContains(t, err, "support_channel.name must be at most")
+	})
+
+	t.Run("url must fit the comment footer reservation", func(t *testing.T) {
+		cfg := validConfig()
+		cfg.SupportChannel = SupportChannelConfig{Name: "#schema-help", URL: "https://example.com/" + strings.Repeat("a", maxSupportChannelURLChars)}
+		err := cfg.Validate()
+		assert.ErrorContains(t, err, "support_channel.url must be at most")
 	})
 }
 

--- a/pkg/cmd/commands/logs.go
+++ b/pkg/cmd/commands/logs.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/block/schemabot/pkg/cmd/client"
 	"github.com/block/schemabot/pkg/cmd/internal/templates"
+	webhooktemplates "github.com/block/schemabot/pkg/webhook/templates"
 )
 
 // LogsCmd views apply logs for a database or specific apply.
@@ -130,18 +131,21 @@ func printLogs(logs []*client.LogEntry) {
 	}
 }
 
-// formatLogLevel returns a colored log level indicator.
+// formatLogLevel returns a colored log level indicator, wrapping the shared
+// tag text so the terminal output and the PR-comment log fold stay identical
+// apart from color.
 func formatLogLevel(level string) string {
+	tag := webhooktemplates.LogLevelTag(level)
 	switch strings.ToLower(level) {
 	case "error":
-		return fmt.Sprintf("%s[ERR]%s", "\033[31m", templates.ANSIReset) // Red
+		return "\033[31m" + tag + templates.ANSIReset // Red
 	case "warn":
-		return fmt.Sprintf("%s[WRN]%s", templates.ANSIYellow, templates.ANSIReset)
+		return templates.ANSIYellow + tag + templates.ANSIReset
 	case "info":
-		return fmt.Sprintf("%s[INF]%s", templates.ANSIGreen, templates.ANSIReset)
+		return templates.ANSIGreen + tag + templates.ANSIReset
 	case "debug":
-		return fmt.Sprintf("%s[DBG]%s", templates.ANSIDim, templates.ANSIReset)
+		return templates.ANSIDim + tag + templates.ANSIReset
 	default:
-		return fmt.Sprintf("[%s]", strings.ToUpper(level))
+		return tag
 	}
 }

--- a/pkg/storage/mysqlstore/apply_logs.go
+++ b/pkg/storage/mysqlstore/apply_logs.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"slices"
 
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/spirit/pkg/utils"
@@ -104,6 +105,30 @@ func (s *applyLogStore) GetByApply(ctx context.Context, applyID int64) ([]*stora
 	defer utils.CloseAndLog(rows)
 
 	return scanApplyLogs(rows)
+}
+
+// GetRecentByApply returns the newest limit logs for an apply, ordered by
+// created_at ascending. Ties on created_at (second precision) are broken by
+// id so entries keep their insertion order.
+func (s *applyLogStore) GetRecentByApply(ctx context.Context, applyID int64, limit int) ([]*storage.ApplyLog, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT `+applyLogColumns+`
+		FROM apply_logs
+		WHERE apply_id = ?
+		ORDER BY created_at DESC, id DESC
+		LIMIT ?
+	`, applyID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer utils.CloseAndLog(rows)
+
+	logs, err := scanApplyLogs(rows)
+	if err != nil {
+		return nil, err
+	}
+	slices.Reverse(logs)
+	return logs, nil
 }
 
 // List returns logs matching the filter criteria, ordered by created_at.

--- a/pkg/storage/mysqlstore/apply_logs_test.go
+++ b/pkg/storage/mysqlstore/apply_logs_test.go
@@ -1,0 +1,55 @@
+//go:build integration
+
+package mysqlstore
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApplyLogStore_GetRecentByApply verifies the bounded tail read used by
+// the failed-summary comment: only the newest limit entries are returned, in
+// chronological order, even when entries share a created_at second (id breaks
+// the tie so insertion order is preserved).
+func TestApplyLogStore_GetRecentByApply(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "recent_logs_db", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_recent_logs", 601, state.Apply.Running, "staging")
+
+	const seeded = 5
+	for i := 1; i <= seeded; i++ {
+		require.NoError(t, store.ApplyLogs().Append(ctx, &storage.ApplyLog{
+			ApplyID:   apply.ID,
+			Level:     storage.LogLevelInfo,
+			EventType: storage.LogEventInfo,
+			Source:    storage.LogSourceSchemaBot,
+			Message:   fmt.Sprintf("entry %d", i),
+		}))
+	}
+
+	recent, err := store.ApplyLogs().GetRecentByApply(ctx, apply.ID, 3)
+	require.NoError(t, err)
+	require.Len(t, recent, 3)
+	assert.Equal(t, "entry 3", recent[0].Message)
+	assert.Equal(t, "entry 4", recent[1].Message)
+	assert.Equal(t, "entry 5", recent[2].Message)
+
+	all, err := store.ApplyLogs().GetRecentByApply(ctx, apply.ID, seeded*2)
+	require.NoError(t, err)
+	require.Len(t, all, seeded)
+	for i, entry := range all {
+		assert.Equal(t, fmt.Sprintf("entry %d", i+1), entry.Message)
+	}
+
+	none, err := store.ApplyLogs().GetRecentByApply(ctx, apply.ID+1000, 3)
+	require.NoError(t, err)
+	assert.Empty(t, none)
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -623,6 +623,12 @@ type ApplyLogStore interface {
 	// GetByApply returns all logs for an apply, ordered by created_at.
 	GetByApply(ctx context.Context, applyID int64) ([]*ApplyLog, error)
 
+	// GetRecentByApply returns the newest limit logs for an apply, ordered by
+	// created_at ascending so the result reads chronologically. The query is
+	// bounded — long-running applies can accumulate far more log rows than a
+	// caller rendering a tail needs.
+	GetRecentByApply(ctx context.Context, applyID int64, limit int) ([]*ApplyLog, error)
+
 	// List returns logs matching the filter criteria, ordered by created_at.
 	List(ctx context.Context, filter ApplyLogFilter) ([]*ApplyLog, error)
 }

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -2663,10 +2663,16 @@ func (c *GRPCClient) markRemoteApplyFailedWithOptions(ctx context.Context, remot
 		storedApply.CompletedAt = &now
 	}
 	storedApply.UpdatedAt = now
+	// Append the terminal log line before committing the failed state: watchers
+	// (the comment observer's poller) act the moment the applies row turns
+	// failed, and anything they render from apply_logs — the failure summary's
+	// log fold — must already contain the failure line. A failed update after
+	// the append leaves the row non-terminal and re-drivable; the retry appends
+	// a duplicate line to the event log, which is harmless.
+	c.logApplyStateTransition(ctx, storedApply, storage.LogLevelError, fmt.Sprintf("Remote apply failed: %s", message), oldState)
 	if err := c.storage.Applies().Update(ctx, storedApply); err != nil {
 		return fmt.Errorf("update remote gRPC apply failure %s: %w", storedApply.ApplyIdentifier, err)
 	}
-	c.logApplyStateTransition(ctx, storedApply, storage.LogLevelError, fmt.Sprintf("Remote apply failed: %s", message), oldState)
 	*remoteApply = *storedApply
 	metrics.AdjustActiveApplies(ctx, -1, storedApply.Database, storedApply.Deployment, storedApply.Environment)
 	return nil

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -470,7 +470,7 @@ func (o *CommentObserver) summaryCommentFromOps(apply *storage.Apply, ops []*sto
 	} else {
 		body = formatApplySummaryComment(apply, ops, o.resolveReleased(apply, ops), tasks, o.resolveDisplay(apply, ops), shardsByTable, o.tenant)
 	}
-	return body + failureLogsSection(context.Background(), o.stor, o.logger, apply)
+	return body + failureLogsSection(context.Background(), o.stor, o.logger, apply, body)
 }
 
 func (o *CommentObserver) shouldDeferCutover(apply *storage.Apply) bool {

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -458,14 +458,28 @@ func (o *CommentObserver) formatTerminalSummaryComment(apply *storage.Apply) str
 // operation rows, applying the same single-deployment fallback as
 // formatTerminalSummaryComment when the load failed. Callers that already hold
 // the operation set (e.g. OnTerminal) use this to avoid re-reading
-// apply_operations.
+// apply_operations. A failed apply's summary carries the collapsed recent-logs
+// section, appended after whichever layout rendered, so triage data lands on
+// the PR without an extra operator step.
 func (o *CommentObserver) summaryCommentFromOps(apply *storage.Apply, ops []*storage.ApplyOperation, opsErr error, tasks []*storage.Task, shardsByTable map[string][]*storage.Task) string {
+	var body string
 	if opsErr != nil {
 		o.logger.Error("observer: failed to load apply operations for summary comment dispatch; rendering single-deployment layout",
 			"apply_id", o.applyID, "error", opsErr)
-		return formatSummaryComment(apply, tasks, shardsByTable, o.tenant)
+		body = formatSummaryComment(apply, tasks, shardsByTable, o.tenant)
+	} else {
+		body = formatApplySummaryComment(apply, ops, o.resolveReleased(apply, ops), tasks, o.resolveDisplay(apply, ops), shardsByTable, o.tenant)
 	}
-	return formatApplySummaryComment(apply, ops, o.resolveReleased(apply, ops), tasks, o.resolveDisplay(apply, ops), shardsByTable, o.tenant)
+	return body + o.recentFailureLogsSection(apply)
+}
+
+// recentFailureLogsSection loads and renders the failed apply's recent-logs
+// section with a short, independent deadline so a slow storage read degrades
+// to a summary without logs rather than blocking the terminal comment.
+func (o *CommentObserver) recentFailureLogsSection(apply *storage.Apply) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	return failureLogsSection(ctx, o.stor, o.logger, apply)
 }
 
 func (o *CommentObserver) shouldDeferCutover(apply *storage.Apply) bool {

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -298,7 +298,7 @@ func (o *CommentObserver) OnTerminal(apply *storage.Apply, tasks []*storage.Task
 		// aggregate CAS-winner observer re-edits it with the full task set. The
 		// summary marker is always upserted so FindMissingSummaryComment (outbox
 		// query) doesn't false-positive on restart for cutover applies.
-		finalBody := o.summaryCommentFromOps(apply, ops, opsErr, tasks, shardsByTable)
+		finalBody := o.summaryCommentFromOps(ctx, apply, ops, opsErr, tasks, shardsByTable)
 		o.editTrackedComment(apply, activeCommentState, finalBody)
 		o.markSummaryPosted(apply, activeCommentState)
 	} else {
@@ -318,7 +318,7 @@ func (o *CommentObserver) OnTerminal(apply *storage.Apply, tasks []*storage.Task
 		// so a per-driver observer holding one operation's task slice must defer
 		// to it rather than post a duplicate, partial summary.
 		if o.shouldPublishSeparateSummary(apply, ops, opsErr) {
-			summaryBody := o.summaryCommentFromOps(apply, ops, opsErr, tasks, shardsByTable)
+			summaryBody := o.summaryCommentFromOps(ctx, apply, ops, opsErr, tasks, shardsByTable)
 			o.postAndTrackComment(apply, state.Comment.Summary, summaryBody)
 		}
 	}
@@ -451,7 +451,7 @@ func (o *CommentObserver) formatTerminalSummaryComment(apply *storage.Apply) str
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	ops, err := o.stor.ApplyOperations().ListByApply(ctx, o.applyID)
-	return o.summaryCommentFromOps(apply, ops, err, nil, o.shardsByTable(ctx, apply, ops))
+	return o.summaryCommentFromOps(ctx, apply, ops, err, nil, o.shardsByTable(ctx, apply, ops))
 }
 
 // summaryCommentFromOps renders the terminal summary from already-loaded
@@ -461,7 +461,7 @@ func (o *CommentObserver) formatTerminalSummaryComment(apply *storage.Apply) str
 // apply_operations. A failed apply's summary carries the collapsed recent-logs
 // section, appended after whichever layout rendered, so triage data lands on
 // the PR without an extra operator step.
-func (o *CommentObserver) summaryCommentFromOps(apply *storage.Apply, ops []*storage.ApplyOperation, opsErr error, tasks []*storage.Task, shardsByTable map[string][]*storage.Task) string {
+func (o *CommentObserver) summaryCommentFromOps(ctx context.Context, apply *storage.Apply, ops []*storage.ApplyOperation, opsErr error, tasks []*storage.Task, shardsByTable map[string][]*storage.Task) string {
 	var body string
 	if opsErr != nil {
 		o.logger.Error("observer: failed to load apply operations for summary comment dispatch; rendering single-deployment layout",
@@ -470,7 +470,7 @@ func (o *CommentObserver) summaryCommentFromOps(apply *storage.Apply, ops []*sto
 	} else {
 		body = formatApplySummaryComment(apply, ops, o.resolveReleased(apply, ops), tasks, o.resolveDisplay(apply, ops), shardsByTable, o.tenant)
 	}
-	return body + failureLogsSection(context.Background(), o.stor, o.logger, apply, body)
+	return body + failureLogsSection(ctx, o.stor, o.logger, apply, body)
 }
 
 func (o *CommentObserver) shouldDeferCutover(apply *storage.Apply) bool {

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -470,16 +470,7 @@ func (o *CommentObserver) summaryCommentFromOps(apply *storage.Apply, ops []*sto
 	} else {
 		body = formatApplySummaryComment(apply, ops, o.resolveReleased(apply, ops), tasks, o.resolveDisplay(apply, ops), shardsByTable, o.tenant)
 	}
-	return body + o.recentFailureLogsSection(apply)
-}
-
-// recentFailureLogsSection loads and renders the failed apply's recent-logs
-// section with a short, independent deadline so a slow storage read degrades
-// to a summary without logs rather than blocking the terminal comment.
-func (o *CommentObserver) recentFailureLogsSection(apply *storage.Apply) string {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	return failureLogsSection(ctx, o.stor, o.logger, apply)
+	return body + failureLogsSection(context.Background(), o.stor, o.logger, apply)
 }
 
 func (o *CommentObserver) shouldDeferCutover(apply *storage.Apply) bool {

--- a/pkg/webhook/failure_logs.go
+++ b/pkg/webhook/failure_logs.go
@@ -47,11 +47,18 @@ func failureLogsSection(ctx context.Context, stor storage.Storage, logger interf
 	}
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), failureLogsLoadTimeout)
 	defer cancel()
-	logs, err := stor.ApplyLogs().GetRecentByApply(ctx, apply.ID, failureSummaryLogLimit)
+	// Load one entry beyond the limit so the fold can label itself honestly:
+	// "Logs" when it carries the complete history, "Recent logs" when older
+	// entries exist beyond the tail.
+	logs, err := stor.ApplyLogs().GetRecentByApply(ctx, apply.ID, failureSummaryLogLimit+1)
 	if err != nil {
 		logger.Error("failed to load apply logs for failure summary; posting summary without recent logs",
 			append(apply.LogAttrs(), "error", err)...)
 		return ""
+	}
+	hasOlder := len(logs) > failureSummaryLogLimit
+	if hasOlder {
+		logs = logs[len(logs)-failureSummaryLogLimit:]
 	}
 	entries := make([]templates.LogEntryData, len(logs))
 	for i, entry := range logs {
@@ -64,7 +71,7 @@ func failureLogsSection(ctx context.Context, stor storage.Storage, logger interf
 		}
 	}
 	available := gitHubIssueCommentMaxChars - commentChromeHeadroom - len(baseBody)
-	section := templates.RenderRecentFailureLogs(entries, available)
+	section := templates.RenderRecentFailureLogs(entries, available, hasOlder)
 	if section == "" && len(entries) > 0 {
 		logger.Error("summary body leaves no room for the recent-logs section under the GitHub comment size limit; posting summary without recent logs",
 			append(apply.LogAttrs(), "summary_chars", len(baseBody), "log_entries", len(entries))...)

--- a/pkg/webhook/failure_logs.go
+++ b/pkg/webhook/failure_logs.go
@@ -9,29 +9,25 @@ import (
 	"github.com/block/schemabot/pkg/webhook/templates"
 )
 
+// commentChromeHeadroom reserves room under GitHub's comment size cap for
+// markup added to the body after the section is appended (the support-channel
+// footer) plus margin, so the assembled comment never lands exactly at the
+// limit.
+const commentChromeHeadroom = 1024
+
 // failureSummaryLogLimit bounds the log load for a failed apply's summary
-// comment. It is derived, not a product choice: the fold's byte budget is the
-// real limit, and this is the most entries that could ever render within it.
-// Loading more rows could never add a rendered line, so the query stays
+// comment. It is derived, not a product choice: the comment's byte budget is
+// the real limit, and this is the most entries that could ever render within
+// it. Loading more rows could never add a rendered line, so the query stays
 // bounded (engine log lines flow into apply_logs, so a long apply accumulates
 // far more rows than any comment can carry) without the load bound ever being
 // the reason a line is dropped. The newest entries are kept — the tail leading
 // up to the failure is what an operator triaging from the PR needs.
-const failureSummaryLogLimit = templates.MaxFailureLogsSectionChars / templates.MinRenderedLogLineChars
+const failureSummaryLogLimit = (templates.GitHubIssueCommentMaxChars - commentChromeHeadroom) / templates.MinRenderedLogLineChars
 
 // failureLogsLoadTimeout bounds the log load so a slow storage read degrades
 // to a summary without logs rather than delaying the terminal comment.
 const failureLogsLoadTimeout = 2 * time.Second
-
-// gitHubIssueCommentMaxChars is GitHub's hard cap on an issue comment body — a
-// larger body is rejected outright, so anything appended to a summary must fit
-// within what the summary itself leaves free.
-const gitHubIssueCommentMaxChars = 65536
-
-// commentChromeHeadroom reserves room under the GitHub cap for markup added to
-// the body after the section is appended (the support-channel footer) plus
-// margin, so the assembled comment never lands exactly at the limit.
-const commentChromeHeadroom = 1024
 
 // failureLogsSection renders the collapsed recent-logs section for a terminal
 // summary comment whose already-rendered body is baseBody. Only a failed apply
@@ -75,7 +71,7 @@ func failureLogsSection(ctx context.Context, stor storage.Storage, logger interf
 			NewState:  entry.NewState,
 		}
 	}
-	available := gitHubIssueCommentMaxChars - commentChromeHeadroom - len(baseBody)
+	available := templates.GitHubIssueCommentMaxChars - commentChromeHeadroom - len(baseBody)
 	section := templates.RenderRecentFailureLogs(entries, available, hasOlder)
 	if section == "" && len(entries) > 0 {
 		logger.Error("summary body leaves no room for the recent-logs section under the GitHub comment size limit; posting summary without recent logs",

--- a/pkg/webhook/failure_logs.go
+++ b/pkg/webhook/failure_logs.go
@@ -9,10 +9,15 @@ import (
 	"github.com/block/schemabot/pkg/webhook/templates"
 )
 
-// failureSummaryLogLimit is how many log entries a failed apply's summary
-// comment carries. The newest entries are kept — the tail leading up to the
-// failure is what an operator triaging from the PR needs.
-const failureSummaryLogLimit = 50
+// failureSummaryLogLimit bounds the log load for a failed apply's summary
+// comment. It is derived, not a product choice: the fold's byte budget is the
+// real limit, and this is the most entries that could ever render within it.
+// Loading more rows could never add a rendered line, so the query stays
+// bounded (engine log lines flow into apply_logs, so a long apply accumulates
+// far more rows than any comment can carry) without the load bound ever being
+// the reason a line is dropped. The newest entries are kept — the tail leading
+// up to the failure is what an operator triaging from the PR needs.
+const failureSummaryLogLimit = templates.MaxFailureLogsSectionChars / templates.MinRenderedLogLineChars
 
 // failureLogsLoadTimeout bounds the log load so a slow storage read degrades
 // to a summary without logs rather than delaying the terminal comment.
@@ -38,7 +43,7 @@ const commentChromeHeadroom = 1024
 // load runs under its own short deadline, detached from the caller's
 // cancellation, so the section is decided by storage health alone. Best-effort:
 // a log-load failure is logged and returns "" so the summary comment still
-// posts; the full logs remain available from the CLI.
+// posts; the full history remains available from the CLI and the server logs.
 func failureLogsSection(ctx context.Context, stor storage.Storage, logger interface {
 	Error(msg string, args ...any)
 }, apply *storage.Apply, baseBody string) string {

--- a/pkg/webhook/failure_logs.go
+++ b/pkg/webhook/failure_logs.go
@@ -18,16 +18,30 @@ const failureSummaryLogLimit = 50
 // to a summary without logs rather than delaying the terminal comment.
 const failureLogsLoadTimeout = 2 * time.Second
 
+// gitHubIssueCommentMaxChars is GitHub's hard cap on an issue comment body — a
+// larger body is rejected outright, so anything appended to a summary must fit
+// within what the summary itself leaves free.
+const gitHubIssueCommentMaxChars = 65536
+
+// commentChromeHeadroom reserves room under the GitHub cap for markup added to
+// the body after the section is appended (the support-channel footer) plus
+// margin, so the assembled comment never lands exactly at the limit.
+const commentChromeHeadroom = 1024
+
 // failureLogsSection renders the collapsed recent-logs section for a terminal
-// summary comment. Only a failed apply carries logs — a completed, stopped, or
-// cancelled apply's summary stays clean, so this returns "" for those states.
-// The load runs under its own short deadline, detached from the caller's
+// summary comment whose already-rendered body is baseBody. Only a failed apply
+// carries logs — a completed, stopped, or cancelled apply's summary stays
+// clean, so this returns "" for those states. The section spends only the room
+// baseBody leaves under GitHub's comment size cap: a large summary shrinks the
+// fold, and one that leaves no meaningful room drops it, so appending never
+// pushes the comment over the limit and blocks the summary from posting. The
+// load runs under its own short deadline, detached from the caller's
 // cancellation, so the section is decided by storage health alone. Best-effort:
 // a log-load failure is logged and returns "" so the summary comment still
 // posts; the full logs remain available from the CLI.
 func failureLogsSection(ctx context.Context, stor storage.Storage, logger interface {
 	Error(msg string, args ...any)
-}, apply *storage.Apply) string {
+}, apply *storage.Apply, baseBody string) string {
 	if !state.IsState(apply.State, state.Apply.Failed) {
 		return ""
 	}
@@ -49,5 +63,11 @@ func failureLogsSection(ctx context.Context, stor storage.Storage, logger interf
 			NewState:  entry.NewState,
 		}
 	}
-	return templates.RenderRecentFailureLogs(entries)
+	available := gitHubIssueCommentMaxChars - commentChromeHeadroom - len(baseBody)
+	section := templates.RenderRecentFailureLogs(entries, available)
+	if section == "" && len(entries) > 0 {
+		logger.Error("summary body leaves no room for the recent-logs section under the GitHub comment size limit; posting summary without recent logs",
+			append(apply.LogAttrs(), "summary_chars", len(baseBody), "log_entries", len(entries))...)
+	}
+	return section
 }

--- a/pkg/webhook/failure_logs.go
+++ b/pkg/webhook/failure_logs.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"context"
+	"time"
 
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
@@ -13,25 +14,30 @@ import (
 // failure is what an operator triaging from the PR needs.
 const failureSummaryLogLimit = 50
 
+// failureLogsLoadTimeout bounds the log load so a slow storage read degrades
+// to a summary without logs rather than delaying the terminal comment.
+const failureLogsLoadTimeout = 2 * time.Second
+
 // failureLogsSection renders the collapsed recent-logs section for a terminal
 // summary comment. Only a failed apply carries logs — a completed, stopped, or
 // cancelled apply's summary stays clean, so this returns "" for those states.
-// Best-effort: a log-load failure is logged and returns "" so the summary
-// comment still posts; the full logs remain available from the CLI.
+// The load runs under its own short deadline, detached from the caller's
+// cancellation, so the section is decided by storage health alone. Best-effort:
+// a log-load failure is logged and returns "" so the summary comment still
+// posts; the full logs remain available from the CLI.
 func failureLogsSection(ctx context.Context, stor storage.Storage, logger interface {
 	Error(msg string, args ...any)
 }, apply *storage.Apply) string {
 	if !state.IsState(apply.State, state.Apply.Failed) {
 		return ""
 	}
-	logs, err := stor.ApplyLogs().GetByApply(ctx, apply.ID)
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), failureLogsLoadTimeout)
+	defer cancel()
+	logs, err := stor.ApplyLogs().GetRecentByApply(ctx, apply.ID, failureSummaryLogLimit)
 	if err != nil {
 		logger.Error("failed to load apply logs for failure summary; posting summary without recent logs",
 			append(apply.LogAttrs(), "error", err)...)
 		return ""
-	}
-	if len(logs) > failureSummaryLogLimit {
-		logs = logs[len(logs)-failureSummaryLogLimit:]
 	}
 	entries := make([]templates.LogEntryData, len(logs))
 	for i, entry := range logs {

--- a/pkg/webhook/failure_logs.go
+++ b/pkg/webhook/failure_logs.go
@@ -1,0 +1,47 @@
+package webhook
+
+import (
+	"context"
+
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/webhook/templates"
+)
+
+// failureSummaryLogLimit is how many log entries a failed apply's summary
+// comment carries. The newest entries are kept — the tail leading up to the
+// failure is what an operator triaging from the PR needs.
+const failureSummaryLogLimit = 50
+
+// failureLogsSection renders the collapsed recent-logs section for a terminal
+// summary comment. Only a failed apply carries logs — a completed, stopped, or
+// cancelled apply's summary stays clean, so this returns "" for those states.
+// Best-effort: a log-load failure is logged and returns "" so the summary
+// comment still posts; the full logs remain available from the CLI.
+func failureLogsSection(ctx context.Context, stor storage.Storage, logger interface {
+	Error(msg string, args ...any)
+}, apply *storage.Apply) string {
+	if !state.IsState(apply.State, state.Apply.Failed) {
+		return ""
+	}
+	logs, err := stor.ApplyLogs().GetByApply(ctx, apply.ID)
+	if err != nil {
+		logger.Error("failed to load apply logs for failure summary; posting summary without recent logs",
+			append(apply.LogAttrs(), "error", err)...)
+		return ""
+	}
+	if len(logs) > failureSummaryLogLimit {
+		logs = logs[len(logs)-failureSummaryLogLimit:]
+	}
+	entries := make([]templates.LogEntryData, len(logs))
+	for i, entry := range logs {
+		entries[i] = templates.LogEntryData{
+			CreatedAt: entry.CreatedAt,
+			Level:     entry.Level,
+			Message:   entry.Message,
+			OldState:  entry.OldState,
+			NewState:  entry.NewState,
+		}
+	}
+	return templates.RenderRecentFailureLogs(entries)
+}

--- a/pkg/webhook/failure_logs.go
+++ b/pkg/webhook/failure_logs.go
@@ -49,8 +49,8 @@ func failureLogsSection(ctx context.Context, stor storage.Storage, logger interf
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), failureLogsLoadTimeout)
 	defer cancel()
 	// Load one entry beyond the limit so the fold can label itself honestly:
-	// "Logs" when it carries the complete history, "Recent logs" when older
-	// entries exist beyond the tail.
+	// "Show logs" when it carries the complete history, "Show recent logs"
+	// when older entries exist beyond the tail.
 	logs, err := stor.ApplyLogs().GetRecentByApply(ctx, apply.ID, failureSummaryLogLimit+1)
 	if err != nil {
 		logger.Error("failed to load apply logs for failure summary; posting summary without recent logs",

--- a/pkg/webhook/failure_logs.go
+++ b/pkg/webhook/failure_logs.go
@@ -12,7 +12,8 @@ import (
 // commentChromeHeadroom reserves room under GitHub's comment size cap for
 // markup added to the body after the section is appended (the support-channel
 // footer) plus margin, so the assembled comment never lands exactly at the
-// limit.
+// limit. Config validation caps the support-channel name and URL lengths so
+// the rendered footer always fits inside this reservation.
 const commentChromeHeadroom = 1024
 
 // failureSummaryLogLimit bounds the log load for a failed apply's summary
@@ -46,6 +47,14 @@ func failureLogsSection(ctx context.Context, stor storage.Storage, logger interf
 	if !state.IsState(apply.State, state.Apply.Failed) {
 		return ""
 	}
+	// Check the room before touching storage: a summary body that leaves no
+	// renderable space makes the load pure waste.
+	available := templates.GitHubIssueCommentMaxChars - commentChromeHeadroom - len(baseBody)
+	if available < templates.MinFailureLogsSectionChars {
+		logger.Error("summary body leaves no room for the recent-logs section under the GitHub comment size limit; posting summary without recent logs",
+			append(apply.LogAttrs(), "summary_chars", len(baseBody))...)
+		return ""
+	}
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), failureLogsLoadTimeout)
 	defer cancel()
 	// Load one entry beyond the limit so the fold can label itself honestly:
@@ -71,11 +80,5 @@ func failureLogsSection(ctx context.Context, stor storage.Storage, logger interf
 			NewState:  entry.NewState,
 		}
 	}
-	available := templates.GitHubIssueCommentMaxChars - commentChromeHeadroom - len(baseBody)
-	section := templates.RenderRecentFailureLogs(entries, available, hasOlder)
-	if section == "" && len(entries) > 0 {
-		logger.Error("summary body leaves no room for the recent-logs section under the GitHub comment size limit; posting summary without recent logs",
-			append(apply.LogAttrs(), "summary_chars", len(baseBody), "log_entries", len(entries))...)
-	}
-	return section
+	return templates.RenderRecentFailureLogs(entries, available, hasOlder)
 }

--- a/pkg/webhook/failure_logs_integration_test.go
+++ b/pkg/webhook/failure_logs_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -138,6 +139,14 @@ func TestE2EFailedApplySummaryCarriesRecentLogs(t *testing.T) {
 	assert.Contains(t, summary, "[INF] Apply claimed by driver [queued -> running]")
 	assert.Contains(t, summary, "[ERR] Apply failed: lost MySQL connection during copy [running -> failed]")
 
+	// A summary body that already fills GitHub's comment budget leaves no room
+	// for the section — it must be dropped so the summary itself still posts.
+	hugeBase := strings.Repeat("x", gitHubIssueCommentMaxChars)
+	noRoom := failureLogsSection(ctx, st,
+		slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})),
+		&terminalApply, hugeBase)
+	assert.Empty(t, noRoom)
+
 	// Completed apply: the summary stays clean even though log entries exist.
 	completedApply := seedApply("done")
 	completedTask := task(completedApply, state.Task.Completed)
@@ -179,7 +188,7 @@ func waitForSummaryCreate(t *testing.T, capture *commentCapture) string {
 	select {
 	case created := <-capture.creates:
 		return created.Body
-	case <-time.After(5 * time.Second):
+	case <-time.After(webhookIntegrationCheckRunDeadline):
 		t.Fatal("timed out waiting for terminal summary comment")
 		return ""
 	}

--- a/pkg/webhook/failure_logs_integration_test.go
+++ b/pkg/webhook/failure_logs_integration_test.go
@@ -1,0 +1,186 @@
+//go:build integration
+
+package webhook
+
+import (
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/storage/mysqlstore"
+	"github.com/block/spirit/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This scenario covers the failure-triage UX on the PR timeline: when an apply
+// fails, its terminal summary comment must carry the apply's recent log entries
+// folded into a details block — the same entries the CLI logs command shows —
+// so an operator can triage without leaving GitHub. A successful apply's
+// summary must stay clean: no logs section.
+func TestE2EFailedApplySummaryCarriesRecentLogs(t *testing.T) {
+	ctx := t.Context()
+
+	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
+	require.NoError(t, err)
+	require.NoError(t, schemabotDB.PingContext(ctx))
+	t.Cleanup(func() { utils.CloseAndLog(schemabotDB) })
+
+	st := mysqlstore.New(schemabotDB)
+	repo := "org/failure-logs"
+
+	_, err = schemabotDB.ExecContext(ctx, "DELETE al FROM apply_logs al JOIN applies a ON al.apply_id = a.id WHERE a.repository = ?", repo)
+	require.NoError(t, err)
+	_, err = schemabotDB.ExecContext(ctx, "DELETE ac FROM apply_comments ac JOIN applies a ON ac.apply_id = a.id WHERE a.repository = ?", repo)
+	require.NoError(t, err)
+	_, err = schemabotDB.ExecContext(ctx, "DELETE FROM tasks WHERE repository = ?", repo)
+	require.NoError(t, err)
+	_, err = schemabotDB.ExecContext(ctx, "DELETE FROM applies WHERE repository = ?", repo)
+	require.NoError(t, err)
+
+	seedApply := func(suffix string) *storage.Apply {
+		now := time.Now()
+		apply := &storage.Apply{
+			ApplyIdentifier: fmt.Sprintf("apply_faillogs_%s_%d", suffix, now.UnixNano()),
+			PlanID:          1,
+			Database:        "e2e_failure_logs_db_" + suffix,
+			DatabaseType:    storage.DatabaseTypeMySQL,
+			Repository:      repo,
+			PullRequest:     46,
+			Environment:     "staging",
+			Caller:          repo + "#46",
+			InstallationID:  12345,
+			Engine:          storage.EngineSpirit,
+			State:           state.Apply.Running,
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		}
+		applyID, err := st.Applies().Create(ctx, apply)
+		require.NoError(t, err)
+		apply.ID = applyID
+		_, err = schemabotDB.ExecContext(ctx, `
+			UPDATE applies
+			SET lease_owner = ?, lease_token = ?, lease_acquired_at = NOW()
+			WHERE id = ?
+		`, "failure-logs-driver", "failure-logs-token-"+suffix, applyID)
+		require.NoError(t, err)
+		return apply
+	}
+
+	task := func(apply *storage.Apply, taskState string) *storage.Task {
+		now := time.Now()
+		task := &storage.Task{
+			TaskIdentifier: fmt.Sprintf("task_%s", apply.ApplyIdentifier),
+			ApplyID:        apply.ID,
+			PlanID:         apply.PlanID,
+			Database:       apply.Database,
+			DatabaseType:   apply.DatabaseType,
+			Engine:         storage.EngineSpirit,
+			Repository:     apply.Repository,
+			PullRequest:    apply.PullRequest,
+			Environment:    apply.Environment,
+			State:          taskState,
+			TableName:      "users",
+			DDL:            "ALTER TABLE `users` ADD COLUMN `failure_logs_note` varchar(255)",
+			DDLAction:      "alter",
+			Options:        []byte("{}"),
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}
+		taskID, err := st.Tasks().Create(ctx, task)
+		require.NoError(t, err)
+		task.ID = taskID
+		return task
+	}
+
+	// Failed apply: the summary must fold the recent log entries.
+	failedApply := seedApply("failed")
+	failedTask := task(failedApply, state.Task.Failed)
+	require.NoError(t, st.ApplyLogs().Append(ctx, &storage.ApplyLog{
+		ApplyID: failedApply.ID, Level: "info", EventType: "state_transition",
+		Message: "Apply claimed by driver", OldState: "queued", NewState: "running",
+	}))
+	require.NoError(t, st.ApplyLogs().Append(ctx, &storage.ApplyLog{
+		ApplyID: failedApply.ID, Level: "error", EventType: "state_transition",
+		Message: "Apply failed: lost MySQL connection during copy", OldState: "running", NewState: "failed",
+	}))
+
+	installClient, capture := setupFakeGitHubForComments(t)
+	observer := NewCommentObserver(CommentObserverConfig{
+		GHClient:       &fakeClientFactory{client: installClient},
+		Storage:        st,
+		Repo:           repo,
+		PR:             46,
+		InstallationID: 12345,
+		ApplyID:        failedApply.ID,
+		ApplyLease: storage.ApplyLease{
+			ApplyID: failedApply.ID,
+			Owner:   "failure-logs-driver",
+			Token:   "failure-logs-token-failed",
+		},
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})),
+	})
+
+	terminalApply := *failedApply
+	terminalApply.State = state.Apply.Failed
+	terminalApply.ErrorMessage = "lost MySQL connection during copy"
+	now := time.Now()
+	terminalApply.CompletedAt = &now
+	observer.OnTerminal(&terminalApply, []*storage.Task{failedTask})
+
+	summary := waitForSummaryCreate(t, capture)
+	assert.Contains(t, summary, "<summary>Recent logs (2)</summary>")
+	assert.Contains(t, summary, "[INF] Apply claimed by driver [queued -> running]")
+	assert.Contains(t, summary, "[ERR] Apply failed: lost MySQL connection during copy [running -> failed]")
+
+	// Completed apply: the summary stays clean even though log entries exist.
+	completedApply := seedApply("done")
+	completedTask := task(completedApply, state.Task.Completed)
+	require.NoError(t, st.ApplyLogs().Append(ctx, &storage.ApplyLog{
+		ApplyID: completedApply.ID, Level: "info", EventType: "state_transition",
+		Message: "Apply claimed by driver", OldState: "queued", NewState: "running",
+	}))
+
+	installClient2, capture2 := setupFakeGitHubForComments(t)
+	observer2 := NewCommentObserver(CommentObserverConfig{
+		GHClient:       &fakeClientFactory{client: installClient2},
+		Storage:        st,
+		Repo:           repo,
+		PR:             46,
+		InstallationID: 12345,
+		ApplyID:        completedApply.ID,
+		ApplyLease: storage.ApplyLease{
+			ApplyID: completedApply.ID,
+			Owner:   "failure-logs-driver",
+			Token:   "failure-logs-token-done",
+		},
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})),
+	})
+
+	terminalDone := *completedApply
+	terminalDone.State = state.Apply.Completed
+	terminalDone.CompletedAt = &now
+	observer2.OnTerminal(&terminalDone, []*storage.Task{completedTask})
+
+	doneSummary := waitForSummaryCreate(t, capture2)
+	assert.NotContains(t, doneSummary, "Recent logs")
+}
+
+// waitForSummaryCreate reads created comments until the terminal summary
+// appears (OnTerminal also freezes the progress comment via edit; only creates
+// arrive on this channel, and the summary is the only create in this flow).
+func waitForSummaryCreate(t *testing.T, capture *commentCapture) string {
+	t.Helper()
+	select {
+	case created := <-capture.creates:
+		return created.Body
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for terminal summary comment")
+		return ""
+	}
+}

--- a/pkg/webhook/failure_logs_integration_test.go
+++ b/pkg/webhook/failure_logs_integration_test.go
@@ -135,7 +135,7 @@ func TestE2EFailedApplySummaryCarriesRecentLogs(t *testing.T) {
 	observer.OnTerminal(&terminalApply, []*storage.Task{failedTask})
 
 	summary := waitForSummaryCreate(t, capture)
-	assert.Contains(t, summary, "<summary>Recent logs (2)</summary>")
+	assert.Contains(t, summary, "<summary>Logs (2)</summary>")
 	assert.Contains(t, summary, "[INF] Apply claimed by driver [queued -> running]")
 	assert.Contains(t, summary, "[ERR] Apply failed: lost MySQL connection during copy [running -> failed]")
 
@@ -177,6 +177,7 @@ func TestE2EFailedApplySummaryCarriesRecentLogs(t *testing.T) {
 	observer2.OnTerminal(&terminalDone, []*storage.Task{completedTask})
 
 	doneSummary := waitForSummaryCreate(t, capture2)
+	assert.NotContains(t, doneSummary, "<summary>Logs (")
 	assert.NotContains(t, doneSummary, "Recent logs")
 }
 

--- a/pkg/webhook/failure_logs_integration_test.go
+++ b/pkg/webhook/failure_logs_integration_test.go
@@ -136,7 +136,7 @@ func TestE2EFailedApplySummaryCarriesRecentLogs(t *testing.T) {
 	observer.OnTerminal(&terminalApply, []*storage.Task{failedTask})
 
 	summary := waitForSummaryCreate(t, capture)
-	assert.Contains(t, summary, "<summary>Logs (2)</summary>")
+	assert.Contains(t, summary, "<summary>Show logs (2 entries)</summary>")
 	assert.Contains(t, summary, "[INF] Apply claimed by driver [queued -> running]")
 	assert.Contains(t, summary, "[ERR] Apply failed: lost MySQL connection during copy [running -> failed]")
 
@@ -178,8 +178,8 @@ func TestE2EFailedApplySummaryCarriesRecentLogs(t *testing.T) {
 	observer2.OnTerminal(&terminalDone, []*storage.Task{completedTask})
 
 	doneSummary := waitForSummaryCreate(t, capture2)
-	assert.NotContains(t, doneSummary, "<summary>Logs (")
-	assert.NotContains(t, doneSummary, "Recent logs")
+	assert.NotContains(t, doneSummary, "<summary>Show logs (")
+	assert.NotContains(t, doneSummary, "Show recent logs")
 }
 
 // waitForSummaryCreate reads created comments until the terminal summary

--- a/pkg/webhook/failure_logs_integration_test.go
+++ b/pkg/webhook/failure_logs_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/storage/mysqlstore"
+	"github.com/block/schemabot/pkg/webhook/templates"
 	"github.com/block/spirit/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -141,7 +142,7 @@ func TestE2EFailedApplySummaryCarriesRecentLogs(t *testing.T) {
 
 	// A summary body that already fills GitHub's comment budget leaves no room
 	// for the section — it must be dropped so the summary itself still posts.
-	hugeBase := strings.Repeat("x", gitHubIssueCommentMaxChars)
+	hugeBase := strings.Repeat("x", templates.GitHubIssueCommentMaxChars)
 	noRoom := failureLogsSection(ctx, st,
 		slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})),
 		&terminalApply, hugeBase)

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -418,7 +418,8 @@ func (h *Handler) ReconcileMissingSummaryComments(ctx context.Context) {
 			ops = nil
 		}
 		released := releasedForApply(ctx, h.service.Storage(), apply, ops, h.logger)
-		summaryBody := formatApplySummaryComment(apply, ops, released, tasks, resolveDisplayByOperation(ctx, h.service.Storage(), apply, ops), nil, h.deploymentTenant())
+		summaryBody := formatApplySummaryComment(apply, ops, released, tasks, resolveDisplayByOperation(ctx, h.service.Storage(), apply, ops), nil, h.deploymentTenant()) +
+			failureLogsSection(ctx, h.service.Storage(), h.logger, apply)
 		h.postAndTrackComment(ctx, apply.Repository, apply.PullRequest, apply.InstallationID, apply.ID, state.Comment.Summary, summaryBody)
 	}
 }

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -418,8 +418,8 @@ func (h *Handler) ReconcileMissingSummaryComments(ctx context.Context) {
 			ops = nil
 		}
 		released := releasedForApply(ctx, h.service.Storage(), apply, ops, h.logger)
-		summaryBody := formatApplySummaryComment(apply, ops, released, tasks, resolveDisplayByOperation(ctx, h.service.Storage(), apply, ops), nil, h.deploymentTenant()) +
-			failureLogsSection(ctx, h.service.Storage(), h.logger, apply)
+		summaryBase := formatApplySummaryComment(apply, ops, released, tasks, resolveDisplayByOperation(ctx, h.service.Storage(), apply, ops), nil, h.deploymentTenant())
+		summaryBody := summaryBase + failureLogsSection(ctx, h.service.Storage(), h.logger, apply, summaryBase)
 		h.postAndTrackComment(ctx, apply.Repository, apply.PullRequest, apply.InstallationID, apply.ID, state.Comment.Summary, summaryBody)
 	}
 }

--- a/pkg/webhook/templates/failure_logs.go
+++ b/pkg/webhook/templates/failure_logs.go
@@ -50,9 +50,9 @@ const minFailureLogsSectionChars = 512
 // RenderRecentFailureLogs renders the collapsed logs section appended to a
 // failed apply's summary comment, formatted like the CLI logs output
 // (timestamp, level tag, message, state transition). The fold is labeled
-// "Logs" when it carries the apply's complete log history and "Recent logs"
-// when it is a tail — hasOlder reports that entries older than entries[0]
-// exist but were not loaded. The section spends at most available characters —
+// "Show logs" when it carries the apply's complete log history and "Show
+// recent logs" when it is a tail — hasOlder reports that entries older than
+// entries[0] exist but were not loaded. The section spends at most available characters —
 // the room the rest of the comment leaves under GitHub's size limit, so a
 // large summary body shrinks the fold instead of pushing the comment over the
 // limit. Returns "" when there are no entries or no meaningful room, so the
@@ -72,11 +72,15 @@ func RenderRecentFailureLogs(entries []LogEntryData, available int, hasOlder boo
 	}
 	lines, omitted := trimLogLinesToBudget(lines, budget-sectionChromeChars)
 
-	label := "Logs"
+	label := "Show logs"
 	if hasOlder || omitted > 0 {
-		label = "Recent logs"
+		label = "Show recent logs"
 	}
-	section := fmt.Sprintf("\n<details>\n<summary>%s (%d)</summary>\n\n", label, len(lines))
+	noun := "entries"
+	if len(lines) == 1 {
+		noun = "entry"
+	}
+	section := fmt.Sprintf("\n<details>\n<summary>%s (%d %s)</summary>\n\n", label, len(lines), noun)
 	if omitted > 0 {
 		section += fmt.Sprintf("_%d earlier entries omitted to fit the comment size limit._\n\n", omitted)
 	}

--- a/pkg/webhook/templates/failure_logs.go
+++ b/pkg/webhook/templates/failure_logs.go
@@ -58,11 +58,25 @@ func formatLogEntryLine(entry LogEntryData) string {
 	line := fmt.Sprintf("%s %s %s",
 		entry.CreatedAt.UTC().Format("2006-01-02 15:04:05 UTC"),
 		logLevelTag(entry.Level),
-		entry.Message)
+		sanitizeLogText(entry.Message))
 	if entry.OldState != "" && entry.NewState != "" {
-		line += fmt.Sprintf(" [%s -> %s]", entry.OldState, entry.NewState)
+		line += fmt.Sprintf(" [%s -> %s]", sanitizeLogText(entry.OldState), sanitizeLogText(entry.NewState))
 	}
 	return line
+}
+
+// sanitizeLogText makes untrusted log text safe inside the section's fenced
+// code block. Engine log messages pass through verbatim, so they can carry
+// newlines (which would break the one-line-per-entry format and the size
+// accounting) or a ``` sequence (which would close the fence and let the rest
+// of the text render as comment markup). Newlines collapse to spaces; backtick
+// runs are split with a space until no fence marker remains.
+func sanitizeLogText(text string) string {
+	text = strings.NewReplacer("\r\n", " ", "\n", " ", "\r", " ").Replace(text)
+	for strings.Contains(text, "```") {
+		text = strings.ReplaceAll(text, "```", "`` `")
+	}
+	return text
 }
 
 // logLevelTag returns the CLI's bracketed level indicator without colors.

--- a/pkg/webhook/templates/failure_logs.go
+++ b/pkg/webhook/templates/failure_logs.go
@@ -22,19 +22,37 @@ type LogEntryData struct {
 	NewState string
 }
 
-// maxFailureLogsSectionChars caps the rendered log block so the summary
-// comment stays under GitHub's comment size limit with headroom for the
-// summary body and fold markup. When the block would exceed it, the earliest
-// lines are dropped — the entries closest to the failure are what an operator
-// reading the PR needs.
+// maxFailureLogsSectionChars caps the rendered log block regardless of how
+// much room the summary body leaves, so a short summary never carries an
+// unreadably long fold. When the block would exceed the effective budget, the
+// earliest lines are dropped — the entries closest to the failure are what an
+// operator reading the PR needs.
 const maxFailureLogsSectionChars = 50000
+
+// sectionChromeChars reserves room within the budget for the section's own
+// markup: the details/summary fold, the omitted-entries note, and the code
+// fences.
+const sectionChromeChars = 256
+
+// minFailureLogsSectionChars is the smallest budget worth rendering for — below
+// this, not even one truncated log line would convey anything useful, so the
+// section is dropped entirely.
+const minFailureLogsSectionChars = 512
 
 // RenderRecentFailureLogs renders the collapsed recent-logs section appended
 // to a failed apply's summary comment, formatted like the CLI logs output
-// (timestamp, level tag, message, state transition). Returns "" when there are
-// no entries so the summary renders unchanged.
-func RenderRecentFailureLogs(entries []LogEntryData) string {
+// (timestamp, level tag, message, state transition). The section spends at
+// most min(available, maxFailureLogsSectionChars) characters — available is
+// the room the rest of the comment leaves under GitHub's size limit, so a
+// large summary body shrinks the fold instead of pushing the comment over the
+// limit. Returns "" when there are no entries or no meaningful room, so the
+// summary renders unchanged.
+func RenderRecentFailureLogs(entries []LogEntryData, available int) string {
 	if len(entries) == 0 {
+		return ""
+	}
+	budget := min(available, maxFailureLogsSectionChars)
+	if budget < minFailureLogsSectionChars {
 		return ""
 	}
 
@@ -42,7 +60,7 @@ func RenderRecentFailureLogs(entries []LogEntryData) string {
 	for i, entry := range entries {
 		lines[i] = formatLogEntryLine(entry)
 	}
-	lines, omitted := trimLogLinesToBudget(lines, maxFailureLogsSectionChars)
+	lines, omitted := trimLogLinesToBudget(lines, budget-sectionChromeChars)
 
 	section := fmt.Sprintf("\n<details>\n<summary>Recent logs (%d)</summary>\n\n", len(entries))
 	if omitted > 0 {
@@ -97,8 +115,9 @@ func logLevelTag(level string) string {
 
 // trimLogLinesToBudget drops the earliest lines until the joined block fits
 // the budget, returning the kept lines and how many were dropped. The newest
-// lines always survive; a single oversized line is kept rather than rendering
-// an empty block.
+// lines always survive; when the last remaining line alone exceeds the budget
+// (a single enormous engine error message), it is truncated to fit rather than
+// carried oversize — the block must never exceed the budget.
 func trimLogLinesToBudget(lines []string, budget int) ([]string, int) {
 	total := 0
 	for _, line := range lines {
@@ -110,7 +129,32 @@ func trimLogLinesToBudget(lines []string, budget int) ([]string, int) {
 		lines = lines[1:]
 		omitted++
 	}
+	if len(lines) == 1 && total > budget {
+		lines[0] = truncateToBytes(lines[0], budget-len("…")-1) + "…"
+	}
 	return lines, omitted
+}
+
+// truncateToBytes cuts text to at most maxBytes without splitting a UTF-8
+// rune, so the truncated line stays valid text.
+func truncateToBytes(text string, maxBytes int) string {
+	if maxBytes <= 0 {
+		return ""
+	}
+	if len(text) <= maxBytes {
+		return text
+	}
+	cut := maxBytes
+	for cut > 0 && !isUTF8Start(text[cut]) {
+		cut--
+	}
+	return text[:cut]
+}
+
+// isUTF8Start reports whether b is the first byte of a UTF-8 rune (i.e. not a
+// continuation byte).
+func isUTF8Start(b byte) bool {
+	return b&0xC0 != 0x80
 }
 
 // sampleFailureLogEntries returns the log entries shared by the failed-summary

--- a/pkg/webhook/templates/failure_logs.go
+++ b/pkg/webhook/templates/failure_logs.go
@@ -39,15 +39,18 @@ const sectionChromeChars = 256
 // section is dropped entirely.
 const minFailureLogsSectionChars = 512
 
-// RenderRecentFailureLogs renders the collapsed recent-logs section appended
-// to a failed apply's summary comment, formatted like the CLI logs output
-// (timestamp, level tag, message, state transition). The section spends at
-// most min(available, maxFailureLogsSectionChars) characters — available is
-// the room the rest of the comment leaves under GitHub's size limit, so a
-// large summary body shrinks the fold instead of pushing the comment over the
+// RenderRecentFailureLogs renders the collapsed logs section appended to a
+// failed apply's summary comment, formatted like the CLI logs output
+// (timestamp, level tag, message, state transition). The fold is labeled
+// "Logs" when it carries the apply's complete log history and "Recent logs"
+// when it is a tail — hasOlder reports that entries older than entries[0]
+// exist but were not loaded. The section spends at most
+// min(available, maxFailureLogsSectionChars) characters — available is the
+// room the rest of the comment leaves under GitHub's size limit, so a large
+// summary body shrinks the fold instead of pushing the comment over the
 // limit. Returns "" when there are no entries or no meaningful room, so the
 // summary renders unchanged.
-func RenderRecentFailureLogs(entries []LogEntryData, available int) string {
+func RenderRecentFailureLogs(entries []LogEntryData, available int, hasOlder bool) string {
 	if len(entries) == 0 {
 		return ""
 	}
@@ -62,7 +65,11 @@ func RenderRecentFailureLogs(entries []LogEntryData, available int) string {
 	}
 	lines, omitted := trimLogLinesToBudget(lines, budget-sectionChromeChars)
 
-	section := fmt.Sprintf("\n<details>\n<summary>Recent logs (%d)</summary>\n\n", len(entries))
+	label := "Logs"
+	if hasOlder || omitted > 0 {
+		label = "Recent logs"
+	}
+	section := fmt.Sprintf("\n<details>\n<summary>%s (%d)</summary>\n\n", label, len(lines))
 	if omitted > 0 {
 		section += fmt.Sprintf("_%d earlier entries omitted to fit the comment size limit._\n\n", omitted)
 	}

--- a/pkg/webhook/templates/failure_logs.go
+++ b/pkg/webhook/templates/failure_logs.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // LogEntryData is one apply log line rendered into the recent-logs section of
@@ -31,21 +32,23 @@ type LogEntryData struct {
 const GitHubIssueCommentMaxChars = 65536
 
 // MinRenderedLogLineChars is the smallest a rendered log line can be: the UTC
-// timestamp, the bracketed level tag, and at least one message character plus
-// the joining newline. Callers use it to bound how many entries could ever
-// fit in a fold — loading more than budget / MinRenderedLogLineChars entries
-// can never add a rendered line.
-const MinRenderedLogLineChars = len("2006-01-02 15:04:05 UTC [INF] x") + 1
+// timestamp and the bracketed level tag with their separating spaces, plus the
+// joining newline — the degenerate case of an empty level and empty message.
+// Callers use it to bound how many entries could ever fit in a fold — loading
+// more than budget / MinRenderedLogLineChars entries can never add a rendered
+// line.
+const MinRenderedLogLineChars = len("2006-01-02 15:04:05 UTC [] ") + 1
 
 // sectionChromeChars reserves room within the budget for the section's own
 // markup: the details/summary fold, the omitted-entries note, and the code
 // fences.
 const sectionChromeChars = 256
 
-// minFailureLogsSectionChars is the smallest budget worth rendering for — below
-// this, not even one truncated log line would convey anything useful, so the
-// section is dropped entirely.
-const minFailureLogsSectionChars = 512
+// MinFailureLogsSectionChars is the smallest budget worth rendering for —
+// below this, not even one truncated log line would convey anything useful, so
+// the section is dropped entirely. Callers can pre-check their available room
+// against it to skip loading entries that could never render.
+const MinFailureLogsSectionChars = 512
 
 // RenderRecentFailureLogs renders the collapsed logs section appended to a
 // failed apply's summary comment, formatted like the CLI logs output
@@ -61,7 +64,7 @@ func RenderRecentFailureLogs(entries []LogEntryData, available int, hasOlder boo
 	if len(entries) == 0 {
 		return ""
 	}
-	if available < minFailureLogsSectionChars {
+	if available < MinFailureLogsSectionChars {
 		return ""
 	}
 	budget := available
@@ -82,7 +85,11 @@ func RenderRecentFailureLogs(entries []LogEntryData, available int, hasOlder boo
 	}
 	section := fmt.Sprintf("\n<details>\n<summary>%s (%d %s)</summary>\n\n", label, len(lines), noun)
 	if omitted > 0 {
-		section += fmt.Sprintf("_%d earlier entries omitted to fit the comment size limit._\n\n", omitted)
+		note := fmt.Sprintf("_%d earlier entries omitted to fit the comment size limit", omitted)
+		if hasOlder {
+			note += " (older entries also exist)"
+		}
+		section += note + "._\n\n"
 	}
 	section += "```text\n" + strings.Join(lines, "\n") + "\n```\n\n</details>\n"
 	return section
@@ -93,7 +100,7 @@ func RenderRecentFailureLogs(entries []LogEntryData, available int, hasOlder boo
 func formatLogEntryLine(entry LogEntryData) string {
 	line := fmt.Sprintf("%s %s %s",
 		entry.CreatedAt.UTC().Format("2006-01-02 15:04:05 UTC"),
-		logLevelTag(entry.Level),
+		LogLevelTag(entry.Level),
 		sanitizeLogText(entry.Message))
 	if entry.OldState != "" && entry.NewState != "" {
 		line += fmt.Sprintf(" [%s -> %s]", sanitizeLogText(entry.OldState), sanitizeLogText(entry.NewState))
@@ -115,8 +122,11 @@ func sanitizeLogText(text string) string {
 	return text
 }
 
-// logLevelTag returns the CLI's bracketed level indicator without colors.
-func logLevelTag(level string) string {
+// LogLevelTag returns the bracketed apply-log level indicator without colors:
+// [ERR], [WRN], [INF], [DBG], or [LEVEL] for anything else. It is the single
+// source of the tag text — the CLI logs output wraps it in ANSI colors, and
+// the failed-summary fold renders it bare — so the two surfaces cannot drift.
+func LogLevelTag(level string) string {
 	switch strings.ToLower(level) {
 	case "error":
 		return "[ERR]"
@@ -163,16 +173,10 @@ func truncateToBytes(text string, maxBytes int) string {
 		return text
 	}
 	cut := maxBytes
-	for cut > 0 && !isUTF8Start(text[cut]) {
+	for cut > 0 && !utf8.RuneStart(text[cut]) {
 		cut--
 	}
 	return text[:cut]
-}
-
-// isUTF8Start reports whether b is the first byte of a UTF-8 rune (i.e. not a
-// continuation byte).
-func isUTF8Start(b byte) bool {
-	return b&0xC0 != 0x80
 }
 
 // sampleFailureLogEntries returns the log entries shared by the failed-summary

--- a/pkg/webhook/templates/failure_logs.go
+++ b/pkg/webhook/templates/failure_logs.go
@@ -22,18 +22,19 @@ type LogEntryData struct {
 	NewState string
 }
 
-// MaxFailureLogsSectionChars caps the rendered log block regardless of how
-// much room the summary body leaves, so a short summary never carries an
-// unreadably long fold. When the block would exceed the effective budget, the
-// earliest lines are dropped — the entries closest to the failure are what an
-// operator reading the PR needs.
-const MaxFailureLogsSectionChars = 50000
+// GitHubIssueCommentMaxChars is GitHub's hard cap on an issue comment body —
+// a larger body is rejected outright, so everything rendered into a comment
+// must fit under it. This is the only size limit on the logs section: the
+// fold spends whatever room the rest of the comment leaves, and when the
+// block would exceed that, the earliest lines are dropped — the entries
+// closest to the failure are what an operator reading the PR needs.
+const GitHubIssueCommentMaxChars = 65536
 
 // MinRenderedLogLineChars is the smallest a rendered log line can be: the UTC
 // timestamp, the bracketed level tag, and at least one message character plus
 // the joining newline. Callers use it to bound how many entries could ever
-// fit in a fold — loading more than MaxFailureLogsSectionChars /
-// MinRenderedLogLineChars entries can never add a rendered line.
+// fit in a fold — loading more than budget / MinRenderedLogLineChars entries
+// can never add a rendered line.
 const MinRenderedLogLineChars = len("2006-01-02 15:04:05 UTC [INF] x") + 1
 
 // sectionChromeChars reserves room within the budget for the section's own
@@ -51,20 +52,19 @@ const minFailureLogsSectionChars = 512
 // (timestamp, level tag, message, state transition). The fold is labeled
 // "Logs" when it carries the apply's complete log history and "Recent logs"
 // when it is a tail — hasOlder reports that entries older than entries[0]
-// exist but were not loaded. The section spends at most
-// min(available, MaxFailureLogsSectionChars) characters — available is the
-// room the rest of the comment leaves under GitHub's size limit, so a large
-// summary body shrinks the fold instead of pushing the comment over the
+// exist but were not loaded. The section spends at most available characters —
+// the room the rest of the comment leaves under GitHub's size limit, so a
+// large summary body shrinks the fold instead of pushing the comment over the
 // limit. Returns "" when there are no entries or no meaningful room, so the
 // summary renders unchanged.
 func RenderRecentFailureLogs(entries []LogEntryData, available int, hasOlder bool) string {
 	if len(entries) == 0 {
 		return ""
 	}
-	budget := min(available, MaxFailureLogsSectionChars)
-	if budget < minFailureLogsSectionChars {
+	if available < minFailureLogsSectionChars {
 		return ""
 	}
+	budget := available
 
 	lines := make([]string, len(entries))
 	for i, entry := range entries {

--- a/pkg/webhook/templates/failure_logs.go
+++ b/pkg/webhook/templates/failure_logs.go
@@ -22,12 +22,19 @@ type LogEntryData struct {
 	NewState string
 }
 
-// maxFailureLogsSectionChars caps the rendered log block regardless of how
+// MaxFailureLogsSectionChars caps the rendered log block regardless of how
 // much room the summary body leaves, so a short summary never carries an
 // unreadably long fold. When the block would exceed the effective budget, the
 // earliest lines are dropped — the entries closest to the failure are what an
 // operator reading the PR needs.
-const maxFailureLogsSectionChars = 50000
+const MaxFailureLogsSectionChars = 50000
+
+// MinRenderedLogLineChars is the smallest a rendered log line can be: the UTC
+// timestamp, the bracketed level tag, and at least one message character plus
+// the joining newline. Callers use it to bound how many entries could ever
+// fit in a fold — loading more than MaxFailureLogsSectionChars /
+// MinRenderedLogLineChars entries can never add a rendered line.
+const MinRenderedLogLineChars = len("2006-01-02 15:04:05 UTC [INF] x") + 1
 
 // sectionChromeChars reserves room within the budget for the section's own
 // markup: the details/summary fold, the omitted-entries note, and the code
@@ -45,7 +52,7 @@ const minFailureLogsSectionChars = 512
 // "Logs" when it carries the apply's complete log history and "Recent logs"
 // when it is a tail — hasOlder reports that entries older than entries[0]
 // exist but were not loaded. The section spends at most
-// min(available, maxFailureLogsSectionChars) characters — available is the
+// min(available, MaxFailureLogsSectionChars) characters — available is the
 // room the rest of the comment leaves under GitHub's size limit, so a large
 // summary body shrinks the fold instead of pushing the comment over the
 // limit. Returns "" when there are no entries or no meaningful room, so the
@@ -54,7 +61,7 @@ func RenderRecentFailureLogs(entries []LogEntryData, available int, hasOlder boo
 	if len(entries) == 0 {
 		return ""
 	}
-	budget := min(available, maxFailureLogsSectionChars)
+	budget := min(available, MaxFailureLogsSectionChars)
 	if budget < minFailureLogsSectionChars {
 		return ""
 	}

--- a/pkg/webhook/templates/failure_logs.go
+++ b/pkg/webhook/templates/failure_logs.go
@@ -1,0 +1,114 @@
+package templates
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// LogEntryData is one apply log line rendered into the recent-logs section of
+// a failed apply's summary comment.
+type LogEntryData struct {
+	// CreatedAt is when the entry was written; rendered in UTC because PR
+	// comments are read across timezones.
+	CreatedAt time.Time
+	// Level is the log level: "debug", "info", "warn", "error".
+	Level string
+	// Message is the human-readable log message.
+	Message string
+	// OldState and NewState carry the transition for state-change entries;
+	// both empty for plain messages.
+	OldState string
+	NewState string
+}
+
+// maxFailureLogsSectionChars caps the rendered log block so the summary
+// comment stays under GitHub's comment size limit with headroom for the
+// summary body and fold markup. When the block would exceed it, the earliest
+// lines are dropped — the entries closest to the failure are what an operator
+// reading the PR needs.
+const maxFailureLogsSectionChars = 50000
+
+// RenderRecentFailureLogs renders the collapsed recent-logs section appended
+// to a failed apply's summary comment, formatted like the CLI logs output
+// (timestamp, level tag, message, state transition). Returns "" when there are
+// no entries so the summary renders unchanged.
+func RenderRecentFailureLogs(entries []LogEntryData) string {
+	if len(entries) == 0 {
+		return ""
+	}
+
+	lines := make([]string, len(entries))
+	for i, entry := range entries {
+		lines[i] = formatLogEntryLine(entry)
+	}
+	lines, omitted := trimLogLinesToBudget(lines, maxFailureLogsSectionChars)
+
+	section := fmt.Sprintf("\n<details>\n<summary>Recent logs (%d)</summary>\n\n", len(entries))
+	if omitted > 0 {
+		section += fmt.Sprintf("_%d earlier entries omitted to fit the comment size limit._\n\n", omitted)
+	}
+	section += "```text\n" + strings.Join(lines, "\n") + "\n```\n\n</details>\n"
+	return section
+}
+
+// formatLogEntryLine renders one log entry in the CLI logs format, minus the
+// terminal colors: `2026-07-12 16:32:01 UTC [INF] message [running -> stopped]`.
+func formatLogEntryLine(entry LogEntryData) string {
+	line := fmt.Sprintf("%s %s %s",
+		entry.CreatedAt.UTC().Format("2006-01-02 15:04:05 UTC"),
+		logLevelTag(entry.Level),
+		entry.Message)
+	if entry.OldState != "" && entry.NewState != "" {
+		line += fmt.Sprintf(" [%s -> %s]", entry.OldState, entry.NewState)
+	}
+	return line
+}
+
+// logLevelTag returns the CLI's bracketed level indicator without colors.
+func logLevelTag(level string) string {
+	switch strings.ToLower(level) {
+	case "error":
+		return "[ERR]"
+	case "warn":
+		return "[WRN]"
+	case "info":
+		return "[INF]"
+	case "debug":
+		return "[DBG]"
+	default:
+		return "[" + strings.ToUpper(level) + "]"
+	}
+}
+
+// trimLogLinesToBudget drops the earliest lines until the joined block fits
+// the budget, returning the kept lines and how many were dropped. The newest
+// lines always survive; a single oversized line is kept rather than rendering
+// an empty block.
+func trimLogLinesToBudget(lines []string, budget int) ([]string, int) {
+	total := 0
+	for _, line := range lines {
+		total += len(line) + 1
+	}
+	omitted := 0
+	for total > budget && len(lines) > 1 {
+		total -= len(lines[0]) + 1
+		lines = lines[1:]
+		omitted++
+	}
+	return lines, omitted
+}
+
+// sampleFailureLogEntries returns the log entries shared by the failed-summary
+// previews: the tail of an apply that failed mid-copy, ending with the given
+// failure so the fold reads coherently with the preview's error block.
+func sampleFailureLogEntries(failedTable, failureMessage string) []LogEntryData {
+	start := sampleTime().Add(-8 * time.Minute)
+	return []LogEntryData{
+		{CreatedAt: start, Level: "info", Message: "Apply claimed by driver", OldState: "queued", NewState: "running"},
+		{CreatedAt: start.Add(15 * time.Second), Level: "info", Message: "Task started: schema change on `" + failedTable + "`"},
+		{CreatedAt: start.Add(3 * time.Minute), Level: "warn", Message: "Copy throttled by replication lag (1.2s)"},
+		{CreatedAt: start.Add(6 * time.Minute), Level: "error", Message: "Task failed: " + failureMessage},
+		{CreatedAt: start.Add(7 * time.Minute), Level: "error", Message: "Apply failed", OldState: "running", NewState: "failed"},
+	}
+}

--- a/pkg/webhook/templates/failure_logs_test.go
+++ b/pkg/webhook/templates/failure_logs_test.go
@@ -9,20 +9,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestRenderRecentFailureLogs verifies the recent-logs section appended to a
-// failed apply's summary folds the entries into a details block and formats
-// each line like the CLI logs output: UTC timestamp, bracketed level tag,
-// message, and state transition when set.
+// TestRenderRecentFailureLogs verifies the logs section appended to a failed
+// apply's summary folds the entries into a details block and formats each
+// line like the CLI logs output: UTC timestamp, bracketed level tag, message,
+// and state transition when set. A complete history is labeled "Logs" — no
+// entries were left out, so the fold must not suggest a subset.
 func TestRenderRecentFailureLogs(t *testing.T) {
 	at := time.Date(2026, 7, 12, 16, 32, 1, 0, time.UTC)
 	rendered := RenderRecentFailureLogs([]LogEntryData{
 		{CreatedAt: at, Level: "info", Message: "Apply claimed by driver", OldState: "queued", NewState: "running"},
 		{CreatedAt: at.Add(3 * time.Second), Level: "warn", Message: "Copy throttled by replication lag"},
 		{CreatedAt: at.Add(9 * time.Second), Level: "error", Message: "Lost MySQL connection; retrying"},
-	}, maxFailureLogsSectionChars)
+	}, maxFailureLogsSectionChars, false)
 
 	assert.Contains(t, rendered, "<details>")
-	assert.Contains(t, rendered, "<summary>Recent logs (3)</summary>")
+	assert.Contains(t, rendered, "<summary>Logs (3)</summary>")
+	assert.NotContains(t, rendered, "Recent logs")
 	assert.Contains(t, rendered, "```text")
 	assert.Contains(t, rendered, "2026-07-12 16:32:01 UTC [INF] Apply claimed by driver [queued -> running]")
 	assert.Contains(t, rendered, "2026-07-12 16:32:04 UTC [WRN] Copy throttled by replication lag")
@@ -30,10 +32,22 @@ func TestRenderRecentFailureLogs(t *testing.T) {
 	assert.NotContains(t, rendered, "omitted")
 }
 
+// TestRenderRecentFailureLogsTailLabel verifies that when older entries exist
+// beyond the loaded tail, the fold is labeled "Recent logs" so the operator
+// knows they are seeing a subset, not the full history.
+func TestRenderRecentFailureLogsTailLabel(t *testing.T) {
+	at := time.Date(2026, 7, 12, 16, 32, 1, 0, time.UTC)
+	rendered := RenderRecentFailureLogs([]LogEntryData{
+		{CreatedAt: at, Level: "error", Message: "Apply failed", OldState: "running", NewState: "failed"},
+	}, maxFailureLogsSectionChars, true)
+
+	assert.Contains(t, rendered, "<summary>Recent logs (1)</summary>")
+}
+
 // TestRenderRecentFailureLogsEmpty verifies an apply with no log entries adds
 // nothing to the summary — no empty details block.
 func TestRenderRecentFailureLogsEmpty(t *testing.T) {
-	assert.Empty(t, RenderRecentFailureLogs(nil, maxFailureLogsSectionChars))
+	assert.Empty(t, RenderRecentFailureLogs(nil, maxFailureLogsSectionChars, false))
 }
 
 // TestRenderRecentFailureLogsSanitizesUntrustedText verifies engine-supplied
@@ -46,7 +60,7 @@ func TestRenderRecentFailureLogsSanitizesUntrustedText(t *testing.T) {
 		{CreatedAt: at, Level: "error", Message: "line one\r\nline two\nline three"},
 		{CreatedAt: at.Add(time.Second), Level: "error", Message: "fence breakout ```\n# not a heading"},
 		{CreatedAt: at.Add(2 * time.Second), Level: "error", Message: "long run `````x"},
-	}, maxFailureLogsSectionChars)
+	}, maxFailureLogsSectionChars, false)
 
 	assert.Contains(t, rendered, "[ERR] line one line two line three")
 	assert.Contains(t, rendered, "[ERR] fence breakout `` ` # not a heading")
@@ -56,7 +70,8 @@ func TestRenderRecentFailureLogsSanitizesUntrustedText(t *testing.T) {
 
 // TestRenderRecentFailureLogsTrimsToSizeBudget verifies that when the rendered
 // log block would blow GitHub's comment size limit, the earliest lines are
-// dropped, the newest are kept, and the fold says how many were omitted.
+// dropped, the newest are kept, the fold says how many were omitted, and the
+// label flips to "Recent logs" because a subset is shown.
 func TestRenderRecentFailureLogsTrimsToSizeBudget(t *testing.T) {
 	at := time.Date(2026, 7, 12, 16, 0, 0, 0, time.UTC)
 	entries := make([]LogEntryData, 100)
@@ -67,10 +82,10 @@ func TestRenderRecentFailureLogsTrimsToSizeBudget(t *testing.T) {
 			Message:   strings.Repeat("x", 1000) + " #" + time.Duration(i).String(),
 		}
 	}
-	rendered := RenderRecentFailureLogs(entries, maxFailureLogsSectionChars)
+	rendered := RenderRecentFailureLogs(entries, maxFailureLogsSectionChars, false)
 
 	require.Less(t, len(rendered), 65536, "rendered section must leave room inside GitHub's size limit")
-	assert.Contains(t, rendered, "<summary>Recent logs (100)</summary>")
+	assert.Contains(t, rendered, "<summary>Recent logs (")
 	assert.Contains(t, rendered, "earlier entries omitted")
 	assert.NotContains(t, rendered, "16:00:00 UTC", "earliest entry is dropped first")
 	assert.Contains(t, rendered, "16:01:39 UTC", "newest entry always survives")
@@ -91,7 +106,7 @@ func TestRenderRecentFailureLogsShrinksToAvailableRoom(t *testing.T) {
 		}
 	}
 	available := 2000
-	rendered := RenderRecentFailureLogs(entries, available)
+	rendered := RenderRecentFailureLogs(entries, available, false)
 
 	require.NotEmpty(t, rendered)
 	assert.LessOrEqual(t, len(rendered), available, "the section must fit in the room the summary body leaves")
@@ -108,9 +123,9 @@ func TestRenderRecentFailureLogsSkipsWhenNoRoom(t *testing.T) {
 	entries := []LogEntryData{
 		{CreatedAt: time.Date(2026, 7, 12, 16, 0, 0, 0, time.UTC), Level: "error", Message: "Apply failed"},
 	}
-	assert.Empty(t, RenderRecentFailureLogs(entries, 0))
-	assert.Empty(t, RenderRecentFailureLogs(entries, -500))
-	assert.Empty(t, RenderRecentFailureLogs(entries, minFailureLogsSectionChars-1))
+	assert.Empty(t, RenderRecentFailureLogs(entries, 0, false))
+	assert.Empty(t, RenderRecentFailureLogs(entries, -500, false))
+	assert.Empty(t, RenderRecentFailureLogs(entries, minFailureLogsSectionChars-1, false))
 }
 
 // TestRenderRecentFailureLogsTruncatesSingleOversizedLine verifies one
@@ -125,7 +140,7 @@ func TestRenderRecentFailureLogsTruncatesSingleOversizedLine(t *testing.T) {
 		},
 	}
 	available := 4000
-	rendered := RenderRecentFailureLogs(entries, available)
+	rendered := RenderRecentFailureLogs(entries, available, false)
 
 	require.NotEmpty(t, rendered)
 	assert.LessOrEqual(t, len(rendered), available, "a single oversized line must be truncated to the budget")

--- a/pkg/webhook/templates/failure_logs_test.go
+++ b/pkg/webhook/templates/failure_logs_test.go
@@ -125,7 +125,7 @@ func TestRenderRecentFailureLogsSkipsWhenNoRoom(t *testing.T) {
 	}
 	assert.Empty(t, RenderRecentFailureLogs(entries, 0, false))
 	assert.Empty(t, RenderRecentFailureLogs(entries, -500, false))
-	assert.Empty(t, RenderRecentFailureLogs(entries, minFailureLogsSectionChars-1, false))
+	assert.Empty(t, RenderRecentFailureLogs(entries, MinFailureLogsSectionChars-1, false))
 }
 
 // TestRenderRecentFailureLogsTruncatesSingleOversizedLine verifies one

--- a/pkg/webhook/templates/failure_logs_test.go
+++ b/pkg/webhook/templates/failure_logs_test.go
@@ -36,6 +36,24 @@ func TestRenderRecentFailureLogsEmpty(t *testing.T) {
 	assert.Empty(t, RenderRecentFailureLogs(nil))
 }
 
+// TestRenderRecentFailureLogsSanitizesUntrustedText verifies engine-supplied
+// log text cannot break out of the fenced code block: newlines collapse to
+// spaces so every entry stays on one line, and backtick fences are split so
+// the rest of the comment cannot be reinterpreted as markup.
+func TestRenderRecentFailureLogsSanitizesUntrustedText(t *testing.T) {
+	at := time.Date(2026, 7, 12, 16, 32, 1, 0, time.UTC)
+	rendered := RenderRecentFailureLogs([]LogEntryData{
+		{CreatedAt: at, Level: "error", Message: "line one\r\nline two\nline three"},
+		{CreatedAt: at.Add(time.Second), Level: "error", Message: "fence breakout ```\n# not a heading"},
+		{CreatedAt: at.Add(2 * time.Second), Level: "error", Message: "long run `````x"},
+	})
+
+	assert.Contains(t, rendered, "[ERR] line one line two line three")
+	assert.Contains(t, rendered, "[ERR] fence breakout `` ` # not a heading")
+	assert.Equal(t, 2, strings.Count(rendered, "```"), "only the section's own fence markers survive")
+	assert.Equal(t, strings.Index(rendered, "```text"), strings.Index(rendered, "```"), "first fence marker is the section's opener")
+}
+
 // TestRenderRecentFailureLogsTrimsToSizeBudget verifies that when the rendered
 // log block would blow GitHub's comment size limit, the earliest lines are
 // dropped, the newest are kept, and the fold says how many were omitted.

--- a/pkg/webhook/templates/failure_logs_test.go
+++ b/pkg/webhook/templates/failure_logs_test.go
@@ -19,7 +19,7 @@ func TestRenderRecentFailureLogs(t *testing.T) {
 		{CreatedAt: at, Level: "info", Message: "Apply claimed by driver", OldState: "queued", NewState: "running"},
 		{CreatedAt: at.Add(3 * time.Second), Level: "warn", Message: "Copy throttled by replication lag"},
 		{CreatedAt: at.Add(9 * time.Second), Level: "error", Message: "Lost MySQL connection; retrying"},
-	})
+	}, maxFailureLogsSectionChars)
 
 	assert.Contains(t, rendered, "<details>")
 	assert.Contains(t, rendered, "<summary>Recent logs (3)</summary>")
@@ -33,7 +33,7 @@ func TestRenderRecentFailureLogs(t *testing.T) {
 // TestRenderRecentFailureLogsEmpty verifies an apply with no log entries adds
 // nothing to the summary — no empty details block.
 func TestRenderRecentFailureLogsEmpty(t *testing.T) {
-	assert.Empty(t, RenderRecentFailureLogs(nil))
+	assert.Empty(t, RenderRecentFailureLogs(nil, maxFailureLogsSectionChars))
 }
 
 // TestRenderRecentFailureLogsSanitizesUntrustedText verifies engine-supplied
@@ -46,7 +46,7 @@ func TestRenderRecentFailureLogsSanitizesUntrustedText(t *testing.T) {
 		{CreatedAt: at, Level: "error", Message: "line one\r\nline two\nline three"},
 		{CreatedAt: at.Add(time.Second), Level: "error", Message: "fence breakout ```\n# not a heading"},
 		{CreatedAt: at.Add(2 * time.Second), Level: "error", Message: "long run `````x"},
-	})
+	}, maxFailureLogsSectionChars)
 
 	assert.Contains(t, rendered, "[ERR] line one line two line three")
 	assert.Contains(t, rendered, "[ERR] fence breakout `` ` # not a heading")
@@ -67,11 +67,69 @@ func TestRenderRecentFailureLogsTrimsToSizeBudget(t *testing.T) {
 			Message:   strings.Repeat("x", 1000) + " #" + time.Duration(i).String(),
 		}
 	}
-	rendered := RenderRecentFailureLogs(entries)
+	rendered := RenderRecentFailureLogs(entries, maxFailureLogsSectionChars)
 
 	require.Less(t, len(rendered), 65536, "rendered section must leave room inside GitHub's size limit")
 	assert.Contains(t, rendered, "<summary>Recent logs (100)</summary>")
 	assert.Contains(t, rendered, "earlier entries omitted")
 	assert.NotContains(t, rendered, "16:00:00 UTC", "earliest entry is dropped first")
 	assert.Contains(t, rendered, "16:01:39 UTC", "newest entry always survives")
+}
+
+// TestRenderRecentFailureLogsShrinksToAvailableRoom verifies a large summary
+// body shrinks the section: with less room available than the default cap, the
+// section trims to what fits so appending it never pushes the assembled
+// comment over GitHub's size limit.
+func TestRenderRecentFailureLogsShrinksToAvailableRoom(t *testing.T) {
+	at := time.Date(2026, 7, 12, 16, 0, 0, 0, time.UTC)
+	entries := make([]LogEntryData, 20)
+	for i := range entries {
+		entries[i] = LogEntryData{
+			CreatedAt: at.Add(time.Duration(i) * time.Second),
+			Level:     "info",
+			Message:   strings.Repeat("x", 200) + " #" + time.Duration(i).String(),
+		}
+	}
+	available := 2000
+	rendered := RenderRecentFailureLogs(entries, available)
+
+	require.NotEmpty(t, rendered)
+	assert.LessOrEqual(t, len(rendered), available, "the section must fit in the room the summary body leaves")
+	assert.Contains(t, rendered, "earlier entries omitted")
+	assert.Contains(t, rendered, "16:00:19 UTC", "newest entry always survives")
+	assert.NotContains(t, rendered, "16:00:00 UTC", "earliest entry is dropped first")
+}
+
+// TestRenderRecentFailureLogsSkipsWhenNoRoom verifies that a summary body
+// leaving no meaningful room under the comment size limit drops the section
+// entirely — the summary must still post, and a fold too small to carry a log
+// line is noise.
+func TestRenderRecentFailureLogsSkipsWhenNoRoom(t *testing.T) {
+	entries := []LogEntryData{
+		{CreatedAt: time.Date(2026, 7, 12, 16, 0, 0, 0, time.UTC), Level: "error", Message: "Apply failed"},
+	}
+	assert.Empty(t, RenderRecentFailureLogs(entries, 0))
+	assert.Empty(t, RenderRecentFailureLogs(entries, -500))
+	assert.Empty(t, RenderRecentFailureLogs(entries, minFailureLogsSectionChars-1))
+}
+
+// TestRenderRecentFailureLogsTruncatesSingleOversizedLine verifies one
+// enormous engine error message cannot blow the budget on its own: the sole
+// surviving line is truncated to fit rather than carried oversize.
+func TestRenderRecentFailureLogsTruncatesSingleOversizedLine(t *testing.T) {
+	entries := []LogEntryData{
+		{
+			CreatedAt: time.Date(2026, 7, 12, 16, 0, 0, 0, time.UTC),
+			Level:     "error",
+			Message:   "Apply failed: " + strings.Repeat("é", maxFailureLogsSectionChars),
+		},
+	}
+	available := 4000
+	rendered := RenderRecentFailureLogs(entries, available)
+
+	require.NotEmpty(t, rendered)
+	assert.LessOrEqual(t, len(rendered), available, "a single oversized line must be truncated to the budget")
+	assert.Contains(t, rendered, "Apply failed: ")
+	assert.Contains(t, rendered, "…", "the truncated line ends with an ellipsis")
+	assert.True(t, strings.HasSuffix(strings.TrimSpace(rendered), "</details>"), "the fold still closes cleanly")
 }

--- a/pkg/webhook/templates/failure_logs_test.go
+++ b/pkg/webhook/templates/failure_logs_test.go
@@ -20,7 +20,7 @@ func TestRenderRecentFailureLogs(t *testing.T) {
 		{CreatedAt: at, Level: "info", Message: "Apply claimed by driver", OldState: "queued", NewState: "running"},
 		{CreatedAt: at.Add(3 * time.Second), Level: "warn", Message: "Copy throttled by replication lag"},
 		{CreatedAt: at.Add(9 * time.Second), Level: "error", Message: "Lost MySQL connection; retrying"},
-	}, maxFailureLogsSectionChars, false)
+	}, MaxFailureLogsSectionChars, false)
 
 	assert.Contains(t, rendered, "<details>")
 	assert.Contains(t, rendered, "<summary>Logs (3)</summary>")
@@ -39,7 +39,7 @@ func TestRenderRecentFailureLogsTailLabel(t *testing.T) {
 	at := time.Date(2026, 7, 12, 16, 32, 1, 0, time.UTC)
 	rendered := RenderRecentFailureLogs([]LogEntryData{
 		{CreatedAt: at, Level: "error", Message: "Apply failed", OldState: "running", NewState: "failed"},
-	}, maxFailureLogsSectionChars, true)
+	}, MaxFailureLogsSectionChars, true)
 
 	assert.Contains(t, rendered, "<summary>Recent logs (1)</summary>")
 }
@@ -47,7 +47,7 @@ func TestRenderRecentFailureLogsTailLabel(t *testing.T) {
 // TestRenderRecentFailureLogsEmpty verifies an apply with no log entries adds
 // nothing to the summary — no empty details block.
 func TestRenderRecentFailureLogsEmpty(t *testing.T) {
-	assert.Empty(t, RenderRecentFailureLogs(nil, maxFailureLogsSectionChars, false))
+	assert.Empty(t, RenderRecentFailureLogs(nil, MaxFailureLogsSectionChars, false))
 }
 
 // TestRenderRecentFailureLogsSanitizesUntrustedText verifies engine-supplied
@@ -60,7 +60,7 @@ func TestRenderRecentFailureLogsSanitizesUntrustedText(t *testing.T) {
 		{CreatedAt: at, Level: "error", Message: "line one\r\nline two\nline three"},
 		{CreatedAt: at.Add(time.Second), Level: "error", Message: "fence breakout ```\n# not a heading"},
 		{CreatedAt: at.Add(2 * time.Second), Level: "error", Message: "long run `````x"},
-	}, maxFailureLogsSectionChars, false)
+	}, MaxFailureLogsSectionChars, false)
 
 	assert.Contains(t, rendered, "[ERR] line one line two line three")
 	assert.Contains(t, rendered, "[ERR] fence breakout `` ` # not a heading")
@@ -82,7 +82,7 @@ func TestRenderRecentFailureLogsTrimsToSizeBudget(t *testing.T) {
 			Message:   strings.Repeat("x", 1000) + " #" + time.Duration(i).String(),
 		}
 	}
-	rendered := RenderRecentFailureLogs(entries, maxFailureLogsSectionChars, false)
+	rendered := RenderRecentFailureLogs(entries, MaxFailureLogsSectionChars, false)
 
 	require.Less(t, len(rendered), 65536, "rendered section must leave room inside GitHub's size limit")
 	assert.Contains(t, rendered, "<summary>Recent logs (")
@@ -136,7 +136,7 @@ func TestRenderRecentFailureLogsTruncatesSingleOversizedLine(t *testing.T) {
 		{
 			CreatedAt: time.Date(2026, 7, 12, 16, 0, 0, 0, time.UTC),
 			Level:     "error",
-			Message:   "Apply failed: " + strings.Repeat("é", maxFailureLogsSectionChars),
+			Message:   "Apply failed: " + strings.Repeat("é", MaxFailureLogsSectionChars),
 		},
 	}
 	available := 4000

--- a/pkg/webhook/templates/failure_logs_test.go
+++ b/pkg/webhook/templates/failure_logs_test.go
@@ -12,8 +12,8 @@ import (
 // TestRenderRecentFailureLogs verifies the logs section appended to a failed
 // apply's summary folds the entries into a details block and formats each
 // line like the CLI logs output: UTC timestamp, bracketed level tag, message,
-// and state transition when set. A complete history is labeled "Logs" — no
-// entries were left out, so the fold must not suggest a subset.
+// and state transition when set. A complete history is labeled "Show logs" —
+// no entries were left out, so the fold must not suggest a subset.
 func TestRenderRecentFailureLogs(t *testing.T) {
 	at := time.Date(2026, 7, 12, 16, 32, 1, 0, time.UTC)
 	rendered := RenderRecentFailureLogs([]LogEntryData{
@@ -23,8 +23,8 @@ func TestRenderRecentFailureLogs(t *testing.T) {
 	}, GitHubIssueCommentMaxChars, false)
 
 	assert.Contains(t, rendered, "<details>")
-	assert.Contains(t, rendered, "<summary>Logs (3)</summary>")
-	assert.NotContains(t, rendered, "Recent logs")
+	assert.Contains(t, rendered, "<summary>Show logs (3 entries)</summary>")
+	assert.NotContains(t, rendered, "Show recent logs")
 	assert.Contains(t, rendered, "```text")
 	assert.Contains(t, rendered, "2026-07-12 16:32:01 UTC [INF] Apply claimed by driver [queued -> running]")
 	assert.Contains(t, rendered, "2026-07-12 16:32:04 UTC [WRN] Copy throttled by replication lag")
@@ -33,15 +33,15 @@ func TestRenderRecentFailureLogs(t *testing.T) {
 }
 
 // TestRenderRecentFailureLogsTailLabel verifies that when older entries exist
-// beyond the loaded tail, the fold is labeled "Recent logs" so the operator
-// knows they are seeing a subset, not the full history.
+// beyond the loaded tail, the fold is labeled "Show recent logs" so the
+// operator knows they are seeing a subset, not the full history.
 func TestRenderRecentFailureLogsTailLabel(t *testing.T) {
 	at := time.Date(2026, 7, 12, 16, 32, 1, 0, time.UTC)
 	rendered := RenderRecentFailureLogs([]LogEntryData{
 		{CreatedAt: at, Level: "error", Message: "Apply failed", OldState: "running", NewState: "failed"},
 	}, GitHubIssueCommentMaxChars, true)
 
-	assert.Contains(t, rendered, "<summary>Recent logs (1)</summary>")
+	assert.Contains(t, rendered, "<summary>Show recent logs (1 entry)</summary>")
 }
 
 // TestRenderRecentFailureLogsEmpty verifies an apply with no log entries adds
@@ -71,7 +71,7 @@ func TestRenderRecentFailureLogsSanitizesUntrustedText(t *testing.T) {
 // TestRenderRecentFailureLogsTrimsToSizeBudget verifies that when the rendered
 // log block would blow GitHub's comment size limit, the earliest lines are
 // dropped, the newest are kept, the fold says how many were omitted, and the
-// label flips to "Recent logs" because a subset is shown.
+// label flips to "Show recent logs" because a subset is shown.
 func TestRenderRecentFailureLogsTrimsToSizeBudget(t *testing.T) {
 	at := time.Date(2026, 7, 12, 16, 0, 0, 0, time.UTC)
 	entries := make([]LogEntryData, 100)
@@ -85,7 +85,7 @@ func TestRenderRecentFailureLogsTrimsToSizeBudget(t *testing.T) {
 	rendered := RenderRecentFailureLogs(entries, GitHubIssueCommentMaxChars, false)
 
 	require.Less(t, len(rendered), 65536, "rendered section must leave room inside GitHub's size limit")
-	assert.Contains(t, rendered, "<summary>Recent logs (")
+	assert.Contains(t, rendered, "<summary>Show recent logs (")
 	assert.Contains(t, rendered, "earlier entries omitted")
 	assert.NotContains(t, rendered, "16:00:00 UTC", "earliest entry is dropped first")
 	assert.Contains(t, rendered, "16:01:39 UTC", "newest entry always survives")

--- a/pkg/webhook/templates/failure_logs_test.go
+++ b/pkg/webhook/templates/failure_logs_test.go
@@ -20,7 +20,7 @@ func TestRenderRecentFailureLogs(t *testing.T) {
 		{CreatedAt: at, Level: "info", Message: "Apply claimed by driver", OldState: "queued", NewState: "running"},
 		{CreatedAt: at.Add(3 * time.Second), Level: "warn", Message: "Copy throttled by replication lag"},
 		{CreatedAt: at.Add(9 * time.Second), Level: "error", Message: "Lost MySQL connection; retrying"},
-	}, MaxFailureLogsSectionChars, false)
+	}, GitHubIssueCommentMaxChars, false)
 
 	assert.Contains(t, rendered, "<details>")
 	assert.Contains(t, rendered, "<summary>Logs (3)</summary>")
@@ -39,7 +39,7 @@ func TestRenderRecentFailureLogsTailLabel(t *testing.T) {
 	at := time.Date(2026, 7, 12, 16, 32, 1, 0, time.UTC)
 	rendered := RenderRecentFailureLogs([]LogEntryData{
 		{CreatedAt: at, Level: "error", Message: "Apply failed", OldState: "running", NewState: "failed"},
-	}, MaxFailureLogsSectionChars, true)
+	}, GitHubIssueCommentMaxChars, true)
 
 	assert.Contains(t, rendered, "<summary>Recent logs (1)</summary>")
 }
@@ -47,7 +47,7 @@ func TestRenderRecentFailureLogsTailLabel(t *testing.T) {
 // TestRenderRecentFailureLogsEmpty verifies an apply with no log entries adds
 // nothing to the summary — no empty details block.
 func TestRenderRecentFailureLogsEmpty(t *testing.T) {
-	assert.Empty(t, RenderRecentFailureLogs(nil, MaxFailureLogsSectionChars, false))
+	assert.Empty(t, RenderRecentFailureLogs(nil, GitHubIssueCommentMaxChars, false))
 }
 
 // TestRenderRecentFailureLogsSanitizesUntrustedText verifies engine-supplied
@@ -60,7 +60,7 @@ func TestRenderRecentFailureLogsSanitizesUntrustedText(t *testing.T) {
 		{CreatedAt: at, Level: "error", Message: "line one\r\nline two\nline three"},
 		{CreatedAt: at.Add(time.Second), Level: "error", Message: "fence breakout ```\n# not a heading"},
 		{CreatedAt: at.Add(2 * time.Second), Level: "error", Message: "long run `````x"},
-	}, MaxFailureLogsSectionChars, false)
+	}, GitHubIssueCommentMaxChars, false)
 
 	assert.Contains(t, rendered, "[ERR] line one line two line three")
 	assert.Contains(t, rendered, "[ERR] fence breakout `` ` # not a heading")
@@ -82,7 +82,7 @@ func TestRenderRecentFailureLogsTrimsToSizeBudget(t *testing.T) {
 			Message:   strings.Repeat("x", 1000) + " #" + time.Duration(i).String(),
 		}
 	}
-	rendered := RenderRecentFailureLogs(entries, MaxFailureLogsSectionChars, false)
+	rendered := RenderRecentFailureLogs(entries, GitHubIssueCommentMaxChars, false)
 
 	require.Less(t, len(rendered), 65536, "rendered section must leave room inside GitHub's size limit")
 	assert.Contains(t, rendered, "<summary>Recent logs (")
@@ -136,7 +136,7 @@ func TestRenderRecentFailureLogsTruncatesSingleOversizedLine(t *testing.T) {
 		{
 			CreatedAt: time.Date(2026, 7, 12, 16, 0, 0, 0, time.UTC),
 			Level:     "error",
-			Message:   "Apply failed: " + strings.Repeat("é", MaxFailureLogsSectionChars),
+			Message:   "Apply failed: " + strings.Repeat("é", GitHubIssueCommentMaxChars),
 		},
 	}
 	available := 4000

--- a/pkg/webhook/templates/failure_logs_test.go
+++ b/pkg/webhook/templates/failure_logs_test.go
@@ -1,0 +1,59 @@
+package templates
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRenderRecentFailureLogs verifies the recent-logs section appended to a
+// failed apply's summary folds the entries into a details block and formats
+// each line like the CLI logs output: UTC timestamp, bracketed level tag,
+// message, and state transition when set.
+func TestRenderRecentFailureLogs(t *testing.T) {
+	at := time.Date(2026, 7, 12, 16, 32, 1, 0, time.UTC)
+	rendered := RenderRecentFailureLogs([]LogEntryData{
+		{CreatedAt: at, Level: "info", Message: "Apply claimed by driver", OldState: "queued", NewState: "running"},
+		{CreatedAt: at.Add(3 * time.Second), Level: "warn", Message: "Copy throttled by replication lag"},
+		{CreatedAt: at.Add(9 * time.Second), Level: "error", Message: "Lost MySQL connection; retrying"},
+	})
+
+	assert.Contains(t, rendered, "<details>")
+	assert.Contains(t, rendered, "<summary>Recent logs (3)</summary>")
+	assert.Contains(t, rendered, "```text")
+	assert.Contains(t, rendered, "2026-07-12 16:32:01 UTC [INF] Apply claimed by driver [queued -> running]")
+	assert.Contains(t, rendered, "2026-07-12 16:32:04 UTC [WRN] Copy throttled by replication lag")
+	assert.Contains(t, rendered, "2026-07-12 16:32:10 UTC [ERR] Lost MySQL connection; retrying")
+	assert.NotContains(t, rendered, "omitted")
+}
+
+// TestRenderRecentFailureLogsEmpty verifies an apply with no log entries adds
+// nothing to the summary — no empty details block.
+func TestRenderRecentFailureLogsEmpty(t *testing.T) {
+	assert.Empty(t, RenderRecentFailureLogs(nil))
+}
+
+// TestRenderRecentFailureLogsTrimsToSizeBudget verifies that when the rendered
+// log block would blow GitHub's comment size limit, the earliest lines are
+// dropped, the newest are kept, and the fold says how many were omitted.
+func TestRenderRecentFailureLogsTrimsToSizeBudget(t *testing.T) {
+	at := time.Date(2026, 7, 12, 16, 0, 0, 0, time.UTC)
+	entries := make([]LogEntryData, 100)
+	for i := range entries {
+		entries[i] = LogEntryData{
+			CreatedAt: at.Add(time.Duration(i) * time.Second),
+			Level:     "info",
+			Message:   strings.Repeat("x", 1000) + " #" + time.Duration(i).String(),
+		}
+	}
+	rendered := RenderRecentFailureLogs(entries)
+
+	require.Less(t, len(rendered), 65536, "rendered section must leave room inside GitHub's size limit")
+	assert.Contains(t, rendered, "<summary>Recent logs (100)</summary>")
+	assert.Contains(t, rendered, "earlier entries omitted")
+	assert.NotContains(t, rendered, "16:00:00 UTC", "earliest entry is dropped first")
+	assert.Contains(t, rendered, "16:01:39 UTC", "newest entry always survives")
+}

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -1521,7 +1521,7 @@ func PreviewCommentSummaryFailed() string {
 	data := sampleSummaryData(state.Apply.Failed, tables)
 	data.ErrorMessage = "table users failed: schema change failed: unsafe warning: Field 'name' doesn't have a default value"
 	return RenderApplySummaryComment(data) +
-		RenderRecentFailureLogs(sampleFailureLogEntries("users", "unsafe warning: Field 'name' doesn't have a default value"), maxFailureLogsSectionChars)
+		RenderRecentFailureLogs(sampleFailureLogEntries("users", "unsafe warning: Field 'name' doesn't have a default value"), maxFailureLogsSectionChars, false)
 }
 
 // PreviewCommentSummaryStopped renders a sample stopped summary comment.
@@ -1577,7 +1577,7 @@ func PreviewCommentSummaryFailedLarge() string {
 	data := sampleSummaryDataWithDuration(state.Apply.Failed, tables, 3*time.Hour+30*time.Minute)
 	data.ErrorMessage = "Error 1062: Duplicate entry '12345' for key 'addresses.idx_user_id'"
 	return RenderApplySummaryComment(data) +
-		RenderRecentFailureLogs(sampleFailureLogEntries("addresses", "Error 1062: Duplicate entry '12345' for key 'addresses.idx_user_id'"), maxFailureLogsSectionChars)
+		RenderRecentFailureLogs(sampleFailureLogEntries("addresses", "Error 1062: Duplicate entry '12345' for key 'addresses.idx_user_id'"), maxFailureLogsSectionChars, false)
 }
 
 // PreviewCommentSummaryMultiNamespaceFailed renders a failed summary with tables from multiple namespaces.
@@ -1592,7 +1592,7 @@ func PreviewCommentSummaryMultiNamespaceFailed() string {
 	data := sampleSummaryData(state.Apply.Failed, tables)
 	data.ErrorMessage = "table customers.addresses failed: Error 1205: Lock wait timeout exceeded"
 	return RenderApplySummaryComment(data) +
-		RenderRecentFailureLogs(sampleFailureLogEntries("addresses", "Error 1205: Lock wait timeout exceeded"), maxFailureLogsSectionChars)
+		RenderRecentFailureLogs(sampleFailureLogEntries("addresses", "Error 1205: Lock wait timeout exceeded"), maxFailureLogsSectionChars, false)
 }
 
 // PreviewCommentSummaryMultiNamespaceCompleted renders a completed summary with tables from multiple namespaces.

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -1521,7 +1521,7 @@ func PreviewCommentSummaryFailed() string {
 	data := sampleSummaryData(state.Apply.Failed, tables)
 	data.ErrorMessage = "table users failed: schema change failed: unsafe warning: Field 'name' doesn't have a default value"
 	return RenderApplySummaryComment(data) +
-		RenderRecentFailureLogs(sampleFailureLogEntries("users", "unsafe warning: Field 'name' doesn't have a default value"))
+		RenderRecentFailureLogs(sampleFailureLogEntries("users", "unsafe warning: Field 'name' doesn't have a default value"), maxFailureLogsSectionChars)
 }
 
 // PreviewCommentSummaryStopped renders a sample stopped summary comment.
@@ -1577,7 +1577,7 @@ func PreviewCommentSummaryFailedLarge() string {
 	data := sampleSummaryDataWithDuration(state.Apply.Failed, tables, 3*time.Hour+30*time.Minute)
 	data.ErrorMessage = "Error 1062: Duplicate entry '12345' for key 'addresses.idx_user_id'"
 	return RenderApplySummaryComment(data) +
-		RenderRecentFailureLogs(sampleFailureLogEntries("addresses", "Error 1062: Duplicate entry '12345' for key 'addresses.idx_user_id'"))
+		RenderRecentFailureLogs(sampleFailureLogEntries("addresses", "Error 1062: Duplicate entry '12345' for key 'addresses.idx_user_id'"), maxFailureLogsSectionChars)
 }
 
 // PreviewCommentSummaryMultiNamespaceFailed renders a failed summary with tables from multiple namespaces.
@@ -1592,7 +1592,7 @@ func PreviewCommentSummaryMultiNamespaceFailed() string {
 	data := sampleSummaryData(state.Apply.Failed, tables)
 	data.ErrorMessage = "table customers.addresses failed: Error 1205: Lock wait timeout exceeded"
 	return RenderApplySummaryComment(data) +
-		RenderRecentFailureLogs(sampleFailureLogEntries("addresses", "Error 1205: Lock wait timeout exceeded"))
+		RenderRecentFailureLogs(sampleFailureLogEntries("addresses", "Error 1205: Lock wait timeout exceeded"), maxFailureLogsSectionChars)
 }
 
 // PreviewCommentSummaryMultiNamespaceCompleted renders a completed summary with tables from multiple namespaces.

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -1521,7 +1521,7 @@ func PreviewCommentSummaryFailed() string {
 	data := sampleSummaryData(state.Apply.Failed, tables)
 	data.ErrorMessage = "table users failed: schema change failed: unsafe warning: Field 'name' doesn't have a default value"
 	return RenderApplySummaryComment(data) +
-		RenderRecentFailureLogs(sampleFailureLogEntries("users", "unsafe warning: Field 'name' doesn't have a default value"), maxFailureLogsSectionChars, false)
+		RenderRecentFailureLogs(sampleFailureLogEntries("users", "unsafe warning: Field 'name' doesn't have a default value"), MaxFailureLogsSectionChars, false)
 }
 
 // PreviewCommentSummaryStopped renders a sample stopped summary comment.
@@ -1577,7 +1577,7 @@ func PreviewCommentSummaryFailedLarge() string {
 	data := sampleSummaryDataWithDuration(state.Apply.Failed, tables, 3*time.Hour+30*time.Minute)
 	data.ErrorMessage = "Error 1062: Duplicate entry '12345' for key 'addresses.idx_user_id'"
 	return RenderApplySummaryComment(data) +
-		RenderRecentFailureLogs(sampleFailureLogEntries("addresses", "Error 1062: Duplicate entry '12345' for key 'addresses.idx_user_id'"), maxFailureLogsSectionChars, false)
+		RenderRecentFailureLogs(sampleFailureLogEntries("addresses", "Error 1062: Duplicate entry '12345' for key 'addresses.idx_user_id'"), MaxFailureLogsSectionChars, false)
 }
 
 // PreviewCommentSummaryMultiNamespaceFailed renders a failed summary with tables from multiple namespaces.
@@ -1592,7 +1592,7 @@ func PreviewCommentSummaryMultiNamespaceFailed() string {
 	data := sampleSummaryData(state.Apply.Failed, tables)
 	data.ErrorMessage = "table customers.addresses failed: Error 1205: Lock wait timeout exceeded"
 	return RenderApplySummaryComment(data) +
-		RenderRecentFailureLogs(sampleFailureLogEntries("addresses", "Error 1205: Lock wait timeout exceeded"), maxFailureLogsSectionChars, false)
+		RenderRecentFailureLogs(sampleFailureLogEntries("addresses", "Error 1205: Lock wait timeout exceeded"), MaxFailureLogsSectionChars, false)
 }
 
 // PreviewCommentSummaryMultiNamespaceCompleted renders a completed summary with tables from multiple namespaces.

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -1507,7 +1507,8 @@ func PreviewCommentSummaryCompletedVitessVSchemaOnly() string {
 	return RenderApplySummaryComment(data)
 }
 
-// PreviewCommentSummaryFailed renders a sample failed summary comment.
+// PreviewCommentSummaryFailed renders a sample failed summary comment,
+// including the collapsed recent-logs section every failed summary carries.
 func PreviewCommentSummaryFailed() string {
 	tables := sampleApplyTables()
 	tables[0].Status = state.Task.Completed
@@ -1519,7 +1520,8 @@ func PreviewCommentSummaryFailed() string {
 	tables[2].Status = state.Task.Cancelled
 	data := sampleSummaryData(state.Apply.Failed, tables)
 	data.ErrorMessage = "table users failed: schema change failed: unsafe warning: Field 'name' doesn't have a default value"
-	return RenderApplySummaryComment(data)
+	return RenderApplySummaryComment(data) +
+		RenderRecentFailureLogs(sampleFailureLogEntries("users", "unsafe warning: Field 'name' doesn't have a default value"))
 }
 
 // PreviewCommentSummaryStopped renders a sample stopped summary comment.
@@ -1574,7 +1576,8 @@ func PreviewCommentSummaryFailedLarge() string {
 	}
 	data := sampleSummaryDataWithDuration(state.Apply.Failed, tables, 3*time.Hour+30*time.Minute)
 	data.ErrorMessage = "Error 1062: Duplicate entry '12345' for key 'addresses.idx_user_id'"
-	return RenderApplySummaryComment(data)
+	return RenderApplySummaryComment(data) +
+		RenderRecentFailureLogs(sampleFailureLogEntries("addresses", "Error 1062: Duplicate entry '12345' for key 'addresses.idx_user_id'"))
 }
 
 // PreviewCommentSummaryMultiNamespaceFailed renders a failed summary with tables from multiple namespaces.
@@ -1588,7 +1591,8 @@ func PreviewCommentSummaryMultiNamespaceFailed() string {
 	}
 	data := sampleSummaryData(state.Apply.Failed, tables)
 	data.ErrorMessage = "table customers.addresses failed: Error 1205: Lock wait timeout exceeded"
-	return RenderApplySummaryComment(data)
+	return RenderApplySummaryComment(data) +
+		RenderRecentFailureLogs(sampleFailureLogEntries("addresses", "Error 1205: Lock wait timeout exceeded"))
 }
 
 // PreviewCommentSummaryMultiNamespaceCompleted renders a completed summary with tables from multiple namespaces.

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -1521,7 +1521,7 @@ func PreviewCommentSummaryFailed() string {
 	data := sampleSummaryData(state.Apply.Failed, tables)
 	data.ErrorMessage = "table users failed: schema change failed: unsafe warning: Field 'name' doesn't have a default value"
 	return RenderApplySummaryComment(data) +
-		RenderRecentFailureLogs(sampleFailureLogEntries("users", "unsafe warning: Field 'name' doesn't have a default value"), MaxFailureLogsSectionChars, false)
+		RenderRecentFailureLogs(sampleFailureLogEntries("users", "unsafe warning: Field 'name' doesn't have a default value"), GitHubIssueCommentMaxChars, false)
 }
 
 // PreviewCommentSummaryStopped renders a sample stopped summary comment.
@@ -1577,7 +1577,7 @@ func PreviewCommentSummaryFailedLarge() string {
 	data := sampleSummaryDataWithDuration(state.Apply.Failed, tables, 3*time.Hour+30*time.Minute)
 	data.ErrorMessage = "Error 1062: Duplicate entry '12345' for key 'addresses.idx_user_id'"
 	return RenderApplySummaryComment(data) +
-		RenderRecentFailureLogs(sampleFailureLogEntries("addresses", "Error 1062: Duplicate entry '12345' for key 'addresses.idx_user_id'"), MaxFailureLogsSectionChars, false)
+		RenderRecentFailureLogs(sampleFailureLogEntries("addresses", "Error 1062: Duplicate entry '12345' for key 'addresses.idx_user_id'"), GitHubIssueCommentMaxChars, false)
 }
 
 // PreviewCommentSummaryMultiNamespaceFailed renders a failed summary with tables from multiple namespaces.
@@ -1592,7 +1592,7 @@ func PreviewCommentSummaryMultiNamespaceFailed() string {
 	data := sampleSummaryData(state.Apply.Failed, tables)
 	data.ErrorMessage = "table customers.addresses failed: Error 1205: Lock wait timeout exceeded"
 	return RenderApplySummaryComment(data) +
-		RenderRecentFailureLogs(sampleFailureLogEntries("addresses", "Error 1205: Lock wait timeout exceeded"), MaxFailureLogsSectionChars, false)
+		RenderRecentFailureLogs(sampleFailureLogEntries("addresses", "Error 1205: Lock wait timeout exceeded"), GitHubIssueCommentMaxChars, false)
 }
 
 // PreviewCommentSummaryMultiNamespaceCompleted renders a completed summary with tables from multiple namespaces.


### PR DESCRIPTION
**Why this matters:** When an apply fails, the summary comment shows the terminal error but not the trail leading up to it — operators had to leave the PR to answer "what happened?", at exactly the wrong moment.

**What it does:** A failed apply's terminal summary comment ends with a collapsed logs section, formatted like the CLI logs output. Only failed summaries carry it — completed, stopped, and cancelled summaries stay clean. It's appended in the observer's summary funnel, so every path that produces a failed summary gets it. Details:

- Labeled `Show logs (N entries)` when it holds the apply's complete history, `Show recent logs (N entries)` only when earlier lines were dropped. There is no entry cap — the comment size budget is the only limit.
- Spends only the room the summary body leaves under GitHub's comment size cap — a large summary shrinks the fold; no room drops it, so the summary itself always posts.
- Best-effort: a log-load failure posts the summary without logs. Full history stays available in the CLI and the server logs.

**What it looks like** (the `Summary: Failed` preview from TEMPLATES.md — the fold at the bottom is the new section):

---

## ❌ Schema Change Failed — Staging

**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6` | **Duration**: 8m

*Applied by @jackjackbits at 2026-03-15 14:22:00 UTC*

> ⚠️ **Error:** table users failed: schema change failed: unsafe warning: Field 'name' doesn't have a default value

1 of 3 tables completed before failure.

**`users`** — Failed at 30%
```sql
ALTER TABLE `users`
    ADD COLUMN `name` varchar(255) NOT NULL AFTER `id`;
```

To retry:
```
schemabot apply -e staging
```

<details>
<summary>Show logs (5 entries)</summary>

```text
2026-03-15 14:22:00 UTC [INF] Apply claimed by driver [queued -> running]
2026-03-15 14:22:15 UTC [INF] Task started: schema change on `users`
2026-03-15 14:25:00 UTC [WRN] Copy throttled by replication lag (1.2s)
2026-03-15 14:28:00 UTC [ERR] Task failed: unsafe warning: Field 'name' doesn't have a default value
2026-03-15 14:29:00 UTC [ERR] Apply failed [running -> failed]
```

</details>

---

**How it moves toward the northstar:** A failed schema change should be triageable from the PR where it was requested — the failure's log tail is now one click away on the PR timeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


