### PR TITLE
add webhook inbox reconciler with stuck-row sweep

### DIFF
--- a/pkg/api/webhook_inbox_metrics_test.go
+++ b/pkg/api/webhook_inbox_metrics_test.go
@@ -57,6 +57,14 @@ func (f *fakeWebhookEventStore) Release(context.Context, int64, string) error {
 	return errors.New("unused")
 }
 
+func (f *fakeWebhookEventStore) HasEventForHead(context.Context, string, string, int, string) (bool, error) {
+	return false, errors.New("unused")
+}
+
+func (f *fakeWebhookEventStore) TerminateStuckProcessing(context.Context, string) (int64, error) {
+	return 0, errors.New("unused")
+}
+
 func newInboxMetricsTestService(t *testing.T, store storage.WebhookEventStore) *Service {
 	t.Helper()
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -40,6 +40,24 @@ func addCounter(ctx context.Context, name, description, unit string, attrs ...at
 	counter.Add(ctx, 1, otelmetric.WithAttributes(attrs...))
 }
 
+// addCounterN increments a named Int64Counter by n with the given attributes,
+// logging and skipping if the instrument cannot be created. n <= 0 is a no-op.
+func addCounterN(ctx context.Context, n int64, name, description, unit string, attrs ...attribute.KeyValue) {
+	if n <= 0 {
+		return
+	}
+	meter := otel.Meter(meterName)
+	counter, err := meter.Int64Counter(name,
+		otelmetric.WithDescription(description),
+		otelmetric.WithUnit(unit),
+	)
+	if err != nil {
+		slog.Warn("failed to create counter", "metric", name, "error", err)
+		return
+	}
+	counter.Add(ctx, n, otelmetric.WithAttributes(attrs...))
+}
+
 // addUpDownCounter adjusts a named Int64UpDownCounter by delta with the given
 // attributes, logging and skipping if the instrument cannot be created.
 func addUpDownCounter(ctx context.Context, name string, delta int64, description, unit string, attrs ...attribute.KeyValue) {
@@ -1221,6 +1239,17 @@ func RecordWebhookReconcileMissingEvent(ctx context.Context, repo string) {
 		"Total number of open PR heads found without a webhook inbox delivery", "{event}",
 		EnvironmentAttribute(""),
 		attribute.String("repository", repo))
+}
+
+// RecordWebhookReconcileStuckTerminated counts webhook inbox rows the
+// reconciler terminated because they were parked in processing with an expired
+// lease at the attempt cap — a driver hard-killed on its final attempt. A
+// nonzero rate means deliveries are being lost to crashes mid-processing; each
+// terminated row emits as a failure and becomes eligible for redelivery.
+func RecordWebhookReconcileStuckTerminated(ctx context.Context, count int64) {
+	addCounterN(ctx, count, "schemabot.webhook.reconcile_stuck_terminated_total",
+		"Total number of stuck processing webhook inbox rows terminated by the reconciler", "{event}",
+		EnvironmentAttribute(""))
 }
 
 var knownStatusCheckOperations = map[string]bool{

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1211,6 +1211,18 @@ func RecordWebhookInboxStatsCollectionFailure(ctx context.Context) {
 	)
 }
 
+// RecordWebhookReconcileMissingEvent counts open PR heads the webhook
+// reconciler found with no corresponding inbox delivery. A nonzero rate means
+// deliveries are being lost upstream of the inbox (edge auth, GitHub send
+// failures) — the divergence signal that report-only reconciliation exists to
+// surface.
+func RecordWebhookReconcileMissingEvent(ctx context.Context, repo string) {
+	addCounter(ctx, "schemabot.webhook.reconcile_missing_events_total",
+		"Total number of open PR heads found without a webhook inbox delivery", "{event}",
+		EnvironmentAttribute(""),
+		attribute.String("repository", repo))
+}
+
 var knownStatusCheckOperations = map[string]bool{
 	"plan_check_recorded":                  true,
 	"apply_started":                        true,

--- a/pkg/serve/serve.go
+++ b/pkg/serve/serve.go
@@ -679,7 +679,8 @@ func buildSingleAppWebhookRuntime(serverConfig *api.ServerConfig, svc *api.Servi
 		ghclient.WithConfigDirHints(serverConfig))
 	handler := webhook.NewHandler(svc, ghClient, []byte(ghWebhookSecret), logger,
 		webhook.WithRepoWebhookSecret([]byte(repoWebhookSecret)),
-		webhook.WithDurableWebhookDispatch())
+		webhook.WithDurableWebhookDispatch(),
+		webhook.WithWebhookReconciler())
 	svc.SetCheckRunBackfiller(handler)
 	logger.Info("GitHub webhook endpoint registered",
 		"app_id", appID, "trusted_check_app_slugs", serverConfig.GitHub.TrustedCheckAppSlugs,
@@ -757,6 +758,7 @@ func buildMultiAppWebhookRuntime(serverConfig *api.ServerConfig, svc *api.Servic
 		appByID,
 		logger,
 		webhook.WithDurableWebhookDispatch(),
+		webhook.WithWebhookReconciler(),
 	)
 	svc.SetCheckRunBackfiller(handler)
 	logger.Info("GitHub multi-App webhook endpoint registered", "apps", len(serverConfig.Apps))

--- a/pkg/storage/mysqlstore/webhook_events.go
+++ b/pkg/storage/mysqlstore/webhook_events.go
@@ -326,6 +326,34 @@ func (s *webhookEventStore) Release(ctx context.Context, id int64, leaseToken st
 	return s.checkWebhookEventLeaseResult(ctx, result, id, leaseToken)
 }
 
+// TerminateStuckProcessing marks failed every processing row whose lease has
+// expired and whose attempts have reached the cap. FindNext stops reclaiming a
+// processing row once attempts == MaxWebhookEventAttempts, so a driver
+// hard-killed on its final attempt leaves the row parked in processing forever;
+// this sweep terminalizes it (clearing the lease and preserving completed_at)
+// so it emits as a failure and its delivery GUID becomes eligible for the
+// redeliver-reopen path. Unlike MarkFailed it is lease-token-agnostic: the
+// owning driver is gone, so there is no token to present. Returns the number of
+// rows terminated.
+func (s *webhookEventStore) TerminateStuckProcessing(ctx context.Context, reason string) (int64, error) {
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE webhook_events
+		SET state = ?, last_error = ?, completed_at = COALESCE(completed_at, NOW()),
+			lease_owner = NULL, lease_token = NULL, lease_expires_at = NULL,
+			retry_after = NULL, updated_at = NOW()
+		WHERE state = ? AND lease_expires_at <= NOW(6) AND attempts >= ?
+	`, storage.WebhookEventFailed, nullString(reason),
+		storage.WebhookEventProcessing, storage.MaxWebhookEventAttempts)
+	if err != nil {
+		return 0, fmt.Errorf("terminate stuck processing webhook events: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("read terminate stuck processing rows affected: %w", err)
+	}
+	return rows, nil
+}
+
 func scanWebhookEvent(row *sql.Row) (*storage.WebhookEvent, error) {
 	event, err := scanWebhookEventInto(row)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/pkg/storage/mysqlstore/webhook_events.go
+++ b/pkg/storage/mysqlstore/webhook_events.go
@@ -329,12 +329,14 @@ func (s *webhookEventStore) Release(ctx context.Context, id int64, leaseToken st
 // TerminateStuckProcessing marks failed every processing row whose lease has
 // expired and whose attempts have reached the cap. FindNext stops reclaiming a
 // processing row once attempts == MaxWebhookEventAttempts, so a driver
-// hard-killed on its final attempt leaves the row parked in processing forever;
-// this sweep terminalizes it (clearing the lease and preserving completed_at)
-// so it emits as a failure and its delivery GUID becomes eligible for the
-// redeliver-reopen path. Unlike MarkFailed it is lease-token-agnostic: the
-// owning driver is gone, so there is no token to present. Returns the number of
-// rows terminated.
+// hard-killed on its final attempt leaves the row stuck in processing until it
+// is either terminalized here or reopened by a GitHub Redeliver (see
+// reopenTerminalWebhookEvent). This sweep is the automatic complement to
+// redelivery: it clears the lease (preserving completed_at) and emits the row
+// as a durable failure so it surfaces in metrics/alerting and drains the
+// stuck-processing gauge without operator action. Unlike MarkFailed it is
+// lease-token-agnostic: the owning driver is gone, so there is no token to
+// present. Returns the number of rows terminated.
 func (s *webhookEventStore) TerminateStuckProcessing(ctx context.Context, reason string) (int64, error) {
 	result, err := s.db.ExecContext(ctx, `
 		UPDATE webhook_events

--- a/pkg/storage/mysqlstore/webhook_events.go
+++ b/pkg/storage/mysqlstore/webhook_events.go
@@ -151,6 +151,29 @@ func webhookClaimableArgs() []any {
 	}
 }
 
+func (s *webhookEventStore) HasEventForHead(ctx context.Context, provider, repository string, pullRequest int, headSHA string) (bool, error) {
+	if provider == "" {
+		provider = storage.WebhookProviderGitHub
+	}
+	if repository == "" || pullRequest == 0 || headSHA == "" {
+		return false, fmt.Errorf("repository, pull request, and head SHA are required")
+	}
+	var one int
+	err := s.db.QueryRowContext(ctx, `
+		SELECT 1
+		FROM webhook_events
+		WHERE provider = ? AND repository = ? AND pull_request = ? AND head_sha = ?
+		LIMIT 1
+	`, provider, repository, pullRequest, headSHA).Scan(&one)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func (s *webhookEventStore) FindNext(ctx context.Context, owner string, leaseDuration time.Duration) (*storage.WebhookEvent, error) {
 	if owner == "" {
 		return nil, fmt.Errorf("webhook driver owner is required")

--- a/pkg/storage/mysqlstore/webhook_events_test.go
+++ b/pkg/storage/mysqlstore/webhook_events_test.go
@@ -70,6 +70,50 @@ func TestWebhookEventStore_CreateDeduplicatesByProviderAndDeliveryID(t *testing.
 	require.True(t, inserted)
 }
 
+func TestWebhookEventStore_HasEventForHead(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	_, err := store.WebhookEvents().Create(ctx, &storage.WebhookEvent{
+		DeliveryID:  "delivery-head-1",
+		Event:       "pull_request",
+		Action:      "synchronize",
+		Repository:  "block/example",
+		PullRequest: 7,
+		HeadSHA:     "head-sha-1",
+		Payload:     []byte(`{}`),
+	})
+	require.NoError(t, err)
+
+	found, err := store.WebhookEvents().HasEventForHead(ctx, storage.WebhookProviderGitHub, "block/example", 7, "head-sha-1")
+	require.NoError(t, err)
+	assert.True(t, found)
+
+	// Provider defaults to GitHub.
+	found, err = store.WebhookEvents().HasEventForHead(ctx, "", "block/example", 7, "head-sha-1")
+	require.NoError(t, err)
+	assert.True(t, found)
+
+	for _, tc := range []struct {
+		name    string
+		repo    string
+		pr      int
+		headSHA string
+	}{
+		{"different head SHA", "block/example", 7, "head-sha-2"},
+		{"different PR", "block/example", 8, "head-sha-1"},
+		{"different repo", "block/other", 7, "head-sha-1"},
+	} {
+		found, err = store.WebhookEvents().HasEventForHead(ctx, storage.WebhookProviderGitHub, tc.repo, tc.pr, tc.headSHA)
+		require.NoError(t, err, tc.name)
+		assert.False(t, found, tc.name)
+	}
+
+	_, err = store.WebhookEvents().HasEventForHead(ctx, storage.WebhookProviderGitHub, "", 7, "head-sha-1")
+	require.Error(t, err, "missing repository must be rejected")
+}
+
 func TestWebhookEventStore_FindNextClaimsOldestPendingEvent(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/mysqlstore/webhook_events_test.go
+++ b/pkg/storage/mysqlstore/webhook_events_test.go
@@ -726,3 +726,64 @@ func TestWebhookEventStore_InboxStats(t *testing.T) {
 	assert.GreaterOrEqual(t, stats.OldestClaimableAge, 110*time.Second)
 	assert.Less(t, stats.OldestClaimableAge, 5*time.Minute)
 }
+
+// TerminateStuckProcessing sweeps out rows a hard-killed driver left parked in
+// processing at the attempt cap with an expired lease — FindNext never reclaims
+// those, so the reconciler must terminalize them. Rows below the cap, or whose
+// lease is still fresh, must be left alone.
+func TestWebhookEventStore_TerminateStuckProcessing(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	// Seed three processing rows, then drive each into the exact state under
+	// test via SQL so the assertions don't depend on FindNext claim ordering.
+	setProcessing := func(deliveryID string, attempts int, leaseExpiresAt string) {
+		t.Helper()
+		inserted, err := store.WebhookEvents().Create(ctx, &storage.WebhookEvent{DeliveryID: deliveryID, Event: "pull_request", Payload: []byte(`{}`)})
+		require.NoError(t, err)
+		require.True(t, inserted)
+		_, err = testDB.ExecContext(ctx, `
+			UPDATE webhook_events
+			SET state = ?, attempts = ?, lease_owner = 'driver', lease_token = ?,
+				lease_expires_at = `+leaseExpiresAt+`
+			WHERE provider = ? AND delivery_id = ?
+		`, storage.WebhookEventProcessing, attempts, deliveryID, storage.WebhookProviderGitHub, deliveryID)
+		require.NoError(t, err)
+	}
+
+	// stuck: at the attempt cap, lease expired -> terminated by the sweep.
+	setProcessing("stuck", storage.MaxWebhookEventAttempts, "NOW(6) - INTERVAL 1 SECOND")
+	// belowCap: expired lease but under the cap -> FindNext reclaims it, not the sweep.
+	setProcessing("below-cap", storage.MaxWebhookEventAttempts-1, "NOW(6) - INTERVAL 1 SECOND")
+	// fresh: at the cap but lease still valid -> a driver is still working it.
+	setProcessing("fresh", storage.MaxWebhookEventAttempts, "NOW(6) + INTERVAL 1 MINUTE")
+
+	terminated, err := store.WebhookEvents().TerminateStuckProcessing(ctx, "reconciler sweep")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), terminated, "only the cap-exhausted expired-lease row should be terminated")
+
+	got, err := store.WebhookEvents().GetByDeliveryID(ctx, storage.WebhookProviderGitHub, "stuck")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, storage.WebhookEventFailed, got.State)
+	assert.Equal(t, "reconciler sweep", got.LastError)
+	assert.Empty(t, got.LeaseToken)
+	assert.Nil(t, got.LeaseExpiresAt)
+	assert.NotNil(t, got.CompletedAt)
+
+	belowGot, err := store.WebhookEvents().GetByDeliveryID(ctx, storage.WebhookProviderGitHub, "below-cap")
+	require.NoError(t, err)
+	require.NotNil(t, belowGot)
+	assert.Equal(t, storage.WebhookEventProcessing, belowGot.State)
+
+	freshGot, err := store.WebhookEvents().GetByDeliveryID(ctx, storage.WebhookProviderGitHub, "fresh")
+	require.NoError(t, err)
+	require.NotNil(t, freshGot)
+	assert.Equal(t, storage.WebhookEventProcessing, freshGot.State)
+
+	// A terminated stuck row is redeliverable: reusing its GUID re-opens it.
+	reopened, err := store.WebhookEvents().Create(ctx, &storage.WebhookEvent{DeliveryID: "stuck", Event: "pull_request", Payload: []byte(`{}`)})
+	require.NoError(t, err)
+	require.True(t, reopened)
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -258,6 +258,17 @@ type WebhookEventStore interface {
 	// rows wedged in processing past the attempt cap with an expired lease. It
 	// is read-only and safe to call on a periodic cadence.
 	InboxStats(ctx context.Context) (*WebhookInboxStats, error)
+
+	// TerminateStuckProcessing marks as terminally failed every processing row
+	// whose lease has expired and whose attempts have reached
+	// MaxWebhookEventAttempts. Such a row is a driver that was hard-killed on
+	// its final attempt before recording a terminal state — FindNext never
+	// reclaims it (it stops reclaiming at the cap), so without this sweep it
+	// stays parked in processing forever and its delivery GUID deduplicates
+	// every redelivery. Terminalizing it emits the row as a failure and makes
+	// it eligible for the redeliver-reopen path. Returns the number of rows
+	// terminated.
+	TerminateStuckProcessing(ctx context.Context, reason string) (int64, error)
 }
 
 // PlanStore manages schema change plans.

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -215,6 +215,12 @@ type WebhookEventStore interface {
 	// GetByDeliveryID returns a webhook event by provider + delivery GUID, or nil if not found.
 	GetByDeliveryID(ctx context.Context, provider, deliveryID string) (*WebhookEvent, error)
 
+	// HasEventForHead reports whether any delivery is recorded for the given
+	// provider + repository + pull request + head SHA, in any state. The
+	// reconciliation loop uses it to detect open PR heads whose webhook
+	// delivery never reached the inbox.
+	HasEventForHead(ctx context.Context, provider, repository string, pullRequest int, headSHA string) (bool, error)
+
 	// FindNext atomically claims one pending, retryable, or lease-expired event.
 	// The claim rotates lease_owner/lease_token, increments attempts, and sets a
 	// lease expiry in the same transaction. Retryable and lease-expired rows are

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -263,11 +263,12 @@ type WebhookEventStore interface {
 	// whose lease has expired and whose attempts have reached
 	// MaxWebhookEventAttempts. Such a row is a driver that was hard-killed on
 	// its final attempt before recording a terminal state — FindNext never
-	// reclaims it (it stops reclaiming at the cap), so without this sweep it
-	// stays parked in processing forever and its delivery GUID deduplicates
-	// every redelivery. Terminalizing it emits the row as a failure and makes
-	// it eligible for the redeliver-reopen path. Returns the number of rows
-	// terminated.
+	// reclaims it (it stops reclaiming at the cap). GitHub Redeliver can already
+	// reopen an expired-lease processing row on demand (see
+	// reopenTerminalWebhookEvent), so this sweep is the automatic complement: it
+	// terminalizes rows nobody redelivered, emitting each as a durable failure
+	// (for metrics/alerting) and draining the stuck-processing gauge without
+	// operator action. Returns the number of rows terminated.
 	TerminateStuckProcessing(ctx context.Context, reason string) (int64, error)
 }
 

--- a/pkg/webhook/durable_dispatch.go
+++ b/pkg/webhook/durable_dispatch.go
@@ -62,15 +62,18 @@ func (h *Handler) StartDurableWebhookDispatch(ctx context.Context) {
 	h.durableWebhookStop = stop
 	h.durableWebhookCancel = cancel
 	h.durableWebhookWake = wake
-	// Register every driver goroutine on the WaitGroup while the mutex is still
-	// held. Adding to the WaitGroup concurrently with a StopDurableWebhookDispatch
-	// Wait is the documented reuse misuse; holding the lock across the spawn keeps
-	// Start and Stop from racing.
+	// Register every driver (and the reconciler) on the WaitGroup while the mutex
+	// is still held. Adding to the WaitGroup concurrently with a
+	// StopDurableWebhookDispatch Wait is the documented reuse misuse; holding the
+	// lock across the spawn keeps Start and Stop from racing.
 	for i := range driverCount {
 		driverID := i
 		h.durableWebhookWg.Go(func() {
 			h.durableWebhookDriver(driverCtx, driverID, stop, wake)
 		})
+	}
+	if h.webhookReconciler {
+		h.startWebhookReconciler(driverCtx, stop)
 	}
 	h.durableWebhookMu.Unlock()
 

--- a/pkg/webhook/durable_dispatch_test.go
+++ b/pkg/webhook/durable_dispatch_test.go
@@ -67,6 +67,19 @@ func (s *recordingWebhookEventStore) GetByDeliveryID(_ context.Context, provider
 	return &copy, nil
 }
 
+func (s *recordingWebhookEventStore) HasEventForHead(_ context.Context, provider, repository string, pullRequest int, headSHA string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, event := range s.events {
+		if event.Provider == provider && event.Repository == repository &&
+			event.PullRequest == pullRequest && event.HeadSHA == headSHA {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (s *recordingWebhookEventStore) FindNext(context.Context, string, time.Duration) (*storage.WebhookEvent, error) {
 	return nil, errors.New("FindNext not implemented by recordingWebhookEventStore")
 }

--- a/pkg/webhook/durable_dispatch_test.go
+++ b/pkg/webhook/durable_dispatch_test.go
@@ -104,6 +104,28 @@ func (s *recordingWebhookEventStore) InboxStats(context.Context) (*storage.Webho
 	return nil, errors.New("InboxStats not implemented by recordingWebhookEventStore")
 }
 
+func (s *recordingWebhookEventStore) TerminateStuckProcessing(_ context.Context, reason string) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	var terminated int64
+	for _, event := range s.events {
+		leaseExpired := event.LeaseExpiresAt != nil && !event.LeaseExpiresAt.After(now)
+		if event.State == storage.WebhookEventProcessing && leaseExpired &&
+			event.Attempts >= storage.MaxWebhookEventAttempts {
+			event.State = storage.WebhookEventFailed
+			event.LastError = reason
+			event.LeaseOwner = ""
+			event.LeaseToken = ""
+			event.LeaseExpiresAt = nil
+			event.RetryAfter = nil
+			terminated++
+		}
+	}
+	return terminated, nil
+}
+
 func TestDurablePullRequestWebhookQueuesAndAcks(t *testing.T) {
 	events := newRecordingWebhookEventStore()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))

--- a/pkg/webhook/durable_dispatch_test.go
+++ b/pkg/webhook/durable_dispatch_test.go
@@ -120,6 +120,11 @@ func (s *recordingWebhookEventStore) TerminateStuckProcessing(_ context.Context,
 			event.LeaseToken = ""
 			event.LeaseExpiresAt = nil
 			event.RetryAfter = nil
+			// Mirror the real SQL's completed_at = COALESCE(completed_at, NOW()).
+			if event.CompletedAt == nil {
+				completedAt := now
+				event.CompletedAt = &completedAt
+			}
 			terminated++
 		}
 	}

--- a/pkg/webhook/durable_reconcile.go
+++ b/pkg/webhook/durable_reconcile.go
@@ -1,11 +1,16 @@
-// durable_reconcile.go implements the report-only webhook reconciliation loop:
-// the correctness backstop for deliveries lost upstream of the durable inbox
-// (edge auth failures, GitHub-side send failures). It periodically lists
-// recently updated open PRs in registered repositories and reports any PR head
-// that has no corresponding webhook_events row. This phase only logs and emits
-// metrics; a later phase will synthesize pull_request-equivalent inbox rows
-// (delivery_id "recon:<repo>#<pr>@<sha>", naturally deduped) once report-only
-// output has been tuned.
+// durable_reconcile.go implements the webhook reconciliation loop: the
+// correctness backstop for deliveries the durable inbox cannot recover on its
+// own. Each pass does two things:
+//
+//   - Actively terminates inbox rows wedged in processing (driver hard-killed on
+//     its final attempt, lease expired, attempts at the cap) so they emit as
+//     failures and become redeliverable — FindNext never reclaims them.
+//   - Reports (report-only) any recently updated open PR head in a registered
+//     repository that has no corresponding webhook_events row, surfacing
+//     deliveries lost upstream of the inbox (edge auth failures, GitHub-side
+//     send failures). A later phase will synthesize pull_request-equivalent
+//     inbox rows (delivery_id "recon:<repo>#<pr>@<sha>", naturally deduped) once
+//     report-only output has been tuned.
 package webhook
 
 import (
@@ -42,7 +47,7 @@ func (h *Handler) startWebhookReconciler(ctx context.Context, stop <-chan struct
 	h.durableWebhookWg.Go(func() {
 		ticker := time.NewTicker(h.webhookReconcileInterval)
 		defer ticker.Stop()
-		h.logger.Info("webhook reconciler started (report-only)",
+		h.logger.Info("webhook reconciler started",
 			"interval", h.webhookReconcileInterval,
 			"lookback", h.webhookReconcileLookback,
 			"grace", h.webhookReconcileGrace)
@@ -69,13 +74,21 @@ func (h *Handler) reconcileWebhookInbox(ctx context.Context) {
 		h.logger.Warn("webhook reconciler skipped because webhook event storage is unavailable")
 		return
 	}
+	// The stuck-processing sweep scans the whole inbox by state, not by repo, so
+	// it runs before the registry check — it must reclaim crashed deliveries
+	// even when the registry is allow-all and the missing-delivery scan below
+	// cannot enumerate repos.
+	h.terminateStuckWebhookEvents(ctx, store)
+
 	cfg := h.service.Config()
 	if cfg == nil || len(cfg.Repos) == 0 {
 		// An empty repo registry means "allow all", which is not an enumerable
-		// set; reconciliation needs an explicit registry to know what to scan.
-		h.logger.Debug("webhook reconciler skipped because the repo registry is empty (allow-all)")
+		// set; the missing-delivery scan needs an explicit registry to know what
+		// to scan.
+		h.logger.Debug("webhook reconciler missing-delivery scan skipped because the repo registry is empty (allow-all)")
 		return
 	}
+
 	repos := make([]string, 0, len(cfg.Repos))
 	for repo := range cfg.Repos {
 		repos = append(repos, repo)
@@ -92,9 +105,32 @@ func (h *Handler) reconcileWebhookInbox(ctx context.Context) {
 		scanned += repoScanned
 		missing += repoMissing
 	}
-	h.logger.Info("webhook reconcile pass finished (report-only)",
+	h.logger.Info("webhook reconcile missing-delivery scan finished (report-only)",
 		"repos", len(repos), "prs_scanned", scanned, "missing_inbox_rows", missing,
 		"duration", time.Since(start))
+}
+
+// webhookReconcileStuckReason is the terminal last_error recorded on rows the
+// reconciler sweeps out of a wedged processing state.
+const webhookReconcileStuckReason = "terminated by reconciler: driver crashed on final attempt with lease expired"
+
+// terminateStuckWebhookEvents marks failed every inbox row parked in processing
+// with an expired lease at the attempt cap — a driver hard-killed on its final
+// attempt. FindNext stops reclaiming a processing row once attempts reach the
+// cap, so without this sweep such a row stays unclaimable forever and its
+// delivery GUID deduplicates every redelivery. Terminalizing it emits the row
+// as a failure and makes it eligible for the redeliver-reopen path.
+func (h *Handler) terminateStuckWebhookEvents(ctx context.Context, store storage.WebhookEventStore) {
+	terminated, err := store.TerminateStuckProcessing(ctx, webhookReconcileStuckReason)
+	if err != nil {
+		h.logger.Warn("webhook reconciler failed to terminate stuck processing events", "error", err)
+		return
+	}
+	if terminated == 0 {
+		return
+	}
+	h.logger.Warn("webhook reconciler terminated stuck processing events", "terminated", terminated)
+	metrics.RecordWebhookReconcileStuckTerminated(ctx, terminated)
 }
 
 // reconcileRepoWebhookInbox scans one repository's recently updated open PRs

--- a/pkg/webhook/durable_reconcile.go
+++ b/pkg/webhook/durable_reconcile.go
@@ -1,0 +1,156 @@
+// durable_reconcile.go implements the report-only webhook reconciliation loop:
+// the correctness backstop for deliveries lost upstream of the durable inbox
+// (edge auth failures, GitHub-side send failures). It periodically lists
+// recently updated open PRs in registered repositories and reports any PR head
+// that has no corresponding webhook_events row. This phase only logs and emits
+// metrics; a later phase will synthesize pull_request-equivalent inbox rows
+// (delivery_id "recon:<repo>#<pr>@<sha>", naturally deduped) once report-only
+// output has been tuned.
+package webhook
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/block/schemabot/pkg/metrics"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+const (
+	defaultWebhookReconcileInterval = 30 * time.Minute
+
+	// defaultWebhookReconcileLookback bounds how far back the updated-descending
+	// PR listing is walked. It also suppresses a permanent false-positive class:
+	// open PRs whose last activity predates the inbox feature never have rows.
+	defaultWebhookReconcileLookback = 48 * time.Hour
+
+	// defaultWebhookReconcileGrace skips PRs updated moments ago, whose webhook
+	// delivery may legitimately still be in flight to the inbox.
+	defaultWebhookReconcileGrace = 15 * time.Minute
+
+	defaultWebhookReconcileMaxPages = 5
+	webhookReconcilePageSize        = 100
+)
+
+// startWebhookReconciler launches the reconcile loop on the durable-dispatch
+// lifecycle: it shares the dispatch stop channel, context, and wait group, so
+// StopDurableWebhookDispatch also stops the reconciler. The first pass runs
+// after one full interval — deliberately not at startup — so a rolling deploy
+// does not fan a GitHub list scan out across every starting replica.
+func (h *Handler) startWebhookReconciler(ctx context.Context, stop <-chan struct{}) {
+	h.durableWebhookWg.Go(func() {
+		ticker := time.NewTicker(h.webhookReconcileInterval)
+		defer ticker.Stop()
+		h.logger.Info("webhook reconciler started (report-only)",
+			"interval", h.webhookReconcileInterval,
+			"lookback", h.webhookReconcileLookback,
+			"grace", h.webhookReconcileGrace)
+		for {
+			select {
+			case <-stop:
+				h.logger.Debug("webhook reconciler stopping")
+				return
+			case <-ctx.Done():
+				h.logger.Debug("webhook reconciler context cancelled")
+				return
+			case <-ticker.C:
+				h.reconcileWebhookInbox(ctx)
+			}
+		}
+	})
+}
+
+// reconcileWebhookInbox runs one report-only pass over all registered
+// repositories.
+func (h *Handler) reconcileWebhookInbox(ctx context.Context) {
+	store := h.webhookEventStore()
+	if store == nil {
+		h.logger.Warn("webhook reconciler skipped because webhook event storage is unavailable")
+		return
+	}
+	cfg := h.service.Config()
+	if cfg == nil || len(cfg.Repos) == 0 {
+		// An empty repo registry means "allow all", which is not an enumerable
+		// set; reconciliation needs an explicit registry to know what to scan.
+		h.logger.Debug("webhook reconciler skipped because the repo registry is empty (allow-all)")
+		return
+	}
+	repos := make([]string, 0, len(cfg.Repos))
+	for repo := range cfg.Repos {
+		repos = append(repos, repo)
+	}
+	sort.Strings(repos)
+
+	start := time.Now()
+	var scanned, missing int
+	for _, repo := range repos {
+		if ctx.Err() != nil {
+			return
+		}
+		repoScanned, repoMissing := h.reconcileRepoWebhookInbox(ctx, store, repo)
+		scanned += repoScanned
+		missing += repoMissing
+	}
+	h.logger.Info("webhook reconcile pass finished (report-only)",
+		"repos", len(repos), "prs_scanned", scanned, "missing_inbox_rows", missing,
+		"duration", time.Since(start))
+}
+
+// reconcileRepoWebhookInbox scans one repository's recently updated open PRs
+// and reports heads with no inbox delivery. Returns how many PRs were checked
+// and how many were missing rows.
+func (h *Handler) reconcileRepoWebhookInbox(ctx context.Context, store storage.WebhookEventStore, repo string) (scanned, missing int) {
+	installationID, err := h.resolveRepoWebhookInstallation(ctx, repo)
+	if err != nil {
+		h.logger.Warn("webhook reconciler could not resolve installation for repository", "repo", repo, "error", err)
+		return 0, 0
+	}
+	client, err := h.clientForRepo(repo, installationID)
+	if err != nil {
+		h.logger.Warn("webhook reconciler could not build client for repository", "repo", repo, "error", err)
+		return 0, 0
+	}
+
+	now := time.Now()
+	cutoff := now.Add(-h.webhookReconcileLookback)
+	grace := now.Add(-h.webhookReconcileGrace)
+	page := 1
+pages:
+	for range h.webhookReconcileMaxPages {
+		prs, nextPage, _, err := client.ListOpenPullRequestsPage(ctx, repo, page, webhookReconcilePageSize)
+		if err != nil {
+			h.logger.Warn("webhook reconciler failed to list open pull requests", "repo", repo, "page", page, "error", err)
+			return scanned, missing
+		}
+		for _, pr := range prs {
+			if pr.UpdatedAt.Before(cutoff) {
+				// The listing is newest-updated first; everything after this is
+				// older than the lookback window.
+				break pages
+			}
+			if pr.HeadSHA == "" || pr.UpdatedAt.After(grace) {
+				continue
+			}
+			scanned++
+			found, err := store.HasEventForHead(ctx, storage.WebhookProviderGitHub, repo, pr.Number, pr.HeadSHA)
+			if err != nil {
+				h.logger.Warn("webhook reconciler failed to query inbox for PR head",
+					"repo", repo, "pr", pr.Number, "head_sha", pr.HeadSHA, "error", err)
+				continue
+			}
+			if found {
+				continue
+			}
+			missing++
+			h.logger.Warn("webhook reconciler found open PR head with no inbox delivery (report-only)",
+				"repo", repo, "pr", pr.Number, "head_sha", pr.HeadSHA, "updated_at", pr.UpdatedAt)
+			metrics.RecordWebhookReconcileMissingEvent(ctx, repo)
+		}
+		if nextPage == 0 {
+			break
+		}
+		page = nextPage
+	}
+	return scanned, missing
+}

--- a/pkg/webhook/durable_reconcile.go
+++ b/pkg/webhook/durable_reconcile.go
@@ -51,6 +51,20 @@ func (h *Handler) startWebhookReconciler(ctx context.Context, stop <-chan struct
 			"interval", h.webhookReconcileInterval,
 			"lookback", h.webhookReconcileLookback,
 			"grace", h.webhookReconcileGrace)
+		// The stuck-processing sweep is a single cheap DB UPDATE, not a GitHub
+		// list scan, so it runs once at startup rather than waiting a full
+		// interval. A fleet that crash-loops faster than the reconcile interval
+		// would otherwise never reclaim the rows those very crashes wedged. The
+		// missing-delivery scan still waits for the first tick (see the
+		// startup-delay rationale below) to avoid fanning GitHub list calls out
+		// across every starting replica on a rolling deploy.
+		if ctx.Err() == nil {
+			if store := h.webhookEventStore(); store != nil {
+				h.terminateStuckWebhookEvents(ctx, store)
+			} else {
+				h.logger.Warn("webhook reconciler startup stuck-processing sweep skipped because webhook event storage is unavailable")
+			}
+		}
 		for {
 			select {
 			case <-stop:
@@ -99,6 +113,8 @@ func (h *Handler) reconcileWebhookInbox(ctx context.Context) {
 	var scanned, missing int
 	for _, repo := range repos {
 		if ctx.Err() != nil {
+			h.logger.Debug("webhook reconcile missing-delivery scan stopped early because the context was cancelled",
+				"repos_scanned", scanned, "error", ctx.Err())
 			return
 		}
 		repoScanned, repoMissing := h.reconcileRepoWebhookInbox(ctx, store, repo)
@@ -111,12 +127,15 @@ func (h *Handler) reconcileWebhookInbox(ctx context.Context) {
 }
 
 // webhookReconcileStuckReason is the terminal last_error recorded on rows the
-// reconciler sweeps out of a wedged processing state.
-const webhookReconcileStuckReason = "terminated by reconciler: driver crashed on final attempt with lease expired"
+// reconciler sweeps out of a wedged processing state. The row reached the
+// attempt cap and its lease expired without a terminal write — usually a driver
+// hard-killed mid-attempt, but it can also be a dispatch that completed its work
+// yet died before recording completion. The reason stays agnostic between those.
+const webhookReconcileStuckReason = "terminated by reconciler: processing lease expired at attempt cap without a terminal write"
 
 // terminateStuckWebhookEvents marks failed every inbox row parked in processing
-// with an expired lease at the attempt cap — a driver hard-killed on its final
-// attempt. FindNext stops reclaiming a processing row once attempts reach the
+// with an expired lease at the attempt cap — the driver reached the cap and its
+// lease expired without a terminal write. FindNext stops reclaiming a processing row once attempts reach the
 // cap, so without this sweep such a row stays unclaimable forever and its
 // delivery GUID deduplicates every redelivery. Terminalizing it emits the row
 // as a failure and makes it eligible for the redeliver-reopen path.
@@ -165,7 +184,18 @@ pages:
 				// older than the lookback window.
 				break pages
 			}
-			if pr.HeadSHA == "" || pr.UpdatedAt.After(grace) {
+			if pr.HeadSHA == "" {
+				// A PR listing without a head SHA can't be matched to an inbox
+				// delivery; skip rather than emit a spurious missing-row report.
+				h.logger.Debug("webhook reconciler skipped open PR with no head SHA",
+					"repo", repo, "pr", pr.Number)
+				continue
+			}
+			if pr.UpdatedAt.After(grace) {
+				// Updated within the grace window; its webhook delivery may still
+				// be in flight to the inbox, so a missing row here is expected.
+				h.logger.Debug("webhook reconciler skipped recently updated open PR within grace window",
+					"repo", repo, "pr", pr.Number, "updated_at", pr.UpdatedAt)
 				continue
 			}
 			scanned++

--- a/pkg/webhook/durable_reconcile.go
+++ b/pkg/webhook/durable_reconcile.go
@@ -80,8 +80,11 @@ func (h *Handler) startWebhookReconciler(ctx context.Context, stop <-chan struct
 	})
 }
 
-// reconcileWebhookInbox runs one report-only pass over all registered
-// repositories.
+// reconcileWebhookInbox runs one reconciliation pass in two stages: an active
+// stuck-processing sweep that terminalizes inbox rows wedged past the attempt
+// cap, followed by a report-only missing-delivery scan over registered
+// repositories. Only the missing-delivery scan is report-only; the sweep
+// mutates rows.
 func (h *Handler) reconcileWebhookInbox(ctx context.Context) {
 	store := h.webhookEventStore()
 	if store == nil {

--- a/pkg/webhook/durable_reconcile.go
+++ b/pkg/webhook/durable_reconcile.go
@@ -3,8 +3,11 @@
 // own. Each pass does two things:
 //
 //   - Actively terminates inbox rows wedged in processing (driver hard-killed on
-//     its final attempt, lease expired, attempts at the cap) so they emit as
-//     failures and become redeliverable — FindNext never reclaims them.
+//     its final attempt, lease expired, attempts at the cap) that FindNext never
+//     reclaims, emitting each as a durable failure so it surfaces in
+//     metrics/alerting and drains the stuck-processing gauge. GitHub Redeliver
+//     can also reopen such a row on demand; this sweep is the automatic
+//     complement that recovers rows nobody redelivered.
 //   - Reports (report-only) any recently updated open PR head in a registered
 //     repository that has no corresponding webhook_events row, surfacing
 //     deliveries lost upstream of the inbox (edge auth failures, GitHub-side
@@ -174,6 +177,7 @@ func (h *Handler) reconcileRepoWebhookInbox(ctx context.Context, store storage.W
 	cutoff := now.Add(-h.webhookReconcileLookback)
 	grace := now.Add(-h.webhookReconcileGrace)
 	page := 1
+	coverageComplete := false
 pages:
 	for range h.webhookReconcileMaxPages {
 		prs, nextPage, _, err := client.ListOpenPullRequestsPage(ctx, repo, page, webhookReconcilePageSize)
@@ -185,6 +189,7 @@ pages:
 			if pr.UpdatedAt.Before(cutoff) {
 				// The listing is newest-updated first; everything after this is
 				// older than the lookback window.
+				coverageComplete = true
 				break pages
 			}
 			if pr.HeadSHA == "" {
@@ -217,9 +222,17 @@ pages:
 			metrics.RecordWebhookReconcileMissingEvent(ctx, repo)
 		}
 		if nextPage == 0 {
+			coverageComplete = true
 			break
 		}
 		page = nextPage
+	}
+	if !coverageComplete {
+		// The page budget ran out before the walk reached the lookback cutoff,
+		// so open PR heads older than the last page scanned went unchecked this
+		// pass. Surface the truncated coverage rather than silently capping it.
+		h.logger.Warn("webhook reconciler exhausted its page budget before reaching the lookback cutoff; open PR coverage is truncated this pass",
+			"repo", repo, "max_pages", h.webhookReconcileMaxPages, "page_size", webhookReconcilePageSize)
 	}
 	return scanned, missing
 }

--- a/pkg/webhook/durable_reconcile_test.go
+++ b/pkg/webhook/durable_reconcile_test.go
@@ -116,6 +116,35 @@ func TestWebhookReconcilerSkipsAllowAllRegistry(t *testing.T) {
 	require.False(t, listed, "allow-all registry is not enumerable; no GitHub calls expected")
 }
 
+func TestWebhookReconcilerTerminatesStuckProcessingEvent(t *testing.T) {
+	store := newRecordingWebhookEventStore()
+	leaseExpired := time.Now().Add(-time.Minute)
+	_, err := store.Create(t.Context(), &storage.WebhookEvent{
+		Provider:       storage.WebhookProviderGitHub,
+		DeliveryID:     "delivery-stuck",
+		Event:          "pull_request",
+		Repository:     "octocat/hello-world",
+		PullRequest:    7,
+		HeadSHA:        "head-sha",
+		State:          storage.WebhookEventProcessing,
+		Attempts:       storage.MaxWebhookEventAttempts,
+		LeaseExpiresAt: &leaseExpired,
+		Payload:        []byte(`{}`),
+	})
+	require.NoError(t, err)
+	// An allow-all registry: the sweep must still run even though the
+	// missing-delivery scan cannot enumerate repos.
+	h, _ := newReconcileTestHandler(t, store, nil)
+
+	h.reconcileWebhookInbox(t.Context())
+
+	got, err := store.GetByDeliveryID(t.Context(), storage.WebhookProviderGitHub, "delivery-stuck")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, storage.WebhookEventFailed, got.State)
+	require.NotEmpty(t, got.LastError)
+}
+
 func TestWebhookReconcilerRunsOnDispatchLifecycle(t *testing.T) {
 	store := newScriptedWebhookEventStore()
 	h, mux := newReconcileTestHandler(t, store, map[string]api.RepoConfig{"octocat/hello-world": {}})

--- a/pkg/webhook/durable_reconcile_test.go
+++ b/pkg/webhook/durable_reconcile_test.go
@@ -162,7 +162,7 @@ func TestWebhookReconcilerRunsOnDispatchLifecycle(t *testing.T) {
 	select {
 	case <-listed:
 	case <-time.After(durableWebhookTestDeadline):
-		t.Fatal("expected the reconciler to list open PRs on the dispatch lifecycle")
+		require.FailNow(t, "expected the reconciler to list open PRs on the dispatch lifecycle")
 	}
 	h.StopDurableWebhookDispatch()
 }

--- a/pkg/webhook/durable_reconcile_test.go
+++ b/pkg/webhook/durable_reconcile_test.go
@@ -161,7 +161,7 @@ func TestWebhookReconcilerRunsOnDispatchLifecycle(t *testing.T) {
 	h.StartDurableWebhookDispatch(t.Context())
 	select {
 	case <-listed:
-	case <-time.After(5 * time.Second):
+	case <-time.After(durableWebhookTestDeadline):
 		t.Fatal("expected the reconciler to list open PRs on the dispatch lifecycle")
 	}
 	h.StopDurableWebhookDispatch()

--- a/pkg/webhook/durable_reconcile_test.go
+++ b/pkg/webhook/durable_reconcile_test.go
@@ -1,0 +1,139 @@
+package webhook
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/api"
+	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// newReconcileTestHandler builds a reconciler-enabled handler whose GitHub
+// client talks to a fake server; register PR list responses on the returned mux.
+func newReconcileTestHandler(t *testing.T, store storage.WebhookEventStore, repos map[string]api.RepoConfig) (*Handler, *http.ServeMux) {
+	t.Helper()
+	ghc, mux := setupGitHubServer(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	service := api.New(&durableWebhookTestStorage{webhookEvents: store}, &api.ServerConfig{Repos: repos}, nil, logger)
+	factory := &fakeClientFactory{client: ghclient.NewInstallationClient(ghc, logger)}
+	h := NewHandler(service, factory, nil, logger, WithDurableWebhookDispatch(), WithWebhookReconciler())
+	return h, mux
+}
+
+func openPR(number int, headSHA string, updatedAt time.Time) map[string]any {
+	return map[string]any{
+		"number":     number,
+		"title":      fmt.Sprintf("PR %d", number),
+		"updated_at": updatedAt.UTC().Format(time.RFC3339),
+		"head":       map[string]any{"sha": headSHA, "ref": "feature"},
+		"base":       map[string]any{"ref": "main"},
+		"user":       map[string]any{"login": "octocat"},
+	}
+}
+
+func writeOpenPRs(t *testing.T, w http.ResponseWriter, prs ...map[string]any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if prs == nil {
+		prs = []map[string]any{}
+	}
+	require.NoError(t, json.NewEncoder(w).Encode(prs))
+}
+
+func TestWebhookReconcilerReportsMissingInboxRow(t *testing.T) {
+	store := newRecordingWebhookEventStore()
+	h, mux := newReconcileTestHandler(t, store, map[string]api.RepoConfig{"octocat/hello-world": {}})
+	mux.HandleFunc("/repos/octocat/hello-world/pulls", func(w http.ResponseWriter, _ *http.Request) {
+		writeOpenPRs(t, w, openPR(7, "head-sha", time.Now().Add(-time.Hour)))
+	})
+
+	scanned, missing := h.reconcileRepoWebhookInbox(t.Context(), store, "octocat/hello-world")
+
+	require.Equal(t, 1, scanned)
+	require.Equal(t, 1, missing)
+}
+
+func TestWebhookReconcilerSkipsRecordedHead(t *testing.T) {
+	store := newRecordingWebhookEventStore()
+	_, err := store.Create(t.Context(), &storage.WebhookEvent{
+		Provider:    storage.WebhookProviderGitHub,
+		DeliveryID:  "delivery-recorded",
+		Event:       "pull_request",
+		Repository:  "octocat/hello-world",
+		PullRequest: 7,
+		HeadSHA:     "head-sha",
+		Payload:     []byte(`{}`),
+	})
+	require.NoError(t, err)
+	h, mux := newReconcileTestHandler(t, store, map[string]api.RepoConfig{"octocat/hello-world": {}})
+	mux.HandleFunc("/repos/octocat/hello-world/pulls", func(w http.ResponseWriter, _ *http.Request) {
+		writeOpenPRs(t, w, openPR(7, "head-sha", time.Now().Add(-time.Hour)))
+	})
+
+	scanned, missing := h.reconcileRepoWebhookInbox(t.Context(), store, "octocat/hello-world")
+
+	require.Equal(t, 1, scanned)
+	require.Equal(t, 0, missing)
+}
+
+func TestWebhookReconcilerSkipsGraceAndLookbackWindows(t *testing.T) {
+	store := newRecordingWebhookEventStore()
+	h, mux := newReconcileTestHandler(t, store, map[string]api.RepoConfig{"octocat/hello-world": {}})
+	mux.HandleFunc("/repos/octocat/hello-world/pulls", func(w http.ResponseWriter, _ *http.Request) {
+		// Listing is newest-updated first: one PR inside the grace window (a
+		// delivery may still be in flight), one past the lookback window (its
+		// activity predates the inbox's coverage).
+		writeOpenPRs(t, w,
+			openPR(1, "fresh-sha", time.Now().Add(-time.Minute)),
+			openPR(2, "stale-sha", time.Now().Add(-72*time.Hour)),
+		)
+	})
+
+	scanned, missing := h.reconcileRepoWebhookInbox(t.Context(), store, "octocat/hello-world")
+
+	require.Equal(t, 0, scanned)
+	require.Equal(t, 0, missing)
+}
+
+func TestWebhookReconcilerSkipsAllowAllRegistry(t *testing.T) {
+	store := newRecordingWebhookEventStore()
+	h, mux := newReconcileTestHandler(t, store, nil)
+	listed := false
+	mux.HandleFunc("/", func(http.ResponseWriter, *http.Request) {
+		listed = true
+	})
+
+	h.reconcileWebhookInbox(t.Context())
+
+	require.False(t, listed, "allow-all registry is not enumerable; no GitHub calls expected")
+}
+
+func TestWebhookReconcilerRunsOnDispatchLifecycle(t *testing.T) {
+	store := newScriptedWebhookEventStore()
+	h, mux := newReconcileTestHandler(t, store, map[string]api.RepoConfig{"octocat/hello-world": {}})
+	h.webhookReconcileInterval = 10 * time.Millisecond
+	listed := make(chan struct{}, 4)
+	mux.HandleFunc("/repos/octocat/hello-world/pulls", func(w http.ResponseWriter, _ *http.Request) {
+		select {
+		case listed <- struct{}{}:
+		default:
+		}
+		writeOpenPRs(t, w)
+	})
+
+	h.StartDurableWebhookDispatch(t.Context())
+	select {
+	case <-listed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the reconciler to list open PRs on the dispatch lifecycle")
+	}
+	h.StopDurableWebhookDispatch()
+}

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -174,10 +174,14 @@ func WithDurableWebhookDispatch() HandlerOption {
 	}
 }
 
-// WithWebhookReconciler enables the report-only webhook reconciliation loop:
-// a periodic scan of recently updated open PRs in registered repositories that
-// reports PR heads with no corresponding inbox delivery. It only takes effect
-// alongside WithDurableWebhookDispatch, whose lifecycle it shares.
+// WithWebhookReconciler enables the webhook reconciliation loop. It does two
+// things per pass: (1) an active stuck-processing sweep that terminalizes inbox
+// rows wedged past the attempt cap so they emit failures and become
+// redeliverable, and (2) a report-only scan of recently updated open PRs in
+// registered repositories that reports PR heads with no corresponding inbox
+// delivery (no rows are synthesized). Only the missing-delivery scan is
+// report-only. It takes effect alongside WithDurableWebhookDispatch, whose
+// lifecycle it shares.
 func WithWebhookReconciler() HandlerOption {
 	return func(h *Handler) {
 		h.webhookReconciler = true

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -139,6 +139,12 @@ type Handler struct {
 	// deterministically. Production code never sets it.
 	durableWebhookProcessOverride func(ctx context.Context, event *storage.WebhookEvent) (retry bool, err error)
 
+	webhookReconciler        bool
+	webhookReconcileInterval time.Duration
+	webhookReconcileLookback time.Duration
+	webhookReconcileGrace    time.Duration
+	webhookReconcileMaxPages int
+
 	logger                     *slog.Logger
 	priorEnvCheckMaxAttempts   int
 	priorEnvCheckRetryInterval time.Duration
@@ -165,6 +171,16 @@ func WithRepoWebhookSecret(secret []byte) HandlerOption {
 func WithDurableWebhookDispatch() HandlerOption {
 	return func(h *Handler) {
 		h.durableWebhookDispatch = true
+	}
+}
+
+// WithWebhookReconciler enables the report-only webhook reconciliation loop:
+// a periodic scan of recently updated open PRs in registered repositories that
+// reports PR heads with no corresponding inbox delivery. It only takes effect
+// alongside WithDurableWebhookDispatch, whose lifecycle it shares.
+func WithWebhookReconciler() HandlerOption {
+	return func(h *Handler) {
+		h.webhookReconciler = true
 	}
 }
 
@@ -206,6 +222,10 @@ func NewHandlerWithDispatch(service *api.Service, ghClients github.ClientSet, we
 		logger:                      logger,
 		durableWebhookPollInterval:  defaultDurableWebhookPollInterval,
 		durableWebhookLeaseDuration: defaultDurableWebhookLeaseDuration,
+		webhookReconcileInterval:    defaultWebhookReconcileInterval,
+		webhookReconcileLookback:    defaultWebhookReconcileLookback,
+		webhookReconcileGrace:       defaultWebhookReconcileGrace,
+		webhookReconcileMaxPages:    defaultWebhookReconcileMaxPages,
 		priorEnvCheckMaxAttempts:    defaultPriorEnvCheckMaxAttempts,
 		priorEnvCheckRetryInterval:  defaultPriorEnvCheckRetryInterval,
 	}


### PR DESCRIPTION
## Summary

Adds the reconciliation backstop for the durable webhook inbox: a periodic loop that (1) actively terminates inbox rows wedged in `processing` that the driver pool can never recover, and (2) reports (report-only) open PR heads that have no inbox delivery, surfacing deliveries lost upstream of the inbox.

Stacked on #705 — review that first.

## What

- **Stuck-row sweep (active).** Each pass calls `TerminateStuckProcessing`, which marks failed every row parked in `processing` with an expired lease at the attempt cap. `FindNext` stops reclaiming a row once attempts reach the cap, so a driver hard-killed on its final attempt leaves the row unclaimable by the driver pool. A GitHub Redeliver already reopens such a row on demand (`reopenTerminalWebhookEvent`, #728), so this sweep is the *no-operator-needed* complement: it terminalizes rows nobody redelivered, emits each as a durable failure, and drains the stuck-processing gauge. The sweep runs before the repo-registry check so it fires even in allow-all mode. New `schemabot.webhook.reconcile_stuck_terminated_total` metric.
- **Missing-delivery scan (report-only).** Lists recently updated open PRs in registered repos and logs/metrics any PR head with no `webhook_events` row. Bounded by lookback, grace, and page-budget windows; only logs and emits `reconcile_missing_events_total`, and warns when the page budget is exhausted before the lookback cutoff so truncated coverage is never silent. A later phase will synthesize inbox rows.
- Runs on the durable-dispatch lifecycle; first pass fires after one full interval so a rolling deploy doesn't fan a list scan across every starting replica.

## Why

The inbox in #705 recovers deliveries once they land, but two gaps remain: a row can wedge in `processing` past the reclaim cap (crash on the final attempt), and a delivery can be lost before it ever reaches the inbox (edge auth, GitHub send failure). The reconciler closes the first gap actively and surfaces the second for tuning before it acts on it.

## Before / after (stuck row)

```text
Driver hard-killed on final attempt (attempts=cap, lease held)
                          │
                          ▼
             row stuck `processing`, lease expires
             └─ FindNext never reclaims it (at the cap)
                          │
        ┌─────────────────┴─────────────────────┐
        ▼                                       ▼
  operator Redeliver (#728)              reconciler pass (automatic)
   └─ reopenTerminalWebhookEvent          └─ TerminateStuckProcessing()
      reopens expired-lease                  └─ state=failed, lease cleared,
      processing row → pending                  completed_at set, metric++
                                          recovers rows nobody redelivered
```

Recovery no longer depends on the sweep: #728 makes Redeliver an on-demand lever, and the sweep is the automatic path for rows nobody notices.
