### PR TITLE
feat(github): track posted plan comments and support minimizing comments

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -39,6 +39,7 @@ func (m *mockStorage) Tasks() storage.TaskStore                     { return nil
 func (m *mockStorage) ApplyLogs() storage.ApplyLogStore             { return nil }
 func (m *mockStorage) ControlRequests() storage.ControlRequestStore { return nil }
 func (m *mockStorage) ApplyComments() storage.ApplyCommentStore     { return nil }
+func (m *mockStorage) PlanComments() storage.PlanCommentStore       { return nil }
 func (m *mockStorage) ApplyOperations() storage.ApplyOperationStore { return nil }
 func (m *mockStorage) Checks() storage.CheckStore                   { return nil }
 func (m *mockStorage) Settings() storage.SettingsStore              { return nil }

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -4,13 +4,16 @@
 package github
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"path"
 	"sort"
 	"strings"
@@ -543,16 +546,18 @@ func splitRepo(repo string) (owner, repoName string) {
 	return repo, ""
 }
 
-// CreateIssueComment posts a comment on a PR/issue.
-func (ic *InstallationClient) CreateIssueComment(ctx context.Context, repo string, pr int, body string) (int64, error) {
+// CreateIssueComment posts a comment on a PR/issue. It returns the REST
+// comment ID (used for edits) and the GraphQL node ID (used to minimize the
+// comment when a newer one supersedes it).
+func (ic *InstallationClient) CreateIssueComment(ctx context.Context, repo string, pr int, body string) (int64, string, error) {
 	owner, repoName := splitRepo(repo)
 	comment, _, err := ic.client.Issues.CreateComment(ctx, owner, repoName, pr, &gh.IssueComment{
 		Body: new(body),
 	})
 	if err != nil {
-		return 0, fmt.Errorf("create issue comment: %w", err)
+		return 0, "", fmt.Errorf("create issue comment: %w", err)
 	}
-	return comment.GetID(), nil
+	return comment.GetID(), comment.GetNodeID(), nil
 }
 
 // GetIssueComment returns the current body of an existing PR/issue comment.
@@ -575,6 +580,71 @@ func (ic *InstallationClient) EditIssueComment(ctx context.Context, repo string,
 		return fmt.Errorf("edit issue comment: %w", err)
 	}
 	return nil
+}
+
+// MinimizeComment collapses a PR comment in the GitHub timeline as outdated.
+// The comment stays expandable — minimizing hides it from the default view
+// without editing or deleting the record. GitHub exposes this only through
+// the GraphQL API, so this posts a minimizeComment mutation using the node ID
+// returned when the comment was created.
+func (ic *InstallationClient) MinimizeComment(ctx context.Context, repo, nodeID string) error {
+	payload, err := json.Marshal(map[string]any{
+		"query":     `mutation($id: ID!) { minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) { minimizedComment { isMinimized } } }`,
+		"variables": map[string]string{"id": nodeID},
+	})
+	if err != nil {
+		return fmt.Errorf("minimize comment %s: marshal GraphQL request: %w", nodeID, err)
+	}
+
+	ctx = withGitHubRateLimitContext(ctx, metrics.GitHubOperationGraphQLMinimizeComment, repo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ic.graphQLURL(), bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("minimize comment %s: build GraphQL request: %w", nodeID, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ic.client.Client().Do(req)
+	if err != nil {
+		return fmt.Errorf("minimize comment %s: %w", nodeID, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("minimize comment %s: GraphQL endpoint returned %s", nodeID, resp.Status)
+	}
+
+	// GraphQL reports failures as a 200 with an errors array; a response that
+	// carries neither an error nor isMinimized=true did not minimize anything.
+	var result struct {
+		Data struct {
+			MinimizeComment struct {
+				MinimizedComment struct {
+					IsMinimized bool `json:"isMinimized"`
+				} `json:"minimizedComment"`
+			} `json:"minimizeComment"`
+		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("minimize comment %s: decode GraphQL response: %w", nodeID, err)
+	}
+	if len(result.Errors) > 0 {
+		return fmt.Errorf("minimize comment %s: GraphQL error: %s", nodeID, result.Errors[0].Message)
+	}
+	if !result.Data.MinimizeComment.MinimizedComment.IsMinimized {
+		return fmt.Errorf("minimize comment %s: GitHub did not report the comment as minimized", nodeID)
+	}
+	return nil
+}
+
+// graphQLURL derives the GraphQL endpoint from the configured REST base URL:
+// /graphql on the same scheme and host (https://api.github.com/graphql for
+// the standard base; test servers follow the same shape).
+func (ic *InstallationClient) graphQLURL() string {
+	base := ic.client.BaseURL
+	u := url.URL{Scheme: base.Scheme, Host: base.Host, Path: "/graphql"}
+	return u.String()
 }
 
 // AddReactionToComment adds a reaction emoji to a comment.

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -638,12 +638,16 @@ func (ic *InstallationClient) MinimizeComment(ctx context.Context, repo, nodeID 
 	return nil
 }
 
-// graphQLURL derives the GraphQL endpoint from the configured REST base URL:
-// /graphql on the same scheme and host (https://api.github.com/graphql for
-// the standard base; test servers follow the same shape).
+// graphQLURL derives the GraphQL endpoint from the configured REST base URL.
+// github.com serves GraphQL at /graphql on the API host, while GitHub
+// Enterprise Server serves REST under /api/v3/ and GraphQL at /api/graphql on
+// the same host.
 func (ic *InstallationClient) graphQLURL() string {
 	base := ic.client.BaseURL
 	u := url.URL{Scheme: base.Scheme, Host: base.Host, Path: "/graphql"}
+	if strings.HasSuffix(base.Path, "/api/v3/") {
+		u.Path = strings.TrimSuffix(base.Path, "v3/") + "graphql"
+	}
 	return u.String()
 }
 

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -72,14 +72,15 @@ func TestCreateIssueCommentRetriesSecondaryRateLimitedWrite(t *testing.T) {
 			writeGitHubSecondaryRateLimitError(t, w, http.StatusTooManyRequests)
 			return
 		}
-		require.NoError(t, json.NewEncoder(w).Encode(gh.IssueComment{ID: new(int64(5678))}))
+		require.NoError(t, json.NewEncoder(w).Encode(gh.IssueComment{ID: new(int64(5678)), NodeID: new("IC_node5678")}))
 	})
 
 	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
-	commentID, err := ic.CreateIssueComment(t.Context(), "octocat/hello-world", 1, "hello")
+	commentID, nodeID, err := ic.CreateIssueComment(t.Context(), "octocat/hello-world", 1, "hello")
 
 	require.NoError(t, err)
 	assert.Equal(t, int64(5678), commentID)
+	assert.Equal(t, "IC_node5678", nodeID)
 	assert.Equal(t, int64(2), attempts.Load())
 }
 

--- a/pkg/github/minimize_comment_test.go
+++ b/pkg/github/minimize_comment_test.go
@@ -1,0 +1,88 @@
+package github
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// minimizeGraphQLRequest mirrors the minimizeComment mutation payload so the
+// fake server can assert on the node ID and classifier the client sends.
+type minimizeGraphQLRequest struct {
+	Query     string            `json:"query"`
+	Variables map[string]string `json:"variables"`
+}
+
+func TestMinimizeCommentSendsOutdatedMutation(t *testing.T) {
+	client, mux := setupRateLimitedTestGitHubServer(t)
+	mux.HandleFunc("POST /graphql", func(w http.ResponseWriter, r *http.Request) {
+		var req minimizeGraphQLRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Contains(t, req.Query, "minimizeComment")
+		assert.Contains(t, req.Query, "OUTDATED")
+		assert.Equal(t, "IC_node1234", req.Variables["id"])
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"minimizeComment": map[string]any{
+					"minimizedComment": map[string]any{"isMinimized": true},
+				},
+			},
+		})
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	require.NoError(t, ic.MinimizeComment(t.Context(), "octocat/hello-world", "IC_node1234"))
+}
+
+func TestMinimizeCommentReturnsGraphQLError(t *testing.T) {
+	client, mux := setupRateLimitedTestGitHubServer(t)
+	mux.HandleFunc("POST /graphql", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": nil,
+			"errors": []map[string]any{
+				{"message": "Could not resolve to a node with the global id"},
+			},
+		})
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	err := ic.MinimizeComment(t.Context(), "octocat/hello-world", "IC_bogus")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Could not resolve to a node")
+	assert.Contains(t, err.Error(), "IC_bogus")
+}
+
+func TestMinimizeCommentRejectsUnminimizedResult(t *testing.T) {
+	client, mux := setupRateLimitedTestGitHubServer(t)
+	mux.HandleFunc("POST /graphql", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"minimizeComment": map[string]any{
+					"minimizedComment": map[string]any{"isMinimized": false},
+				},
+			},
+		})
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	err := ic.MinimizeComment(t.Context(), "octocat/hello-world", "IC_node1234")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "did not report the comment as minimized")
+}
+
+func TestMinimizeCommentReturnsHTTPError(t *testing.T) {
+	client, mux := setupRateLimitedTestGitHubServer(t)
+	mux.HandleFunc("POST /graphql", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	err := ic.MinimizeComment(t.Context(), "octocat/hello-world", "IC_node1234")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "502")
+}

