### PR TITLE
feat(cli): scan open PRs for missing and stuck Check Runs, backfill safely

### DIFF
--- a/docs/check-runs.md
+++ b/docs/check-runs.md
@@ -21,6 +21,7 @@
 - [Check States](#check-states)
 - [Blocking Reasons](#blocking-reasons)
 - [Operator Guidance](#operator-guidance)
+  - [Backfilling missing Check Runs](#backfilling-missing-check-runs)
 - [SHA Handling](#sha-handling)
 - [Edge Cases](#edge-cases)
   - [PR opened](#pr-opened)
@@ -587,6 +588,68 @@ Common fail-closed scenarios:
 | Stored check ownership miss | A newer plan or apply owns the stored check state for the same PR, environment, and database. Letting the older driver write would overwrite newer safety state. | Inspect the newest apply for that repo/PR/environment/database with the CLI, for example `schemabot status -d <database> -e <environment>` or `schemabot progress <apply-id>`. Let the newest apply finish, or reconcile it with operator commands before retrying PR comments. |
 | Schema changes were removed while an apply may still be running | The live database may still change even though the current PR no longer represents that change. | Inspect the in-flight apply in Tern or with the CLI. If the change reached the live database, either put the schema change back in the PR and comment `schemabot plan -e <environment>` before applying again, or roll back/reconcile the live schema first. |
 | Stale in-progress row after a pod crash | Stored check state says an apply is running, but the watcher may have died before publishing the terminal result. | Comment `schemabot plan -e <environment>` or `schemabot apply -e <environment>` to trigger stale-check reconciliation. If reconciliation fails, inspect SchemaBot storage and the latest apply for that database. |
+
+### Backfilling missing Check Runs
+
+`schemabot checks backfill` converges Check Run state across open PRs — after
+an incident, before enabling required checks on a repository, or as a one-time
+backfill for PRs that predate check enablement. Per open PR it reports heads
+whose expected SchemaBot Check Run is missing and (outside `--dry-run`)
+recreates each by replaying the auto-plan flow server-side. Check Runs that
+exist but never completed are reported for investigation, never acted on — an
+uncompleted run can belong to a genuinely in-flight apply.
+
+**The backfill is scoped to the deployment it runs against.** A SchemaBot
+instance scans with its own GitHub App credentials, its own `repos:` config,
+its own `allowed_environments`, and its own storage, so one run converges only
+the checks that instance owns:
+
+- **Repositories.** `--repo` scans one repository; `--all-repos` scans every
+  repository declared in the instance's `repos:` config. A legacy single-App
+  config declares no repos, so there `--all-repos` is rejected and repositories
+  must be named explicitly.
+- **Apps.** Each repository resolves to the GitHub App that owns it (see
+  [Multi-App Routing](configuration.md#multi-app-routing)); the scan and the
+  recreated Check Runs both use that App's installation. An instance hosting
+  several Apps covers all of them in one `--all-repos` sweep.
+- **Check names and environments.** The expected names are derived per
+  repository: the owning App's check-name base crossed with the instance's
+  `allowed_environments` — `SchemaBot (staging)` and `SchemaBot (production)`
+  for a dual-environment instance, the bare base for an environment-unscoped
+  one. `--environment` narrows the scan to one environment, and an environment
+  the instance does not handle is rejected up front — scanning for a check
+  name that can never exist would report every PR as missing it.
+  `--check-name` overrides the derivation entirely.
+- **Split deployments.** In a
+  [multi-environment deployment](configuration.md#multi-environment-deployment)
+  — separate staging and production instances with separate GitHub Apps — each
+  instance can only see and recreate its own environment's check. Full coverage
+  of a repository means one run against each instance, and the same holds for
+  any fleet of independent deployments: run the backfill once per deployment;
+  nothing spans them.
+
+Presence is decided under the
+[cross-deployment trust model](#cross-deployment-trust-model): a Check Run
+with the expected name created by an untrusted App does not count as present.
+The scan reports it as an untrusted-App conflict rather than silently trusting
+it or replacing it.
+
+Started applies remain authoritative here as everywhere. The server refuses to
+backfill any PR with a non-terminal apply — replaying auto-plan over one could
+replace an apply-owned merge block with a fresh passing plan — and refuses
+when the apply lookup itself fails, since without the apply rows there is no
+proof the PR is safe to re-plan. The CLI additionally holds any missing-check
+PR whose head carries an uncompleted Check Run of any age, because that run
+may belong to a started apply the scanning instance cannot see.
+
+For repositories where several deployments coordinate one shared check
+through a leader/participant aggregate configuration, the same scoping
+applies: a backfill creates only the deployment's own check. Run against a
+participant, it recreates the participant check the leader folds; run against
+the leader, it replays the role-aware auto-plan flow, whose fold fails closed
+on expected participants that have not reported. A missing participant check
+is repaired by running the backfill on that participant's deployment — never
+by the leader.
 
 [github-create-check-run]: https://docs.github.com/en/rest/checks/runs#create-a-check-run
 [github-check-runs]: https://docs.github.com/en/rest/checks/runs

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -754,6 +754,8 @@ GitHub sends `X-GitHub-Hook-Installation-Target-ID` (the App's numeric ID) and `
 
 The legacy single-`github:` shape does not require the header and continues to verify against the single configured secret.
 
+Operator commands inherit this scoping: a Check Run scan or backfill resolves each repository to its owning App and derives the expected check names from that App's `check-name` and the instance's `allowed_environments`. See [Backfilling missing Check Runs](check-runs.md#backfilling-missing-check-runs).
+
 ## Secret Resolution
 
 DSN values support secret resolution prefixes:

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -709,6 +709,7 @@ func (s *Service) ConfigureRoutes(mux *http.ServeMux) {
 	handle("POST /api/webhooks/redrive", s.handleWebhookRedrive)
 	handle("POST /api/checks/scan", s.handleChecksScan)
 	handle("POST /api/checks/synthesize", s.handleChecksSynthesize)
+	handle("POST /api/checks/repos", s.handleChecksRepos)
 
 	// Lock API (database-level locking)
 	handle("POST /api/locks/acquire", s.handleLockAcquire)

--- a/pkg/api/webhook_ops_handlers.go
+++ b/pkg/api/webhook_ops_handlers.go
@@ -78,6 +78,8 @@ type WebhookRedriveSelection = apitypes.WebhookRedriveSelection
 type ChecksScanRequest = apitypes.ChecksScanRequest
 type ChecksScanResponse = apitypes.ChecksScanResponse
 type MissingCheckPR = apitypes.MissingCheckPR
+type StuckCheckPR = apitypes.StuckCheckPR
+type IncompleteCheckRun = apitypes.IncompleteCheckRun
 
 // CheckRunBackfiller replays the auto-plan flow for a PR to recreate missing
 // Check Runs, exactly as the check-creating webhook delivery would have. The
@@ -672,12 +674,21 @@ func scanWebhookMissingChecks(ctx context.Context, client webhookMissingCheckSca
 	for _, pr := range prs {
 		var missing []string
 		var untrustedConflicts []string
+		var incomplete []IncompleteCheckRun
 		for _, checkName := range checkNames {
 			run, untrustedApps, err := client.FindCheckRunByName(ctx, repo, pr.HeadSHA, checkName)
 			if err != nil {
 				return nil, fmt.Errorf("scan %s#%d for check %q at %s: %w", repo, pr.Number, checkName, pr.HeadSHA, err)
 			}
 			if run != nil {
+				if !checkRunCompleted(run) {
+					incomplete = append(incomplete, IncompleteCheckRun{
+						Name:       run.Name,
+						CheckRunID: run.ID,
+						Status:     run.Status,
+						StartedAt:  formatCheckRunStartedAt(run.StartedAt),
+					})
+				}
 				continue
 			}
 			missing = append(missing, checkName)
@@ -687,6 +698,16 @@ func scanWebhookMissingChecks(ctx context.Context, client webhookMissingCheckSca
 			if len(untrustedApps) > 0 {
 				untrustedConflicts = append(untrustedConflicts, checkName)
 			}
+		}
+		if len(incomplete) > 0 {
+			result.Stuck = append(result.Stuck, StuckCheckPR{
+				Number:  pr.Number,
+				URL:     fmt.Sprintf("https://github.com/%s/pull/%d", repo, pr.Number),
+				Title:   pr.Title,
+				HeadSHA: pr.HeadSHA,
+				HeadRef: pr.HeadRef,
+				Checks:  incomplete,
+			})
 		}
 		if len(missing) == 0 {
 			continue
@@ -702,4 +723,22 @@ func scanWebhookMissingChecks(ctx context.Context, client webhookMissingCheckSca
 		})
 	}
 	return result, nil
+}
+
+// checkRunCompleted reports whether the Check Run has reached a conclusion.
+// Anything else (queued, in_progress, pending) is still holding its slot
+// without gating, which the scan surfaces so an operator can judge whether
+// the run is legitimately in flight or wedged.
+func checkRunCompleted(run *ghclient.CheckRunResult) bool {
+	return run.Status == "completed"
+}
+
+// formatCheckRunStartedAt renders the start time for the API response; GitHub
+// can omit it, and a zero time would otherwise serialize as a misleading
+// year-one timestamp.
+func formatCheckRunStartedAt(startedAt time.Time) string {
+	if startedAt.IsZero() {
+		return ""
+	}
+	return startedAt.UTC().Format(time.RFC3339)
 }

--- a/pkg/api/webhook_ops_handlers.go
+++ b/pkg/api/webhook_ops_handlers.go
@@ -725,10 +725,10 @@ func scanWebhookMissingChecks(ctx context.Context, client webhookMissingCheckSca
 	return result, nil
 }
 
-// checkRunCompleted reports whether the Check Run has reached a conclusion.
-// Anything else (queued, in_progress, pending) is still holding its slot
-// without gating, which the scan surfaces so an operator can judge whether
-// the run is legitimately in flight or wedged.
+// checkRunCompleted reports whether the Check Run's status is "completed".
+// Any other status (queued, in_progress) is still holding its slot without a
+// conclusion, which the scan surfaces so an operator can judge whether the
+// run is legitimately in flight or wedged.
 func checkRunCompleted(run *ghclient.CheckRunResult) bool {
 	return run.Status == "completed"
 }

--- a/pkg/api/webhook_ops_handlers.go
+++ b/pkg/api/webhook_ops_handlers.go
@@ -77,6 +77,7 @@ type WebhookRedriveResult = apitypes.WebhookRedriveResult
 type WebhookRedriveSelection = apitypes.WebhookRedriveSelection
 type ChecksScanRequest = apitypes.ChecksScanRequest
 type ChecksScanResponse = apitypes.ChecksScanResponse
+type ChecksReposResponse = apitypes.ChecksReposResponse
 type MissingCheckPR = apitypes.MissingCheckPR
 type StuckCheckPR = apitypes.StuckCheckPR
 type IncompleteCheckRun = apitypes.IncompleteCheckRun
@@ -137,7 +138,7 @@ func executeChecksSynthesize(ctx context.Context, cfg *ServerConfig, backfiller 
 	if logger == nil {
 		logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
 	}
-	_, installationID, err := resolveRepoInstallationClient(ctx, cfg, req.Repo, logger)
+	installationClient, installationID, err := resolveRepoInstallationClient(ctx, cfg, req.Repo, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +154,29 @@ func executeChecksSynthesize(ctx context.Context, cfg *ServerConfig, backfiller 
 		}
 		response.Results = append(response.Results, result)
 	}
+	response.RateLimit = gitHubRateLimitSnapshot(ctx, installationClient, logger, "checks synthesize batch")
 	return response, nil
+}
+
+// gitHubRateLimitSnapshot reads the installation's remaining core budget so
+// the caller can pace a large backfill instead of starving the live webhook
+// path that shares the same budget. The snapshot is advisory: the operation
+// that produced the response already succeeded, so a read failure is logged
+// and the pacing info omitted rather than failing the request.
+func gitHubRateLimitSnapshot(ctx context.Context, client interface {
+	CoreRateLimit(ctx context.Context) (remaining, limit int, resetAt time.Time, err error)
+}, logger *slog.Logger, operation string) *apitypes.GitHubRateLimit {
+	remaining, limit, resetAt, err := client.CoreRateLimit(ctx)
+	if err != nil {
+		logger.Warn("failed to read GitHub rate limit; response omits pacing info and the caller will not pause",
+			"operation", operation, "error", err)
+		return nil
+	}
+	return &apitypes.GitHubRateLimit{
+		Remaining: remaining,
+		Limit:     limit,
+		ResetAt:   resetAt.UTC().Format(time.RFC3339),
+	}
 }
 
 type webhookRedriveDeliveryClient interface {
@@ -263,6 +286,14 @@ func executeChecksScan(ctx context.Context, cfg *ServerConfig, req ChecksScanReq
 	if req.Environment != "" && !cfg.IsEnvironmentAllowed(req.Environment) {
 		return nil, webhookOpsRequestErrorf("environment %q is not one this instance handles", req.Environment)
 	}
+	var updatedSince time.Time
+	if req.UpdatedSince != "" {
+		var err error
+		updatedSince, err = time.Parse(time.RFC3339, req.UpdatedSince)
+		if err != nil {
+			return nil, webhookOpsRequestErrorf("parse updated_since %q as RFC3339: %v", req.UpdatedSince, err)
+		}
+	}
 	if logger == nil {
 		logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
 	}
@@ -270,7 +301,40 @@ func executeChecksScan(ctx context.Context, cfg *ServerConfig, req ChecksScanReq
 	if err != nil {
 		return nil, err
 	}
-	return scanWebhookMissingChecks(ctx, installationClient, req.Repo, webhookMissingCheckNames(cfg, req.Repo, req.Environment, req.CheckName), req.Page)
+	response, err := scanWebhookMissingChecks(ctx, installationClient, req.Repo, webhookMissingCheckNames(cfg, req.Repo, req.Environment, req.CheckName), req.Page, updatedSince)
+	if err != nil {
+		return nil, err
+	}
+	response.RateLimit = gitHubRateLimitSnapshot(ctx, installationClient, logger, "checks scan page")
+	return response, nil
+}
+
+func (s *Service) handleChecksRepos(w http.ResponseWriter, r *http.Request) {
+	response, err := executeChecksRepos(s.config)
+	if err != nil {
+		s.writeWebhookOpsError(w, err)
+		return
+	}
+	s.writeJSON(w, http.StatusOK, response)
+}
+
+// executeChecksRepos lists the repositories declared in the server's repos
+// config — the inventory a fleet-wide checks scan iterates. A legacy
+// single-App config declares no repos, so a fleet sweep cannot know what to
+// scan; the operator must name repositories explicitly there.
+func executeChecksRepos(cfg *ServerConfig) (*ChecksReposResponse, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("server config is nil")
+	}
+	if len(cfg.Repos) == 0 {
+		return nil, webhookOpsRequestErrorf("this server declares no repos config; name a repository explicitly instead of scanning all repos")
+	}
+	repos := make([]string, 0, len(cfg.Repos))
+	for repo := range cfg.Repos {
+		repos = append(repos, repo)
+	}
+	sort.Strings(repos)
+	return &ChecksReposResponse{Repos: repos}, nil
 }
 
 // resolveRepoInstallationClient builds an installation-scoped GitHub client
@@ -665,13 +729,20 @@ type webhookMissingCheckScanClient interface {
 	FindCheckRunByName(ctx context.Context, repo, headSHA, checkName string) (*ghclient.CheckRunResult, []string, error)
 }
 
-func scanWebhookMissingChecks(ctx context.Context, client webhookMissingCheckScanClient, repo string, checkNames []string, page int) (*ChecksScanResponse, error) {
+func scanWebhookMissingChecks(ctx context.Context, client webhookMissingCheckScanClient, repo string, checkNames []string, page int, updatedSince time.Time) (*ChecksScanResponse, error) {
 	prs, nextPage, err := client.ListOpenPullRequestsPage(ctx, repo, page, webhookScanPRPageSize)
 	if err != nil {
 		return nil, err
 	}
-	result := &ChecksScanResponse{Repo: repo, CheckNames: checkNames, Scanned: len(prs), NextPage: nextPage}
+	result := &ChecksScanResponse{Repo: repo, CheckNames: checkNames, NextPage: nextPage}
 	for _, pr := range prs {
+		if !updatedSince.IsZero() && pr.UpdatedAt.Before(updatedSince) {
+			// The listing is ordered newest-updated first, so every PR from
+			// here on is older than the requested window: the sweep is done.
+			result.NextPage = 0
+			break
+		}
+		result.Scanned++
 		var missing []string
 		var untrustedConflicts []string
 		var incomplete []IncompleteCheckRun

--- a/pkg/api/webhook_ops_handlers.go
+++ b/pkg/api/webhook_ops_handlers.go
@@ -725,16 +725,21 @@ func webhookMissingCheckNames(cfg *ServerConfig, repo, environment, override str
 }
 
 type webhookMissingCheckScanClient interface {
-	ListOpenPullRequestsPage(ctx context.Context, repo string, page, perPage int) ([]ghclient.OpenPullRequest, int, error)
+	ListOpenPullRequestsPage(ctx context.Context, repo string, page, perPage int) (prs []ghclient.OpenPullRequest, nextPage, lastPage int, err error)
 	FindCheckRunByName(ctx context.Context, repo, headSHA, checkName string) (*ghclient.CheckRunResult, []string, error)
 }
 
 func scanWebhookMissingChecks(ctx context.Context, client webhookMissingCheckScanClient, repo string, checkNames []string, page int, updatedSince time.Time) (*ChecksScanResponse, error) {
-	prs, nextPage, err := client.ListOpenPullRequestsPage(ctx, repo, page, webhookScanPRPageSize)
+	prs, nextPage, lastPage, err := client.ListOpenPullRequestsPage(ctx, repo, page, webhookScanPRPageSize)
 	if err != nil {
 		return nil, err
 	}
-	result := &ChecksScanResponse{Repo: repo, CheckNames: checkNames, NextPage: nextPage}
+	result := &ChecksScanResponse{
+		Repo:             repo,
+		CheckNames:       checkNames,
+		NextPage:         nextPage,
+		EstimatedOpenPRs: estimateOpenPRCount(page, lastPage, len(prs)),
+	}
 	for _, pr := range prs {
 		if !updatedSince.IsZero() && pr.UpdatedAt.Before(updatedSince) {
 			// The listing is ordered newest-updated first, so every PR from
@@ -794,6 +799,22 @@ func scanWebhookMissingChecks(ctx context.Context, client webhookMissingCheckSca
 		})
 	}
 	return result, nil
+}
+
+// estimateOpenPRCount derives the repository's total open-PR count from one
+// listing page, so a long scan can report progress against a denominator that
+// is recomputed every page instead of feeling unbounded. GitHub reports the
+// listing's last page while more pages remain — an upper bound of
+// lastPage×pageSize — and on the final page (lastPage 0) the count is exact:
+// the PRs before this page plus the PRs on it.
+func estimateOpenPRCount(page, lastPage, pageLen int) int {
+	if lastPage > 0 {
+		return lastPage * webhookScanPRPageSize
+	}
+	if page <= 0 {
+		page = 1
+	}
+	return (page-1)*webhookScanPRPageSize + pageLen
 }
 
 // checkRunCompleted reports whether the Check Run's status is "completed".

--- a/pkg/api/webhook_ops_handlers_test.go
+++ b/pkg/api/webhook_ops_handlers_test.go
@@ -518,6 +518,64 @@ func TestScanWebhookMissingChecksReportsOpenPRsMissingConfiguredChecks(t *testin
 	assert.Empty(t, result.Missing[0].UntrustedConflictNames)
 }
 
+// An expected Check Run that exists but never completed is reported as stuck,
+// with its raw status and start time, so the operator can tell a wedged check
+// apart from a missing one — completed runs and missing runs stay out of the
+// stuck list, and an uncompleted run is never misreported as missing.
+func TestScanWebhookMissingChecksReportsUncompletedRuns(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, 7, 12, 9, 0, 0, 0, time.UTC)
+	client := fakeWebhookMissingCheckScanClient{
+		prs: []ghclient.OpenPullRequest{
+			{Number: 7, Title: "wedged check", HeadSHA: "sha7", HeadRef: "feature-7"},
+			{Number: 8, Title: "healthy check", HeadSHA: "sha8", HeadRef: "feature-8"},
+		},
+		runs: map[string]*ghclient.CheckRunResult{
+			"sha7/SchemaBot (production)": {ID: 70, Name: "SchemaBot (production)", Status: "in_progress", StartedAt: startedAt},
+			"sha8/SchemaBot (production)": {ID: 80, Name: "SchemaBot (production)", Status: "completed", Conclusion: "success"},
+		},
+	}
+
+	result, err := scanWebhookMissingChecks(t.Context(), client, "octo/repo", []string{"SchemaBot (production)"}, 0)
+
+	require.NoError(t, err)
+	assert.Empty(t, result.Missing, "an existing run is not missing, even when uncompleted")
+	require.Len(t, result.Stuck, 1)
+	stuck := result.Stuck[0]
+	assert.Equal(t, 7, stuck.Number)
+	assert.Equal(t, "https://github.com/octo/repo/pull/7", stuck.URL)
+	require.Len(t, stuck.Checks, 1)
+	assert.Equal(t, "SchemaBot (production)", stuck.Checks[0].Name)
+	assert.Equal(t, int64(70), stuck.Checks[0].CheckRunID)
+	assert.Equal(t, "in_progress", stuck.Checks[0].Status)
+	assert.Equal(t, "2026-07-12T09:00:00Z", stuck.Checks[0].StartedAt)
+}
+
+// A stuck run without a reported start time serializes an empty started_at
+// rather than a misleading year-one timestamp.
+func TestScanWebhookMissingChecksReportsUncompletedRunWithoutStartTime(t *testing.T) {
+	t.Parallel()
+
+	client := fakeWebhookMissingCheckScanClient{
+		prs: []ghclient.OpenPullRequest{
+			{Number: 9, Title: "queued forever", HeadSHA: "sha9", HeadRef: "feature-9"},
+		},
+		runs: map[string]*ghclient.CheckRunResult{
+			"sha9/SchemaBot (production)": {ID: 90, Name: "SchemaBot (production)", Status: "queued"},
+		},
+	}
+
+	result, err := scanWebhookMissingChecks(t.Context(), client, "octo/repo", []string{"SchemaBot (production)"}, 0)
+
+	require.NoError(t, err)
+	assert.Empty(t, result.Missing)
+	require.Len(t, result.Stuck, 1)
+	require.Len(t, result.Stuck[0].Checks, 1)
+	assert.Equal(t, "queued", result.Stuck[0].Checks[0].Status)
+	assert.Empty(t, result.Stuck[0].Checks[0].StartedAt)
+}
+
 // A missing check whose name is already taken by an untrusted app's Check Run
 // is reported distinctly, so the operator knows backfill alone leaves a
 // conflicting check to resolve.

--- a/pkg/api/webhook_ops_handlers_test.go
+++ b/pkg/api/webhook_ops_handlers_test.go
@@ -507,7 +507,7 @@ func TestScanWebhookMissingChecksReportsOpenPRsMissingConfiguredChecks(t *testin
 		},
 	}
 
-	result, err := scanWebhookMissingChecks(t.Context(), client, "octo/repo", []string{"SchemaBot (production)"}, 0)
+	result, err := scanWebhookMissingChecks(t.Context(), client, "octo/repo", []string{"SchemaBot (production)"}, 0, time.Time{})
 
 	require.NoError(t, err)
 	assert.Equal(t, 2, result.Scanned)
@@ -537,7 +537,7 @@ func TestScanWebhookMissingChecksReportsUncompletedRuns(t *testing.T) {
 		},
 	}
 
-	result, err := scanWebhookMissingChecks(t.Context(), client, "octo/repo", []string{"SchemaBot (production)"}, 0)
+	result, err := scanWebhookMissingChecks(t.Context(), client, "octo/repo", []string{"SchemaBot (production)"}, 0, time.Time{})
 
 	require.NoError(t, err)
 	assert.Empty(t, result.Missing, "an existing run is not missing, even when uncompleted")
@@ -566,7 +566,7 @@ func TestScanWebhookMissingChecksReportsUncompletedRunWithoutStartTime(t *testin
 		},
 	}
 
-	result, err := scanWebhookMissingChecks(t.Context(), client, "octo/repo", []string{"SchemaBot (production)"}, 0)
+	result, err := scanWebhookMissingChecks(t.Context(), client, "octo/repo", []string{"SchemaBot (production)"}, 0, time.Time{})
 
 	require.NoError(t, err)
 	assert.Empty(t, result.Missing)
@@ -574,6 +574,67 @@ func TestScanWebhookMissingChecksReportsUncompletedRunWithoutStartTime(t *testin
 	require.Len(t, result.Stuck[0].Checks, 1)
 	assert.Equal(t, "queued", result.Stuck[0].Checks[0].Status)
 	assert.Empty(t, result.Stuck[0].Checks[0].StartedAt)
+}
+
+// A windowed sweep stops at the window boundary: the open-PR listing is
+// ordered newest-updated first, so once a PR older than updated_since
+// appears the rest of the repo cannot be in the window — the scan reports
+// only the in-window PRs and clears next_page so the caller stops paging.
+// This bounds an incident sweep by the incident window, not the repo's total
+// open-PR count.
+func TestScanWebhookMissingChecksStopsAtUpdatedSince(t *testing.T) {
+	t.Parallel()
+
+	updatedSince := time.Date(2026, 7, 12, 8, 0, 0, 0, time.UTC)
+	client := fakeWebhookMissingCheckScanClient{
+		prs: []ghclient.OpenPullRequest{
+			{Number: 1, Title: "in window, missing check", HeadSHA: "sha1", HeadRef: "f1", UpdatedAt: updatedSince.Add(2 * time.Hour)},
+			{Number: 2, Title: "in window, has check", HeadSHA: "sha2", HeadRef: "f2", UpdatedAt: updatedSince.Add(time.Hour)},
+			{Number: 3, Title: "before window, also missing check", HeadSHA: "sha3", HeadRef: "f3", UpdatedAt: updatedSince.Add(-time.Hour)},
+			{Number: 4, Title: "before window", HeadSHA: "sha4", HeadRef: "f4", UpdatedAt: updatedSince.Add(-2 * time.Hour)},
+		},
+		runs: map[string]*ghclient.CheckRunResult{
+			"sha2/SchemaBot (production)": {ID: 20, Name: "SchemaBot (production)", Status: "completed", Conclusion: "success"},
+		},
+	}
+
+	result, err := scanWebhookMissingChecks(t.Context(), client, "octo/repo", []string{"SchemaBot (production)"}, 0, updatedSince)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.Scanned, "only the in-window PRs count as scanned")
+	assert.Zero(t, result.NextPage, "crossing the window boundary ends the sweep")
+	require.Len(t, result.Missing, 1)
+	assert.Equal(t, 1, result.Missing[0].Number)
+}
+
+// An unparseable updated_since is a request error, not a full unwindowed scan.
+func TestExecuteChecksScanRejectsInvalidUpdatedSince(t *testing.T) {
+	t.Parallel()
+
+	cfg := &ServerConfig{AllowedEnvironments: []string{"production"}}
+
+	_, err := executeChecksScan(t.Context(), cfg, ChecksScanRequest{Repo: "octo/repo", UpdatedSince: "yesterday"}, discardLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "updated_since")
+}
+
+// The repos inventory returns the declared repos config sorted, and a legacy
+// single-App config (which declares no repos) is a request error telling the
+// operator to name a repository — a fleet sweep cannot guess what to scan.
+func TestExecuteChecksRepos(t *testing.T) {
+	t.Parallel()
+
+	cfg := &ServerConfig{
+		Apps:  map[string]GitHubAppConfig{"main": {AppID: "1", PrivateKey: "key"}},
+		Repos: map[string]RepoConfig{"octo/zebra": {GitHubApp: "main"}, "octo/alpha": {GitHubApp: "main"}},
+	}
+	response, err := executeChecksRepos(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"octo/alpha", "octo/zebra"}, response.Repos)
+
+	_, err = executeChecksRepos(&ServerConfig{GitHub: GitHubConfig{AppID: "1", PrivateKey: "key"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "declares no repos config")
 }
 
 // A missing check whose name is already taken by an untrusted app's Check Run
@@ -591,7 +652,7 @@ func TestScanWebhookMissingChecksSurfacesUntrustedConflicts(t *testing.T) {
 		},
 	}
 
-	result, err := scanWebhookMissingChecks(t.Context(), client, "octo/repo", []string{"SchemaBot (production)"}, 0)
+	result, err := scanWebhookMissingChecks(t.Context(), client, "octo/repo", []string{"SchemaBot (production)"}, 0, time.Time{})
 
 	require.NoError(t, err)
 	require.Len(t, result.Missing, 1)

--- a/pkg/api/webhook_ops_handlers_test.go
+++ b/pkg/api/webhook_ops_handlers_test.go
@@ -461,20 +461,24 @@ type fakeWebhookMissingCheckScanClient struct {
 	untrusted map[string][]string
 }
 
-func (f fakeWebhookMissingCheckScanClient) ListOpenPullRequestsPage(_ context.Context, _ string, page, perPage int) ([]ghclient.OpenPullRequest, int, error) {
+func (f fakeWebhookMissingCheckScanClient) ListOpenPullRequestsPage(_ context.Context, _ string, page, perPage int) ([]ghclient.OpenPullRequest, int, int, error) {
 	if page <= 0 {
 		page = 1
 	}
 	start := (page - 1) * perPage
 	if start >= len(f.prs) {
-		return nil, 0, nil
+		return nil, 0, 0, nil
 	}
 	end := min(start+perPage, len(f.prs))
 	nextPage := 0
+	lastPage := 0
 	if end < len(f.prs) {
 		nextPage = page + 1
+		// GitHub's Link header names the last page only while more pages
+		// remain; the final page carries no last rel.
+		lastPage = (len(f.prs) + perPage - 1) / perPage
 	}
-	return f.prs[start:end], nextPage, nil
+	return f.prs[start:end], nextPage, lastPage, nil
 }
 
 func (f fakeWebhookMissingCheckScanClient) FindCheckRunByName(_ context.Context, _ string, headSHA, checkName string) (*ghclient.CheckRunResult, []string, error) {
@@ -516,6 +520,18 @@ func TestScanWebhookMissingChecksReportsOpenPRsMissingConfiguredChecks(t *testin
 	assert.Equal(t, "https://github.com/octo/repo/pull/2", result.Missing[0].URL)
 	assert.Equal(t, []string{"SchemaBot (production)"}, result.Missing[0].MissingNames)
 	assert.Empty(t, result.Missing[0].UntrustedConflictNames)
+	assert.Equal(t, 2, result.EstimatedOpenPRs, "a single-page listing pins the exact open-PR count")
+}
+
+// A scan page carries the repository's open-PR count so the caller can render
+// a progress denominator: GitHub's last-page pointer gives an upper bound
+// while pages remain, and the final page pins the exact count.
+func TestEstimateOpenPRCount(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, 50*webhookScanPRPageSize, estimateOpenPRCount(2, 50, webhookScanPRPageSize), "mid-listing: upper bound from GitHub's last-page pointer")
+	assert.Equal(t, 3*webhookScanPRPageSize+12, estimateOpenPRCount(4, 0, 12), "final page: the pages before it plus the PRs on it")
+	assert.Equal(t, 12, estimateOpenPRCount(0, 0, 12), "an unpaginated listing is the whole repository")
 }
 
 // An expected Check Run that exists but never completed is reported as stuck,

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -116,11 +116,16 @@ type ChecksScanRequest struct {
 }
 
 type ChecksScanResponse struct {
-	Repo       string           `json:"repo"`
-	CheckNames []string         `json:"check_names"`
-	Scanned    int              `json:"scanned"`
-	NextPage   int              `json:"next_page,omitempty"`
-	Missing    []MissingCheckPR `json:"missing"`
+	Repo       string   `json:"repo"`
+	CheckNames []string `json:"check_names"`
+	Scanned    int      `json:"scanned"`
+	NextPage   int      `json:"next_page,omitempty"`
+	// EstimatedOpenPRs is the repository's total open-PR count as GitHub
+	// reports it for this page's listing — an upper bound while more pages
+	// remain, exact on the final page. Recomputed every page so the caller
+	// can render a progress denominator that stays honest across a long scan.
+	EstimatedOpenPRs int              `json:"estimated_open_prs,omitempty"`
+	Missing          []MissingCheckPR `json:"missing"`
 	// Stuck lists open PRs whose expected Check Run exists but has not
 	// completed. The server reports the raw status and start time; the caller
 	// decides how old is old enough to call stuck, because an uncompleted

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -108,6 +108,11 @@ type ChecksScanRequest struct {
 	// page). Each request scans a single page so it finishes well within any
 	// intermediary HTTP timeout; the caller loops until next_page is 0.
 	Page int `json:"page,omitempty"`
+	// UpdatedSince, when set (RFC3339), scans only PRs updated at or after
+	// this instant. The open-PR listing is ordered newest-updated first, so
+	// the scan stops paging as soon as it crosses the cutoff — bounding an
+	// incident-window sweep by the window instead of the repo's PR count.
+	UpdatedSince string `json:"updated_since,omitempty"`
 }
 
 type ChecksScanResponse struct {
@@ -121,6 +126,26 @@ type ChecksScanResponse struct {
 	// decides how old is old enough to call stuck, because an uncompleted
 	// check is legitimate while an apply or plan is genuinely in flight.
 	Stuck []StuckCheckPR `json:"stuck,omitempty"`
+	// RateLimit reports the GitHub budget left on the installation that
+	// served this page, so the caller can pace itself instead of starving
+	// the live webhook path that shares the same budget. Nil when the rate
+	// state could not be read (advisory only; the scan itself succeeded).
+	RateLimit *GitHubRateLimit `json:"rate_limit,omitempty"`
+}
+
+// GitHubRateLimit is a point-in-time snapshot of a GitHub installation's
+// core REST budget.
+type GitHubRateLimit struct {
+	Remaining int `json:"remaining"`
+	Limit     int `json:"limit"`
+	// ResetAt is RFC3339; when the budget replenishes.
+	ResetAt string `json:"reset_at"`
+}
+
+// ChecksReposResponse lists the repositories declared in the server's repos
+// config — the inventory a fleet-wide scan iterates.
+type ChecksReposResponse struct {
+	Repos []string `json:"repos"`
 }
 
 // ChecksSynthesizeRequest asks the server to recreate missing Check Runs for
@@ -135,6 +160,9 @@ type ChecksSynthesizeRequest struct {
 type ChecksSynthesizeResponse struct {
 	Repo    string                   `json:"repo"`
 	Results []ChecksSynthesizeResult `json:"results"`
+	// RateLimit mirrors ChecksScanResponse.RateLimit: the installation's
+	// remaining GitHub budget after this batch, for caller-side pacing.
+	RateLimit *GitHubRateLimit `json:"rate_limit,omitempty"`
 }
 
 type ChecksSynthesizeResult struct {

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -116,6 +116,11 @@ type ChecksScanResponse struct {
 	Scanned    int              `json:"scanned"`
 	NextPage   int              `json:"next_page,omitempty"`
 	Missing    []MissingCheckPR `json:"missing"`
+	// Stuck lists open PRs whose expected Check Run exists but has not
+	// completed. The server reports the raw status and start time; the caller
+	// decides how old is old enough to call stuck, because an uncompleted
+	// check is legitimate while an apply or plan is genuinely in flight.
+	Stuck []StuckCheckPR `json:"stuck,omitempty"`
 }
 
 // ChecksSynthesizeRequest asks the server to recreate missing Check Runs for
@@ -150,6 +155,27 @@ type MissingCheckPR struct {
 	// still recreates the trusted check, but the operator likely also needs to
 	// remove/rename the conflicting check or adjust the trusted-app config.
 	UntrustedConflictNames []string `json:"untrusted_conflict_check_names,omitempty"`
+}
+
+// StuckCheckPR is an open PR carrying at least one expected SchemaBot Check
+// Run that exists but has not reached a conclusion.
+type StuckCheckPR struct {
+	Number  int                  `json:"number"`
+	URL     string               `json:"url"`
+	Title   string               `json:"title"`
+	HeadSHA string               `json:"head_sha"`
+	HeadRef string               `json:"head_ref"`
+	Checks  []IncompleteCheckRun `json:"checks"`
+}
+
+// IncompleteCheckRun describes one Check Run that exists on the PR head but
+// has not completed.
+type IncompleteCheckRun struct {
+	Name       string `json:"name"`
+	CheckRunID int64  `json:"check_run_id"`
+	Status     string `json:"status"`
+	// StartedAt is RFC3339; empty when GitHub did not report a start time.
+	StartedAt string `json:"started_at,omitempty"`
 }
 
 // =============================================================================

--- a/pkg/cmd/client/client.go
+++ b/pkg/cmd/client/client.go
@@ -96,6 +96,16 @@ func ChecksSynthesize(ctx context.Context, endpoint string, req apitypes.ChecksS
 	return &result, nil
 }
 
+// ChecksRepos lists the repositories declared in the server's repos config —
+// the inventory a fleet-wide checks scan iterates.
+func ChecksRepos(ctx context.Context, endpoint string) (*apitypes.ChecksReposResponse, error) {
+	var result apitypes.ChecksReposResponse
+	if err := doSlowPostIntoCtx(ctx, endpoint, "/api/checks/repos", struct{}{}, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 // PullSchemaOptions controls optional live schema pull request fields.
 type PullSchemaOptions struct {
 	Namespaces    []string

--- a/pkg/cmd/commands/checks_backfill.go
+++ b/pkg/cmd/commands/checks_backfill.go
@@ -464,9 +464,9 @@ func writeChecksBackfillReport(w io.Writer, report *checksBackfillReport) error 
 	}
 
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	header := "PR\tHEAD SHA\tMISSING CHECKS\tACTION\tTITLE"
+	header := "PR\tHEAD SHA\tMISSING CHECKS\tACTION"
 	if !report.DryRun {
-		header = "PR\tHEAD SHA\tMISSING CHECKS\tOUTCOME\tTITLE"
+		header = "PR\tHEAD SHA\tMISSING CHECKS\tOUTCOME"
 	}
 	if _, err := fmt.Fprintln(tw, header); err != nil {
 		return err
@@ -484,10 +484,9 @@ func writeChecksBackfillReport(w io.Writer, report *checksBackfillReport) error 
 				failed++
 			}
 		}
-		// The status (server outcome/error) and the GitHub-controlled title are
-		// tab-separated cells: strip tabs/newlines so a value containing them
-		// cannot break the table layout.
-		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", action.URL, shortSHA(action.HeadSHA), strings.Join(action.MissingNames, ", "), sanitizeCell(status), sanitizeCell(action.Title)); err != nil {
+		// The status (server outcome/error) is a tab-separated cell: strip
+		// tabs/newlines so a value containing them cannot break the layout.
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", action.URL, shortSHA(action.HeadSHA), strings.Join(action.MissingNames, ", "), sanitizeCell(status)); err != nil {
 			return err
 		}
 	}
@@ -520,11 +519,11 @@ func writeChecksStuckSection(w io.Writer, report *checksBackfillReport) error {
 		return err
 	}
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	if _, err := fmt.Fprintln(tw, "PR\tHEAD SHA\tCHECK\tSTATUS\tAGE\tTITLE"); err != nil {
+	if _, err := fmt.Fprintln(tw, "PR\tHEAD SHA\tCHECK\tSTATUS\tAGE"); err != nil {
 		return err
 	}
 	for _, stuck := range report.Stuck {
-		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n", stuck.URL, shortSHA(stuck.HeadSHA), stuck.CheckName, stuck.Status, stuck.Age, sanitizeCell(stuck.Title)); err != nil {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", stuck.URL, shortSHA(stuck.HeadSHA), stuck.CheckName, stuck.Status, stuck.Age); err != nil {
 			return err
 		}
 	}
@@ -547,7 +546,7 @@ func sortedKeys[V any](m map[string]V) []string {
 }
 
 // sanitizeCell collapses tabs and newlines to spaces so a caller-influenced
-// value (a PR title, a server error string) cannot break the tab-separated
+// value (a server outcome or error string) cannot break the tab-separated
 // table layout.
 func sanitizeCell(s string) string {
 	return strings.NewReplacer("\t", " ", "\n", " ", "\r", " ").Replace(s)

--- a/pkg/cmd/commands/checks_backfill.go
+++ b/pkg/cmd/commands/checks_backfill.go
@@ -171,10 +171,12 @@ func (cmd *ChecksBackfillCmd) Run(ctx context.Context, g *Globals) error {
 		StuckAfter: cmd.StuckAfter,
 	}
 	checkNamesSeen := map[string]bool{}
+	held := 0
 scanning:
 	for i, repo := range repos {
 		page := 1
 		repoScanned := 0
+		repoEstimate := 0
 		for {
 			chunk, err := cmdclient.ChecksScan(ctx, endpoint, apitypes.ChecksScanRequest{
 				Repo:         repo,
@@ -197,6 +199,9 @@ scanning:
 			}
 			repoScanned += chunk.Scanned
 			report.Scanned += chunk.Scanned
+			if chunk.EstimatedOpenPRs > 0 {
+				repoEstimate = chunk.EstimatedOpenPRs
+			}
 			// Every uncompleted run holds its PR, regardless of how long it has
 			// been sitting — --stuck-after shapes the stuck *report*, but an
 			// uncompleted run of any age could belong to an in-flight apply.
@@ -205,7 +210,7 @@ scanning:
 				uncompleted[stuckPR.Number] = true
 			}
 			for _, missing := range chunk.Missing {
-				report.Actions = append(report.Actions, checksBackfillAction{
+				action := checksBackfillAction{
 					Repo:                   repo,
 					PR:                     missing.Number,
 					URL:                    missing.URL,
@@ -214,10 +219,14 @@ scanning:
 					MissingNames:           missing.MissingNames,
 					UntrustedConflictNames: missing.UntrustedConflictNames,
 					Held:                   uncompleted[missing.Number],
-				})
+				}
+				if action.Held {
+					held++
+				}
+				report.Actions = append(report.Actions, action)
 			}
 			report.Stuck = append(report.Stuck, stuckChecksPastThreshold(repo, chunk.Stuck, stuckAfter, webhookRedriveNow())...)
-			updateProgress(fmt.Sprintf("repo %d/%d %s: %d PRs scanned (%d total) — %d missing, %d stuck Check Runs so far", i+1, len(repos), repo, repoScanned, report.Scanned, len(report.Actions), len(report.Stuck)))
+			updateProgress(checksScanProgressLine(i+1, len(repos), repo, repoScanned, repoEstimate, report.Scanned, len(report.Actions), held, len(report.Stuck)))
 			if cmd.Limit > 0 && report.Scanned >= cmd.Limit {
 				break scanning
 			}
@@ -251,6 +260,33 @@ scanning:
 	}
 	stopProgress()
 	return cmd.write(report)
+}
+
+// checksScanProgressLine renders one scan progress update. The denominator is
+// GitHub's own open-PR count for the repository, recomputed every page, so a
+// long sweep always reads as progress toward a bound instead of an endless
+// loop; the counts after the dash say what the sweep has found so far. The
+// denominator is an upper bound until the repo's final page (a --last window
+// legitimately stops short of it).
+func checksScanProgressLine(repoIndex, repoCount int, repo string, repoScanned, repoEstimate, totalScanned, missing, held, stuck int) string {
+	var b strings.Builder
+	if repoCount > 1 {
+		fmt.Fprintf(&b, "repo %d/%d ", repoIndex, repoCount)
+	}
+	fmt.Fprintf(&b, "%s: %d", repo, repoScanned)
+	if repoEstimate > repoScanned {
+		fmt.Fprintf(&b, "/~%d", repoEstimate)
+	}
+	b.WriteString(" PRs scanned")
+	if repoCount > 1 {
+		fmt.Fprintf(&b, " (%d across all repos)", totalScanned)
+	}
+	fmt.Fprintf(&b, " — %d missing", missing)
+	if held > 0 {
+		fmt.Fprintf(&b, " (%d held)", held)
+	}
+	fmt.Fprintf(&b, ", %d stuck Check Runs", stuck)
+	return b.String()
 }
 
 // backfillCanceledError maps an operator cancellation (Ctrl+C) to a clean
@@ -367,16 +403,26 @@ func (cmd *ChecksBackfillCmd) act(ctx context.Context, endpoint string, report *
 		}
 		synthesizeByRepo[action.Repo] = append(synthesizeByRepo[action.Repo], action.PR)
 	}
+	failed := 0
 	for _, repo := range sortedKeys(synthesizeByRepo) {
 		prs := synthesizeByRepo[repo]
 		for start := 0; start < len(prs); start += checksSynthesizeBatchSize {
 			batch := prs[start:min(start+checksSynthesizeBatchSize, len(prs))]
-			updateProgress(fmt.Sprintf("synthesizing Check Runs for %d/%d PRs in %s...", min(start+len(batch), len(prs)), len(prs), repo))
+			progressLine := fmt.Sprintf("synthesizing Check Runs for %d/%d PRs in %s...", min(start+len(batch), len(prs)), len(prs), repo)
+			if failed > 0 {
+				// Surface failures as they happen so the operator can interrupt a
+				// failing sweep instead of discovering it in the final table.
+				progressLine += fmt.Sprintf(" (%d failed so far)", failed)
+			}
+			updateProgress(progressLine)
 			resp, err := cmdclient.ChecksSynthesize(ctx, endpoint, apitypes.ChecksSynthesizeRequest{Repo: repo, PRs: batch})
 			if err != nil {
 				return fmt.Errorf("synthesize Check Runs for %s: %w", repo, err)
 			}
 			for _, result := range resp.Results {
+				if result.Error != "" {
+					failed++
+				}
 				if action, ok := actionByPR[repoPR{repo: repo, pr: result.PR}]; ok {
 					action.Outcome = result.Outcome
 					action.Error = result.Error

--- a/pkg/cmd/commands/checks_backfill.go
+++ b/pkg/cmd/commands/checks_backfill.go
@@ -106,11 +106,11 @@ func (cmd *ChecksBackfillCmd) Run(ctx context.Context, g *Globals) error {
 	if cmd.MaxDeliveryPages <= 0 {
 		return fmt.Errorf("--max-delivery-pages must be positive")
 	}
-	deliveryWindow, err := parseWebhookRedriveLast(cmd.DeliveryWindow)
+	deliveryWindow, err := parseOperatorDuration(cmd.DeliveryWindow)
 	if err != nil {
 		return fmt.Errorf("parse --delivery-window: %w", err)
 	}
-	stuckAfter, err := parseWebhookRedriveLast(cmd.StuckAfter)
+	stuckAfter, err := parseOperatorDuration(cmd.StuckAfter)
 	if err != nil {
 		return fmt.Errorf("parse --stuck-after: %w", err)
 	}
@@ -226,8 +226,9 @@ func backfillCanceledError(err error, stopProgress func()) error {
 
 // stuckChecksPastThreshold flattens the scan's uncompleted Check Runs to one
 // row per (PR, check), keeping only runs that have been sitting longer than
-// stuckAfter. A run with no reported start time is always kept — its age
-// cannot prove it is young, and the scan must not hide it.
+// stuckAfter. A run whose start time is missing, unparseable, or in the
+// future (clock skew) is always kept with an "unknown" age — a start time
+// that cannot prove the run is young must not hide it.
 func stuckChecksPastThreshold(prs []apitypes.StuckCheckPR, stuckAfter time.Duration, now time.Time) []checksStuckCheck {
 	var out []checksStuckCheck
 	for _, pr := range prs {
@@ -235,7 +236,7 @@ func stuckChecksPastThreshold(prs []apitypes.StuckCheckPR, stuckAfter time.Durat
 			age := "unknown"
 			if check.StartedAt != "" {
 				startedAt, err := time.Parse(time.RFC3339, check.StartedAt)
-				if err == nil {
+				if err == nil && !startedAt.After(now) {
 					sitting := now.Sub(startedAt)
 					if sitting < stuckAfter {
 						continue

--- a/pkg/cmd/commands/checks_backfill.go
+++ b/pkg/cmd/commands/checks_backfill.go
@@ -464,9 +464,9 @@ func writeChecksBackfillReport(w io.Writer, report *checksBackfillReport) error 
 	}
 
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	header := "PR\tHEAD SHA\tMISSING CHECKS\tACTION"
+	header := "PR\tMISSING CHECKS\tACTION"
 	if !report.DryRun {
-		header = "PR\tHEAD SHA\tMISSING CHECKS\tOUTCOME"
+		header = "PR\tMISSING CHECKS\tOUTCOME"
 	}
 	if _, err := fmt.Fprintln(tw, header); err != nil {
 		return err
@@ -486,7 +486,7 @@ func writeChecksBackfillReport(w io.Writer, report *checksBackfillReport) error 
 		}
 		// The status (server outcome/error) is a tab-separated cell: strip
 		// tabs/newlines so a value containing them cannot break the layout.
-		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", action.URL, shortSHA(action.HeadSHA), strings.Join(action.MissingNames, ", "), sanitizeCell(status)); err != nil {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\n", action.URL, strings.Join(action.MissingNames, ", "), sanitizeCell(status)); err != nil {
 			return err
 		}
 	}
@@ -519,11 +519,11 @@ func writeChecksStuckSection(w io.Writer, report *checksBackfillReport) error {
 		return err
 	}
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	if _, err := fmt.Fprintln(tw, "PR\tHEAD SHA\tCHECK\tSTATUS\tAGE"); err != nil {
+	if _, err := fmt.Fprintln(tw, "PR\tCHECK\tSTATUS\tAGE"); err != nil {
 		return err
 	}
 	for _, stuck := range report.Stuck {
-		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", stuck.URL, shortSHA(stuck.HeadSHA), stuck.CheckName, stuck.Status, stuck.Age); err != nil {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", stuck.URL, stuck.CheckName, stuck.Status, stuck.Age); err != nil {
 			return err
 		}
 	}
@@ -550,11 +550,4 @@ func sortedKeys[V any](m map[string]V) []string {
 // table layout.
 func sanitizeCell(s string) string {
 	return strings.NewReplacer("\t", " ", "\n", " ", "\r", " ").Replace(s)
-}
-
-func shortSHA(sha string) string {
-	if len(sha) <= 12 {
-		return sha
-	}
-	return sha[:12]
 }

--- a/pkg/cmd/commands/checks_backfill.go
+++ b/pkg/cmd/commands/checks_backfill.go
@@ -17,13 +17,17 @@ import (
 
 // ChecksCmd groups SchemaBot Check Run operator commands.
 type ChecksCmd struct {
-	Backfill ChecksBackfillCmd `cmd:"" help:"Find open PRs missing SchemaBot Check Runs and recreate them"`
+	Backfill ChecksBackfillCmd `cmd:"" help:"Find open PRs with missing or stuck SchemaBot Check Runs; recreate the missing ones"`
 }
 
 // ChecksBackfillCmd finds open PRs missing SchemaBot Check Runs and recreates
 // them, choosing the right remedy per PR: redeliver the PR's failed webhook
 // delivery when GitHub still retains one, otherwise replay the auto-plan flow
-// server-side. --dry-run prints the per-PR classification without acting.
+// server-side. It also reports Check Runs that exist but never completed
+// (stuck in queued/in_progress past --stuck-after) — those are surfaced for
+// investigation, never acted on, because an uncompleted check can belong to a
+// genuinely in-flight apply. --dry-run prints the per-PR classification
+// without acting.
 type ChecksBackfillCmd struct {
 	Repo             string `arg:"" help:"Repository to backfill, in owner/name form"`
 	Environment      string `help:"Only backfill this environment's SchemaBot Check Run name"`
@@ -31,6 +35,7 @@ type ChecksBackfillCmd struct {
 	Limit            int    `help:"Maximum open PRs to consider; 0 considers all" default:"0"`
 	DeliveryWindow   string `help:"How far back to search delivery history for redriveable deliveries, for example 6h or 14d" default:"14d"`
 	MaxDeliveryPages int    `help:"Maximum delivery pages to search per App" default:"300"`
+	StuckAfter       string `help:"Report an existing but uncompleted Check Run as stuck once it has been sitting this long, for example 1h or 2d" default:"1h"`
 	DryRun           bool   `help:"Print the per-PR classification without redelivering or synthesizing"`
 	JSON             bool   `help:"Output as JSON"`
 }
@@ -66,13 +71,32 @@ type checksBackfillAction struct {
 	Error        string             `json:"error,omitempty"`
 }
 
+// checksStuckCheck is one existing-but-uncompleted Check Run on an open PR,
+// aged past --stuck-after. Reported for investigation only; the backfill
+// never acts on a check that already exists.
+type checksStuckCheck struct {
+	PR         int    `json:"pr"`
+	URL        string `json:"url"`
+	Title      string `json:"title"`
+	HeadSHA    string `json:"head_sha"`
+	CheckName  string `json:"check_name"`
+	CheckRunID int64  `json:"check_run_id"`
+	Status     string `json:"status"`
+	StartedAt  string `json:"started_at,omitempty"`
+	// Age is how long the run has been sitting uncompleted at scan time;
+	// "unknown" when GitHub did not report a start time.
+	Age string `json:"age"`
+}
+
 type checksBackfillReport struct {
 	Repo                   string                 `json:"repo"`
 	CheckNames             []string               `json:"check_names"`
 	Scanned                int                    `json:"scanned"`
 	DeliverySearchComplete bool                   `json:"delivery_search_complete"`
 	DryRun                 bool                   `json:"dry_run"`
+	StuckAfter             string                 `json:"stuck_after"`
 	Actions                []checksBackfillAction `json:"actions"`
+	Stuck                  []checksStuckCheck     `json:"stuck,omitempty"`
 }
 
 func (cmd *ChecksBackfillCmd) Run(ctx context.Context, g *Globals) error {
@@ -85,6 +109,10 @@ func (cmd *ChecksBackfillCmd) Run(ctx context.Context, g *Globals) error {
 	deliveryWindow, err := parseWebhookRedriveLast(cmd.DeliveryWindow)
 	if err != nil {
 		return fmt.Errorf("parse --delivery-window: %w", err)
+	}
+	stuckAfter, err := parseWebhookRedriveLast(cmd.StuckAfter)
+	if err != nil {
+		return fmt.Errorf("parse --stuck-after: %w", err)
 	}
 	endpoint, err := g.Resolve()
 	if err != nil {
@@ -120,8 +148,10 @@ func (cmd *ChecksBackfillCmd) Run(ctx context.Context, g *Globals) error {
 	redriveable, searchComplete := indexRedriveableDeliveries(crawl)
 
 	// Phase 2: page through open PRs missing the configured Check Runs and
-	// classify each against the delivery index.
-	report := &checksBackfillReport{Repo: cmd.Repo, DeliverySearchComplete: searchComplete, DryRun: cmd.DryRun}
+	// classify each against the delivery index. The scan also returns Check
+	// Runs that exist but never completed; those aged past --stuck-after are
+	// reported for investigation.
+	report := &checksBackfillReport{Repo: cmd.Repo, DeliverySearchComplete: searchComplete, DryRun: cmd.DryRun, StuckAfter: cmd.StuckAfter}
 	page := 1
 	for {
 		chunk, err := cmdclient.ChecksScan(ctx, endpoint, apitypes.ChecksScanRequest{
@@ -154,7 +184,8 @@ func (cmd *ChecksBackfillCmd) Run(ctx context.Context, g *Globals) error {
 			}
 			report.Actions = append(report.Actions, action)
 		}
-		updateProgress(fmt.Sprintf("scanned %d open PRs in %s, %d missing Check Runs so far", report.Scanned, cmd.Repo, len(report.Actions)))
+		report.Stuck = append(report.Stuck, stuckChecksPastThreshold(chunk.Stuck, stuckAfter, webhookRedriveNow())...)
+		updateProgress(fmt.Sprintf("scanned %d open PRs in %s, %d missing and %d stuck Check Runs so far", report.Scanned, cmd.Repo, len(report.Actions), len(report.Stuck)))
 		if chunk.NextPage == 0 || (cmd.Limit > 0 && report.Scanned >= cmd.Limit) {
 			break
 		}
@@ -191,6 +222,41 @@ func backfillCanceledError(err error, stopProgress func()) error {
 	stopProgress()
 	fmt.Fprintln(os.Stderr, "checks backfill canceled")
 	return ErrSilent
+}
+
+// stuckChecksPastThreshold flattens the scan's uncompleted Check Runs to one
+// row per (PR, check), keeping only runs that have been sitting longer than
+// stuckAfter. A run with no reported start time is always kept — its age
+// cannot prove it is young, and the scan must not hide it.
+func stuckChecksPastThreshold(prs []apitypes.StuckCheckPR, stuckAfter time.Duration, now time.Time) []checksStuckCheck {
+	var out []checksStuckCheck
+	for _, pr := range prs {
+		for _, check := range pr.Checks {
+			age := "unknown"
+			if check.StartedAt != "" {
+				startedAt, err := time.Parse(time.RFC3339, check.StartedAt)
+				if err == nil {
+					sitting := now.Sub(startedAt)
+					if sitting < stuckAfter {
+						continue
+					}
+					age = sitting.Truncate(time.Minute).String()
+				}
+			}
+			out = append(out, checksStuckCheck{
+				PR:         pr.Number,
+				URL:        pr.URL,
+				Title:      pr.Title,
+				HeadSHA:    pr.HeadSHA,
+				CheckName:  check.Name,
+				CheckRunID: check.CheckRunID,
+				Status:     check.Status,
+				StartedAt:  check.StartedAt,
+				Age:        age,
+			})
+		}
+	}
+	return out
 }
 
 // redriveableDeliveries is one PR's failed check-creating deliveries; all of
@@ -315,6 +381,9 @@ func writeChecksBackfillReport(w io.Writer, report *checksBackfillReport) error 
 			return err
 		}
 	}
+	if err := writeChecksStuckSection(w, report); err != nil {
+		return err
+	}
 	if len(report.Actions) == 0 {
 		_, err := fmt.Fprintln(w, "No missing SchemaBot Check Runs found.")
 		return err
@@ -359,6 +428,34 @@ func writeChecksBackfillReport(w io.Writer, report *checksBackfillReport) error 
 		return fmt.Errorf("%d Check Run backfills failed; see the outcomes above", failed)
 	}
 	return nil
+}
+
+// writeChecksStuckSection renders the stuck Check Runs the scan found: runs
+// that exist on an open PR's head but have sat uncompleted past --stuck-after.
+// Backfill never acts on these — an existing run may belong to an in-flight
+// apply, and overwriting it could convert real uncertainty into a passing
+// check — so the section tells the operator to investigate instead.
+func writeChecksStuckSection(w io.Writer, report *checksBackfillReport) error {
+	if len(report.Stuck) == 0 {
+		return nil
+	}
+	if _, err := fmt.Fprintf(w, "\nStuck Check Runs — uncompleted for over %s (backfill does not act on existing Check Runs; investigate the apply or plan that owns each):\n", report.StuckAfter); err != nil {
+		return err
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "PR\tHEAD SHA\tCHECK\tSTATUS\tAGE\tTITLE"); err != nil {
+		return err
+	}
+	for _, stuck := range report.Stuck {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n", stuck.URL, shortSHA(stuck.HeadSHA), stuck.CheckName, stuck.Status, stuck.Age, sanitizeCell(stuck.Title)); err != nil {
+			return err
+		}
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintln(w)
+	return err
 }
 
 // describeBackfillPlan renders a dry-run action, naming the remedy the

--- a/pkg/cmd/commands/checks_backfill.go
+++ b/pkg/cmd/commands/checks_backfill.go
@@ -20,23 +20,32 @@ type ChecksCmd struct {
 	Backfill ChecksBackfillCmd `cmd:"" help:"Find open PRs with missing or stuck SchemaBot Check Runs; recreate the missing ones"`
 }
 
-// ChecksBackfillCmd finds open PRs missing SchemaBot Check Runs and recreates
-// them, choosing the right remedy per PR: redeliver the PR's failed webhook
-// delivery when GitHub still retains one, otherwise replay the auto-plan flow
-// server-side. It also reports Check Runs that exist but never completed
-// (stuck in queued/in_progress past --stuck-after) — those are surfaced for
-// investigation, never acted on, because an uncompleted check can belong to a
-// genuinely in-flight apply. --dry-run prints the per-PR classification
-// without acting.
+// ChecksBackfillCmd walks open PRs and asks the two questions that matter
+// for the check gate: is the expected SchemaBot Check Run present, and if
+// present, did it complete? Missing checks are recreated by replaying the
+// auto-plan flow server-side; existing-but-uncompleted checks aged past
+// --stuck-after are reported for investigation, never acted on, because an
+// uncompleted check can belong to a genuinely in-flight apply.
+//
+// --all-repos sweeps every repository declared on the server, and --last
+// bounds the sweep to PRs updated within a window — together they make an
+// incident sweep cost O(incident) instead of O(every open PR at the org).
+// Without --last the scan covers every open PR, which is the one-time
+// backfill for a repository that predates check enablement. --dry-run
+// reports without acting.
 type ChecksBackfillCmd struct {
-	Repo             string `arg:"" help:"Repository to backfill, in owner/name form"`
+	Repo             string `arg:"" optional:"" help:"Repository to backfill, in owner/name form; omit with --all-repos"`
+	AllRepos         bool   `help:"Scan every repository declared in the server's repos config"`
+	Last             string `help:"Only scan PRs updated within this window, for example 1h or 1d; by default every open PR is scanned"`
 	Environment      string `help:"Only backfill this environment's SchemaBot Check Run name"`
 	CheckName        string `help:"Override the SchemaBot Check Run name to look for"`
-	Limit            int    `help:"Maximum open PRs to consider; 0 considers all" default:"0"`
-	DeliveryWindow   string `help:"How far back to search delivery history for redriveable deliveries, for example 6h or 14d" default:"14d"`
-	MaxDeliveryPages int    `help:"Maximum delivery pages to search per App" default:"300"`
+	Limit            int    `help:"Maximum open PRs to consider across all scanned repositories; 0 considers all" default:"0"`
 	StuckAfter       string `help:"Report an existing but uncompleted Check Run as stuck once it has been sitting this long, for example 1h or 2d" default:"1h"`
-	DryRun           bool   `help:"Print the per-PR classification without redelivering or synthesizing"`
+	RateLimitFloor   int    `help:"Pause whenever the GitHub budget drops below this percentage of its limit, resuming after it resets, so live webhook traffic keeps headroom; 0 disables pacing" default:"20"`
+	Redrive          bool   `help:"Redeliver a missing-check PR's retained failed webhook delivery instead of synthesizing, when GitHub still has one (single repository only; slow: GitHub lists delivery history App-wide)"`
+	DeliveryWindow   string `help:"With --redrive: how far back to search delivery history, for example 6h or 14d" default:"14d"`
+	MaxDeliveryPages int    `help:"With --redrive: maximum delivery pages to search per App" default:"300"`
+	DryRun           bool   `help:"Report missing and stuck Check Runs without redelivering or synthesizing"`
 	JSON             bool   `help:"Output as JSON"`
 }
 
@@ -50,6 +59,7 @@ const checksRedriveBatchSize = 50
 
 // checksBackfillAction is one PR's classification and (after acting) outcome.
 type checksBackfillAction struct {
+	Repo         string   `json:"repo"`
 	PR           int      `json:"pr"`
 	URL          string   `json:"url"`
 	Title        string   `json:"title"`
@@ -60,7 +70,8 @@ type checksBackfillAction struct {
 	// the operator likely also needs to resolve the conflicting one.
 	UntrustedConflictNames []string `json:"untrusted_conflict_names,omitempty"`
 	// Classification is "redrive" when GitHub still retains a failed
-	// check-creating delivery for the PR, otherwise "synthesize".
+	// check-creating delivery for the PR (found only under --redrive),
+	// otherwise "synthesize".
 	Classification string `json:"classification"`
 	// RedriveByApp groups the PR's redriveable delivery IDs by the App that
 	// owns them. A repo/PR can have retained failed deliveries in more than
@@ -75,6 +86,7 @@ type checksBackfillAction struct {
 // aged past --stuck-after. Reported for investigation only; the backfill
 // never acts on a check that already exists.
 type checksStuckCheck struct {
+	Repo       string `json:"repo"`
 	PR         int    `json:"pr"`
 	URL        string `json:"url"`
 	Title      string `json:"title"`
@@ -89,9 +101,13 @@ type checksStuckCheck struct {
 }
 
 type checksBackfillReport struct {
-	Repo                   string                 `json:"repo"`
-	CheckNames             []string               `json:"check_names"`
-	Scanned                int                    `json:"scanned"`
+	Repos      []string `json:"repos"`
+	CheckNames []string `json:"check_names"`
+	Scanned    int      `json:"scanned"`
+	// Last echoes the --last window bounding the sweep; empty means every
+	// open PR was scanned.
+	Last                   string                 `json:"last,omitempty"`
+	Redrive                bool                   `json:"redrive"`
 	DeliverySearchComplete bool                   `json:"delivery_search_complete"`
 	DryRun                 bool                   `json:"dry_run"`
 	StuckAfter             string                 `json:"stuck_after"`
@@ -100,19 +116,32 @@ type checksBackfillReport struct {
 }
 
 func (cmd *ChecksBackfillCmd) Run(ctx context.Context, g *Globals) error {
+	if cmd.Repo == "" && !cmd.AllRepos {
+		return fmt.Errorf("name a repository in owner/name form, or pass --all-repos to sweep every repository declared on the server")
+	}
+	if cmd.Repo != "" && cmd.AllRepos {
+		return fmt.Errorf("use either a repository argument or --all-repos, not both")
+	}
+	if cmd.Redrive && cmd.AllRepos {
+		return fmt.Errorf("--redrive searches one repository's delivery history; use it with a repository argument, not --all-repos")
+	}
 	if cmd.Limit < 0 {
 		return fmt.Errorf("--limit must be non-negative")
 	}
-	if cmd.MaxDeliveryPages <= 0 {
-		return fmt.Errorf("--max-delivery-pages must be positive")
-	}
-	deliveryWindow, err := parseOperatorDuration(cmd.DeliveryWindow)
-	if err != nil {
-		return fmt.Errorf("parse --delivery-window: %w", err)
+	if cmd.RateLimitFloor < 0 || cmd.RateLimitFloor > 99 {
+		return fmt.Errorf("--rate-limit-floor must be between 0 and 99")
 	}
 	stuckAfter, err := parseOperatorDuration(cmd.StuckAfter)
 	if err != nil {
 		return fmt.Errorf("parse --stuck-after: %w", err)
+	}
+	var updatedSince string
+	if cmd.Last != "" {
+		window, err := parseOperatorDuration(cmd.Last)
+		if err != nil {
+			return fmt.Errorf("parse --last: %w", err)
+		}
+		updatedSince = webhookRedriveNow().Add(-window).Format(time.RFC3339)
 	}
 	endpoint, err := g.Resolve()
 	if err != nil {
@@ -122,79 +151,137 @@ func (cmd *ChecksBackfillCmd) Run(ctx context.Context, g *Globals) error {
 	updateProgress, stopProgress := startLiveProgress(!cmd.JSON)
 	defer stopProgress()
 
-	// Phase 1: one crawl of the retained delivery history builds the
-	// redriveable index — proving "no delivery exists" for a PR any other way
-	// would cost a crawl per PR. Partial coverage is tolerated: a PR whose
-	// failed delivery sits beyond the budget is synthesized instead, which
-	// converges to the same checks.
-	windowEnd := webhookRedriveNow()
-	windowStart := windowEnd.Add(-deliveryWindow)
-	updateProgress(fmt.Sprintf("searching delivery history for failed deliveries in %s...", cmd.Repo))
-	crawl, err := runChunkedWebhookRedrive(ctx, cmdclient.RedriveWebhooks, endpoint, apitypes.WebhookRedriveRequest{
-		WindowStart: windowStart.Format(time.RFC3339),
-		WindowEnd:   windowEnd.Format(time.RFC3339),
-		Repo:        cmd.Repo,
-		MaxPages:    cmd.MaxDeliveryPages,
-		DryRun:      true,
-	}, cmd.MaxDeliveryPages, false, func(r apitypes.WebhookRedriveResult) {
-		updateProgress(fmt.Sprintf("app %s: %d delivery pages searched, %d failed deliveries found for %s", r.AppName, r.Pages, len(r.Selected), cmd.Repo))
-	})
-	if canceled := backfillCanceledError(err, stopProgress); canceled != nil {
-		return canceled
+	repos := []string{cmd.Repo}
+	if cmd.AllRepos {
+		updateProgress("listing the repositories declared on the server...")
+		declared, err := cmdclient.ChecksRepos(ctx, endpoint)
+		if canceled := backfillCanceledError(err, stopProgress); canceled != nil {
+			return canceled
+		}
+		if err != nil {
+			return fmt.Errorf("list the server's declared repositories: %w", err)
+		}
+		if len(declared.Repos) == 0 {
+			return fmt.Errorf("the server declared no repositories; name a repository explicitly")
+		}
+		repos = declared.Repos
 	}
-	if err != nil {
-		return fmt.Errorf("search delivery history: %w", err)
-	}
-	redriveable, searchComplete := indexRedriveableDeliveries(crawl)
 
-	// Phase 2: page through open PRs missing the configured Check Runs and
-	// classify each against the delivery index. The scan also returns Check
-	// Runs that exist but never completed; those aged past --stuck-after are
-	// reported for investigation.
-	report := &checksBackfillReport{Repo: cmd.Repo, DeliverySearchComplete: searchComplete, DryRun: cmd.DryRun, StuckAfter: cmd.StuckAfter}
-	page := 1
-	for {
-		chunk, err := cmdclient.ChecksScan(ctx, endpoint, apitypes.ChecksScanRequest{
+	// Optional redrive phase: one crawl of the retained delivery history
+	// builds the redriveable index — proving "no delivery exists" for a PR any
+	// other way would cost a crawl per PR. GitHub lists delivery history
+	// App-wide (there is no repo filter), so the crawl walks every repo's
+	// deliveries and is expensive; it is opt-in because a missing check
+	// synthesizes to the same resulting Check Runs without it.
+	redriveable := map[int]map[string][]int64{}
+	searchComplete := true
+	if cmd.Redrive {
+		windowEnd := webhookRedriveNow()
+		deliveryWindow, err := parseOperatorDuration(cmd.DeliveryWindow)
+		if err != nil {
+			return fmt.Errorf("parse --delivery-window: %w", err)
+		}
+		if cmd.MaxDeliveryPages <= 0 {
+			return fmt.Errorf("--max-delivery-pages must be positive")
+		}
+		windowStart := windowEnd.Add(-deliveryWindow)
+		updateProgress(fmt.Sprintf("searching delivery history for failed deliveries in %s...", cmd.Repo))
+		crawl, err := runChunkedWebhookRedrive(ctx, cmdclient.RedriveWebhooks, endpoint, apitypes.WebhookRedriveRequest{
+			WindowStart: windowStart.Format(time.RFC3339),
+			WindowEnd:   windowEnd.Format(time.RFC3339),
 			Repo:        cmd.Repo,
-			Environment: cmd.Environment,
-			CheckName:   cmd.CheckName,
-			Page:        page,
+			MaxPages:    cmd.MaxDeliveryPages,
+			DryRun:      true,
+		}, cmd.MaxDeliveryPages, false, func(r apitypes.WebhookRedriveResult) {
+			updateProgress(fmt.Sprintf("app %s: %d/%d delivery pages searched, %d failed deliveries found for %s", r.AppName, r.Pages, cmd.MaxDeliveryPages, len(r.Selected), cmd.Repo))
 		})
 		if canceled := backfillCanceledError(err, stopProgress); canceled != nil {
 			return canceled
 		}
 		if err != nil {
-			return fmt.Errorf("scan open PRs for missing Check Runs: %w", err)
+			return fmt.Errorf("search delivery history: %w", err)
 		}
-		report.CheckNames = chunk.CheckNames
-		report.Scanned += chunk.Scanned
-		for _, missing := range chunk.Missing {
-			action := checksBackfillAction{
-				PR:                     missing.Number,
-				URL:                    missing.URL,
-				Title:                  missing.Title,
-				HeadSHA:                missing.HeadSHA,
-				MissingNames:           missing.MissingNames,
-				UntrustedConflictNames: missing.UntrustedConflictNames,
-				Classification:         "synthesize",
-			}
-			if byApp, ok := redriveable[missing.Number]; ok {
-				action.Classification = "redrive"
-				action.RedriveByApp = byApp
-			}
-			report.Actions = append(report.Actions, action)
-		}
-		report.Stuck = append(report.Stuck, stuckChecksPastThreshold(chunk.Stuck, stuckAfter, webhookRedriveNow())...)
-		updateProgress(fmt.Sprintf("scanned %d open PRs in %s, %d missing and %d stuck Check Runs so far", report.Scanned, cmd.Repo, len(report.Actions), len(report.Stuck)))
-		if chunk.NextPage == 0 || (cmd.Limit > 0 && report.Scanned >= cmd.Limit) {
-			break
-		}
-		page = chunk.NextPage
+		redriveable, searchComplete = indexRedriveableDeliveries(crawl)
 	}
 
+	// Scan phase: page through each repository's open PRs and ask the two
+	// questions per PR — is the expected Check Run present, and did it
+	// complete? The listing is newest-updated first, so a --last window stops
+	// each repo's paging as soon as it crosses the window start.
+	report := &checksBackfillReport{
+		Repos:                  repos,
+		Last:                   cmd.Last,
+		Redrive:                cmd.Redrive,
+		DeliverySearchComplete: searchComplete,
+		DryRun:                 cmd.DryRun,
+		StuckAfter:             cmd.StuckAfter,
+	}
+	checkNamesSeen := map[string]bool{}
+scanning:
+	for i, repo := range repos {
+		page := 1
+		repoScanned := 0
+		for {
+			chunk, err := cmdclient.ChecksScan(ctx, endpoint, apitypes.ChecksScanRequest{
+				Repo:         repo,
+				Environment:  cmd.Environment,
+				CheckName:    cmd.CheckName,
+				Page:         page,
+				UpdatedSince: updatedSince,
+			})
+			if canceled := backfillCanceledError(err, stopProgress); canceled != nil {
+				return canceled
+			}
+			if err != nil {
+				return fmt.Errorf("scan %s open PRs for missing or stuck Check Runs: %w", repo, err)
+			}
+			for _, name := range chunk.CheckNames {
+				if !checkNamesSeen[name] {
+					checkNamesSeen[name] = true
+					report.CheckNames = append(report.CheckNames, name)
+				}
+			}
+			repoScanned += chunk.Scanned
+			report.Scanned += chunk.Scanned
+			for _, missing := range chunk.Missing {
+				action := checksBackfillAction{
+					Repo:                   repo,
+					PR:                     missing.Number,
+					URL:                    missing.URL,
+					Title:                  missing.Title,
+					HeadSHA:                missing.HeadSHA,
+					MissingNames:           missing.MissingNames,
+					UntrustedConflictNames: missing.UntrustedConflictNames,
+					Classification:         "synthesize",
+				}
+				if byApp, ok := redriveable[missing.Number]; ok {
+					action.Classification = "redrive"
+					action.RedriveByApp = byApp
+				}
+				report.Actions = append(report.Actions, action)
+			}
+			report.Stuck = append(report.Stuck, stuckChecksPastThreshold(repo, chunk.Stuck, stuckAfter, webhookRedriveNow())...)
+			updateProgress(fmt.Sprintf("repo %d/%d %s: %d PRs scanned (%d total) — %d missing, %d stuck Check Runs so far", i+1, len(repos), repo, repoScanned, report.Scanned, len(report.Actions), len(report.Stuck)))
+			if cmd.Limit > 0 && report.Scanned >= cmd.Limit {
+				break scanning
+			}
+			if chunk.NextPage == 0 {
+				break
+			}
+			if err := pauseForRateLimit(ctx, chunk.RateLimit, cmd.RateLimitFloor, updateProgress); err != nil {
+				if canceled := backfillCanceledError(err, stopProgress); canceled != nil {
+					return canceled
+				}
+				return err
+			}
+			page = chunk.NextPage
+		}
+	}
+	sort.Strings(report.CheckNames)
+
 	if !cmd.DryRun {
-		// Phase 3: act — redeliver the redriveable PRs' deliveries per App,
-		// then synthesize the rest in server-bounded batches.
+		// Act phase: redeliver the redriveable PRs' deliveries per App, then
+		// synthesize the rest in server-bounded batches per repository.
 		err := cmd.act(ctx, endpoint, report, updateProgress)
 		if canceled := backfillCanceledError(err, stopProgress); canceled != nil {
 			// Print what completed before the interrupt, then exit non-zero.
@@ -224,12 +311,55 @@ func backfillCanceledError(err error, stopProgress func()) error {
 	return ErrSilent
 }
 
+// pauseForRateLimit sleeps until the GitHub budget resets when the remaining
+// budget has fallen below floorPct percent of its limit. The backfill shares
+// its installation budget with live webhook serving — check creation for PRs
+// being pushed right now — so a large sweep must leave headroom rather than
+// drain the budget and starve the live path. A nil snapshot (the server could
+// not read the rate state) proceeds without pausing; GitHub's reactive
+// secondary-rate-limit handling still applies underneath.
+func pauseForRateLimit(ctx context.Context, rate *apitypes.GitHubRateLimit, floorPct int, updateProgress func(string)) error {
+	wait, ok := rateLimitPauseDuration(rate, floorPct, webhookRedriveNow())
+	if !ok {
+		return nil
+	}
+	updateProgress(fmt.Sprintf("GitHub budget below %d%% (%d/%d requests left); pausing %s until it resets so live webhook traffic keeps headroom", floorPct, rate.Remaining, rate.Limit, wait.Truncate(time.Second)))
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// rateLimitPauseDuration decides whether the budget snapshot is below the
+// floor and how long to wait for the reset. It returns false — no pause —
+// when pacing is disabled, the snapshot is missing, the budget is above the
+// floor, or the reset time is unparseable or already past (the next request
+// sees a replenished budget, so waiting would only slow the sweep).
+func rateLimitPauseDuration(rate *apitypes.GitHubRateLimit, floorPct int, now time.Time) (time.Duration, bool) {
+	if rate == nil || floorPct <= 0 || rate.Limit <= 0 {
+		return 0, false
+	}
+	if rate.Remaining*100 >= rate.Limit*floorPct {
+		return 0, false
+	}
+	resetAt, err := time.Parse(time.RFC3339, rate.ResetAt)
+	if err != nil || !resetAt.After(now) {
+		return 0, false
+	}
+	// A minute of slack lets GitHub's reset land before the sweep resumes.
+	return resetAt.Sub(now) + time.Minute, true
+}
+
 // stuckChecksPastThreshold flattens the scan's uncompleted Check Runs to one
 // row per (PR, check), keeping only runs that have been sitting longer than
 // stuckAfter. A run whose start time is missing, unparseable, or in the
 // future (clock skew) is always kept with an "unknown" age — a start time
 // that cannot prove the run is young must not hide it.
-func stuckChecksPastThreshold(prs []apitypes.StuckCheckPR, stuckAfter time.Duration, now time.Time) []checksStuckCheck {
+func stuckChecksPastThreshold(repo string, prs []apitypes.StuckCheckPR, stuckAfter time.Duration, now time.Time) []checksStuckCheck {
 	var out []checksStuckCheck
 	for _, pr := range prs {
 		for _, check := range pr.Checks {
@@ -245,6 +375,7 @@ func stuckChecksPastThreshold(prs []apitypes.StuckCheckPR, stuckAfter time.Durat
 				}
 			}
 			out = append(out, checksStuckCheck{
+				Repo:       repo,
 				PR:         pr.Number,
 				URL:        pr.URL,
 				Title:      pr.Title,
@@ -259,9 +390,6 @@ func stuckChecksPastThreshold(prs []apitypes.StuckCheckPR, stuckAfter time.Durat
 	}
 	return out
 }
-
-// redriveableDeliveries is one PR's failed check-creating deliveries; all of
-// a repo's deliveries come from the App that serves it, so one App per PR.
 
 // indexRedriveableDeliveries maps PR number to its failed check-creating
 // deliveries from the crawl. searchComplete is false when any App's crawl
@@ -295,6 +423,12 @@ func indexRedriveableDeliveries(crawl *apitypes.WebhookRedriveResponse) (map[int
 	return redriveable, searchComplete
 }
 
+// repoPR keys a PR within a multi-repo report.
+type repoPR struct {
+	repo string
+	pr   int
+}
+
 func (cmd *ChecksBackfillCmd) act(ctx context.Context, endpoint string, report *checksBackfillReport, updateProgress func(string)) error {
 	// Redeliveries first, grouped per App (a delivery only redelivers with its
 	// own App's token) and chunked so no single request redelivers an
@@ -326,12 +460,12 @@ func (cmd *ChecksBackfillCmd) act(ctx context.Context, endpoint string, report *
 		}
 	}
 
-	// Then synthesize, in server-bounded batches.
-	var synthesizePRs []int
-	actionByPR := make(map[int]*checksBackfillAction)
+	// Then synthesize, per repository, in server-bounded batches.
+	synthesizeByRepo := make(map[string][]int)
+	actionByPR := make(map[repoPR]*checksBackfillAction)
 	for i := range report.Actions {
 		action := &report.Actions[i]
-		actionByPR[action.PR] = action
+		actionByPR[repoPR{repo: action.Repo, pr: action.PR}] = action
 		switch action.Classification {
 		case "redrive":
 			anyFailed := false
@@ -346,20 +480,26 @@ func (cmd *ChecksBackfillCmd) act(ctx context.Context, endpoint string, report *
 				action.Outcome = "redelivered"
 			}
 		case "synthesize":
-			synthesizePRs = append(synthesizePRs, action.PR)
+			synthesizeByRepo[action.Repo] = append(synthesizeByRepo[action.Repo], action.PR)
 		}
 	}
-	for start := 0; start < len(synthesizePRs); start += checksSynthesizeBatchSize {
-		batch := synthesizePRs[start:min(start+checksSynthesizeBatchSize, len(synthesizePRs))]
-		updateProgress(fmt.Sprintf("synthesizing Check Runs for %d/%d PRs...", min(start+len(batch), len(synthesizePRs)), len(synthesizePRs)))
-		resp, err := cmdclient.ChecksSynthesize(ctx, endpoint, apitypes.ChecksSynthesizeRequest{Repo: cmd.Repo, PRs: batch})
-		if err != nil {
-			return fmt.Errorf("synthesize Check Runs: %w", err)
-		}
-		for _, result := range resp.Results {
-			if action, ok := actionByPR[result.PR]; ok {
-				action.Outcome = result.Outcome
-				action.Error = result.Error
+	for _, repo := range sortedKeys(synthesizeByRepo) {
+		prs := synthesizeByRepo[repo]
+		for start := 0; start < len(prs); start += checksSynthesizeBatchSize {
+			batch := prs[start:min(start+checksSynthesizeBatchSize, len(prs))]
+			updateProgress(fmt.Sprintf("synthesizing Check Runs for %d/%d PRs in %s...", min(start+len(batch), len(prs)), len(prs), repo))
+			resp, err := cmdclient.ChecksSynthesize(ctx, endpoint, apitypes.ChecksSynthesizeRequest{Repo: repo, PRs: batch})
+			if err != nil {
+				return fmt.Errorf("synthesize Check Runs for %s: %w", repo, err)
+			}
+			for _, result := range resp.Results {
+				if action, ok := actionByPR[repoPR{repo: repo, pr: result.PR}]; ok {
+					action.Outcome = result.Outcome
+					action.Error = result.Error
+				}
+			}
+			if err := pauseForRateLimit(ctx, resp.RateLimit, cmd.RateLimitFloor, updateProgress); err != nil {
+				return err
 			}
 		}
 	}
@@ -374,10 +514,18 @@ func (cmd *ChecksBackfillCmd) write(report *checksBackfillReport) error {
 }
 
 func writeChecksBackfillReport(w io.Writer, report *checksBackfillReport) error {
-	if _, err := fmt.Fprintf(w, "Scanned %d open PRs in %s for %s.\n", report.Scanned, report.Repo, strings.Join(report.CheckNames, ", ")); err != nil {
+	repoScope := strings.Join(report.Repos, ", ")
+	if len(report.Repos) > 3 {
+		repoScope = fmt.Sprintf("%d repositories", len(report.Repos))
+	}
+	window := ""
+	if report.Last != "" {
+		window = fmt.Sprintf(" updated in the last %s", report.Last)
+	}
+	if _, err := fmt.Fprintf(w, "Scanned %d open PRs%s in %s for %s.\n", report.Scanned, window, repoScope, strings.Join(report.CheckNames, ", ")); err != nil {
 		return err
 	}
-	if !report.DeliverySearchComplete {
+	if report.Redrive && !report.DeliverySearchComplete {
 		if _, err := fmt.Fprintln(w, "Note: the delivery-history search did not cover the full window; PRs with older failed deliveries are synthesized instead (same resulting Check Runs)."); err != nil {
 			return err
 		}
@@ -400,7 +548,7 @@ func writeChecksBackfillReport(w io.Writer, report *checksBackfillReport) error 
 	}
 	failed := 0
 	for _, action := range report.Actions {
-		status := describeBackfillPlan(action)
+		status := describeBackfillPlan(action, report.Redrive)
 		if !report.DryRun {
 			status = action.Outcome
 			if action.Error != "" {
@@ -420,7 +568,7 @@ func writeChecksBackfillReport(w io.Writer, report *checksBackfillReport) error 
 	}
 	for _, action := range report.Actions {
 		if len(action.UntrustedConflictNames) > 0 {
-			if _, err := fmt.Fprintf(w, "Note: PR #%d has checks held by an untrusted app (%s); backfill recreates the trusted check, but resolve the conflicting one too.\n", action.PR, strings.Join(action.UntrustedConflictNames, ", ")); err != nil {
+			if _, err := fmt.Fprintf(w, "Note: %s#%d has checks held by an untrusted app (%s); backfill recreates the trusted check, but resolve the conflicting one too.\n", action.Repo, action.PR, strings.Join(action.UntrustedConflictNames, ", ")); err != nil {
 				return err
 			}
 		}
@@ -460,8 +608,9 @@ func writeChecksStuckSection(w io.Writer, report *checksBackfillReport) error {
 }
 
 // describeBackfillPlan renders a dry-run action, naming the remedy the
-// backfill would use for the PR.
-func describeBackfillPlan(action checksBackfillAction) string {
+// backfill would use for the PR. "no retained delivery" is only a finding
+// when the delivery history was actually searched.
+func describeBackfillPlan(action checksBackfillAction, searchedDeliveries bool) string {
 	if action.Classification == "redrive" {
 		total := 0
 		for _, ids := range action.RedriveByApp {
@@ -469,7 +618,10 @@ func describeBackfillPlan(action checksBackfillAction) string {
 		}
 		return fmt.Sprintf("redrive %d failed deliveries (app %s)", total, strings.Join(sortedKeys(action.RedriveByApp), ", "))
 	}
-	return "synthesize via auto-plan (no retained delivery)"
+	if searchedDeliveries {
+		return "synthesize via auto-plan (no retained delivery)"
+	}
+	return "synthesize via auto-plan"
 }
 
 // sortedKeys returns the map keys in deterministic order, so per-App output

--- a/pkg/cmd/commands/checks_backfill.go
+++ b/pkg/cmd/commands/checks_backfill.go
@@ -25,7 +25,10 @@ type ChecksCmd struct {
 // present, did it complete? Missing checks are recreated by replaying the
 // auto-plan flow server-side; existing-but-uncompleted checks aged past
 // --stuck-after are reported for investigation, never acted on, because an
-// uncompleted check can belong to a genuinely in-flight apply.
+// uncompleted check can belong to a genuinely in-flight apply. For the same
+// reason, a missing-check PR whose head also carries an uncompleted check is
+// held out of the backfill (and the server independently refuses any PR with
+// a non-terminal apply).
 //
 // --all-repos sweeps every repository declared on the server, and --last
 // bounds the sweep to PRs updated within a window — together they make an
@@ -34,28 +37,26 @@ type ChecksCmd struct {
 // backfill for a repository that predates check enablement. --dry-run
 // reports without acting.
 type ChecksBackfillCmd struct {
-	Repo             string `arg:"" optional:"" help:"Repository to backfill, in owner/name form; omit with --all-repos"`
-	AllRepos         bool   `help:"Scan every repository declared in the server's repos config"`
-	Last             string `help:"Only scan PRs updated within this window, for example 1h or 1d; by default every open PR is scanned"`
-	Environment      string `help:"Only backfill this environment's SchemaBot Check Run name"`
-	CheckName        string `help:"Override the SchemaBot Check Run name to look for"`
-	Limit            int    `help:"Maximum open PRs to consider across all scanned repositories; 0 considers all" default:"0"`
-	StuckAfter       string `help:"Report an existing but uncompleted Check Run as stuck once it has been sitting this long, for example 1h or 2d" default:"1h"`
-	RateLimitFloor   int    `help:"Pause whenever the GitHub budget drops below this percentage of its limit, resuming after it resets, so live webhook traffic keeps headroom; 0 disables pacing" default:"20"`
-	Redrive          bool   `help:"Redeliver a missing-check PR's retained failed webhook delivery instead of synthesizing, when GitHub still has one (single repository only; slow: GitHub lists delivery history App-wide)"`
-	DeliveryWindow   string `help:"With --redrive: how far back to search delivery history, for example 6h or 14d" default:"14d"`
-	MaxDeliveryPages int    `help:"With --redrive: maximum delivery pages to search per App" default:"300"`
-	DryRun           bool   `help:"Report missing and stuck Check Runs without redelivering or synthesizing"`
-	JSON             bool   `help:"Output as JSON"`
+	Repo           string `arg:"" optional:"" help:"Repository to backfill, in owner/name form; omit with --all-repos"`
+	AllRepos       bool   `help:"Scan every repository declared in the server's repos config"`
+	Last           string `help:"Only scan PRs updated within this window, for example 1h or 1d; by default every open PR is scanned"`
+	Environment    string `help:"Only backfill this environment's SchemaBot Check Run name"`
+	CheckName      string `help:"Override the SchemaBot Check Run name to look for"`
+	Limit          int    `help:"Maximum open PRs to consider across all scanned repositories; 0 considers all" default:"0"`
+	StuckAfter     string `help:"Report an existing but uncompleted Check Run as stuck once it has been sitting this long, for example 1h or 2d" default:"1h"`
+	RateLimitFloor int    `help:"Pause whenever the GitHub budget drops below this percentage of its limit, resuming after it resets, so live webhook traffic keeps headroom; 0 disables pacing" default:"20"`
+	DryRun         bool   `help:"Report missing and stuck Check Runs without synthesizing"`
+	JSON           bool   `help:"Output as JSON"`
 }
 
 // checksSynthesizeBatchSize matches the server's per-request PR cap.
 const checksSynthesizeBatchSize = 10
 
-// checksRedriveBatchSize bounds the delivery IDs redelivered per request, so
-// the redrive phase stays chunked (like synthesize) and no single request can
-// outlive an intermediary HTTP timeout under the server's per-delivery delay.
-const checksRedriveBatchSize = 50
+// checksBackfillHeldStatus explains a held PR in the action table. The server
+// refuses these too (a non-terminal apply refuses its PR's backfill), but the
+// hold works from the scan's own signal — an uncompleted Check Run on the same
+// head — so the PR never even reaches the server, and the operator sees why.
+const checksBackfillHeldStatus = "held: an uncompleted Check Run sits on this head (a started apply may own it); investigate before backfilling"
 
 // checksBackfillAction is one PR's classification and (after acting) outcome.
 type checksBackfillAction struct {
@@ -69,17 +70,14 @@ type checksBackfillAction struct {
 	// an untrusted app's Check Run; backfill recreates the trusted check but
 	// the operator likely also needs to resolve the conflicting one.
 	UntrustedConflictNames []string `json:"untrusted_conflict_names,omitempty"`
-	// Classification is "redrive" when GitHub still retains a failed
-	// check-creating delivery for the PR (found only under --redrive),
-	// otherwise "synthesize".
-	Classification string `json:"classification"`
-	// RedriveByApp groups the PR's redriveable delivery IDs by the App that
-	// owns them. A repo/PR can have retained failed deliveries in more than
-	// one App (for example after an App migration), and a delivery can only be
-	// redelivered with its own App's token, so the grouping must be preserved.
-	RedriveByApp map[string][]int64 `json:"redrive_by_app,omitempty"`
-	Outcome      string             `json:"outcome,omitempty"`
-	Error        string             `json:"error,omitempty"`
+	// Held marks a missing-check PR the backfill refuses to act on: the same
+	// head also carries an uncompleted Check Run, which a genuinely in-flight
+	// apply may own, and re-planning the PR could replace an apply-owned merge
+	// block with a fresh passing plan. Held PRs are reported, never sent to
+	// the server.
+	Held    bool   `json:"held,omitempty"`
+	Outcome string `json:"outcome,omitempty"`
+	Error   string `json:"error,omitempty"`
 }
 
 // checksStuckCheck is one existing-but-uncompleted Check Run on an open PR,
@@ -106,13 +104,11 @@ type checksBackfillReport struct {
 	Scanned    int      `json:"scanned"`
 	// Last echoes the --last window bounding the sweep; empty means every
 	// open PR was scanned.
-	Last                   string                 `json:"last,omitempty"`
-	Redrive                bool                   `json:"redrive"`
-	DeliverySearchComplete bool                   `json:"delivery_search_complete"`
-	DryRun                 bool                   `json:"dry_run"`
-	StuckAfter             string                 `json:"stuck_after"`
-	Actions                []checksBackfillAction `json:"actions"`
-	Stuck                  []checksStuckCheck     `json:"stuck,omitempty"`
+	Last       string                 `json:"last,omitempty"`
+	DryRun     bool                   `json:"dry_run"`
+	StuckAfter string                 `json:"stuck_after"`
+	Actions    []checksBackfillAction `json:"actions"`
+	Stuck      []checksStuckCheck     `json:"stuck,omitempty"`
 }
 
 func (cmd *ChecksBackfillCmd) Run(ctx context.Context, g *Globals) error {
@@ -121,9 +117,6 @@ func (cmd *ChecksBackfillCmd) Run(ctx context.Context, g *Globals) error {
 	}
 	if cmd.Repo != "" && cmd.AllRepos {
 		return fmt.Errorf("use either a repository argument or --all-repos, not both")
-	}
-	if cmd.Redrive && cmd.AllRepos {
-		return fmt.Errorf("--redrive searches one repository's delivery history; use it with a repository argument, not --all-repos")
 	}
 	if cmd.Limit < 0 {
 		return fmt.Errorf("--limit must be non-negative")
@@ -167,54 +160,15 @@ func (cmd *ChecksBackfillCmd) Run(ctx context.Context, g *Globals) error {
 		repos = declared.Repos
 	}
 
-	// Optional redrive phase: one crawl of the retained delivery history
-	// builds the redriveable index — proving "no delivery exists" for a PR any
-	// other way would cost a crawl per PR. GitHub lists delivery history
-	// App-wide (there is no repo filter), so the crawl walks every repo's
-	// deliveries and is expensive; it is opt-in because a missing check
-	// synthesizes to the same resulting Check Runs without it.
-	redriveable := map[int]map[string][]int64{}
-	searchComplete := true
-	if cmd.Redrive {
-		windowEnd := webhookRedriveNow()
-		deliveryWindow, err := parseOperatorDuration(cmd.DeliveryWindow)
-		if err != nil {
-			return fmt.Errorf("parse --delivery-window: %w", err)
-		}
-		if cmd.MaxDeliveryPages <= 0 {
-			return fmt.Errorf("--max-delivery-pages must be positive")
-		}
-		windowStart := windowEnd.Add(-deliveryWindow)
-		updateProgress(fmt.Sprintf("searching delivery history for failed deliveries in %s...", cmd.Repo))
-		crawl, err := runChunkedWebhookRedrive(ctx, cmdclient.RedriveWebhooks, endpoint, apitypes.WebhookRedriveRequest{
-			WindowStart: windowStart.Format(time.RFC3339),
-			WindowEnd:   windowEnd.Format(time.RFC3339),
-			Repo:        cmd.Repo,
-			MaxPages:    cmd.MaxDeliveryPages,
-			DryRun:      true,
-		}, cmd.MaxDeliveryPages, false, func(r apitypes.WebhookRedriveResult) {
-			updateProgress(fmt.Sprintf("app %s: %d/%d delivery pages searched, %d failed deliveries found for %s", r.AppName, r.Pages, cmd.MaxDeliveryPages, len(r.Selected), cmd.Repo))
-		})
-		if canceled := backfillCanceledError(err, stopProgress); canceled != nil {
-			return canceled
-		}
-		if err != nil {
-			return fmt.Errorf("search delivery history: %w", err)
-		}
-		redriveable, searchComplete = indexRedriveableDeliveries(crawl)
-	}
-
 	// Scan phase: page through each repository's open PRs and ask the two
 	// questions per PR — is the expected Check Run present, and did it
 	// complete? The listing is newest-updated first, so a --last window stops
 	// each repo's paging as soon as it crosses the window start.
 	report := &checksBackfillReport{
-		Repos:                  repos,
-		Last:                   cmd.Last,
-		Redrive:                cmd.Redrive,
-		DeliverySearchComplete: searchComplete,
-		DryRun:                 cmd.DryRun,
-		StuckAfter:             cmd.StuckAfter,
+		Repos:      repos,
+		Last:       cmd.Last,
+		DryRun:     cmd.DryRun,
+		StuckAfter: cmd.StuckAfter,
 	}
 	checkNamesSeen := map[string]bool{}
 scanning:
@@ -243,8 +197,15 @@ scanning:
 			}
 			repoScanned += chunk.Scanned
 			report.Scanned += chunk.Scanned
+			// Every uncompleted run holds its PR, regardless of how long it has
+			// been sitting — --stuck-after shapes the stuck *report*, but an
+			// uncompleted run of any age could belong to an in-flight apply.
+			uncompleted := make(map[int]bool, len(chunk.Stuck))
+			for _, stuckPR := range chunk.Stuck {
+				uncompleted[stuckPR.Number] = true
+			}
 			for _, missing := range chunk.Missing {
-				action := checksBackfillAction{
+				report.Actions = append(report.Actions, checksBackfillAction{
 					Repo:                   repo,
 					PR:                     missing.Number,
 					URL:                    missing.URL,
@@ -252,13 +213,8 @@ scanning:
 					HeadSHA:                missing.HeadSHA,
 					MissingNames:           missing.MissingNames,
 					UntrustedConflictNames: missing.UntrustedConflictNames,
-					Classification:         "synthesize",
-				}
-				if byApp, ok := redriveable[missing.Number]; ok {
-					action.Classification = "redrive"
-					action.RedriveByApp = byApp
-				}
-				report.Actions = append(report.Actions, action)
+					Held:                   uncompleted[missing.Number],
+				})
 			}
 			report.Stuck = append(report.Stuck, stuckChecksPastThreshold(repo, chunk.Stuck, stuckAfter, webhookRedriveNow())...)
 			updateProgress(fmt.Sprintf("repo %d/%d %s: %d PRs scanned (%d total) — %d missing, %d stuck Check Runs so far", i+1, len(repos), repo, repoScanned, report.Scanned, len(report.Actions), len(report.Stuck)))
@@ -280,8 +236,8 @@ scanning:
 	sort.Strings(report.CheckNames)
 
 	if !cmd.DryRun {
-		// Act phase: redeliver the redriveable PRs' deliveries per App, then
-		// synthesize the rest in server-bounded batches per repository.
+		// Act phase: synthesize the missing checks in server-bounded batches
+		// per repository, skipping held PRs.
 		err := cmd.act(ctx, endpoint, report, updateProgress)
 		if canceled := backfillCanceledError(err, stopProgress); canceled != nil {
 			// Print what completed before the interrupt, then exit non-zero.
@@ -391,38 +347,6 @@ func stuckChecksPastThreshold(repo string, prs []apitypes.StuckCheckPR, stuckAft
 	return out
 }
 
-// indexRedriveableDeliveries maps PR number to its failed check-creating
-// deliveries from the crawl. searchComplete is false when any App's crawl
-// stopped before covering the window (page budget), meaning some redriveable
-// PRs may classify as synthesize instead.
-func indexRedriveableDeliveries(crawl *apitypes.WebhookRedriveResponse) (map[int]map[string][]int64, bool) {
-	redriveable := make(map[int]map[string][]int64)
-	searchComplete := true
-	if crawl == nil {
-		return redriveable, searchComplete
-	}
-	for _, result := range crawl.Results {
-		if !result.ReachedWindowStart && !result.HistoryExhausted {
-			searchComplete = false
-		}
-		for _, selected := range result.Selected {
-			if selected.PR == 0 {
-				continue
-			}
-			byApp := redriveable[selected.PR]
-			if byApp == nil {
-				byApp = make(map[string][]int64)
-				redriveable[selected.PR] = byApp
-			}
-			// Preserve the owning App per delivery: a PR can have deliveries in
-			// more than one App, and each can only be redelivered with its own
-			// App's token.
-			byApp[result.AppName] = append(byApp[result.AppName], selected.ID)
-		}
-	}
-	return redriveable, searchComplete
-}
-
 // repoPR keys a PR within a multi-repo report.
 type repoPR struct {
 	repo string
@@ -430,58 +354,18 @@ type repoPR struct {
 }
 
 func (cmd *ChecksBackfillCmd) act(ctx context.Context, endpoint string, report *checksBackfillReport, updateProgress func(string)) error {
-	// Redeliveries first, grouped per App (a delivery only redelivers with its
-	// own App's token) and chunked so no single request redelivers an
-	// unbounded number of deliveries.
-	idsByApp := make(map[string][]int64)
-	for _, action := range report.Actions {
-		for app, ids := range action.RedriveByApp {
-			idsByApp[app] = append(idsByApp[app], ids...)
-		}
-	}
-	redriveFailedByApp := make(map[string]bool)
-	for _, app := range sortedKeys(idsByApp) {
-		ids := idsByApp[app]
-		for start := 0; start < len(ids); start += checksRedriveBatchSize {
-			batch := ids[start:min(start+checksRedriveBatchSize, len(ids))]
-			updateProgress(fmt.Sprintf("redelivering %d/%d failed deliveries via app %s...", min(start+len(batch), len(ids)), len(ids), app))
-			resp, err := cmdclient.RedriveWebhooks(ctx, endpoint, apitypes.WebhookRedriveRequest{
-				App:         app,
-				DeliveryIDs: batch,
-			})
-			if err != nil {
-				return fmt.Errorf("redeliver failed deliveries via app %q: %w", app, err)
-			}
-			for _, result := range resp.Results {
-				if result.Failed > 0 {
-					redriveFailedByApp[app] = true
-				}
-			}
-		}
-	}
-
-	// Then synthesize, per repository, in server-bounded batches.
+	// Synthesize per repository, in server-bounded batches. Held PRs never
+	// reach the server; their outcome records why.
 	synthesizeByRepo := make(map[string][]int)
 	actionByPR := make(map[repoPR]*checksBackfillAction)
 	for i := range report.Actions {
 		action := &report.Actions[i]
 		actionByPR[repoPR{repo: action.Repo, pr: action.PR}] = action
-		switch action.Classification {
-		case "redrive":
-			anyFailed := false
-			for app := range action.RedriveByApp {
-				if redriveFailedByApp[app] {
-					anyFailed = true
-				}
-			}
-			if anyFailed {
-				action.Outcome = "redelivered (some redeliveries failed; see server logs)"
-			} else {
-				action.Outcome = "redelivered"
-			}
-		case "synthesize":
-			synthesizeByRepo[action.Repo] = append(synthesizeByRepo[action.Repo], action.PR)
+		if action.Held {
+			action.Outcome = checksBackfillHeldStatus
+			continue
 		}
+		synthesizeByRepo[action.Repo] = append(synthesizeByRepo[action.Repo], action.PR)
 	}
 	for _, repo := range sortedKeys(synthesizeByRepo) {
 		prs := synthesizeByRepo[repo]
@@ -525,11 +409,6 @@ func writeChecksBackfillReport(w io.Writer, report *checksBackfillReport) error 
 	if _, err := fmt.Fprintf(w, "Scanned %d open PRs%s in %s for %s.\n", report.Scanned, window, repoScope, strings.Join(report.CheckNames, ", ")); err != nil {
 		return err
 	}
-	if report.Redrive && !report.DeliverySearchComplete {
-		if _, err := fmt.Fprintln(w, "Note: the delivery-history search did not cover the full window; PRs with older failed deliveries are synthesized instead (same resulting Check Runs)."); err != nil {
-			return err
-		}
-	}
 	if err := writeChecksStuckSection(w, report); err != nil {
 		return err
 	}
@@ -548,7 +427,10 @@ func writeChecksBackfillReport(w io.Writer, report *checksBackfillReport) error 
 	}
 	failed := 0
 	for _, action := range report.Actions {
-		status := describeBackfillPlan(action, report.Redrive)
+		status := "synthesize via auto-plan"
+		if action.Held {
+			status = checksBackfillHeldStatus
+		}
 		if !report.DryRun {
 			status = action.Outcome
 			if action.Error != "" {
@@ -607,25 +489,8 @@ func writeChecksStuckSection(w io.Writer, report *checksBackfillReport) error {
 	return err
 }
 
-// describeBackfillPlan renders a dry-run action, naming the remedy the
-// backfill would use for the PR. "no retained delivery" is only a finding
-// when the delivery history was actually searched.
-func describeBackfillPlan(action checksBackfillAction, searchedDeliveries bool) string {
-	if action.Classification == "redrive" {
-		total := 0
-		for _, ids := range action.RedriveByApp {
-			total += len(ids)
-		}
-		return fmt.Sprintf("redrive %d failed deliveries (app %s)", total, strings.Join(sortedKeys(action.RedriveByApp), ", "))
-	}
-	if searchedDeliveries {
-		return "synthesize via auto-plan (no retained delivery)"
-	}
-	return "synthesize via auto-plan"
-}
-
-// sortedKeys returns the map keys in deterministic order, so per-App output
-// (dry-run plan, redrive progress) does not depend on map iteration order.
+// sortedKeys returns the map keys in deterministic order, so per-repo output
+// (synthesize progress, batch order) does not depend on map iteration order.
 func sortedKeys[V any](m map[string]V) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {

--- a/pkg/cmd/commands/checks_backfill_test.go
+++ b/pkg/cmd/commands/checks_backfill_test.go
@@ -30,7 +30,7 @@ func TestChecksScanProgressLine(t *testing.T) {
 		"once the scan reaches the repo's count, the denominator adds nothing")
 }
 
-// A PR title or server error containing tabs/newlines is neutralized so it
+// A server outcome or error containing tabs/newlines is neutralized so it
 // cannot break the tab-separated report layout.
 func TestSanitizeCell(t *testing.T) {
 	assert.Equal(t, "a b c", sanitizeCell("a\tb\nc"))

--- a/pkg/cmd/commands/checks_backfill_test.go
+++ b/pkg/cmd/commands/checks_backfill_test.go
@@ -75,8 +75,8 @@ func TestSanitizeCell(t *testing.T) {
 // The stuck filter keeps only uncompleted Check Runs that have sat past the
 // threshold: young runs are legitimately in flight and stay out of the
 // report, aged runs are flattened to one row per (PR, check) with a
-// human-readable age, and a run with no reported start time is always kept —
-// its age cannot prove it is young.
+// human-readable age, and a run whose start time is missing or in the future
+// (clock skew) is always kept — its age cannot prove it is young.
 func TestStuckChecksPastThreshold(t *testing.T) {
 	now := time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC)
 	stuck := stuckChecksPastThreshold([]apitypes.StuckCheckPR{
@@ -93,14 +93,22 @@ func TestStuckChecksPastThreshold(t *testing.T) {
 				{Name: "SchemaBot (production)", CheckRunID: 60, Status: "queued"},
 			},
 		},
+		{
+			Number: 7, URL: "https://github.com/octo/repo/pull/7", Title: "future start time", HeadSHA: "sha7",
+			Checks: []apitypes.IncompleteCheckRun{
+				{Name: "SchemaBot (production)", CheckRunID: 70, Status: "in_progress", StartedAt: "2026-07-12T13:00:00Z"},
+			},
+		},
 	}, time.Hour, now)
 
-	require.Len(t, stuck, 2)
+	require.Len(t, stuck, 3)
 	assert.Equal(t, 5, stuck[0].PR)
 	assert.Equal(t, "SchemaBot (production)", stuck[0].CheckName)
 	assert.Equal(t, "3h30m0s", stuck[0].Age)
 	assert.Equal(t, 6, stuck[1].PR)
 	assert.Equal(t, "unknown", stuck[1].Age)
+	assert.Equal(t, 7, stuck[2].PR)
+	assert.Equal(t, "unknown", stuck[2].Age, "a start time ahead of the scan clock cannot prove the run is young")
 }
 
 // The report renders stuck Check Runs in their own section, telling the

--- a/pkg/cmd/commands/checks_backfill_test.go
+++ b/pkg/cmd/commands/checks_backfill_test.go
@@ -1,7 +1,9 @@
 package commands
 
 import (
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -68,4 +70,66 @@ func TestIndexRedriveableDeliveriesGroupsMultipleAppsPerPR(t *testing.T) {
 func TestSanitizeCell(t *testing.T) {
 	assert.Equal(t, "a b c", sanitizeCell("a\tb\nc"))
 	assert.Equal(t, "plain", sanitizeCell("plain"))
+}
+
+// The stuck filter keeps only uncompleted Check Runs that have sat past the
+// threshold: young runs are legitimately in flight and stay out of the
+// report, aged runs are flattened to one row per (PR, check) with a
+// human-readable age, and a run with no reported start time is always kept —
+// its age cannot prove it is young.
+func TestStuckChecksPastThreshold(t *testing.T) {
+	now := time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC)
+	stuck := stuckChecksPastThreshold([]apitypes.StuckCheckPR{
+		{
+			Number: 5, URL: "https://github.com/octo/repo/pull/5", Title: "aged and young", HeadSHA: "sha5",
+			Checks: []apitypes.IncompleteCheckRun{
+				{Name: "SchemaBot (production)", CheckRunID: 50, Status: "in_progress", StartedAt: "2026-07-12T08:30:00Z"},
+				{Name: "SchemaBot (staging)", CheckRunID: 51, Status: "in_progress", StartedAt: "2026-07-12T11:50:00Z"},
+			},
+		},
+		{
+			Number: 6, URL: "https://github.com/octo/repo/pull/6", Title: "no start time", HeadSHA: "sha6",
+			Checks: []apitypes.IncompleteCheckRun{
+				{Name: "SchemaBot (production)", CheckRunID: 60, Status: "queued"},
+			},
+		},
+	}, time.Hour, now)
+
+	require.Len(t, stuck, 2)
+	assert.Equal(t, 5, stuck[0].PR)
+	assert.Equal(t, "SchemaBot (production)", stuck[0].CheckName)
+	assert.Equal(t, "3h30m0s", stuck[0].Age)
+	assert.Equal(t, 6, stuck[1].PR)
+	assert.Equal(t, "unknown", stuck[1].Age)
+}
+
+// The report renders stuck Check Runs in their own section, telling the
+// operator backfill does not act on them, and still prints it when no checks
+// are missing at all.
+func TestWriteChecksBackfillReportRendersStuckSection(t *testing.T) {
+	report := &checksBackfillReport{
+		Repo:                   "octo/repo",
+		CheckNames:             []string{"SchemaBot (production)"},
+		Scanned:                12,
+		DeliverySearchComplete: true,
+		DryRun:                 true,
+		StuckAfter:             "1h",
+		Stuck: []checksStuckCheck{
+			{
+				PR: 5, URL: "https://github.com/octo/repo/pull/5", Title: "wedged", HeadSHA: "sha5555555555555",
+				CheckName: "SchemaBot (production)", CheckRunID: 50, Status: "in_progress", Age: "3h30m0s",
+			},
+		},
+	}
+
+	var out strings.Builder
+	require.NoError(t, writeChecksBackfillReport(&out, report))
+
+	rendered := out.String()
+	assert.Contains(t, rendered, "Stuck Check Runs — uncompleted for over 1h")
+	assert.Contains(t, rendered, "backfill does not act on existing Check Runs")
+	assert.Contains(t, rendered, "https://github.com/octo/repo/pull/5")
+	assert.Contains(t, rendered, "in_progress")
+	assert.Contains(t, rendered, "3h30m0s")
+	assert.Contains(t, rendered, "No missing SchemaBot Check Runs found.")
 }

--- a/pkg/cmd/commands/checks_backfill_test.go
+++ b/pkg/cmd/commands/checks_backfill_test.go
@@ -79,7 +79,7 @@ func TestSanitizeCell(t *testing.T) {
 // (clock skew) is always kept — its age cannot prove it is young.
 func TestStuckChecksPastThreshold(t *testing.T) {
 	now := time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC)
-	stuck := stuckChecksPastThreshold([]apitypes.StuckCheckPR{
+	stuck := stuckChecksPastThreshold("octo/repo", []apitypes.StuckCheckPR{
 		{
 			Number: 5, URL: "https://github.com/octo/repo/pull/5", Title: "aged and young", HeadSHA: "sha5",
 			Checks: []apitypes.IncompleteCheckRun{
@@ -102,6 +102,7 @@ func TestStuckChecksPastThreshold(t *testing.T) {
 	}, time.Hour, now)
 
 	require.Len(t, stuck, 3)
+	assert.Equal(t, "octo/repo", stuck[0].Repo)
 	assert.Equal(t, 5, stuck[0].PR)
 	assert.Equal(t, "SchemaBot (production)", stuck[0].CheckName)
 	assert.Equal(t, "3h30m0s", stuck[0].Age)
@@ -116,15 +117,16 @@ func TestStuckChecksPastThreshold(t *testing.T) {
 // are missing at all.
 func TestWriteChecksBackfillReportRendersStuckSection(t *testing.T) {
 	report := &checksBackfillReport{
-		Repo:                   "octo/repo",
+		Repos:                  []string{"octo/repo"},
 		CheckNames:             []string{"SchemaBot (production)"},
 		Scanned:                12,
+		Last:                   "1d",
 		DeliverySearchComplete: true,
 		DryRun:                 true,
 		StuckAfter:             "1h",
 		Stuck: []checksStuckCheck{
 			{
-				PR: 5, URL: "https://github.com/octo/repo/pull/5", Title: "wedged", HeadSHA: "sha5555555555555",
+				Repo: "octo/repo", PR: 5, URL: "https://github.com/octo/repo/pull/5", Title: "wedged", HeadSHA: "sha5555555555555",
 				CheckName: "SchemaBot (production)", CheckRunID: 50, Status: "in_progress", Age: "3h30m0s",
 			},
 		},
@@ -134,10 +136,59 @@ func TestWriteChecksBackfillReportRendersStuckSection(t *testing.T) {
 	require.NoError(t, writeChecksBackfillReport(&out, report))
 
 	rendered := out.String()
+	assert.Contains(t, rendered, "Scanned 12 open PRs updated in the last 1d in octo/repo")
 	assert.Contains(t, rendered, "Stuck Check Runs — uncompleted for over 1h")
 	assert.Contains(t, rendered, "backfill does not act on existing Check Runs")
 	assert.Contains(t, rendered, "https://github.com/octo/repo/pull/5")
 	assert.Contains(t, rendered, "in_progress")
 	assert.Contains(t, rendered, "3h30m0s")
 	assert.Contains(t, rendered, "No missing SchemaBot Check Runs found.")
+}
+
+// A fleet-wide report summarizes the repo count instead of naming every
+// repository, and a plain synthesize plan does not claim "no retained
+// delivery" when the delivery history was never searched.
+func TestWriteChecksBackfillReportFleetHeadlineAndPlanWording(t *testing.T) {
+	report := &checksBackfillReport{
+		Repos:      []string{"octo/a", "octo/b", "octo/c", "octo/d"},
+		CheckNames: []string{"SchemaBot (production)"},
+		Scanned:    40,
+		DryRun:     true,
+		StuckAfter: "1h",
+		Actions: []checksBackfillAction{
+			{Repo: "octo/b", PR: 7, URL: "https://github.com/octo/b/pull/7", Title: "missing", HeadSHA: "sha7", MissingNames: []string{"SchemaBot (production)"}, Classification: "synthesize"},
+		},
+	}
+
+	var out strings.Builder
+	require.NoError(t, writeChecksBackfillReport(&out, report))
+
+	rendered := out.String()
+	assert.Contains(t, rendered, "Scanned 40 open PRs in 4 repositories")
+	assert.Contains(t, rendered, "synthesize via auto-plan")
+	assert.NotContains(t, rendered, "no retained delivery", "the crawl never ran, so its absence is not a finding")
+}
+
+// The pacing decision: pause only when the budget snapshot is below the floor
+// and a future reset exists to wait for. Missing snapshots, disabled pacing,
+// healthy budgets, and already-past resets all proceed without waiting.
+func TestRateLimitPauseDuration(t *testing.T) {
+	now := time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC)
+	reset := now.Add(10 * time.Minute).Format(time.RFC3339)
+
+	wait, pause := rateLimitPauseDuration(&apitypes.GitHubRateLimit{Remaining: 500, Limit: 5000, ResetAt: reset}, 20, now)
+	require.True(t, pause, "10% remaining is below a 20% floor")
+	assert.Equal(t, 11*time.Minute, wait, "waits out the reset plus a minute of slack")
+
+	_, pause = rateLimitPauseDuration(&apitypes.GitHubRateLimit{Remaining: 2500, Limit: 5000, ResetAt: reset}, 20, now)
+	assert.False(t, pause, "half the budget left is comfortably above the floor")
+
+	_, pause = rateLimitPauseDuration(nil, 20, now)
+	assert.False(t, pause, "no snapshot means nothing to pace against")
+
+	_, pause = rateLimitPauseDuration(&apitypes.GitHubRateLimit{Remaining: 0, Limit: 5000, ResetAt: reset}, 0, now)
+	assert.False(t, pause, "a zero floor disables pacing")
+
+	_, pause = rateLimitPauseDuration(&apitypes.GitHubRateLimit{Remaining: 0, Limit: 5000, ResetAt: now.Add(-time.Minute).Format(time.RFC3339)}, 20, now)
+	assert.False(t, pause, "a past reset means the next request sees a fresh budget")
 }

--- a/pkg/cmd/commands/checks_backfill_test.go
+++ b/pkg/cmd/commands/checks_backfill_test.go
@@ -11,60 +11,6 @@ import (
 	"github.com/block/schemabot/pkg/apitypes"
 )
 
-// The classification core: a PR with a failed check-creating delivery in the
-// crawl is redriveable (grouped under its App); everything else synthesizes.
-// A crawl that stopped early marks the search incomplete so the report can
-// say why some PRs synthesize instead of redriving.
-func TestIndexRedriveableDeliveries(t *testing.T) {
-	redriveable, complete := indexRedriveableDeliveries(&apitypes.WebhookRedriveResponse{
-		Results: []apitypes.WebhookRedriveResult{
-			{
-				AppName:            "production",
-				ReachedWindowStart: true,
-				Selected: []apitypes.WebhookRedriveSelection{
-					{ID: 11, PR: 5},
-					{ID: 12, PR: 5},
-					{ID: 13, PR: 9},
-					{ID: 14, PR: 0},
-				},
-			},
-		},
-	})
-
-	require.True(t, complete)
-	require.Len(t, redriveable, 2)
-	assert.Equal(t, map[string][]int64{"production": {11, 12}}, redriveable[5])
-	assert.Equal(t, map[string][]int64{"production": {13}}, redriveable[9])
-
-	_, complete = indexRedriveableDeliveries(&apitypes.WebhookRedriveResponse{
-		Results: []apitypes.WebhookRedriveResult{
-			{AppName: "production", NextCursor: "c1"},
-		},
-	})
-	assert.False(t, complete, "a crawl stopped mid-window cannot prove which PRs are redriveable")
-
-	_, complete = indexRedriveableDeliveries(&apitypes.WebhookRedriveResponse{
-		Results: []apitypes.WebhookRedriveResult{
-			{AppName: "production", HistoryExhausted: true},
-		},
-	})
-	assert.True(t, complete, "exhausted history covered everything GitHub retains")
-}
-
-// A PR with retained failed deliveries in more than one App (for example
-// after an App migration) keeps each App's delivery IDs under that App, so
-// each is later redelivered with its own token rather than mixed.
-func TestIndexRedriveableDeliveriesGroupsMultipleAppsPerPR(t *testing.T) {
-	redriveable, _ := indexRedriveableDeliveries(&apitypes.WebhookRedriveResponse{
-		Results: []apitypes.WebhookRedriveResult{
-			{AppName: "old-app", ReachedWindowStart: true, Selected: []apitypes.WebhookRedriveSelection{{ID: 1, PR: 7}}},
-			{AppName: "new-app", ReachedWindowStart: true, Selected: []apitypes.WebhookRedriveSelection{{ID: 2, PR: 7}}},
-		},
-	})
-
-	assert.Equal(t, map[string][]int64{"old-app": {1}, "new-app": {2}}, redriveable[7])
-}
-
 // A PR title or server error containing tabs/newlines is neutralized so it
 // cannot break the tab-separated report layout.
 func TestSanitizeCell(t *testing.T) {
@@ -117,13 +63,12 @@ func TestStuckChecksPastThreshold(t *testing.T) {
 // are missing at all.
 func TestWriteChecksBackfillReportRendersStuckSection(t *testing.T) {
 	report := &checksBackfillReport{
-		Repos:                  []string{"octo/repo"},
-		CheckNames:             []string{"SchemaBot (production)"},
-		Scanned:                12,
-		Last:                   "1d",
-		DeliverySearchComplete: true,
-		DryRun:                 true,
-		StuckAfter:             "1h",
+		Repos:      []string{"octo/repo"},
+		CheckNames: []string{"SchemaBot (production)"},
+		Scanned:    12,
+		Last:       "1d",
+		DryRun:     true,
+		StuckAfter: "1h",
 		Stuck: []checksStuckCheck{
 			{
 				Repo: "octo/repo", PR: 5, URL: "https://github.com/octo/repo/pull/5", Title: "wedged", HeadSHA: "sha5555555555555",
@@ -146,9 +91,10 @@ func TestWriteChecksBackfillReportRendersStuckSection(t *testing.T) {
 }
 
 // A fleet-wide report summarizes the repo count instead of naming every
-// repository, and a plain synthesize plan does not claim "no retained
-// delivery" when the delivery history was never searched.
-func TestWriteChecksBackfillReportFleetHeadlineAndPlanWording(t *testing.T) {
+// repository, a plain missing-check PR plans a synthesize, and a held PR —
+// one whose head also carries an uncompleted Check Run a started apply may
+// own — is explicitly marked as not acted on.
+func TestWriteChecksBackfillReportFleetHeadlineAndHeldPRs(t *testing.T) {
 	report := &checksBackfillReport{
 		Repos:      []string{"octo/a", "octo/b", "octo/c", "octo/d"},
 		CheckNames: []string{"SchemaBot (production)"},
@@ -156,7 +102,8 @@ func TestWriteChecksBackfillReportFleetHeadlineAndPlanWording(t *testing.T) {
 		DryRun:     true,
 		StuckAfter: "1h",
 		Actions: []checksBackfillAction{
-			{Repo: "octo/b", PR: 7, URL: "https://github.com/octo/b/pull/7", Title: "missing", HeadSHA: "sha7", MissingNames: []string{"SchemaBot (production)"}, Classification: "synthesize"},
+			{Repo: "octo/b", PR: 7, URL: "https://github.com/octo/b/pull/7", Title: "missing", HeadSHA: "sha7", MissingNames: []string{"SchemaBot (production)"}},
+			{Repo: "octo/c", PR: 9, URL: "https://github.com/octo/c/pull/9", Title: "missing but uncompleted sibling", HeadSHA: "sha9", MissingNames: []string{"SchemaBot (production)"}, Held: true},
 		},
 	}
 
@@ -166,7 +113,7 @@ func TestWriteChecksBackfillReportFleetHeadlineAndPlanWording(t *testing.T) {
 	rendered := out.String()
 	assert.Contains(t, rendered, "Scanned 40 open PRs in 4 repositories")
 	assert.Contains(t, rendered, "synthesize via auto-plan")
-	assert.NotContains(t, rendered, "no retained delivery", "the crawl never ran, so its absence is not a finding")
+	assert.Contains(t, rendered, "held: an uncompleted Check Run sits on this head")
 }
 
 // The pacing decision: pause only when the budget snapshot is below the floor

--- a/pkg/cmd/commands/checks_backfill_test.go
+++ b/pkg/cmd/commands/checks_backfill_test.go
@@ -11,6 +11,25 @@ import (
 	"github.com/block/schemabot/pkg/apitypes"
 )
 
+// The scan progress line always reads as progress toward a bound: PRs scanned
+// against GitHub's own open-PR count for the repository (while the count still
+// exceeds what was scanned), repo position within a fleet sweep, and the
+// findings so far with held PRs called out inside the missing count.
+func TestChecksScanProgressLine(t *testing.T) {
+	assert.Equal(t,
+		"octo/repo: 90/~1500 PRs scanned — 4 missing, 2 stuck Check Runs",
+		checksScanProgressLine(1, 1, "octo/repo", 90, 1500, 90, 4, 0, 2))
+
+	assert.Equal(t,
+		"repo 2/6 octo/repo: 90/~1500 PRs scanned (312 across all repos) — 4 missing (1 held), 2 stuck Check Runs",
+		checksScanProgressLine(2, 6, "octo/repo", 90, 1500, 312, 4, 1, 2))
+
+	assert.Equal(t,
+		"octo/repo: 12 PRs scanned — 0 missing, 0 stuck Check Runs",
+		checksScanProgressLine(1, 1, "octo/repo", 12, 12, 12, 0, 0, 0),
+		"once the scan reaches the repo's count, the denominator adds nothing")
+}
+
 // A PR title or server error containing tabs/newlines is neutralized so it
 // cannot break the tab-separated report layout.
 func TestSanitizeCell(t *testing.T) {

--- a/pkg/cmd/commands/common.go
+++ b/pkg/cmd/commands/common.go
@@ -224,10 +224,33 @@ func withLoading(message string, show bool, fn func() error) error {
 // startLiveProgress renders a spinner with a caller-updated status line on
 // stderr, for chunked operations that report progress between requests.
 // update replaces the status text; stop clears the line. Both are no-ops when
-// show is false or stderr is not a terminal, so scripted runs stay clean.
+// show is false, so JSON output stays clean. When stderr is not a terminal
+// (a scripted run, a log pipe), each new status prints as its own plain line
+// instead — a long sweep must stay observable in a log file, not go silent.
 func startLiveProgress(show bool) (update func(string), stop func()) {
-	if !show || !loadingSpinnerTerminal() {
+	if !show {
 		return func(string) {}, func() {}
+	}
+	if !loadingSpinnerTerminal() {
+		var mu sync.Mutex
+		last := ""
+		broken := false
+		update = func(text string) {
+			mu.Lock()
+			defer mu.Unlock()
+			// The spinner variant repaints the same text every frame; the plain
+			// variant prints only on change so logs record each step once.
+			if broken || text == last {
+				return
+			}
+			last = text
+			if _, err := fmt.Fprintln(loadingSpinnerWriter, text); err != nil {
+				// Progress is advisory; a stderr that stopped accepting writes
+				// stops further updates, matching the spinner goroutine's exit.
+				broken = true
+			}
+		}
+		return update, func() {}
 	}
 
 	var mu sync.Mutex

--- a/pkg/cmd/commands/loading_test.go
+++ b/pkg/cmd/commands/loading_test.go
@@ -89,6 +89,37 @@ func TestWithLoadingNonTerminalIsSilent(t *testing.T) {
 	assert.Empty(t, out.String())
 }
 
+// A scripted run (stderr piped to a log, CI) still gets progress: each new
+// status prints as its own plain line, repeated updates with the same text
+// print once, and no ANSI control codes leak into the log.
+func TestStartLiveProgressPrintsPlainLinesWhenNotTerminal(t *testing.T) {
+	var out bytes.Buffer
+	withTestLoadingSpinner(t, &out)
+	loadingSpinnerTerminal = func() bool { return false }
+
+	update, stop := startLiveProgress(true)
+	update("scanning page 1")
+	update("scanning page 1")
+	update("scanning page 2")
+	stop()
+
+	assert.Equal(t, "scanning page 1\nscanning page 2\n", out.String())
+}
+
+// JSON mode stays fully silent even off-terminal, so piped output carries
+// nothing but the payload streams.
+func TestStartLiveProgressDisabledIsSilentOffTerminal(t *testing.T) {
+	var out bytes.Buffer
+	withTestLoadingSpinner(t, &out)
+	loadingSpinnerTerminal = func() bool { return false }
+
+	update, stop := startLiveProgress(false)
+	update("scanning page 1")
+	stop()
+
+	assert.Empty(t, out.String())
+}
+
 func withTestLoadingSpinner(t *testing.T, writer interface{ Write([]byte) (int, error) }) {
 	t.Helper()
 	originalDelay := loadingSpinnerDelay

--- a/pkg/cmd/commands/redrive_webhooks.go
+++ b/pkg/cmd/commands/redrive_webhooks.go
@@ -16,9 +16,9 @@ import (
 var webhookRedriveNow = func() time.Time { return time.Now().UTC() }
 
 // WebhooksCmd groups GitHub webhook delivery operator commands. Missing
-// Check Runs are handled by `schemabot checks backfill`, which redrives or
-// synthesizes per PR; redrive here is the window-scoped tool for a known
-// delivery outage.
+// Check Runs are handled by `schemabot checks backfill`, which synthesizes
+// per PR; redrive here is the transport-level, window-scoped tool for a
+// known delivery outage.
 type WebhooksCmd struct {
 	Redrive RedriveWebhooksCmd `cmd:"" help:"Redeliver failed GitHub App webhook deliveries from a time window"`
 }
@@ -61,7 +61,7 @@ func (cmd *RedriveWebhooksCmd) Run(ctx context.Context, g *Globals) error {
 		PR:          cmd.PR,
 		MaxPages:    cmd.MaxPages,
 		DryRun:      cmd.DryRun,
-	}, cmd.MaxPages, true, func(r apitypes.WebhookRedriveResult) {
+	}, cmd.MaxPages, func(r apitypes.WebhookRedriveResult) {
 		updateProgress(redriveProgressLine(r, windowStart, windowEnd, cmd.DryRun))
 	})
 	stopProgress()
@@ -136,10 +136,9 @@ func redriveWindowCoverage(oldestFetched, windowStart, windowEnd string) (int, b
 // requests: the server processes a few delivery pages per request and hands
 // back a cursor, so no single HTTP request can outlive an intermediary
 // timeout no matter how deep the crawl goes. maxPages is the total page
-// budget per App across all requests. With requireFullCoverage, incomplete
-// coverage fails the run; without it, the caller inspects the per-app
-// ReachedWindowStart/HistoryExhausted facts (best-effort classification
-// passes tolerate a partial crawl).
+// budget per App across all requests. Incomplete coverage fails the run: a
+// redrive that silently skipped part of the window would leave the operator
+// believing every failed delivery in it was redelivered.
 //
 // Re-run convergence caveat: the server dedupes already-succeeded redeliveries
 // by GUID, but only within a single request (one cursor chunk). Because this
@@ -150,7 +149,7 @@ func redriveWindowCoverage(oldestFetched, windowStart, windowEnd string) (int, b
 // whose check recompute is idempotent and fail-closed and which never triggers
 // an apply; the worst case is a duplicate plan comment. Running --dry-run first
 // is the operator mitigation.
-func runChunkedWebhookRedrive(ctx context.Context, call func(context.Context, string, apitypes.WebhookRedriveRequest) (*apitypes.WebhookRedriveResponse, error), endpoint string, req apitypes.WebhookRedriveRequest, maxPages int, requireFullCoverage bool, progress func(apitypes.WebhookRedriveResult)) (*apitypes.WebhookRedriveResponse, error) {
+func runChunkedWebhookRedrive(ctx context.Context, call func(context.Context, string, apitypes.WebhookRedriveRequest) (*apitypes.WebhookRedriveResponse, error), endpoint string, req apitypes.WebhookRedriveRequest, maxPages int, progress func(apitypes.WebhookRedriveResult)) (*apitypes.WebhookRedriveResponse, error) {
 	if progress == nil {
 		progress = func(apitypes.WebhookRedriveResult) {}
 	}
@@ -190,7 +189,7 @@ func runChunkedWebhookRedrive(ctx context.Context, call func(context.Context, st
 			appResult = mergeWebhookRedriveResults(appResult, next.Results[0])
 			progress(appResult)
 		}
-		if requireFullCoverage && !appResult.ReachedWindowStart {
+		if !appResult.ReachedWindowStart {
 			if appResult.HistoryExhausted {
 				return merged, fmt.Errorf("app %q: GitHub's retained delivery history ends at %s, after the requested window start %s; older deliveries are no longer redriveable", appResult.AppName, appResult.OldestFetched, req.WindowStart)
 			}

--- a/pkg/cmd/commands/redrive_webhooks.go
+++ b/pkg/cmd/commands/redrive_webhooks.go
@@ -220,9 +220,9 @@ func (cmd *RedriveWebhooksCmd) resolveWindow() (string, string, error) {
 		if cmd.WindowStart != "" || cmd.WindowEnd != "" {
 			return "", "", fmt.Errorf("use either --last or explicit window start/end, not both")
 		}
-		duration, err := parseWebhookRedriveLast(cmd.Last)
+		duration, err := parseOperatorDuration(cmd.Last)
 		if err != nil {
-			return "", "", err
+			return "", "", fmt.Errorf("parse --last: %w", err)
 		}
 		windowEnd := webhookRedriveNow()
 		windowStart := windowEnd.Add(-duration)
@@ -245,28 +245,31 @@ func (cmd *RedriveWebhooksCmd) resolveWindow() (string, string, error) {
 	return cmd.WindowStart, cmd.WindowEnd, nil
 }
 
-func parseWebhookRedriveLast(value string) (time.Duration, error) {
+// parseOperatorDuration parses the human-friendly duration format shared by
+// the operator flags (--last, --delivery-window, --stuck-after). Errors name
+// no flag; the caller wraps with the flag it was parsing.
+func parseOperatorDuration(value string) (time.Duration, error) {
 	trimmed := strings.TrimSpace(strings.ToLower(value))
 	if trimmed == "" {
-		return 0, fmt.Errorf("--last must not be empty")
+		return 0, fmt.Errorf("duration must not be empty")
 	}
 	if duration, err := time.ParseDuration(trimmed); err == nil {
 		if duration <= 0 {
-			return 0, fmt.Errorf("--last must be positive")
+			return 0, fmt.Errorf("duration must be positive")
 		}
 		return duration, nil
 	}
 
 	amountText, unit, ok := strings.Cut(trimmed, " ")
 	if !ok {
-		amountText, unit = splitWebhookRedriveLastAmountAndUnit(trimmed)
+		amountText, unit = splitOperatorDurationAmountAndUnit(trimmed)
 	}
 	amount, err := strconv.Atoi(amountText)
 	if err != nil {
-		return 0, fmt.Errorf("parse --last %q: use a positive duration like 1h, 6h, 2d, or '2 days'", value)
+		return 0, fmt.Errorf("parse duration %q: use a positive duration like 1h, 6h, 2d, or '2 days'", value)
 	}
 	if amount <= 0 {
-		return 0, fmt.Errorf("--last must be positive")
+		return 0, fmt.Errorf("duration must be positive")
 	}
 	switch strings.TrimSpace(unit) {
 	case "d", "day", "days":
@@ -276,10 +279,10 @@ func parseWebhookRedriveLast(value string) (time.Duration, error) {
 	case "m", "min", "mins", "minute", "minutes":
 		return time.Duration(amount) * time.Minute, nil
 	}
-	return 0, fmt.Errorf("parse --last %q: use a positive duration like 1h, 6h, 2d, or '2 days'", value)
+	return 0, fmt.Errorf("parse duration %q: use a positive duration like 1h, 6h, 2d, or '2 days'", value)
 }
 
-func splitWebhookRedriveLastAmountAndUnit(value string) (string, string) {
+func splitOperatorDurationAmountAndUnit(value string) (string, string) {
 	for i, r := range value {
 		if r < '0' || r > '9' {
 			return value[:i], value[i:]

--- a/pkg/cmd/commands/redrive_webhooks_test.go
+++ b/pkg/cmd/commands/redrive_webhooks_test.go
@@ -141,7 +141,7 @@ func TestRunChunkedWebhookRedriveFollowsCursorsAndMerges(t *testing.T) {
 
 	merged, err := runChunkedWebhookRedrive(t.Context(), call, "http://server", apitypes.WebhookRedriveRequest{
 		WindowStart: "2026-07-07T19:40:00Z", WindowEnd: "2026-07-07T19:50:00Z", MaxPages: 10,
-	}, 10, true, nil)
+	}, 10, nil)
 
 	require.NoError(t, err)
 	require.Len(t, requests, 2)
@@ -165,7 +165,7 @@ func TestRunChunkedWebhookRedriveFailsOnIncompleteCoverage(t *testing.T) {
 	}
 	_, err := runChunkedWebhookRedrive(t.Context(), budgetExhausted, "http://server", apitypes.WebhookRedriveRequest{
 		WindowStart: "2026-07-07T19:40:00Z", WindowEnd: "2026-07-07T19:50:00Z", MaxPages: 5,
-	}, 5, true, nil)
+	}, 5, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "increase --max-pages")
 
@@ -176,7 +176,7 @@ func TestRunChunkedWebhookRedriveFailsOnIncompleteCoverage(t *testing.T) {
 	}
 	_, err = runChunkedWebhookRedrive(t.Context(), historyEnded, "http://server", apitypes.WebhookRedriveRequest{
 		WindowStart: "2026-07-07T19:40:00Z", WindowEnd: "2026-07-07T19:50:00Z", MaxPages: 5,
-	}, 5, true, nil)
+	}, 5, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "retained delivery history ends")
 }
@@ -221,7 +221,7 @@ func TestRunChunkedWebhookRedriveReturnsPartialOnCancel(t *testing.T) {
 		WindowStart: "2026-07-07T19:40:00Z",
 		WindowEnd:   "2026-07-07T19:50:00Z",
 		App:         "production",
-	}, 10, true, nil)
+	}, 10, nil)
 
 	require.ErrorIs(t, err, context.Canceled)
 	require.Len(t, merged.Results, 1)

--- a/pkg/cmd/commands/redrive_webhooks_test.go
+++ b/pkg/cmd/commands/redrive_webhooks_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/block/schemabot/pkg/apitypes"
 )
 
-func TestParseWebhookRedriveLast(t *testing.T) {
+func TestParseOperatorDuration(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -30,7 +30,7 @@ func TestParseWebhookRedriveLast(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := parseWebhookRedriveLast(tt.value)
+			got, err := parseOperatorDuration(tt.value)
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
@@ -38,14 +38,14 @@ func TestParseWebhookRedriveLast(t *testing.T) {
 	}
 }
 
-func TestParseWebhookRedriveLastRejectsInvalidValues(t *testing.T) {
+func TestParseOperatorDurationRejectsInvalidValues(t *testing.T) {
 	t.Parallel()
 
 	for _, value := range []string{"", "0h", "-1h", "two days", "2 months"} {
 		t.Run(value, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := parseWebhookRedriveLast(value)
+			_, err := parseOperatorDuration(value)
 
 			require.Error(t, err)
 		})

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -605,10 +605,12 @@ type OpenPullRequest struct {
 
 // ListOpenPullRequestsPage lists one page of open pull requests in a
 // repository, newest updated first. page is 1-based (0 selects the first
-// page). nextPage is 0 when no further pages exist. Fetching one bounded page
-// per call lets operator scans run as many short requests instead of one
-// long one.
-func (ic *InstallationClient) ListOpenPullRequestsPage(ctx context.Context, repo string, page, perPage int) (prs []OpenPullRequest, nextPage int, err error) {
+// page). nextPage is 0 when no further pages exist. lastPage is the final
+// page number GitHub reports for the listing (0 when this page is the last),
+// letting callers derive the repository's total open-PR count for progress
+// denominators. Fetching one bounded page per call lets operator scans run as
+// many short requests instead of one long one.
+func (ic *InstallationClient) ListOpenPullRequestsPage(ctx context.Context, repo string, page, perPage int) (prs []OpenPullRequest, nextPage, lastPage int, err error) {
 	owner, repoName := splitRepo(repo)
 	if page <= 0 {
 		page = 1
@@ -637,7 +639,7 @@ func (ic *InstallationClient) ListOpenPullRequestsPage(ctx context.Context, repo
 		return list, nil
 	})
 	if err != nil {
-		return nil, 0, fmt.Errorf("list open pull requests for %s page %d: %w", repo, page, err)
+		return nil, 0, 0, fmt.Errorf("list open pull requests for %s page %d: %w", repo, page, err)
 	}
 	for _, pr := range ghPRs {
 		prs = append(prs, OpenPullRequest{
@@ -652,8 +654,9 @@ func (ic *InstallationClient) ListOpenPullRequestsPage(ctx context.Context, repo
 	}
 	if resp != nil {
 		nextPage = resp.NextPage
+		lastPage = resp.LastPage
 	}
-	return prs, nextPage, nil
+	return prs, nextPage, lastPage, nil
 }
 
 // CoreRateLimit reports the installation's remaining core REST budget. The

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -597,6 +597,10 @@ type OpenPullRequest struct {
 	HeadSHA string
 	BaseRef string
 	User    string
+	// UpdatedAt is the PR's last-activity time. The listing orders by it
+	// (newest first), so a caller sweeping a time window can stop paging once
+	// a page crosses the window start.
+	UpdatedAt time.Time
 }
 
 // ListOpenPullRequestsPage lists one page of open pull requests in a
@@ -637,18 +641,34 @@ func (ic *InstallationClient) ListOpenPullRequestsPage(ctx context.Context, repo
 	}
 	for _, pr := range ghPRs {
 		prs = append(prs, OpenPullRequest{
-			Number:  pr.GetNumber(),
-			Title:   pr.GetTitle(),
-			HeadRef: pr.GetHead().GetRef(),
-			HeadSHA: pr.GetHead().GetSHA(),
-			BaseRef: pr.GetBase().GetRef(),
-			User:    pr.GetUser().GetLogin(),
+			Number:    pr.GetNumber(),
+			Title:     pr.GetTitle(),
+			HeadRef:   pr.GetHead().GetRef(),
+			HeadSHA:   pr.GetHead().GetSHA(),
+			BaseRef:   pr.GetBase().GetRef(),
+			User:      pr.GetUser().GetLogin(),
+			UpdatedAt: pr.GetUpdatedAt().Time,
 		})
 	}
 	if resp != nil {
 		nextPage = resp.NextPage
 	}
 	return prs, nextPage, nil
+}
+
+// CoreRateLimit reports the installation's remaining core REST budget. The
+// /rate_limit endpoint does not consume the budget it reports, so pacing
+// checks are free. resetAt is when GitHub replenishes the budget.
+func (ic *InstallationClient) CoreRateLimit(ctx context.Context) (remaining, limit int, resetAt time.Time, err error) {
+	limits, _, err := ic.client.RateLimit.Get(ctx)
+	if err != nil {
+		return 0, 0, time.Time{}, fmt.Errorf("get GitHub core rate limit: %w", err)
+	}
+	core := limits.GetCore()
+	if core == nil {
+		return 0, 0, time.Time{}, fmt.Errorf("get GitHub core rate limit: response carried no core bucket")
+	}
+	return core.Remaining, core.Limit, core.Reset.Time, nil
 }
 
 // IsClosed reports whether the PR is closed (merged or unmerged). Callers that

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -931,6 +931,10 @@ type CheckRunResult struct {
 	Name       string
 	Status     string // "queued", "in_progress", "completed"
 	Conclusion string // "success", "failure", "neutral", "action_required"
+	// StartedAt is when the Check Run was started; zero when GitHub did not
+	// report a start time. Lets callers judge how long a run that never
+	// completed has been sitting.
+	StartedAt time.Time
 }
 
 // FindCheckRunByName searches for a check run on a specific commit by name.
@@ -989,6 +993,7 @@ func (ic *InstallationClient) FindCheckRunByName(ctx context.Context, repo, head
 						Name:       run.GetName(),
 						Status:     run.GetStatus(),
 						Conclusion: run.GetConclusion(),
+						StartedAt:  run.GetStartedAt().Time,
 					}
 				}
 			}

--- a/pkg/webhook/apply_test.go
+++ b/pkg/webhook/apply_test.go
@@ -137,7 +137,7 @@ func TestFormatProgressCommentCutoverReadinessCountsOnlyParkedTables(t *testing.
 		{TableName: "orders", State: state.Task.Running},
 	}
 
-	body := formatProgressComment(apply, tasks, nil)
+	body := formatProgressComment(apply, tasks, nil, "")
 
 	assert.Contains(t, body, "**1/2** table(s) ready for cutover — waiting on 1")
 	assert.Contains(t, body, "✅ Ready for cutover")

--- a/pkg/webhook/checks_backfill.go
+++ b/pkg/webhook/checks_backfill.go
@@ -3,6 +3,8 @@ package webhook
 import (
 	"context"
 	"fmt"
+
+	"github.com/block/schemabot/pkg/state"
 )
 
 // BackfillPRCheckRuns recreates a PR's SchemaBot Check Runs by replaying the
@@ -12,6 +14,8 @@ import (
 // leader/participant aggregate routing applies unchanged. Serves the checks
 // operator endpoints for PRs whose delivery was never sent (for example PRs
 // opened before check enablement) or is no longer retained by GitHub.
+// A PR with a non-terminal apply is refused: the started apply remains
+// authoritative for the PR's check state until it reaches a terminal state.
 func (h *Handler) BackfillPRCheckRuns(ctx context.Context, repo string, pr int, installationID int64) (string, error) {
 	client, err := h.clientForRepo(repo, installationID)
 	if err != nil {
@@ -26,6 +30,22 @@ func (h *Handler) BackfillPRCheckRuns(ctx context.Context, repo string, pr int, 
 		// Runs there would resurrect what cleanup settled.
 		h.logger.Info("Check Run backfill skipping closed PR", "repo", repo, "pr", pr)
 		return "skipped: PR is closed", nil
+	}
+	// A started apply is authoritative for its PR's check state: replaying the
+	// auto-plan flow over it could replace an apply-owned merge block with a
+	// fresh passing plan. Refuse while any apply for the PR is non-terminal —
+	// the operator reconciles the apply first, then backfills. Storage
+	// uncertainty refuses too: without the apply rows there is no proof the PR
+	// is safe to re-plan.
+	applies, err := h.service.Storage().Applies().GetByPR(ctx, repo, pr)
+	if err != nil {
+		return "", fmt.Errorf("look up applies before backfilling Check Runs for %s#%d: %w", repo, pr, err)
+	}
+	for _, apply := range applies {
+		if !state.IsTerminalApplyState(apply.State) {
+			h.logger.Info("Check Run backfill refusing PR with a non-terminal apply", apply.LogAttrs()...)
+			return fmt.Sprintf("skipped: apply %s is %s; backfill will not re-plan over a started apply", apply.ApplyIdentifier, apply.State), nil
+		}
 	}
 	h.logger.Info("backfilling Check Runs via the auto-plan flow",
 		"repo", repo, "pr", pr, "head_sha", prInfo.HeadSHA)

--- a/pkg/webhook/checks_backfill_test.go
+++ b/pkg/webhook/checks_backfill_test.go
@@ -1,7 +1,9 @@
 package webhook
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"testing"
 
@@ -9,6 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
 )
 
 // A Check Run backfill on a closed PR is refused: close-time cleanup owns a
@@ -32,9 +36,78 @@ func TestBackfillPRCheckRunsSkipsClosedPR(t *testing.T) {
 	assert.Equal(t, "skipped: PR is closed", outcome)
 }
 
+// appliesByStateStorage serves a fixed set of applies for any PR, so a
+// backfill test can stage in-flight or terminal apply state.
+type appliesByStateStorage struct {
+	emptyStorage
+	applies []*storage.Apply
+	err     error
+}
+
+func (s *appliesByStateStorage) Applies() storage.ApplyStore {
+	return &appliesByStateStore{applies: s.applies, err: s.err}
+}
+
+type appliesByStateStore struct {
+	storage.ApplyStore
+	applies []*storage.Apply
+	err     error
+}
+
+func (s *appliesByStateStore) GetByPR(ctx context.Context, repo string, pr int) ([]*storage.Apply, error) {
+	return s.applies, s.err
+}
+
+// openPRGitHubServer stages the one GitHub route a backfill guard test needs:
+// an open PR whose head the backfill would re-plan.
+func openPRGitHubServer(t *testing.T) *ghclient.InstallationClient {
+	t.Helper()
+	client, mux := setupGitHubServer(t)
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"state": "open",
+			"head":  map[string]any{"sha": "abc123", "ref": "feature-branch"},
+			"base":  map[string]any{"sha": "def456", "ref": "main"},
+			"user":  map[string]any{"login": "testuser"},
+		}))
+	})
+	return ghclient.NewInstallationClient(client, testLogger())
+}
+
+// A backfill on a PR with a non-terminal apply is refused: the started apply
+// remains authoritative for the PR's check state, and replaying the auto-plan
+// flow over it could replace an apply-owned merge block with a fresh passing
+// plan.
+func TestBackfillPRCheckRunsRefusesNonTerminalApply(t *testing.T) {
+	store := &appliesByStateStorage{applies: []*storage.Apply{
+		{ApplyIdentifier: "apply-completed", State: state.Apply.Completed, Repository: "octocat/hello-world", PullRequest: 1},
+		{ApplyIdentifier: "apply-running", State: state.Apply.Running, Repository: "octocat/hello-world", PullRequest: 1},
+	}}
+	h := actorAuthStorageTestHandler(actorAuthTestConfig(false), store, openPRGitHubServer(t))
+
+	outcome, err := h.BackfillPRCheckRuns(t.Context(), "octocat/hello-world", 1, 12345)
+
+	require.NoError(t, err)
+	assert.Equal(t, "skipped: apply apply-running is running; backfill will not re-plan over a started apply", outcome)
+}
+
+// When the apply rows cannot be read, the backfill fails instead of
+// proceeding: without them there is no proof the PR is safe to re-plan.
+func TestBackfillPRCheckRunsFailsClosedOnApplyLookupError(t *testing.T) {
+	store := &appliesByStateStorage{err: errors.New("storage read failed")}
+	h := actorAuthStorageTestHandler(actorAuthTestConfig(false), store, openPRGitHubServer(t))
+
+	_, err := h.BackfillPRCheckRuns(t.Context(), "octocat/hello-world", 1, 12345)
+
+	require.ErrorContains(t, err, "look up applies before backfilling Check Runs for octocat/hello-world#1")
+	require.ErrorContains(t, err, "storage read failed")
+}
+
 // A backfill on an open PR replays the auto-plan flow against the PR's
 // current head — for a PR with no managed schema changes, that is the
 // passing-aggregate path a real check-creating delivery would have taken.
+// Terminal applies do not block it: only a non-terminal apply is
+// authoritative for the PR's check state.
 func TestBackfillPRCheckRunsReplaysAutoPlanFlow(t *testing.T) {
 	client, mux := setupGitHubServer(t)
 	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
@@ -51,7 +124,10 @@ func TestBackfillPRCheckRunsReplaysAutoPlanFlow(t *testing.T) {
 			"status":   "modified",
 		}}))
 	})
-	h := actorAuthStorageTestHandler(actorAuthTestConfig(false), &emptyStorage{}, ghclient.NewInstallationClient(client, testLogger()))
+	store := &appliesByStateStorage{applies: []*storage.Apply{
+		{ApplyIdentifier: "apply-completed", State: state.Apply.Completed, Repository: "octocat/hello-world", PullRequest: 1},
+	}}
+	h := actorAuthStorageTestHandler(actorAuthTestConfig(false), store, ghclient.NewInstallationClient(client, testLogger()))
 
 	outcome, err := h.BackfillPRCheckRuns(t.Context(), "octocat/hello-world", 1, 12345)
 


### PR DESCRIPTION
## Why this matters

`checks backfill` is the operator's answer to "is any PR's check gate silently broken?" — after an incident, before enabling required checks on a repo, or as a one-time backfill for PRs that predate check enablement. The previous shape buried that answer: it crawled the App-wide delivery history first (tens of thousands of deliveries, App-wide because GitHub's delivery API has no repo filter), which dominated the runtime, usually classified nothing as redriveable, and made the command feel like it looped forever. It also skipped any PR whose Check Run existed — a run wedged in `queued`/`in_progress` for hours was invisible.

## What it does

Per open PR, the scan asks the two questions that matter for the check gate:

1. **Is the expected SchemaBot Check Run present?** If not, it's flagged and (outside `--dry-run`) recreated by replaying the auto-plan flow server-side.
2. **If present, did it complete?** An uncompleted run aged past `--stuck-after` (default `1h`) is reported for investigation — never acted on, because an uncompleted check can belong to a genuinely in-flight apply. Runs with missing or future start times are always surfaced; an age that cannot prove a run is young must not hide it.

Started applies stay authoritative, at two layers:
- The server refuses to backfill any PR with a non-terminal apply — replaying the auto-plan flow over one could replace an apply-owned merge block with a fresh passing plan. Storage uncertainty refuses too: without the apply rows there is no proof the PR is safe to re-plan.
- The CLI holds any missing-check PR whose head also carries an uncompleted Check Run (of any age — `--stuck-after` shapes the report, not the hold), so the PR never reaches the server and the operator sees why in the action table.

Delivery-history redelivery is not part of this command: `webhooks redrive` remains the transport-level, window-scoped tool for a known delivery outage, while `checks backfill` converges state per PR. Both remedies produce the same resulting Check Runs, so the backfill doesn't need the crawl.

Scoping is inherited from the deployment the CLI targets: each repo resolves to the GitHub App that owns it, expected check names are the owning App's check-name base crossed with the instance's allowed environments, and split-deployment / multi-tenant fleets converge with one run per deployment. Documented in [check-runs.md § Backfilling missing Check Runs](docs/check-runs.md#backfilling-missing-check-runs), including the aggregate leader/participant interaction.

Incident-shaped scanning:
- `--all-repos` sweeps every repository declared in the server's repos config (new `POST /api/checks/repos` inventory endpoint).
- `--last 1h`/`--last 1d` bounds the sweep to PRs updated within the window. The open-PR listing is newest-updated first, so the server stops paging at the window boundary — an incident sweep costs O(incident), not O(every open PR at the org). Without `--last`, every open PR is scanned (the one-time full backfill).

Rate-limit pacing: the backfill shares its installation budget with live webhook serving — the same budget that creates checks for PRs being pushed right now. Scan and synthesize responses carry the budget snapshot, and the CLI pauses until reset whenever the remaining budget falls below `--rate-limit-floor` (default 20%), so a large sweep leaves headroom instead of starving the live path.

**Progress never feels unbounded.** Every scan response carries GitHub's own open-PR count for the repository (recomputed each page from the listing's last-page pointer — upper bound mid-listing, exact on the final page), so the live status always reads as N of ~M converging, with held PRs and stuck runs counted as they're found. When stderr isn't a terminal, each new status prints as its own plain line so scripted sweeps stay observable in a log file:

```
repo 1/2 octo/api: 90/~1500 PRs scanned (90 across all repos) — 1 missing, 0 stuck Check Runs
repo 2/2 octo/web: 60/~480 PRs scanned (150 across all repos) — 2 missing (1 held), 1 stuck Check Runs
```

## What the operator sees

Output below is generated by the actual report renderer. Dry-run text report:

```
$ schemabot checks backfill --all-repos --last 1d --dry-run
Scanned 214 open PRs updated in the last 1d in octo/api, octo/web for SchemaBot (production), SchemaBot (staging).

Stuck Check Runs — uncompleted for over 1h (backfill does not act on existing Check Runs; investigate the apply or plan that owns each):
PR                                   CHECK                   STATUS       AGE
https://github.com/octo/web/pull/87  SchemaBot (production)  in_progress  3h30m0s

PR                                   MISSING CHECKS                               ACTION
https://github.com/octo/api/pull/41  SchemaBot (production), SchemaBot (staging)  synthesize via auto-plan
https://github.com/octo/web/pull/87  SchemaBot (staging)                          held: an uncompleted Check Run sits on this head (a started apply may own it); investigate before backfilling
```

(PR titles and head SHAs stay in the `--json` output for scripts; the tables lead with the URL, which links to everything else.)

Same report with `--json` (the payload scripts consume):

```json
{
  "repos": ["octo/api", "octo/web"],
  "check_names": ["SchemaBot (production)", "SchemaBot (staging)"],
  "scanned": 214,
  "last": "1d",
  "dry_run": true,
  "stuck_after": "1h",
  "actions": [
    {
      "repo": "octo/api",
      "pr": 41,
      "url": "https://github.com/octo/api/pull/41",
      "title": "add orders index",
      "head_sha": "9f31c2ab77e1d054",
      "missing_names": ["SchemaBot (production)", "SchemaBot (staging)"]
    },
    {
      "repo": "octo/web",
      "pr": 87,
      "url": "https://github.com/octo/web/pull/87",
      "title": "widen customers.email",
      "head_sha": "4c0de9128bb37f60",
      "missing_names": ["SchemaBot (staging)"],
      "held": true
    }
  ],
  "stuck": [
    {
      "repo": "octo/web",
      "pr": 87,
      "url": "https://github.com/octo/web/pull/87",
      "title": "widen customers.email",
      "head_sha": "4c0de9128bb37f60",
      "check_name": "SchemaBot (production)",
      "check_run_id": 4411,
      "status": "in_progress",
      "started_at": "2026-07-13T08:30:00Z",
      "age": "3h30m0s"
    }
  ]
}
```

(Note PR 87 appears in both sections: its production check is wedged, and its missing staging check is held rather than synthesized because that same head may belong to an in-flight apply.)

## How it moves toward the northstar

This is the check-state invariant checker: detection independent of the event-delivery path, bounded by the incident window, safe to run at fleet scale. The same server-side scan is the building block for a timer-driven reconciler with missing/stuck metrics — the SLO that justifies keeping SchemaBot checks required for merging.

Also carries a one-line test-arity fix for the current `pkg/webhook` build break on main (same fix as #712/#713 — resolves trivially whichever lands last).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*This PR was written by Claude Code (claude-fable-5).*
