### PR TITLE
feat(schema): dialect-aware reserved-namespace registry

### DIFF
--- a/pkg/schema/dialect.go
+++ b/pkg/schema/dialect.go
@@ -1,0 +1,71 @@
+package schema
+
+import "strings"
+
+// Dialect identifies a database family for system-schema classification. It is
+// coarser than the per-engine database_type (mysql / vitess / strata all share
+// the MySQL dialect) because reserved system schemas are a property of the
+// underlying database family, not of the engine that drives it.
+type Dialect string
+
+const (
+	// DialectMySQL covers MySQL and every MySQL-protocol engine (Vitess, Strata).
+	DialectMySQL Dialect = "mysql"
+	// DialectPostgres covers PostgreSQL targets.
+	DialectPostgres Dialect = "postgres"
+)
+
+// schemabotReservedNamespaces are reserved regardless of dialect: SchemaBot's
+// own storage schema and its pending-drops quarantine. Any namespace beginning
+// with an underscore is also treated as SchemaBot-internal (see the prefix rule
+// in IsReservedPullNamespaceForDialect).
+var schemabotReservedNamespaces = map[string]struct{}{
+	"_pending_drops": {},
+	"schemabot":      {},
+}
+
+// systemSchemasByDialect maps a dialect to the database-managed schemas that
+// must never be treated as user schema for pull discovery.
+var systemSchemasByDialect = map[Dialect]map[string]struct{}{
+	DialectMySQL: {
+		"information_schema": {},
+		"innodb":             {},
+		"mysql":              {},
+		"performance_schema": {},
+		"sys":                {},
+		"rdsmon":             {},
+		"dbadmin":            {},
+		"polt":               {},
+		"tmp":                {},
+		"topo":               {},
+	},
+	DialectPostgres: {
+		"information_schema": {},
+		"pg_catalog":         {},
+		"pg_toast":           {},
+		"rdsadmin":           {},
+	},
+}
+
+// IsReservedPullNamespaceForDialect reports whether a live namespace should be
+// excluded from schema pull discovery and rejected for explicit pull requests,
+// for the given database dialect. A namespace is reserved when it is a SchemaBot
+// internal namespace, carries the SchemaBot-internal underscore prefix, or is a
+// system schema for the dialect (including the Postgres pg_ prefix).
+func IsReservedPullNamespaceForDialect(dialect Dialect, namespace string) bool {
+	name := strings.ToLower(namespace)
+
+	if _, ok := schemabotReservedNamespaces[name]; ok {
+		return true
+	}
+	if strings.HasPrefix(name, "_") {
+		return true
+	}
+	if _, ok := systemSchemasByDialect[dialect][name]; ok {
+		return true
+	}
+	if dialect == DialectPostgres && strings.HasPrefix(name, "pg_") {
+		return true
+	}
+	return false
+}

--- a/pkg/schema/dialect.go
+++ b/pkg/schema/dialect.go
@@ -15,18 +15,22 @@ const (
 	DialectPostgres Dialect = "postgres"
 )
 
-// DialectForDatabaseType maps a database_type to its database family. Callers
-// must use this instead of converting a database_type string directly to a
-// Dialect: "vitess" and "strata" are MySQL-protocol engines that share the
-// MySQL dialect, so a direct conversion would produce an unregistered dialect.
-// An unrecognized type resolves to DialectMySQL, the conservative default that
-// still reserves MySQL system schemas rather than exposing them.
+// DialectForDatabaseType maps a database_type to its database family for
+// system-schema classification. Callers must use this instead of converting a
+// database_type string directly to a Dialect: "vitess" and "strata" are
+// MySQL-protocol engines that share the MySQL dialect. An unrecognized type is
+// returned as its lowercased value — an unregistered dialect — rather than being
+// forced to a family, so IsReservedPullNamespaceForDialect classifies it
+// conservatively (reserving every known dialect's system schemas) instead of a
+// mislabeled target silently exposing another family's system schemas.
 func DialectForDatabaseType(databaseType string) Dialect {
 	switch strings.ToLower(databaseType) {
+	case "mysql", "vitess", "strata":
+		return DialectMySQL
 	case "postgres":
 		return DialectPostgres
 	default:
-		return DialectMySQL
+		return Dialect(strings.ToLower(databaseType))
 	}
 }
 
