### PR TITLE
fix(e2e): poll for failed aggregate state in multideploy on-failure tests

### DIFF
--- a/e2e/grpc/multideploy_test.go
+++ b/e2e/grpc/multideploy_test.go
@@ -472,13 +472,24 @@ func TestGRPCMultiDeploy_FailureHaltsRollout(t *testing.T) {
 	)
 
 	// The earlier deployment failed; the rollout must have halted — the later
-	// deployment is not completed and the apply itself is failed.
+	// deployment is not completed and the apply itself is failed. The aggregate
+	// is projected by a parent-row CAS that runs after the per-deployment op
+	// rows are persisted, so it can briefly lag the terminal op states above;
+	// poll for it rather than asserting once.
 	final := multiDeployOperationStates(t, apply.ApplyID)
 	assert.Truef(t, failedApplyState(final[first].State), "%s should be failed, was %q", first, final[first].State)
 	assert.Falsef(t, state.IsState(final[second].State, state.Apply.Completed),
 		"%s must not complete after %s failed, was %q", second, first, final[second].State)
-	prog := grpcProgressByApplyID(t, apply.ApplyID)
-	assert.Truef(t, failedApplyState(prog.State), "aggregate apply state should be failed, was %q", prog.State)
+	var prog grpcProgressResponse
+	testutil.Poll(t, testutil.PollDeadline, testutil.PollInterval,
+		func() bool {
+			prog = grpcProgressByApplyID(t, apply.ApplyID)
+			return failedApplyState(prog.State)
+		},
+		func() string {
+			return fmt.Sprintf("aggregate apply state should be failed, was %q", prog.State)
+		},
+	)
 
 	multiDeployEnsureNoActiveChange(t, database, env, first, second)
 }
@@ -650,9 +661,20 @@ func TestGRPCMultiDeploy_OnFailureContinue(t *testing.T) {
 		"%s should complete under on_failure: continue, was %q", second, final[second].State)
 
 	// The apply settles to failed even though a sibling completed — continue
-	// governs rollout continuation, not the verdict.
-	prog := grpcProgressByApplyID(t, apply.ApplyID)
-	assert.Truef(t, failedApplyState(prog.State), "aggregate apply state should be failed, was %q", prog.State)
+	// governs rollout continuation, not the verdict. The aggregate is projected
+	// by a parent-row CAS that runs after the per-deployment op rows are
+	// persisted, so it can briefly lag the terminal op states above; poll for it
+	// rather than asserting once.
+	var prog grpcProgressResponse
+	testutil.Poll(t, testutil.PollDeadline, testutil.PollInterval,
+		func() bool {
+			prog = grpcProgressByApplyID(t, apply.ApplyID)
+			return failedApplyState(prog.State)
+		},
+		func() string {
+			return fmt.Sprintf("aggregate apply state should be failed, was %q", prog.State)
+		},
+	)
 
 	multiDeployEnsureNoActiveChange(t, database, env, first, second)
 }


### PR DESCRIPTION
## Summary
Deflakes the multideploy on-failure e2e tests. Both tests polled the per-deployment operation rows to a terminal state, then asserted the aggregate apply state **once** — racing the parent-row projection.

## What
Replace the one-shot aggregate assert with `testutil.Poll` in `TestGRPCMultiDeploy_OnFailureContinue` (the observed flake) and `TestGRPCMultiDeploy_OnFailureHalt` (identical latent race).

## Why
The aggregate is not written atomically with the op rows: `driveClaimedMultiOperation` persists the per-deployment op row first, then reloads and CAS-projects the parent `applies` row (`UpdateDerivedState`, `WHERE id = ? AND state = ?`). A read landing in that window sees terminal op states but a stale aggregate — a legitimate ordering, not a bug, so the tests must poll.

## Before / after
```
before (flaky)
poll op rows → terminal ─▶ read aggregate once ─▶ assert failed
▲
└─ races parent-row CAS projection
```

```
after
poll op rows → terminal ─▶ poll aggregate until failed (30s deadline)
```