### PR TITLE
feat(github): minimize superseded plan comments to reduce PR noise

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,7 @@
   - [Tenant-scoped command routing](#tenant-scoped-command-routing)
   - [How it works](#how-it-works)
   - [Auto-plan behavior](#auto-plan-behavior)
+  - [Plan comment minimization](#plan-comment-minimization)
 - [Multi-App Routing](#multi-app-routing)
   - [How dispatch works](#how-dispatch-works)
 - [Secret Resolution](#secret-resolution)
@@ -714,6 +715,27 @@ safe. This usually means the database environment config and deployment scoping
 disagree. Align the server environment config with the deployment's
 `allowed_environments`, then run `schemabot plan -e <environment>` or push a new
 commit to refresh checks.
+
+### Plan comment minimization
+
+On a frequently updated PR, plan comments pile up — every push that touches a
+schema file posts a new one. To keep the PR readable, SchemaBot minimizes
+(collapses as **Outdated**) the plan comments a newer one supersedes. This
+applies to auto-plan and `schemabot plan` comments alike; minimized comments
+stay expandable on GitHub, so the full plan history remains auditable.
+
+A newer plan comment for the same database supersedes a prior one when the
+prior was rendered at an older commit, or when it re-renders the same commit
+for the same set of environments. A same-commit comment covering different
+environments is kept expanded — it may be the only visible plan for those
+environments.
+
+One safety hold: a plan comment whose commit produced an apply is never
+minimized, even after new pushes. That comment is the record of what actually
+ran against the database, and it stays visible until an operator reconciles
+the apply. All minimization fails toward visibility — if GitHub or storage
+misbehaves, comments are left expanded (extra noise), never hidden without a
+durable record.
 
 ## Multi-App Routing
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -118,6 +118,20 @@ func RecordPlan(ctx context.Context, repo, database, deployment, environment, st
 	)
 }
 
+// RecordPlanCommentMinimize counts the outcome of retiring one superseded plan
+// comment. Outcomes: "minimized" (hidden on GitHub and marked in storage),
+// "apply_owned" (kept expanded because an apply owns the plan's head),
+// "guard_error" (apply-ownership lookup failed, comment kept expanded fail
+// closed — investigate storage), "minimize_error" (GitHub minimize call
+// failed; retried on the next supersede — investigate GitHub API health).
+func RecordPlanCommentMinimize(ctx context.Context, repo, outcome string) {
+	addCounter(ctx, "schemabot.plan_comment_minimize.total",
+		"Total number of superseded plan-comment minimize attempts by outcome", "{comment}",
+		attribute.String("repository", repo),
+		attribute.String("outcome", outcome),
+	)
+}
+
 // RecordPlanDuration records the duration of a plan operation.
 func RecordPlanDuration(ctx context.Context, duration time.Duration, repo, database, deployment, environment, status string) {
 	recordHistogram(ctx, "schemabot.plan.duration_seconds", duration.Seconds(),

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -123,7 +123,9 @@ func RecordPlan(ctx context.Context, repo, database, deployment, environment, st
 // "apply_owned" (kept expanded because an apply owns the plan's head),
 // "guard_error" (apply-ownership lookup failed, comment kept expanded fail
 // closed — investigate storage), "minimize_error" (GitHub minimize call
-// failed; retried on the next supersede — investigate GitHub API health).
+// failed; retried on the next supersede — investigate GitHub API health),
+// "mark_error" (hidden on GitHub but the storage mark failed; the next
+// supersede re-minimizes it idempotently — investigate storage).
 func RecordPlanCommentMinimize(ctx context.Context, repo, outcome string) {
 	addCounter(ctx, "schemabot.plan_comment_minimize.total",
 		"Total number of superseded plan-comment minimize attempts by outcome", "{comment}",

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -147,7 +147,12 @@ func (h *Handler) handlePlanCommand(w http.ResponseWriter, repo string, pr int, 
 	commentData.RecoveredApplyOwnedCheckState = recoveredApplyOwnedCheckState
 
 	// Post plan comment
-	h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
+	h.postTrackedPlanComment(repo, pr, installationID, planCommentSlot{
+		Database:     schemaResult.Database,
+		DatabaseType: schemaResult.Type,
+		Environments: []string{environment},
+		HeadSHA:      schemaResult.HeadSHA,
+	}, templates.RenderPlanComment(commentData))
 
 	// When drift blocked the check but its record could not be persisted, the
 	// aggregate must not be recomputed from stale (possibly passing) stored rows.
@@ -468,7 +473,12 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName, tenant s
 	}
 
 	// Post a single combined comment
-	h.postComment(repo, pr, installationID, templates.RenderMultiEnvPlanComment(multiEnvData))
+	h.postTrackedPlanComment(repo, pr, installationID, planCommentSlot{
+		Database:     multiEnvData.Database,
+		DatabaseType: multiEnvData.DatabaseType,
+		Environments: multiEnvData.Environments,
+		HeadSHA:      multiEnvData.HeadSHA,
+	}, templates.RenderMultiEnvPlanComment(multiEnvData))
 }
 
 func (h *Handler) postFailingAggregateForMultiEnvSetupError(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, database string, err error) {

--- a/pkg/webhook/plan_comment_minimize.go
+++ b/pkg/webhook/plan_comment_minimize.go
@@ -1,0 +1,158 @@
+package webhook
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/metrics"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// planCommentSlot identifies the stream of plan comments a posted comment
+// belongs to — one database on one PR — plus the head and environments the
+// comment renders. Comments in the same slot supersede each other per
+// planCommentSupersedes; manual and auto-plan comments share the slot.
+type planCommentSlot struct {
+	Database     string
+	DatabaseType string
+	Environments []string
+	HeadSHA      string
+}
+
+// environmentScope canonicalizes the slot's environments (sorted,
+// comma-joined) so the same set always compares equal regardless of the
+// order the caller assembled it in.
+func (s planCommentSlot) environmentScope() string {
+	envs := append([]string(nil), s.Environments...)
+	sort.Strings(envs)
+	return strings.Join(envs, ",")
+}
+
+// postTrackedPlanComment posts a plan comment, records it in plan_comments,
+// and minimizes the prior comments in the same slot that it supersedes.
+// Tracking and minimize failures never affect the posted comment: every
+// failure mode here leaves extra comments expanded on the PR, never a hidden
+// or lost record.
+func (h *Handler) postTrackedPlanComment(repo string, pr int, installationID int64, slot planCommentSlot, body string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client, err := h.clientForRepo(repo, installationID)
+	if err != nil {
+		h.logger.Error("failed to create GitHub client for plan comment",
+			"repo", repo, "pr", pr, "installation_id", installationID, "error", err)
+		return
+	}
+
+	commentID, nodeID, err := client.CreateIssueComment(ctx, repo, pr, h.renderPRComment(body))
+	if err != nil {
+		h.logger.Error("failed to post plan comment",
+			"repo", repo, "pr", pr, "installation_id", installationID, "error", err)
+		return
+	}
+
+	posted := &storage.PlanComment{
+		Repository:       repo,
+		PullRequest:      pr,
+		DatabaseName:     slot.Database,
+		DatabaseType:     slot.DatabaseType,
+		EnvironmentScope: slot.environmentScope(),
+		HeadSHA:          slot.HeadSHA,
+		GitHubCommentID:  commentID,
+		GitHubNodeID:     nodeID,
+	}
+	if err := h.service.Storage().PlanComments().Insert(ctx, posted); err != nil {
+		// The comment is live on GitHub either way. Without a row it will
+		// never be auto-minimized, so it stays expanded until an operator
+		// hides it — still retire its predecessors below.
+		h.logger.Error("failed to record posted plan comment; it will stay expanded when superseded",
+			"repo", repo, "pr", pr, "database", slot.Database, "database_type", slot.DatabaseType,
+			"head_sha", slot.HeadSHA, "comment_id", commentID, "error", err)
+	}
+
+	h.minimizeSupersededPlanComments(ctx, client, posted)
+}
+
+// minimizeSupersededPlanComments collapses the unminimized plan comments that
+// the newly posted comment supersedes. A comment whose plan became an apply
+// is kept expanded: the apply makes it the operational record of what ran,
+// and hiding it costs more than the noise it saves. Every failure keeps the
+// comment expanded and its row unminimized, so the next supersede retries it.
+func (h *Handler) minimizeSupersededPlanComments(ctx context.Context, client *ghclient.InstallationClient, posted *storage.PlanComment) {
+	slotAttrs := []any{
+		"repo", posted.Repository, "pr", posted.PullRequest,
+		"database", posted.DatabaseName, "database_type", posted.DatabaseType,
+		"head_sha", posted.HeadSHA,
+	}
+
+	priors, err := h.service.Storage().PlanComments().ListUnminimizedForSlot(ctx,
+		posted.Repository, posted.PullRequest, posted.DatabaseName, posted.DatabaseType)
+	if err != nil {
+		h.logger.Error("failed to list prior plan comments; superseded plan comments stay expanded until the next plan comment posts",
+			append(slotAttrs, "error", err)...)
+		return
+	}
+
+	for _, prior := range priors {
+		// Skip the comment that was just posted (its row is in the list too).
+		if prior.ID == posted.ID || prior.GitHubCommentID == posted.GitHubCommentID {
+			continue
+		}
+		priorAttrs := []any{
+			"repo", prior.Repository, "pr", prior.PullRequest,
+			"database", prior.DatabaseName, "database_type", prior.DatabaseType,
+			"environment_scope", prior.EnvironmentScope, "head_sha", prior.HeadSHA,
+			"comment_id", prior.GitHubCommentID,
+		}
+		if !planCommentSupersedes(posted, prior) {
+			h.logger.Debug("keeping plan comment expanded: not superseded (same head, different environment scope)", priorAttrs...)
+			continue
+		}
+
+		applyOwned, err := h.service.Storage().Applies().ExistsForDatabaseHead(ctx,
+			prior.Repository, prior.PullRequest, prior.DatabaseName, prior.DatabaseType, prior.HeadSHA)
+		if err != nil {
+			h.logger.Error("failed to check apply ownership for superseded plan comment; keeping it expanded",
+				append(priorAttrs, "error", err)...)
+			metrics.RecordPlanCommentMinimize(ctx, prior.Repository, "guard_error")
+			continue
+		}
+		if applyOwned {
+			h.logger.Info("keeping superseded plan comment expanded: an apply owns its head", priorAttrs...)
+			metrics.RecordPlanCommentMinimize(ctx, prior.Repository, "apply_owned")
+			continue
+		}
+
+		if err := client.MinimizeComment(ctx, prior.Repository, prior.GitHubNodeID); err != nil {
+			h.logger.Error("failed to minimize superseded plan comment; it stays expanded and is retried on the next plan comment",
+				append(priorAttrs, "error", err)...)
+			metrics.RecordPlanCommentMinimize(ctx, prior.Repository, "minimize_error")
+			continue
+		}
+		if err := h.service.Storage().PlanComments().MarkMinimized(ctx, prior.ID); err != nil {
+			// GitHub already minimized the comment; leaving the row
+			// unminimized only means the next supersede re-minimizes it,
+			// which is idempotent.
+			h.logger.Error("minimized plan comment on GitHub but failed to record it; the next supersede re-minimizes it",
+				append(priorAttrs, "error", err)...)
+		}
+		metrics.RecordPlanCommentMinimize(ctx, prior.Repository, "minimized")
+		h.logger.Info("minimized superseded plan comment", priorAttrs...)
+	}
+}
+
+// planCommentSupersedes reports whether the newly posted plan comment makes a
+// prior comment in the same slot outdated. Any comment for a different head
+// is stale — the plan it shows no longer matches the PR branch. On the same
+// head, a comment is only replaced by one covering the same environment
+// scope; a differently-scoped comment may be the sole visible plan for its
+// environments, so it stays expanded.
+func planCommentSupersedes(posted, prior *storage.PlanComment) bool {
+	if prior.HeadSHA != posted.HeadSHA {
+		return true
+	}
+	return prior.EnvironmentScope == posted.EnvironmentScope
+}

--- a/pkg/webhook/plan_comment_minimize.go
+++ b/pkg/webhook/plan_comment_minimize.go
@@ -138,6 +138,8 @@ func (h *Handler) minimizeSupersededPlanComments(ctx context.Context, client *gh
 			// which is idempotent.
 			h.logger.Error("minimized plan comment on GitHub but failed to record it; the next supersede re-minimizes it",
 				append(priorAttrs, "error", err)...)
+			metrics.RecordPlanCommentMinimize(ctx, prior.Repository, "mark_error")
+			continue
 		}
 		metrics.RecordPlanCommentMinimize(ctx, prior.Repository, "minimized")
 		h.logger.Info("minimized superseded plan comment", priorAttrs...)

--- a/pkg/webhook/plan_comment_minimize.go
+++ b/pkg/webhook/plan_comment_minimize.go
@@ -37,6 +37,19 @@ func (s planCommentSlot) environmentScope() string {
 // failure mode here leaves extra comments expanded on the PR, never a hidden
 // or lost record.
 func (h *Handler) postTrackedPlanComment(repo string, pr int, installationID int64, slot planCommentSlot, body string) {
+	if slot.Database == "" || slot.HeadSHA == "" {
+		// A plan whose every environment failed renders an error-only comment
+		// with no resolved database or head, so there is no slot identity to
+		// track. Post it untracked: an untracked comment only stays expanded,
+		// while tracking it under an empty identity would let error-only
+		// comments for different databases supersede each other.
+		h.logger.Info("posting plan comment untracked because no database or head resolved to key the slot",
+			"repo", repo, "pr", pr, "database", slot.Database, "database_type", slot.DatabaseType,
+			"head_sha", slot.HeadSHA)
+		h.postComment(repo, pr, installationID, body)
+		return
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 

--- a/pkg/webhook/plan_comment_minimize_integration_test.go
+++ b/pkg/webhook/plan_comment_minimize_integration_test.go
@@ -223,6 +223,24 @@ func TestPlanCommentSupersedeMinimizesPriorComments(t *testing.T) {
 	assert.Equal(t, 5, fake.createCount(), "every post reached GitHub exactly once")
 }
 
+// TestPlanCommentWithoutSlotIdentityPostsUntracked covers the error-only
+// comment a plan posts when every environment failed before a database or
+// head resolved: with no slot identity to key tracking, the comment still
+// posts (visibility first) but is not tracked, so no empty-identity row can
+// make error-only comments for different databases supersede each other.
+func TestPlanCommentWithoutSlotIdentityPostsUntracked(t *testing.T) {
+	const repo = "org/plan-min-untracked"
+	h, st, fake := setupPlanCommentHandler(t, repo)
+
+	h.postTrackedPlanComment(repo, 42, 12345, planCommentSlot{}, "plan failed in every environment")
+
+	assert.Equal(t, 1, fake.createCount(), "the error-only comment still posts")
+	assert.Empty(t, fake.minimizedNodes())
+	comments, err := st.PlanComments().ListUnminimizedForSlot(t.Context(), repo, 42, "", "")
+	require.NoError(t, err)
+	assert.Empty(t, comments, "no row is tracked under an empty slot identity")
+}
+
 // TestPlanCommentApplyOwnedHeadStaysExpanded covers the safety hold: once an
 // apply exists for the head a plan comment was rendered at, that comment is
 // the operational record of what ran and a newer plan comment must not hide

--- a/pkg/webhook/plan_comment_minimize_integration_test.go
+++ b/pkg/webhook/plan_comment_minimize_integration_test.go
@@ -19,8 +19,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/block/spirit/pkg/utils"
-
 	"github.com/block/schemabot/pkg/api"
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/state"
@@ -132,7 +130,10 @@ func setupPlanCommentHandler(t *testing.T, repo string) (*Handler, storage.Stora
 
 	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
 	require.NoError(t, err)
-	t.Cleanup(func() { utils.CloseAndLog(schemabotDB) })
+	// Redundant close for early-exit leak safety: svc.Close below owns the
+	// handle (the store is built over it), so this close is expected to see an
+	// already-closed DB and must discard the error.
+	t.Cleanup(func() { _ = schemabotDB.Close() })
 	st := mysqlstore.New(schemabotDB)
 
 	for _, stmt := range []string{

--- a/pkg/webhook/plan_comment_minimize_integration_test.go
+++ b/pkg/webhook/plan_comment_minimize_integration_test.go
@@ -1,0 +1,316 @@
+//go:build integration
+
+package webhook
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	gh "github.com/google/go-github/v86/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/spirit/pkg/utils"
+
+	"github.com/block/schemabot/pkg/api"
+	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/storage/mysqlstore"
+	"github.com/block/schemabot/pkg/tern"
+)
+
+// planCommentFakeGitHub captures comment creates (returning REST id and
+// GraphQL node id) and minimizeComment mutations, with per-node failure
+// injection for the retry scenarios.
+type planCommentFakeGitHub struct {
+	mu        sync.Mutex
+	nextID    int64
+	created   []int64
+	minimized []string
+	failNodes map[string]bool
+}
+
+func (f *planCommentFakeGitHub) createComment() (int64, string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.nextID++
+	id := f.nextID
+	f.created = append(f.created, id)
+	return id, fmt.Sprintf("IC_node%d", id)
+}
+
+func (f *planCommentFakeGitHub) minimize(nodeID string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failNodes[nodeID] {
+		return false
+	}
+	f.minimized = append(f.minimized, nodeID)
+	return true
+}
+
+func (f *planCommentFakeGitHub) setMinimizeFails(nodeID string, fails bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failNodes == nil {
+		f.failNodes = map[string]bool{}
+	}
+	f.failNodes[nodeID] = fails
+}
+
+func (f *planCommentFakeGitHub) minimizedNodes() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.minimized...)
+}
+
+func (f *planCommentFakeGitHub) createCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.created)
+}
+
+// setupFakeGitHubForPlanComments serves the comment-create REST endpoint and
+// the GraphQL minimizeComment mutation against any repo/PR.
+func setupFakeGitHubForPlanComments(t *testing.T) (*ghclient.InstallationClient, *planCommentFakeGitHub) {
+	t.Helper()
+
+	fake := &planCommentFakeGitHub{nextID: 1000}
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	mux.HandleFunc("POST /repos/", func(w http.ResponseWriter, _ *http.Request) {
+		id, nodeID := fake.createComment()
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": id, "node_id": nodeID})
+	})
+
+	mux.HandleFunc("POST /graphql", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Variables map[string]string `json:"variables"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		if !fake.minimize(req.Variables["id"]) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"errors": []map[string]any{{"message": "injected minimize failure"}},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"minimizeComment": map[string]any{
+					"minimizedComment": map[string]any{"isMinimized": true},
+				},
+			},
+		})
+	})
+
+	client := gh.NewClient(nil)
+	var err error
+	client.BaseURL, err = url.Parse(server.URL + "/")
+	require.NoError(t, err)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	return ghclient.NewInstallationClient(client, logger), fake
+}
+
+// setupPlanCommentHandler builds a webhook handler over real SchemaBot storage
+// and the plan-comment fake GitHub, clearing prior rows for the given repo.
+func setupPlanCommentHandler(t *testing.T, repo string) (*Handler, storage.Storage, *planCommentFakeGitHub) {
+	t.Helper()
+	ctx := t.Context()
+
+	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
+	require.NoError(t, err)
+	t.Cleanup(func() { utils.CloseAndLog(schemabotDB) })
+	st := mysqlstore.New(schemabotDB)
+
+	for _, stmt := range []string{
+		"DELETE FROM plan_comments WHERE repository = ?",
+		"DELETE FROM applies WHERE repository = ?",
+		"DELETE FROM plans WHERE repository = ?",
+		"DELETE FROM locks WHERE repository = ?",
+	} {
+		_, err := schemabotDB.ExecContext(ctx, stmt, repo)
+		require.NoError(t, err)
+	}
+
+	installClient, fake := setupFakeGitHubForPlanComments(t)
+	factory := &fakeClientFactory{client: installClient}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	svc := api.New(st, &api.ServerConfig{}, map[string]tern.Client{}, logger)
+	t.Cleanup(func() { _ = svc.Close() })
+
+	return NewHandler(svc, factory, nil, logger), st, fake
+}
+
+func unminimizedHeads(t *testing.T, st storage.Storage, repo string, pr int, database, databaseType string) []string {
+	t.Helper()
+	comments, err := st.PlanComments().ListUnminimizedForSlot(t.Context(), repo, pr, database, databaseType)
+	require.NoError(t, err)
+	heads := make([]string, len(comments))
+	for i, c := range comments {
+		heads[i] = c.HeadSHA
+	}
+	return heads
+}
+
+// TestPlanCommentSupersedeMinimizesPriorComments exercises the noise-reduction
+// UX on a frequently updated PR: each newly posted plan comment collapses the
+// prior plan comments it supersedes (older head, or a refresh of the same
+// head and environment scope), while a same-head comment for different
+// environments and comments for other databases stay expanded. Minimized
+// comments stay expandable on GitHub — the record is hidden, never lost.
+func TestPlanCommentSupersedeMinimizesPriorComments(t *testing.T) {
+	const repo = "org/plan-min-lifecycle"
+	h, st, fake := setupPlanCommentHandler(t, repo)
+
+	slot := planCommentSlot{
+		Database:     "orders",
+		DatabaseType: "mysql",
+		Environments: []string{"staging", "production"},
+		HeadSHA:      "sha1",
+	}
+
+	// A comment for another database on the same PR must never be touched.
+	otherSlot := slot
+	otherSlot.Database = "billing"
+	h.postTrackedPlanComment(repo, 42, 12345, otherSlot, "billing plan")
+
+	// First comment in the orders slot: nothing to supersede.
+	h.postTrackedPlanComment(repo, 42, 12345, slot, "plan at sha1")
+	assert.Empty(t, fake.minimizedNodes())
+	assert.Equal(t, []string{"sha1"}, unminimizedHeads(t, st, repo, 42, "orders", "mysql"))
+
+	// A new head supersedes the sha1 comment.
+	slot.HeadSHA = "sha2"
+	h.postTrackedPlanComment(repo, 42, 12345, slot, "plan at sha2")
+	assert.Equal(t, []string{"IC_node1002"}, fake.minimizedNodes(), "the sha1 comment is minimized on GitHub")
+	assert.Equal(t, []string{"sha2"}, unminimizedHeads(t, st, repo, 42, "orders", "mysql"))
+
+	// A manual single-environment plan on the same head covers a narrower
+	// scope: it does not supersede the combined comment, and the combined
+	// comment does not retroactively hide it.
+	stagingSlot := slot
+	stagingSlot.Environments = []string{"staging"}
+	h.postTrackedPlanComment(repo, 42, 12345, stagingSlot, "staging-only plan at sha2")
+	assert.Len(t, fake.minimizedNodes(), 1, "different scope on the same head minimizes nothing")
+	assert.Equal(t, []string{"sha2", "sha2"}, unminimizedHeads(t, st, repo, 42, "orders", "mysql"))
+
+	// Re-running the staging-only plan on the same head refreshes it: the
+	// older staging-only comment collapses, the combined comment stays.
+	h.postTrackedPlanComment(repo, 42, 12345, stagingSlot, "staging-only plan at sha2, again")
+	assert.Equal(t, []string{"IC_node1002", "IC_node1004"}, fake.minimizedNodes())
+	comments, err := st.PlanComments().ListUnminimizedForSlot(t.Context(), repo, 42, "orders", "mysql")
+	require.NoError(t, err)
+	require.Len(t, comments, 2)
+	assert.Equal(t, "production,staging", comments[0].EnvironmentScope)
+	assert.Equal(t, "staging", comments[1].EnvironmentScope)
+
+	// The billing slot was never touched.
+	assert.Equal(t, []string{"sha1"}, unminimizedHeads(t, st, repo, 42, "billing", "mysql"))
+	assert.Equal(t, 5, fake.createCount(), "every post reached GitHub exactly once")
+}
+
+// TestPlanCommentApplyOwnedHeadStaysExpanded covers the safety hold: once an
+// apply exists for the head a plan comment was rendered at, that comment is
+// the operational record of what ran and a newer plan comment must not hide
+// it — the PR keeps showing the plan that produced the apply.
+func TestPlanCommentApplyOwnedHeadStaysExpanded(t *testing.T) {
+	const repo = "org/plan-min-apply-owned"
+	h, st, fake := setupPlanCommentHandler(t, repo)
+	ctx := t.Context()
+
+	slot := planCommentSlot{
+		Database:     "orders",
+		DatabaseType: "mysql",
+		Environments: []string{"staging"},
+		HeadSHA:      "shaA",
+	}
+	h.postTrackedPlanComment(repo, 42, 12345, slot, "plan at shaA")
+
+	// The shaA plan becomes an apply before the next push.
+	planID, err := st.Plans().Create(ctx, &storage.Plan{
+		PlanIdentifier: "plan_owned_shaA",
+		Database:       "orders",
+		DatabaseType:   "mysql",
+		Repository:     repo,
+		PullRequest:    42,
+		Environment:    "staging",
+		HeadSHA:        "shaA",
+		CreatedAt:      time.Now(),
+	})
+	require.NoError(t, err)
+	lock := &storage.Lock{
+		DatabaseName: "orders",
+		DatabaseType: "mysql",
+		Repository:   repo,
+		PullRequest:  42,
+		Owner:        fmt.Sprintf("%s#42", repo),
+	}
+	require.NoError(t, st.Locks().Acquire(ctx, lock))
+	lock, err = st.Locks().Get(ctx, "orders", "mysql")
+	require.NoError(t, err)
+	_, err = st.Applies().Create(ctx, &storage.Apply{
+		ApplyIdentifier: "apply_owned_shaA",
+		LockID:          lock.ID,
+		PlanID:          planID,
+		Database:        "orders",
+		DatabaseType:    "mysql",
+		Repository:      repo,
+		PullRequest:     42,
+		Environment:     "staging",
+		Engine:          "spirit",
+		State:           state.Apply.Running,
+	})
+	require.NoError(t, err)
+
+	slot.HeadSHA = "shaB"
+	h.postTrackedPlanComment(repo, 42, 12345, slot, "plan at shaB")
+
+	assert.Empty(t, fake.minimizedNodes(), "the apply-owned shaA comment must stay expanded")
+	assert.Equal(t, []string{"shaA", "shaB"}, unminimizedHeads(t, st, repo, 42, "orders", "mysql"))
+}
+
+// TestPlanCommentMinimizeFailureRetriesOnNextSupersede covers the retry
+// semantics: a failed GitHub minimize call leaves the row unminimized, so the
+// next plan comment in the slot picks the comment up again. The failure mode
+// is only extra noise on the PR — a comment is never recorded as hidden
+// unless GitHub confirmed it.
+func TestPlanCommentMinimizeFailureRetriesOnNextSupersede(t *testing.T) {
+	const repo = "org/plan-min-retry"
+	h, st, fake := setupPlanCommentHandler(t, repo)
+
+	slot := planCommentSlot{
+		Database:     "orders",
+		DatabaseType: "mysql",
+		Environments: []string{"staging"},
+		HeadSHA:      "shaA",
+	}
+	h.postTrackedPlanComment(repo, 42, 12345, slot, "plan at shaA")
+	fake.setMinimizeFails("IC_node1001", true)
+
+	slot.HeadSHA = "shaB"
+	h.postTrackedPlanComment(repo, 42, 12345, slot, "plan at shaB")
+	assert.Empty(t, fake.minimizedNodes(), "the injected failure leaves the shaA comment expanded")
+	assert.Equal(t, []string{"shaA", "shaB"}, unminimizedHeads(t, st, repo, 42, "orders", "mysql"),
+		"a failed minimize must not be recorded as minimized")
+
+	// GitHub recovers; the next supersede retires both stale comments.
+	fake.setMinimizeFails("IC_node1001", false)
+	slot.HeadSHA = "shaC"
+	h.postTrackedPlanComment(repo, 42, 12345, slot, "plan at shaC")
+	assert.ElementsMatch(t, []string{"IC_node1001", "IC_node1002"}, fake.minimizedNodes())
+	assert.Equal(t, []string{"shaC"}, unminimizedHeads(t, st, repo, 42, "orders", "mysql"))
+}

--- a/pkg/webhook/plan_comment_minimize_test.go
+++ b/pkg/webhook/plan_comment_minimize_test.go
@@ -1,0 +1,54 @@
+package webhook
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/block/schemabot/pkg/storage"
+)
+
+func TestPlanCommentSupersedes(t *testing.T) {
+	tests := []struct {
+		name       string
+		posted     *storage.PlanComment
+		prior      *storage.PlanComment
+		supersedes bool
+	}{
+		{
+			name:       "different head always supersedes",
+			posted:     &storage.PlanComment{HeadSHA: "sha2", EnvironmentScope: "staging"},
+			prior:      &storage.PlanComment{HeadSHA: "sha1", EnvironmentScope: "production,staging"},
+			supersedes: true,
+		},
+		{
+			name:       "same head and same scope is a refresh",
+			posted:     &storage.PlanComment{HeadSHA: "sha1", EnvironmentScope: "production,staging"},
+			prior:      &storage.PlanComment{HeadSHA: "sha1", EnvironmentScope: "production,staging"},
+			supersedes: true,
+		},
+		{
+			name:       "same head with different scope keeps the prior visible",
+			posted:     &storage.PlanComment{HeadSHA: "sha1", EnvironmentScope: "staging"},
+			prior:      &storage.PlanComment{HeadSHA: "sha1", EnvironmentScope: "production,staging"},
+			supersedes: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.supersedes, planCommentSupersedes(tt.posted, tt.prior))
+		})
+	}
+}
+
+func TestPlanCommentSlotEnvironmentScope(t *testing.T) {
+	slot := planCommentSlot{Environments: []string{"staging", "production"}}
+	assert.Equal(t, "production,staging", slot.environmentScope(),
+		"environments are sorted so the same set always compares equal")
+	assert.Equal(t, []string{"staging", "production"}, slot.Environments,
+		"canonicalizing must not reorder the caller's display-ordered slice")
+
+	assert.Equal(t, "staging", planCommentSlot{Environments: []string{"staging"}}.environmentScope())
+	assert.Equal(t, "", planCommentSlot{}.environmentScope())
+}


### PR DESCRIPTION
**Why this matters:** Auto-plan is noisy on frequently updated PRs — every push that touches a schema file posts a new plan comment, burying the current one. This PR collapses the stale ones while keeping the full history expandable.

**What it does:** Each newly posted plan comment (auto-plan and manual alike) minimizes the prior comments in the same slot (repo × PR × database) that it supersedes — collapsed as **Outdated** in the timeline, still expandable, never edited or deleted.

```
new plan comment posted
  └─ for each prior unminimized comment in the slot:
       different head?  ──────────────── yes ─┐
       same head + same env scope? ───── yes ─┤→ superseded
       same head, different env scope? ─ no  →  keep expanded
                                              │
       head produced an apply? ── yes → keep expanded (record of what ran)
       guard/GitHub call failed? ─────→ keep expanded, retry next supersede
                                              │
                                          minimize
```

- A same-head comment covering different environments stays visible — it may be the only plan shown for those environments (e.g. separate staging/production instances posting to the same PR).
- Safety hold: a comment whose head produced an apply is never minimized until an operator reconciles the apply.
- Every failure path leaves comments expanded and unminimized rows retry on the next supersede — the failure mode is extra noise, never a hidden record. Outcomes are counted in a new `schemabot.plan_comment_minimize.total` metric (`minimized` / `apply_owned` / `guard_error` / `minimize_error` / `mark_error`).

**Northstar:** busy PRs show one current plan per database, with the full plan history auditable one click away.

Builds on the tracking storage and minimize client support from #718 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