@@ -57,9 +61,9 @@ var systemSchemasByDialect = map[Dialect]map[string]struct{}{
 	// The Postgres set is provisional: it covers the always-present system
 	// schemas and RDS/Aurora's rdsadmin, but the managed-extension schemas
 	// (aws_commons, aws_s3, aws_lambda, aws_ml, ...) are deliberately not
-	// enumerated yet. It must be finalized when Postgres pull discovery lands
-	// (see the DB-agnostic tracker's Postgres engine slice) so extension-owned
-	// schemas are not surfaced as pullable user namespaces.
+	// enumerated yet. It must be finalized when Postgres pull discovery is
+	// implemented so extension-owned schemas are not surfaced as pullable user
+	// namespaces.
 	DialectPostgres: {
 		"information_schema": {},
 		"pg_catalog":         {},
@@ -83,22 +87,36 @@ var reservedPrefixesByDialect = map[Dialect][]string{
 // system schema for the dialect (including the Postgres pg_ prefix).
 func IsReservedPullNamespaceForDialect(dialect Dialect, namespace string) bool {
 	name := strings.ToLower(namespace)
-	// Normalize the dialect and resolve an unregistered value to DialectMySQL so
-	// a differently-cased or mis-constructed dialect (e.g. a raw "vitess") cannot
-	// silently miss the registry and fail open, treating a reserved system schema
-	// as a user namespace. MySQL is the conservative default: the MySQL-protocol
-	// engines are the only other database_types today, and they share its dialect.
-	dialect = Dialect(strings.ToLower(string(dialect)))
-	if _, known := systemSchemasByDialect[dialect]; !known {
-		dialect = DialectMySQL
-	}
 
+	// SchemaBot-internal namespaces are reserved regardless of dialect.
 	if _, ok := schemabotReservedNamespaces[name]; ok {
 		return true
 	}
 	if strings.HasPrefix(name, "_") {
 		return true
 	}
+
+	dialect = Dialect(strings.ToLower(string(dialect)))
+	if _, known := systemSchemasByDialect[dialect]; known {
+		return isSystemSchemaForDialect(dialect, name)
+	}
+
+	// A mis-constructed or unknown dialect (e.g. a raw "vitess" or a mislabeled
+	// "postgresql") is classified conservatively: reserve any namespace that is a
+	// system schema in ANY known dialect. Over-reserving only excludes a
+	// namespace from pull discovery — the safe direction — whereas failing open
+	// would expose a real system schema as a user namespace.
+	for known := range systemSchemasByDialect {
+		if isSystemSchemaForDialect(known, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// isSystemSchemaForDialect reports whether name is a database-managed schema for
+// a single, registered dialect (by exact name or reserved prefix).
+func isSystemSchemaForDialect(dialect Dialect, name string) bool {
 	if _, ok := systemSchemasByDialect[dialect][name]; ok {
 		return true
 	}

--- a/pkg/schema/dialect.go
+++ b/pkg/schema/dialect.go
@@ -54,6 +54,10 @@ var systemSchemasByDialect = map[Dialect]map[string]struct{}{
 // system schema for the dialect (including the Postgres pg_ prefix).
 func IsReservedPullNamespaceForDialect(dialect Dialect, namespace string) bool {
 	name := strings.ToLower(namespace)
+	// Normalize the dialect so a differently-cased value (e.g. "Postgres")
+	// cannot silently miss the registry and fail open, treating a reserved
+	// system schema as a user namespace.
+	dialect = Dialect(strings.ToLower(string(dialect)))
 
 	if _, ok := schemabotReservedNamespaces[name]; ok {
 		return true

--- a/pkg/schema/dialect.go
+++ b/pkg/schema/dialect.go
@@ -15,6 +15,21 @@ const (
 	DialectPostgres Dialect = "postgres"
 )
 
+// DialectForDatabaseType maps a database_type to its database family. Callers
+// must use this instead of converting a database_type string directly to a
+// Dialect: "vitess" and "strata" are MySQL-protocol engines that share the
+// MySQL dialect, so a direct conversion would produce an unregistered dialect.
+// An unrecognized type resolves to DialectMySQL, the conservative default that
+// still reserves MySQL system schemas rather than exposing them.
+func DialectForDatabaseType(databaseType string) Dialect {
+	switch strings.ToLower(databaseType) {
+	case "postgres":
+		return DialectPostgres
+	default:
+		return DialectMySQL
+	}
+}
+
 // schemabotReservedNamespaces are reserved regardless of dialect: SchemaBot's
 // own storage schema and its pending-drops quarantine. Any namespace beginning
 // with an underscore is also treated as SchemaBot-internal (see the prefix rule
@@ -39,12 +54,26 @@ var systemSchemasByDialect = map[Dialect]map[string]struct{}{
 		"tmp":                {},
 		"topo":               {},
 	},
+	// The Postgres set is provisional: it covers the always-present system
+	// schemas and RDS/Aurora's rdsadmin, but the managed-extension schemas
+	// (aws_commons, aws_s3, aws_lambda, aws_ml, ...) are deliberately not
+	// enumerated yet. It must be finalized when Postgres pull discovery lands
+	// (see the DB-agnostic tracker's Postgres engine slice) so extension-owned
+	// schemas are not surfaced as pullable user namespaces.
 	DialectPostgres: {
 		"information_schema": {},
 		"pg_catalog":         {},
 		"pg_toast":           {},
 		"rdsadmin":           {},
 	},
+}
+
+// reservedPrefixesByDialect lists namespace prefixes that a dialect reserves for
+// database-managed schemas, keeping prefix rules in the registry rather than in
+// control flow. The dialect-independent SchemaBot-internal "_" prefix is handled
+// separately in IsReservedPullNamespaceForDialect.
+var reservedPrefixesByDialect = map[Dialect][]string{
+	DialectPostgres: {"pg_"},
 }
 
 // IsReservedPullNamespaceForDialect reports whether a live namespace should be
@@ -54,10 +83,15 @@ var systemSchemasByDialect = map[Dialect]map[string]struct{}{
 // system schema for the dialect (including the Postgres pg_ prefix).
 func IsReservedPullNamespaceForDialect(dialect Dialect, namespace string) bool {
 	name := strings.ToLower(namespace)
-	// Normalize the dialect so a differently-cased value (e.g. "Postgres")
-	// cannot silently miss the registry and fail open, treating a reserved
-	// system schema as a user namespace.
+	// Normalize the dialect and resolve an unregistered value to DialectMySQL so
+	// a differently-cased or mis-constructed dialect (e.g. a raw "vitess") cannot
+	// silently miss the registry and fail open, treating a reserved system schema
+	// as a user namespace. MySQL is the conservative default: the MySQL-protocol
+	// engines are the only other database_types today, and they share its dialect.
 	dialect = Dialect(strings.ToLower(string(dialect)))
+	if _, known := systemSchemasByDialect[dialect]; !known {
+		dialect = DialectMySQL
+	}
 
 	if _, ok := schemabotReservedNamespaces[name]; ok {
 		return true
@@ -68,8 +102,10 @@ func IsReservedPullNamespaceForDialect(dialect Dialect, namespace string) bool {
 	if _, ok := systemSchemasByDialect[dialect][name]; ok {
 		return true
 	}
-	if dialect == DialectPostgres && strings.HasPrefix(name, "pg_") {
-		return true
+	for _, prefix := range reservedPrefixesByDialect[dialect] {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
 	}
 	return false
 }

--- a/pkg/schema/dialect_test.go
+++ b/pkg/schema/dialect_test.go
@@ -6,9 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// IsReservedPullNamespace must be the MySQL-dialect classification so existing
-// MySQL and Vitess pull discovery is unchanged after routing through the
-// dialect registry.
+// IsReservedPullNamespace is the MySQL-dialect classification, so MySQL and
+// Vitess pull discovery share a single definition of reserved namespaces.
 func TestIsReservedPullNamespaceUsesMySQLDialect(t *testing.T) {
 	for _, ns := range []string{
 		"mysql", "information_schema", "innodb", "performance_schema", "sys",
@@ -70,5 +69,46 @@ func TestIsReservedPullNamespaceForDialect(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.want, IsReservedPullNamespaceForDialect(tc.dialect, tc.namespace))
 		})
+	}
+}
+
+func TestDialectForDatabaseType(t *testing.T) {
+	tests := []struct {
+		databaseType string
+		want         Dialect
+	}{
+		{databaseType: "mysql", want: DialectMySQL},
+		{databaseType: "vitess", want: DialectMySQL},
+		{databaseType: "strata", want: DialectMySQL},
+		{databaseType: "postgres", want: DialectPostgres},
+		{databaseType: "Postgres", want: DialectPostgres},
+		{databaseType: "MYSQL", want: DialectMySQL},
+		{databaseType: "unknown", want: DialectMySQL},
+		{databaseType: "", want: DialectMySQL},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.databaseType, func(t *testing.T) {
+			assert.Equal(t, tc.want, DialectForDatabaseType(tc.databaseType))
+		})
+	}
+}
+
+// A Dialect constructed by casting a raw database_type (e.g. "vitess" or
+// "strata") is not a registered dialect, so classification must resolve it to
+// the MySQL dialect rather than fail open and expose MySQL system schemas as
+// pullable user namespaces.
+func TestIsReservedPullNamespaceForDialectFailsClosed(t *testing.T) {
+	for _, raw := range []string{"vitess", "strata", "somethingelse"} {
+		for _, ns := range []string{"mysql", "information_schema", "innodb", "sys"} {
+			assert.True(t,
+				IsReservedPullNamespaceForDialect(Dialect(raw), ns),
+				"unregistered dialect %q must reserve MySQL system schema %q", raw, ns,
+			)
+		}
+		assert.False(t,
+			IsReservedPullNamespaceForDialect(Dialect(raw), "orders_production"),
+			"unregistered dialect %q must not reserve application namespaces", raw,
+		)
 	}
 }

--- a/pkg/schema/dialect_test.go
+++ b/pkg/schema/dialect_test.go
@@ -1,0 +1,68 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// IsReservedPullNamespace must be the MySQL-dialect classification so existing
+// MySQL and Vitess pull discovery is unchanged after routing through the
+// dialect registry.
+func TestIsReservedPullNamespaceUsesMySQLDialect(t *testing.T) {
+	for _, ns := range []string{
+		"mysql", "information_schema", "innodb", "performance_schema", "sys",
+		"rdsmon", "dbadmin", "polt", "tmp", "topo", "_pending_drops",
+		"schemabot", "_scratch", "orders_production",
+	} {
+		assert.Equal(t,
+			IsReservedPullNamespaceForDialect(DialectMySQL, ns),
+			IsReservedPullNamespace(ns),
+			"IsReservedPullNamespace should match the MySQL dialect for %q", ns,
+		)
+	}
+}
+
+func TestIsReservedPullNamespaceForDialect(t *testing.T) {
+	tests := []struct {
+		name      string
+		dialect   Dialect
+		namespace string
+		want      bool
+	}{
+		// SchemaBot-internal namespaces are reserved for every dialect.
+		{name: "pending drops on mysql", dialect: DialectMySQL, namespace: "_pending_drops", want: true},
+		{name: "pending drops on postgres", dialect: DialectPostgres, namespace: "_pending_drops", want: true},
+		{name: "schemabot storage on postgres", dialect: DialectPostgres, namespace: "schemabot", want: true},
+		{name: "underscore prefix on postgres", dialect: DialectPostgres, namespace: "_scratch", want: true},
+
+		// MySQL system schemas are reserved on MySQL but not on Postgres.
+		{name: "mysql db on mysql", dialect: DialectMySQL, namespace: "mysql", want: true},
+		{name: "innodb on mysql", dialect: DialectMySQL, namespace: "innodb", want: true},
+		{name: "mysql db on postgres", dialect: DialectPostgres, namespace: "mysql", want: false},
+		{name: "innodb on postgres", dialect: DialectPostgres, namespace: "innodb", want: false},
+
+		// Postgres system schemas are reserved on Postgres but not on MySQL.
+		{name: "pg_catalog on postgres", dialect: DialectPostgres, namespace: "pg_catalog", want: true},
+		{name: "pg_toast on postgres", dialect: DialectPostgres, namespace: "pg_toast", want: true},
+		{name: "rdsadmin on postgres", dialect: DialectPostgres, namespace: "rdsadmin", want: true},
+		{name: "pg_temp prefix on postgres", dialect: DialectPostgres, namespace: "pg_temp_3", want: true},
+		{name: "uppercase pg_catalog on postgres", dialect: DialectPostgres, namespace: "PG_CATALOG", want: true},
+		{name: "pg_catalog on mysql", dialect: DialectMySQL, namespace: "pg_catalog", want: false},
+		{name: "pg_temp prefix on mysql", dialect: DialectMySQL, namespace: "pg_temp_3", want: false},
+
+		// information_schema exists in both dialects.
+		{name: "information_schema on mysql", dialect: DialectMySQL, namespace: "information_schema", want: true},
+		{name: "information_schema on postgres", dialect: DialectPostgres, namespace: "information_schema", want: true},
+
+		// Application namespaces are never reserved.
+		{name: "app namespace on mysql", dialect: DialectMySQL, namespace: "orders_production", want: false},
+		{name: "app namespace on postgres", dialect: DialectPostgres, namespace: "orders_production", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsReservedPullNamespaceForDialect(tc.dialect, tc.namespace))
+		})
+	}
+}

--- a/pkg/schema/dialect_test.go
+++ b/pkg/schema/dialect_test.go
@@ -83,8 +83,11 @@ func TestDialectForDatabaseType(t *testing.T) {
 		{databaseType: "postgres", want: DialectPostgres},
 		{databaseType: "Postgres", want: DialectPostgres},
 		{databaseType: "MYSQL", want: DialectMySQL},
-		{databaseType: "unknown", want: DialectMySQL},
-		{databaseType: "", want: DialectMySQL},
+		// Unrecognized types are returned as unregistered dialects (not forced to
+		// MySQL) so classification treats them conservatively.
+		{databaseType: "postgresql", want: Dialect("postgresql")},
+		{databaseType: "unknown", want: Dialect("unknown")},
+		{databaseType: "", want: Dialect("")},
 	}
 
 	for _, tc := range tests {
@@ -94,16 +97,22 @@ func TestDialectForDatabaseType(t *testing.T) {
 	}
 }
 
-// A Dialect constructed by casting a raw database_type (e.g. "vitess" or
-// "strata") is not a registered dialect, so classification must resolve it to
-// the MySQL dialect rather than fail open and expose MySQL system schemas as
-// pullable user namespaces.
+// An unregistered dialect — a raw database_type cast (e.g. "vitess", "strata")
+// or a mislabeled target (e.g. "postgresql") — is classified conservatively:
+// classification reserves the union of every known dialect's system schemas
+// rather than failing open and exposing a real system schema as a pullable user
+// namespace. Application namespaces stay pullable.
 func TestIsReservedPullNamespaceForDialectFailsClosed(t *testing.T) {
-	for _, raw := range []string{"vitess", "strata", "somethingelse"} {
-		for _, ns := range []string{"mysql", "information_schema", "innodb", "sys"} {
+	for _, raw := range []string{"vitess", "strata", "postgresql", "somethingelse"} {
+		for _, ns := range []string{
+			// MySQL system schemas.
+			"mysql", "information_schema", "innodb", "sys",
+			// Postgres system schemas and the pg_ prefix.
+			"pg_catalog", "pg_toast", "rdsadmin", "pg_temp_3",
+		} {
 			assert.True(t,
 				IsReservedPullNamespaceForDialect(Dialect(raw), ns),
-				"unregistered dialect %q must reserve MySQL system schema %q", raw, ns,
+				"unregistered dialect %q must reserve system schema %q from any family", raw, ns,
 			)
 		}
 		assert.False(t,
@@ -111,4 +120,17 @@ func TestIsReservedPullNamespaceForDialectFailsClosed(t *testing.T) {
 			"unregistered dialect %q must not reserve application namespaces", raw,
 		)
 	}
+}
+
+// A database_type routed through DialectForDatabaseType must be classified
+// safely even when it is misspelled: an unknown type resolves to an unregistered
+// dialect, and classification then reserves system schemas from every family.
+func TestDialectForDatabaseTypeClassifiesUnknownConservatively(t *testing.T) {
+	dialect := DialectForDatabaseType("postgresql")
+	assert.True(t, IsReservedPullNamespaceForDialect(dialect, "pg_catalog"),
+		"a mislabeled postgres type must still reserve pg_catalog")
+	assert.True(t, IsReservedPullNamespaceForDialect(dialect, "mysql"),
+		"an unregistered dialect reserves every family's system schemas")
+	assert.False(t, IsReservedPullNamespaceForDialect(dialect, "orders_production"),
+		"application namespaces stay pullable")
 }

--- a/pkg/schema/dialect_test.go
+++ b/pkg/schema/dialect_test.go
@@ -51,6 +51,12 @@ func TestIsReservedPullNamespaceForDialect(t *testing.T) {
 		{name: "pg_catalog on mysql", dialect: DialectMySQL, namespace: "pg_catalog", want: false},
 		{name: "pg_temp prefix on mysql", dialect: DialectMySQL, namespace: "pg_temp_3", want: false},
 
+		// A differently-cased dialect value must not fail open: it still
+		// classifies system schemas for that dialect.
+		{name: "mixed-case postgres dialect matches pg_catalog", dialect: Dialect("Postgres"), namespace: "pg_catalog", want: true},
+		{name: "mixed-case postgres dialect matches pg_ prefix", dialect: Dialect("POSTGRES"), namespace: "pg_temp_3", want: true},
+		{name: "mixed-case mysql dialect matches innodb", dialect: Dialect("MySQL"), namespace: "innodb", want: true},
+
 		// information_schema exists in both dialects.
 		{name: "information_schema on mysql", dialect: DialectMySQL, namespace: "information_schema", want: true},
 		{name: "information_schema on postgres", dialect: DialectPostgres, namespace: "information_schema", want: true},

--- a/pkg/schema/namespace.go
+++ b/pkg/schema/namespace.go
@@ -84,12 +84,9 @@ func GroupFilesByNamespace(files map[string]string, defaultNamespace string, env
 }
 
 // IsReservedPullNamespace reports whether a live namespace should be excluded
-// from schema pull discovery and rejected for explicit pull requests.
+// from schema pull discovery and rejected for explicit pull requests, using the
+// MySQL dialect. Callers that know the target dialect should use
+// IsReservedPullNamespaceForDialect.
 func IsReservedPullNamespace(namespace string) bool {
-	switch strings.ToLower(namespace) {
-	case "_pending_drops", "dbadmin", "information_schema", "innodb", "mysql", "performance_schema", "polt", "rdsmon", "schemabot", "sys", "tmp", "topo":
-		return true
-	default:
-		return strings.HasPrefix(namespace, "_")
-	}
+	return IsReservedPullNamespaceForDialect(DialectMySQL, namespace)
 }


### PR DESCRIPTION
## Summary

Replace the hardcoded MySQL system-schema list in `IsReservedPullNamespace` with a dialect-keyed registry. This is a no-behavior-change refactor for MySQL/Vitess/Strata and adds a Postgres dialect for later engine work to consume.

## What

- Add `Dialect` (`DialectMySQL` / `DialectPostgres`) and `IsReservedPullNamespaceForDialect(dialect, namespace)` in `pkg/schema/dialect.go`, backed by a `systemSchemasByDialect` registry plus dialect-independent SchemaBot-internal namespaces (`schemabot`, `_pending_drops`, and the `_` prefix).
- `IsReservedPullNamespace` now delegates to the MySQL dialect, preserving the exact set it matched before. Existing callers are unchanged.
- Postgres dialect reserves `pg_catalog`, `pg_toast`, `information_schema`, `rdsadmin`, and the `pg_` prefix.

## Why

Reserved system schemas are a property of the database family, not the engine. Centralizing them behind a dialect keeps MySQL behavior intact today and gives the Postgres engine a single place to classify namespaces, instead of scattering `pg_`-aware checks across pull-discovery call sites later.

## Compatibility

`IsReservedPullNamespace(ns)` returns the same result as before for every input — a dedicated test asserts it matches the MySQL dialect across the full reserved set. MySQL/Vitess pull discovery is untouched.