--- a/pkg/github/minimize_comment_test.go
+++ b/pkg/github/minimize_comment_test.go
@@ -5,8 +5,11 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
+	gh "github.com/google/go-github/v86/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -26,13 +29,13 @@ func TestMinimizeCommentSendsOutdatedMutation(t *testing.T) {
 		assert.Contains(t, req.Query, "minimizeComment")
 		assert.Contains(t, req.Query, "OUTDATED")
 		assert.Equal(t, "IC_node1234", req.Variables["id"])
-		_ = json.NewEncoder(w).Encode(map[string]any{
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
 			"data": map[string]any{
 				"minimizeComment": map[string]any{
 					"minimizedComment": map[string]any{"isMinimized": true},
 				},
 			},
-		})
+		}))
 	})
 
 	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
@@ -42,12 +45,12 @@ func TestMinimizeCommentSendsOutdatedMutation(t *testing.T) {
 func TestMinimizeCommentReturnsGraphQLError(t *testing.T) {
 	client, mux := setupRateLimitedTestGitHubServer(t)
 	mux.HandleFunc("POST /graphql", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
 			"data": nil,
 			"errors": []map[string]any{
 				{"message": "Could not resolve to a node with the global id"},
 			},
-		})
+		}))
 	})
 
 	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
@@ -60,19 +63,47 @@ func TestMinimizeCommentReturnsGraphQLError(t *testing.T) {
 func TestMinimizeCommentRejectsUnminimizedResult(t *testing.T) {
 	client, mux := setupRateLimitedTestGitHubServer(t)
 	mux.HandleFunc("POST /graphql", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
 			"data": map[string]any{
 				"minimizeComment": map[string]any{
 					"minimizedComment": map[string]any{"isMinimized": false},
 				},
 			},
-		})
+		}))
 	})
 
 	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	err := ic.MinimizeComment(t.Context(), "octocat/hello-world", "IC_node1234")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "did not report the comment as minimized")
