### PR TITLE
fix formatProgressComment call missed by #706

### DIFF
--- a/pkg/webhook/apply_test.go
+++ b/pkg/webhook/apply_test.go
@@ -137,7 +137,7 @@ func TestFormatProgressCommentCutoverReadinessCountsOnlyParkedTables(t *testing.
 		{TableName: "orders", State: state.Task.Running},
 	}
 
-	body := formatProgressComment(apply, tasks, nil)
+	body := formatProgressComment(apply, tasks, nil, "")
 
 	assert.Contains(t, body, "**1/2** table(s) ready for cutover — waiting on 1")
 	assert.Contains(t, body, "✅ Ready for cutover")


### PR DESCRIPTION
## Summary
Main is red since #706 and #709 landed: #706 added a `tenant` arg to `formatProgressComment` and updated the existing call sites, but #709's new test (`TestFormatProgressCommentCutoverReadinessCountsOnlyParkedTables`) added one more call site that wasn't in #706's branch. Both PRs were green individually; combined, `golangci-lint` and `Tests` fail on main and on every PR merge ref.

## What
One line: pass the empty tenant at the missed call site in `pkg/webhook/apply_test.go`, matching how the other non-tenant tests were updated.

## Why
Unblocks CI for main and all open PRs (e.g. #703) that inherit the typecheck failure via the merge ref.

## References
- Broken by the combination of #706 (`dbedc67`) and #709 (`1203863`)
- Failing main runs: golangci-lint and Tests workflows on `dbedc67`