+}
+
+// GitHub Enterprise Server serves REST under /api/v3/ and GraphQL at
+// /api/graphql on the same host; a client configured with an enterprise base
+// URL must send the minimize mutation to the enterprise GraphQL path.
+func TestMinimizeCommentUsesEnterpriseGraphQLPath(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(&http.Client{Transport: newGitHubRateLimitTransport(http.DefaultTransport)})
+	client.DisableRateLimitCheck = true
+	baseURL, err := url.Parse(server.URL + "/api/v3/")
+	require.NoError(t, err)
+	client.BaseURL = baseURL
+
+	mux.HandleFunc("POST /api/graphql", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"minimizeComment": map[string]any{
+					"minimizedComment": map[string]any{"isMinimized": true},
+				},
+			},
+		}))
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	require.NoError(t, ic.MinimizeComment(t.Context(), "octocat/hello-world", "IC_node1234"))
 }
 
 func TestMinimizeCommentReturnsHTTPError(t *testing.T) {

--- a/pkg/github/rate_limit_metrics.go
+++ b/pkg/github/rate_limit_metrics.go
@@ -357,6 +357,7 @@ func gitHubRequestCategory(operation string) string {
 		metrics.GitHubOperationCreateCheckRun,
 		metrics.GitHubOperationCreateIssueComment,
 		metrics.GitHubOperationEditIssueComment,
+		metrics.GitHubOperationGraphQLMinimizeComment,
 		metrics.GitHubOperationRequestReviewers,
 		metrics.GitHubOperationUpdateCheckRun:
 		return metrics.GitHubRequestCategoryWrite

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -805,6 +805,7 @@ const (
 	GitHubOperationFetchPullRequest              = "fetch_pull_request"
 	GitHubOperationGetCombinedStatus             = "get_combined_status"
 	GitHubOperationGetTeamMembership             = "get_team_membership"
+	GitHubOperationGraphQLMinimizeComment        = "graphql_minimize_comment"
 	GitHubOperationGraphQLStatusCheckRollup      = "graphql_status_check_rollup"
 	GitHubOperationListCheckRunsForRef           = "list_check_runs_for_ref"
 	GitHubOperationListPRFiles                   = "list_pr_files"
@@ -976,6 +977,7 @@ func isKnownGitHubOperation(operation string) bool {
 		GitHubOperationFetchPullRequest,
 		GitHubOperationGetCombinedStatus,
 		GitHubOperationGetTeamMembership,
+		GitHubOperationGraphQLMinimizeComment,
 		GitHubOperationGraphQLStatusCheckRollup,
 		GitHubOperationListCheckRunsForRef,
 		GitHubOperationListPRFiles,

--- a/pkg/schema/mysql/plan_comments.sql
+++ b/pkg/schema/mysql/plan_comments.sql
@@ -12,6 +12,6 @@ CREATE TABLE `plan_comments` (
   `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
-  KEY `idx_slot` (`repository`,`pull_request`,`database_name`,`database_type`),
+  KEY `idx_slot` (`repository`,`pull_request`,`database_name`,`database_type`,`minimized_at`),
   KEY `idx_github_comment` (`github_comment_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci

--- a/pkg/schema/mysql/plan_comments.sql
+++ b/pkg/schema/mysql/plan_comments.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `plan_comments` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `repository` varchar(255) NOT NULL,
+  `pull_request` int unsigned NOT NULL,
+  `database_name` varchar(255) NOT NULL,
+  `database_type` varchar(50) NOT NULL,
+  `environment_scope` varchar(255) NOT NULL DEFAULT '',
+  `head_sha` varchar(64) NOT NULL,
+  `github_comment_id` bigint NOT NULL,
+  `github_node_id` varchar(255) NOT NULL,
+  `minimized_at` datetime DEFAULT NULL,
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `idx_slot` (`repository`,`pull_request`,`database_name`,`database_type`),
+  KEY `idx_github_comment` (`github_comment_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -2009,7 +2009,7 @@ func (s *applyStore) ExistsForDatabaseHead(ctx context.Context, repo string, pr 
 		)
 	`, repo, pr, database, databaseType, headSHA).Scan(&exists)
 	if err != nil {
-		return false, fmt.Errorf("check applies for %s#%d database %s head %s: %w", repo, pr, database, headSHA, err)
+		return false, fmt.Errorf("check applies for %s#%d database %s (%s) head %s: %w", repo, pr, database, databaseType, headSHA, err)
 	}
 	return exists, nil
 }

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -1991,6 +1991,29 @@ func (s *applyStore) GetByPR(ctx context.Context, repo string, pr int) ([]*stora
 	return scanApplies(rows)
 }
 
+// ExistsForDatabaseHead reports whether any apply for the PR and database was
+// created from a plan for headSHA. The LEFT JOIN keeps applies whose plan row
+// was deleted: without the plan there is no proof of which head the apply came
+// from, so it must count as matching any head rather than silently dropping
+// out of the result.
+func (s *applyStore) ExistsForDatabaseHead(ctx context.Context, repo string, pr int, database, databaseType, headSHA string) (bool, error) {
+	var exists bool
+	err := s.db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM applies a
+			LEFT JOIN plans p ON p.id = a.plan_id
+			WHERE a.repository = ? AND a.pull_request = ?
+				AND a.database_name = ? AND a.database_type = ?
+				AND (p.id IS NULL OR p.head_sha = ?)
+		)
+	`, repo, pr, database, databaseType, headSHA).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("check applies for %s#%d database %s head %s: %w", repo, pr, database, headSHA, err)
+	}
+	return exists, nil
+}
+
 // Delete removes an apply by ID, along with its per-deployment
 // apply_operations rows, in a single transaction. Deleting the children
 // transactionally prevents orphan operation rows that the operator claim loop

--- a/pkg/storage/mysqlstore/plan_comments.go
+++ b/pkg/storage/mysqlstore/plan_comments.go
@@ -1,0 +1,92 @@
+// plan_comments.go implements PlanCommentStore for tracking posted plan
+// comments so a newer plan comment for the same database can minimize the
+// ones it supersedes on GitHub.
+package mysqlstore
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/spirit/pkg/utils"
+)
+
+// planCommentColumns lists all columns for SELECT queries.
+const planCommentColumns = `id, repository, pull_request, database_name, database_type, environment_scope, head_sha, github_comment_id, github_node_id, minimized_at, created_at, updated_at`
+
+// planCommentStore implements storage.PlanCommentStore using MySQL.
+type planCommentStore struct {
+	db *sql.DB
+}
+
+// Insert stores a newly posted plan comment and sets comment.ID.
+func (s *planCommentStore) Insert(ctx context.Context, comment *storage.PlanComment) error {
+	result, err := s.db.ExecContext(ctx, `
+		INSERT INTO plan_comments (repository, pull_request, database_name, database_type, environment_scope, head_sha, github_comment_id, github_node_id)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`, comment.Repository, comment.PullRequest, comment.DatabaseName, comment.DatabaseType,
+		comment.EnvironmentScope, comment.HeadSHA, comment.GitHubCommentID, comment.GitHubNodeID)
+	if err != nil {
+		return fmt.Errorf("insert plan comment for %s#%d database %s: %w", comment.Repository, comment.PullRequest, comment.DatabaseName, err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		return fmt.Errorf("read plan comment insert id for %s#%d database %s: %w", comment.Repository, comment.PullRequest, comment.DatabaseName, err)
+	}
+	comment.ID = id
+	return nil
+}
+
+// ListUnminimizedForSlot returns the not-yet-minimized comments for a
+// (repository, pull_request, database) slot, ordered by id ascending.
+func (s *planCommentStore) ListUnminimizedForSlot(ctx context.Context, repo string, pr int, database, databaseType string) ([]*storage.PlanComment, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT `+planCommentColumns+`
+		FROM plan_comments
+		WHERE repository = ? AND pull_request = ? AND database_name = ? AND database_type = ? AND minimized_at IS NULL
+		ORDER BY id
+	`, repo, pr, database, databaseType)
+	if err != nil {
+		return nil, fmt.Errorf("query unminimized plan comments for %s#%d database %s: %w", repo, pr, database, err)
+	}
+	defer utils.CloseAndLog(rows)
+
+	var comments []*storage.PlanComment
+	for rows.Next() {
+		comment, err := scanPlanComment(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan plan comment for %s#%d database %s: %w", repo, pr, database, err)
+		}
+		comments = append(comments, comment)
+	}
+	return comments, rows.Err()
+}
+
+// MarkMinimized stamps minimized_at after the GitHub minimize call succeeded.
+// An already-minimized row is not an error.
+func (s *planCommentStore) MarkMinimized(ctx context.Context, id int64) error {
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE plan_comments SET minimized_at = NOW()
+		WHERE id = ? AND minimized_at IS NULL
+	`, id)
+	if err != nil {
+		return fmt.Errorf("mark plan comment %d minimized: %w", id, err)
+	}
+	return nil
+}
+
+// scanPlanComment scans plan comment data from any scanner (Row or Rows).
+func scanPlanComment(s scanner) (*storage.PlanComment, error) {
+	var comment storage.PlanComment
+	err := s.Scan(
+		&comment.ID, &comment.Repository, &comment.PullRequest,
+		&comment.DatabaseName, &comment.DatabaseType, &comment.EnvironmentScope,
+		&comment.HeadSHA, &comment.GitHubCommentID, &comment.GitHubNodeID,
+		&comment.MinimizedAt, &comment.CreatedAt, &comment.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &comment, nil
+}

--- a/pkg/storage/mysqlstore/plan_comments_test.go
+++ b/pkg/storage/mysqlstore/plan_comments_test.go
@@ -1,0 +1,197 @@
+//go:build integration
+
+package mysqlstore
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/storage"
+)
+
+func insertTestPlanComment(t *testing.T, store *Storage, repo string, pr int, database, databaseType, envScope, headSHA string, commentID int64) *storage.PlanComment {
+	t.Helper()
+	comment := &storage.PlanComment{
+		Repository:       repo,
+		PullRequest:      pr,
+		DatabaseName:     database,
+		DatabaseType:     databaseType,
+		EnvironmentScope: envScope,
+		HeadSHA:          headSHA,
+		GitHubCommentID:  commentID,
+		GitHubNodeID:     fmt.Sprintf("IC_node%d", commentID),
+	}
+	require.NoError(t, store.PlanComments().Insert(t.Context(), comment))
+	require.NotZero(t, comment.ID, "Insert must set the row ID")
+	return comment
+}
+
+func TestPlanCommentStore_InsertAndListUnminimizedForSlot(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	// Two comments in the orders slot, one in a different-database slot on the
+	// same PR, and one for the same database on a different PR.
+	first := insertTestPlanComment(t, store, "org/repo", 42, "orders", "mysql", "production,staging", "sha1", 100)
+	second := insertTestPlanComment(t, store, "org/repo", 42, "orders", "mysql", "production,staging", "sha2", 200)
+	insertTestPlanComment(t, store, "org/repo", 42, "billing", "mysql", "production,staging", "sha1", 300)
+	insertTestPlanComment(t, store, "org/repo", 7, "orders", "mysql", "production,staging", "sha1", 400)
+
+	comments, err := store.PlanComments().ListUnminimizedForSlot(ctx, "org/repo", 42, "orders", "mysql")
+	require.NoError(t, err)
+	require.Len(t, comments, 2, "only the orders slot on PR 42 is listed")
+
+	assert.Equal(t, first.ID, comments[0].ID, "ordered by id ascending")
+	assert.Equal(t, second.ID, comments[1].ID)
+	assert.Equal(t, "org/repo", comments[0].Repository)
+	assert.Equal(t, 42, comments[0].PullRequest)
+	assert.Equal(t, "orders", comments[0].DatabaseName)
+	assert.Equal(t, "mysql", comments[0].DatabaseType)
+	assert.Equal(t, "production,staging", comments[0].EnvironmentScope)
+	assert.Equal(t, "sha1", comments[0].HeadSHA)
+	assert.Equal(t, int64(100), comments[0].GitHubCommentID)
+	assert.Equal(t, "IC_node100", comments[0].GitHubNodeID)
+	assert.Nil(t, comments[0].MinimizedAt)
+	assert.NotZero(t, comments[0].CreatedAt)
+	assert.NotZero(t, comments[0].UpdatedAt)
+
+	// An empty slot lists as empty, not an error.
+	comments, err = store.PlanComments().ListUnminimizedForSlot(ctx, "org/repo", 42, "orders", "vitess")
+	require.NoError(t, err)
+	assert.Empty(t, comments)
+}
+
+func TestPlanCommentStore_MarkMinimized(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	first := insertTestPlanComment(t, store, "org/repo", 42, "orders", "mysql", "staging", "sha1", 100)
+	second := insertTestPlanComment(t, store, "org/repo", 42, "orders", "mysql", "staging", "sha2", 200)
+
+	require.NoError(t, store.PlanComments().MarkMinimized(ctx, first.ID))
+
+	comments, err := store.PlanComments().ListUnminimizedForSlot(ctx, "org/repo", 42, "orders", "mysql")
+	require.NoError(t, err)
+	require.Len(t, comments, 1, "the minimized comment drops out of the unminimized list")
+	assert.Equal(t, second.ID, comments[0].ID)
+
+	var minimizedAt *time.Time
+	require.NoError(t, testDB.QueryRowContext(ctx,
+		"SELECT minimized_at FROM plan_comments WHERE id = ?", first.ID).Scan(&minimizedAt))
+	require.NotNil(t, minimizedAt, "the row is stamped, not deleted")
+
+	// Marking an already-minimized or missing row is a no-op, not an error, and
+	// the original stamp is preserved.
+	require.NoError(t, store.PlanComments().MarkMinimized(ctx, first.ID))
+	require.NoError(t, store.PlanComments().MarkMinimized(ctx, 99999))
+
+	var minimizedAtAfter *time.Time
+	require.NoError(t, testDB.QueryRowContext(ctx,
+		"SELECT minimized_at FROM plan_comments WHERE id = ?", first.ID).Scan(&minimizedAtAfter))
+	require.NotNil(t, minimizedAtAfter)
+	assert.Equal(t, *minimizedAt, *minimizedAtAfter, "a repeat mark must not move the stamp")
+}
+
+// TestApplyStore_ExistsForDatabaseHead exercises the apply-ownership guard
+// used before minimizing a superseded plan comment: a plan comment whose head
+// produced an apply must stay expanded, and an apply whose plan row was
+// deleted counts as owning any head because the head it came from can no
+// longer be proven.
+func TestApplyStore_ExistsForDatabaseHead(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	// No applies at all: nothing owns any head.
+	exists, err := store.Applies().ExistsForDatabaseHead(ctx, "org/repo", 123, "testdb", "mysql", "shaA")
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	planID, err := store.Plans().Create(ctx, &storage.Plan{
+		PlanIdentifier: "plan_exists_head",
+		Database:       "testdb",
+		DatabaseType:   "mysql",
+		Repository:     "org/repo",
+		PullRequest:    123,
+		Environment:    "staging",
+		HeadSHA:        "shaA",
+		CreatedAt:      time.Now(),
+	})
+	require.NoError(t, err)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	createTestApply(t, store, lock, "apply_exists_head", planID)
+
+	exists, err = store.Applies().ExistsForDatabaseHead(ctx, "org/repo", 123, "testdb", "mysql", "shaA")
+	require.NoError(t, err)
+	assert.True(t, exists, "an apply from a plan at this head owns it")
+
+	exists, err = store.Applies().ExistsForDatabaseHead(ctx, "org/repo", 123, "testdb", "mysql", "shaB")
+	require.NoError(t, err)
+	assert.False(t, exists, "a different head is not owned while the plan row proves the apply's head")
+
+	// Other PRs and other databases are isolated.
+	exists, err = store.Applies().ExistsForDatabaseHead(ctx, "org/repo", 999, "testdb", "mysql", "shaA")
+	require.NoError(t, err)
+	assert.False(t, exists)
+	exists, err = store.Applies().ExistsForDatabaseHead(ctx, "org/repo", 123, "otherdb", "mysql", "shaA")
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	// Deleting the plan removes the proof of which head the apply came from;
+	// the apply then counts as owning every head.
+	require.NoError(t, store.Plans().Delete(ctx, planID))
+	exists, err = store.Applies().ExistsForDatabaseHead(ctx, "org/repo", 123, "testdb", "mysql", "shaB")
+	require.NoError(t, err)
+	assert.True(t, exists, "an apply without a plan row owns any head")
+}
+
+// DB error tests
+
+func TestPlanCommentStore_Insert_DBError(t *testing.T) {
+	db, err := sql.Open("mysql", testDSN)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	store := New(db)
+	err = store.PlanComments().Insert(t.Context(), &storage.PlanComment{
+		Repository: "org/repo", PullRequest: 1, DatabaseName: "db", DatabaseType: "mysql",
+	})
+	require.Error(t, err)
+}
+
+func TestPlanCommentStore_ListUnminimizedForSlot_DBError(t *testing.T) {
+	db, err := sql.Open("mysql", testDSN)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	store := New(db)
+	_, err = store.PlanComments().ListUnminimizedForSlot(t.Context(), "org/repo", 1, "db", "mysql")
+	require.Error(t, err)
+}
+
+func TestPlanCommentStore_MarkMinimized_DBError(t *testing.T) {
+	db, err := sql.Open("mysql", testDSN)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	store := New(db)
+	require.Error(t, store.PlanComments().MarkMinimized(t.Context(), 1))
+}
+
+func TestApplyStore_ExistsForDatabaseHead_DBError(t *testing.T) {
+	db, err := sql.Open("mysql", testDSN)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	store := New(db)
+	_, err = store.Applies().ExistsForDatabaseHead(t.Context(), "org/repo", 1, "db", "mysql", "sha")
+	require.Error(t, err)
+}

--- a/pkg/storage/mysqlstore/storage.go
+++ b/pkg/storage/mysqlstore/storage.go
@@ -18,6 +18,7 @@ type Storage struct {
 	applyLogs       *applyLogStore
 	controlRequests *controlRequestStore
 	applyComments   *applyCommentStore
+	planComments    *planCommentStore
 	applyOperations *applyOperationStore
 	checks          *checkStore
 	settings        *settingsStore
@@ -35,6 +36,7 @@ func New(db *sql.DB) *Storage {
 		applyLogs:       &applyLogStore{db: db},
 		controlRequests: &controlRequestStore{db: db},
 		applyComments:   &applyCommentStore{db: db},
+		planComments:    &planCommentStore{db: db},
 		applyOperations: &applyOperationStore{db: db},
 		checks:          &checkStore{db: db},
 		settings:        &settingsStore{db: db},
@@ -75,6 +77,11 @@ func (s *Storage) ControlRequests() storage.ControlRequestStore {
 // ApplyComments returns the apply comment store.
 func (s *Storage) ApplyComments() storage.ApplyCommentStore {
 	return s.applyComments
+}
+
+// PlanComments returns the plan comment store.
+func (s *Storage) PlanComments() storage.PlanCommentStore {
+	return s.planComments
 }
 
 // ApplyOperations returns the apply-operations store.

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -35,6 +35,9 @@ type Storage interface {
 	// ApplyComments returns the apply comment store.
 	ApplyComments() ApplyCommentStore
 
+	// PlanComments returns the plan comment store.
+	PlanComments() PlanCommentStore
+
 	// ApplyOperations returns the apply-operations store.
 	ApplyOperations() ApplyOperationStore
 
@@ -420,6 +423,13 @@ type ApplyStore interface {
 	// GetByPR returns all applies for a PR.
 	GetByPR(ctx context.Context, repo string, pr int) ([]*Apply, error)
 
+	// ExistsForDatabaseHead reports whether any apply for the PR and database
+	// was created from a plan for headSHA. An apply whose plan row no longer
+	// exists also counts: without the plan there is no proof of which head it
+	// came from, so callers deciding whether a record is safe to retire must
+	// treat it as owning.
+	ExistsForDatabaseHead(ctx context.Context, repo string, pr int, database, databaseType, headSHA string) (bool, error)
+
 	// Delete removes an apply by ID.
 	Delete(ctx context.Context, id int64) error
 
@@ -545,6 +555,25 @@ type ApplyCommentStore interface {
 	// has landed on GitHub. A missing row or an already-clear marker is not an
 	// error.
 	ClearPendingFreeze(ctx context.Context, applyID int64, commentState string) error
+}
+
+// PlanCommentStore tracks plan comments posted on PRs so a newer plan comment
+// for the same database can minimize the ones it supersedes. Rows exist only
+// for comments actually posted; minimized_at is set only after the GitHub
+// minimize call succeeded, so an unminimized row is always retried by the next
+// supersede.
+type PlanCommentStore interface {
+	// Insert stores a newly posted plan comment and sets comment.ID.
+	Insert(ctx context.Context, comment *PlanComment) error
+
+	// ListUnminimizedForSlot returns the not-yet-minimized comments for a
+	// (repository, pull_request, database) slot, ordered by id ascending. The
+	// caller decides which of them a newly posted comment supersedes.
+	ListUnminimizedForSlot(ctx context.Context, repo string, pr int, database, databaseType string) ([]*PlanComment, error)
+
+	// MarkMinimized stamps minimized_at after the GitHub minimize call
+	// succeeded. An already-minimized row is not an error.
+	MarkMinimized(ctx context.Context, id int64) error
 }
 
 // ApplyOperationStore manages per-(apply, deployment, operation_key) child rows

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -1142,6 +1142,55 @@ type ApplyComment struct {
 	UpdatedAt time.Time
 }
 
+// PlanComment tracks a plan comment posted on a PR so a newer plan comment for
+// the same database can minimize it on GitHub. Rows are written only when a
+// comment is actually posted — a plan whose comment was suppressed leaves no
+// row. The GitHub comment itself is never edited or deleted through this
+// record; minimizing collapses it in the PR timeline while keeping it
+// expandable as the record of what was shown.
+type PlanComment struct {
+	// ID is the unique identifier (BIGINT AUTO_INCREMENT).
+	ID int64
+
+	// Repository is the "owner/name" repository the comment was posted on.
+	Repository string
+
+	// PullRequest is the PR number the comment was posted on.
+	PullRequest int
+
+	// DatabaseName and DatabaseType identify the database the plan comment
+	// describes. Together with Repository and PullRequest they form the slot a
+	// newer plan comment supersedes.
+	DatabaseName string
+	DatabaseType string
+
+	// EnvironmentScope names the environments the comment covers, sorted and
+	// comma-joined (e.g. "production,staging" for a multi-environment comment,
+	// "staging" for a single-environment one).
+	EnvironmentScope string
+
+	// HeadSHA is the PR head commit the plan was computed against.
+	HeadSHA string
+
+	// GitHubCommentID is the REST comment ID, kept for triage and reconciliation.
+	GitHubCommentID int64
+
+	// GitHubNodeID is the GraphQL node ID required by the minimizeComment
+	// mutation.
+	GitHubNodeID string
+
+	// MinimizedAt is set only after the GitHub minimize call succeeded. Nil
+	// means the comment is still expanded on the PR — including after a failed
+	// minimize, so the next supersede retries it.
+	MinimizedAt *time.Time
+
+	// CreatedAt is when the comment was posted.
+	CreatedAt time.Time
+
+	// UpdatedAt is when this record last changed.
+	UpdatedAt time.Time
+}
+
 // ApplyLogLevel constants for log entry severity.
 const (
 	LogLevelDebug = "debug"

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -904,7 +904,7 @@ func (o *CommentObserver) postAndTrackComment(apply *storage.Apply, commentState
 		return 0, false, false
 	}
 
-	commentID, err = client.CreateIssueComment(ctx, o.repo, o.pr, o.renderPRComment(body))
+	commentID, _, err = client.CreateIssueComment(ctx, o.repo, o.pr, o.renderPRComment(body))
 	if err != nil {
 		o.logError(apply, "observer: failed to post comment", "error", err, "comment_state", commentState)
 		return 0, false, false

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -428,7 +428,7 @@ func (h *Handler) postComment(repo string, pr int, installationID int64, body st
 		return
 	}
 
-	if _, err := client.CreateIssueComment(ctx, repo, pr, h.renderPRComment(body)); err != nil {
+	if _, _, err := client.CreateIssueComment(ctx, repo, pr, h.renderPRComment(body)); err != nil {
 		h.logger.Error("failed to post comment",
 			"repo", repo, "pr", pr, "installation_id", installationID, "error", err)
 	}
@@ -449,7 +449,7 @@ func (h *Handler) postAndTrackComment(
 		return
 	}
 
-	commentID, err := client.CreateIssueComment(ctx, repo, pr, h.renderPRComment(body))
+	commentID, _, err := client.CreateIssueComment(ctx, repo, pr, h.renderPRComment(body))
 	if err != nil {
 		h.logger.Error("failed to post tracked comment",
 			"repo", repo, "pr", pr, "commentState", commentState, "error", err)


### PR DESCRIPTION
**Why this matters:** On a frequently updated PR, plan comments pile up — every push that touches a schema file posts a new one. This is the groundwork for collapsing superseded plan comments; no behavior changes in this PR.

**What it does:**
- New self-bootstrapping `plan_comments` table records every posted plan comment: slot identity (repo × PR × database × type), environment scope, head SHA, REST comment ID, and GraphQL node ID. `minimized_at` is stamped only after GitHub confirms a minimize, so an unminimized row is always retried.
- `Applies().ExistsForDatabaseHead` is the safety guard a minimize pass will use: it reports whether a head produced an apply, and an apply whose plan row was deleted counts as owning *any* head — without the plan there is no proof of which head it came from, so it must fail toward keeping comments visible.
- `CreateIssueComment` now also returns the comment's GraphQL node ID, and a new `MinimizeComment` posts the `minimizeComment` mutation (classifier `OUTDATED`) through the installation transport, inheriting auth, retry, and rate-limit accounting. The operation is categorized as a write for rate-limit metrics.

**Northstar:** busy PRs show one current plan per database, with the full plan history still expandable and auditable — never edited, never deleted.

Stacked under the behavior PR that wires this into the webhook plan paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)