### PR TITLE
refactor(storage): introduce Dialect seam for mysqlstore upserts

### DIFF
--- a/pkg/storage/mysqlstore/apply_comments.go
+++ b/pkg/storage/mysqlstore/apply_comments.go
@@ -17,7 +17,8 @@ const applyCommentColumns = `id, apply_id, comment_state, github_comment_id, pos
 
 // applyCommentStore implements storage.ApplyCommentStore using MySQL.
 type applyCommentStore struct {
-	db *sql.DB
+	db      *sql.DB
+	dialect Dialect
 }
 
 // Upsert creates or updates a comment record.
@@ -29,16 +30,20 @@ func (s *applyCommentStore) Upsert(ctx context.Context, comment *storage.ApplyCo
 	if err != nil {
 		return err
 	}
+	upsert := s.dialect.UpsertClause(
+		[]string{"apply_id", "comment_state"},
+		[]UpsertAssignment{
+			{Column: "github_comment_id"},
+			{Column: "posted_volume"},
+			{Column: "pending_freeze_github_comment_id"},
+			{Column: "superseded_at", Expr: "NULL"},
+		},
+	)
 	if !hasLease {
 		_, err := s.db.ExecContext(ctx, `
 			INSERT INTO apply_comments (apply_id, comment_state, github_comment_id, posted_volume, pending_freeze_github_comment_id)
 			VALUES (?, ?, ?, ?, ?)
-			ON DUPLICATE KEY UPDATE
-				github_comment_id = VALUES(github_comment_id),
-				posted_volume = VALUES(posted_volume),
-				pending_freeze_github_comment_id = VALUES(pending_freeze_github_comment_id),
-				superseded_at = NULL
-		`, comment.ApplyID, comment.CommentState, comment.GitHubCommentID, comment.PostedVolume, comment.PendingFreezeCommentID)
+			`+upsert, comment.ApplyID, comment.CommentState, comment.GitHubCommentID, comment.PostedVolume, comment.PendingFreezeCommentID)
 		return err
 	}
 
@@ -46,12 +51,7 @@ func (s *applyCommentStore) Upsert(ctx context.Context, comment *storage.ApplyCo
 		INSERT INTO apply_comments (apply_id, comment_state, github_comment_id, posted_volume, pending_freeze_github_comment_id)
 		SELECT ?, ?, ?, ?, ? FROM applies a
 		WHERE a.id = ? AND a.lease_token = ?
-		ON DUPLICATE KEY UPDATE
-			github_comment_id = VALUES(github_comment_id),
-			posted_volume = VALUES(posted_volume),
-			pending_freeze_github_comment_id = VALUES(pending_freeze_github_comment_id),
-			superseded_at = NULL
-	`, comment.ApplyID, comment.CommentState, comment.GitHubCommentID, comment.PostedVolume, comment.PendingFreezeCommentID, comment.ApplyID, lease.Token)
+		`+upsert, comment.ApplyID, comment.CommentState, comment.GitHubCommentID, comment.PostedVolume, comment.PendingFreezeCommentID, comment.ApplyID, lease.Token)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/mysqlstore/checks.go
+++ b/pkg/storage/mysqlstore/checks.go
@@ -24,7 +24,8 @@ const (
 
 // checkStore implements storage.CheckStore using MySQL.
 type checkStore struct {
-	db *sql.DB
+	db      *sql.DB
+	dialect Dialect
 }
 
 // Upsert creates or updates stored check state.
@@ -41,6 +42,20 @@ func (s *checkStore) Upsert(ctx context.Context, check *storage.Check) error {
 
 	op := fmt.Sprintf("upsert check result for %s#%d %s/%s/%s",
 		check.Repository, check.PullRequest, check.Environment, check.DatabaseType, check.DatabaseName)
+	upsert := s.dialect.UpsertClause(
+		[]string{"repository", "pull_request", "environment", "database_type", "database_name"},
+		[]UpsertAssignment{
+			{Column: "head_sha"},
+			{Column: "check_run_id"},
+			{Column: "apply_id"},
+			{Column: "has_changes"},
+			{Column: "status"},
+			{Column: "conclusion"},
+			{Column: "blocking_reason"},
+			{Column: "error_message"},
+			{Column: "change_summary", Expr: "COALESCE(NULLIF(" + s.dialect.ExcludedValue("change_summary") + ", ''), change_summary)"},
+		},
+	)
 	return withLockRetry(ctx, op, func() error {
 		_, err := s.db.ExecContext(ctx, `
 			INSERT INTO checks (
@@ -48,17 +63,7 @@ func (s *checkStore) Upsert(ctx context.Context, check *storage.Check) error {
 				environment, database_type, database_name,
 				check_run_id, apply_id, has_changes, status, conclusion, blocking_reason, error_message, change_summary
 			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-			ON DUPLICATE KEY UPDATE
-				head_sha = VALUES(head_sha),
-				check_run_id = VALUES(check_run_id),
-				apply_id = VALUES(apply_id),
-				has_changes = VALUES(has_changes),
-				status = VALUES(status),
-				conclusion = VALUES(conclusion),
-				blocking_reason = VALUES(blocking_reason),
-				error_message = VALUES(error_message),
-				change_summary = COALESCE(NULLIF(VALUES(change_summary), ''), change_summary)
-		`, check.Repository, check.PullRequest, check.HeadSHA,
+			`+upsert, check.Repository, check.PullRequest, check.HeadSHA,
 			check.Environment, check.DatabaseType, check.DatabaseName,
 			checkRunID, applyID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage, nullString(check.ChangeSummary))
 		return err

--- a/pkg/storage/mysqlstore/dialect.go
+++ b/pkg/storage/mysqlstore/dialect.go
@@ -1,0 +1,52 @@
+package mysqlstore
+
+import "strings"
+
+// Dialect abstracts the SQL-syntax differences between database families (MySQL
+// and, in the future, Postgres) that the state store depends on, so the same
+// store logic can target either engine. It currently lives here alongside its
+// MySQLDialect implementation; when a Postgres store is introduced this
+// interface likely moves to a shared package so neither store depends on the
+// other.
+type Dialect interface {
+	// UpsertClause returns the trailing conflict-resolution clause that turns an
+	// INSERT into an upsert. conflictColumns names the unique key that defines a
+	// conflict; MySQL infers the key from the table and ignores it, while
+	// Postgres requires it for the ON CONFLICT target. assignments lists the
+	// columns to overwrite when a conflicting row already exists.
+	UpsertClause(conflictColumns []string, assignments []UpsertAssignment) string
+	// ExcludedValue references the value from the row that failed to insert, for
+	// use inside an UpsertAssignment expression (MySQL: VALUES(col); Postgres:
+	// EXCLUDED.col).
+	ExcludedValue(column string) string
+}
+
+// UpsertAssignment describes how one column is updated when an upsert matches an
+// existing row. Expr is the raw SQL update expression; when empty, the column is
+// set to its excluded (to-be-inserted) value.
+type UpsertAssignment struct {
+	Column string
+	Expr   string
+}
+
+// MySQLDialect implements Dialect for MySQL and MySQL-protocol engines.
+type MySQLDialect struct{}
+
+// ExcludedValue returns the MySQL reference to the proposed row value.
+func (MySQLDialect) ExcludedValue(column string) string {
+	return "VALUES(" + column + ")"
+}
+
+// UpsertClause builds a MySQL ON DUPLICATE KEY UPDATE clause. conflictColumns is
+// unused because MySQL resolves conflicts against every unique key on the table.
+func (d MySQLDialect) UpsertClause(_ []string, assignments []UpsertAssignment) string {
+	sets := make([]string, len(assignments))
+	for i, a := range assignments {
+		expr := a.Expr
+		if expr == "" {
+			expr = d.ExcludedValue(a.Column)
+		}
+		sets[i] = a.Column + " = " + expr
+	}
+	return "ON DUPLICATE KEY UPDATE " + strings.Join(sets, ", ")
+}

--- a/pkg/storage/mysqlstore/dialect_test.go
+++ b/pkg/storage/mysqlstore/dialect_test.go
@@ -1,0 +1,64 @@
+package mysqlstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMySQLDialectExcludedValue(t *testing.T) {
+	assert.Equal(t, "VALUES(setting_value)", MySQLDialect{}.ExcludedValue("setting_value"))
+}
+
+// UpsertClause must produce a MySQL ON DUPLICATE KEY UPDATE clause that matches
+// the hand-written SQL the store used before the dialect seam, including the
+// column set, ordering, defaulted excluded values, and custom expressions. The
+// conflict columns are accepted but not rendered, since MySQL resolves the
+// conflict against the table's unique keys.
+func TestMySQLDialectUpsertClause(t *testing.T) {
+	d := MySQLDialect{}
+
+	tests := []struct {
+		name        string
+		conflict    []string
+		assignments []UpsertAssignment
+		want        string
+	}{
+		{
+			name:        "single defaulted column",
+			conflict:    []string{"setting_key"},
+			assignments: []UpsertAssignment{{Column: "setting_value"}},
+			want:        "ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value)",
+		},
+		{
+			name:     "defaulted columns with a literal expression",
+			conflict: []string{"apply_id", "comment_state"},
+			assignments: []UpsertAssignment{
+				{Column: "github_comment_id"},
+				{Column: "posted_volume"},
+				{Column: "pending_freeze_github_comment_id"},
+				{Column: "superseded_at", Expr: "NULL"},
+			},
+			want: "ON DUPLICATE KEY UPDATE github_comment_id = VALUES(github_comment_id), " +
+				"posted_volume = VALUES(posted_volume), " +
+				"pending_freeze_github_comment_id = VALUES(pending_freeze_github_comment_id), " +
+				"superseded_at = NULL",
+		},
+		{
+			name:     "custom expression referencing the excluded value",
+			conflict: []string{"repository", "pull_request", "environment", "database_type", "database_name"},
+			assignments: []UpsertAssignment{
+				{Column: "head_sha"},
+				{Column: "change_summary", Expr: "COALESCE(NULLIF(" + d.ExcludedValue("change_summary") + ", ''), change_summary)"},
+			},
+			want: "ON DUPLICATE KEY UPDATE head_sha = VALUES(head_sha), " +
+				"change_summary = COALESCE(NULLIF(VALUES(change_summary), ''), change_summary)",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, d.UpsertClause(tc.conflict, tc.assignments))
+		})
+	}
+}

--- a/pkg/storage/mysqlstore/settings.go
+++ b/pkg/storage/mysqlstore/settings.go
@@ -15,7 +15,8 @@ const settingColumns = `id, setting_key, setting_value, created_at, updated_at`
 
 // settingsStore implements storage.SettingsStore using MySQL.
 type settingsStore struct {
-	db *sql.DB
+	db      *sql.DB
+	dialect Dialect
 }
 
 // Get returns a setting by key, or nil if not found.
@@ -39,12 +40,14 @@ func (s *settingsStore) Get(ctx context.Context, key string) (*storage.Setting, 
 
 // Set saves a setting. Creates if not exists, updates if exists.
 func (s *settingsStore) Set(ctx context.Context, key, value string) error {
+	upsert := s.dialect.UpsertClause(
+		[]string{"setting_key"},
+		[]UpsertAssignment{{Column: "setting_value"}},
+	)
 	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO settings (setting_key, setting_value)
 		VALUES (?, ?)
-		ON DUPLICATE KEY UPDATE
-			setting_value = VALUES(setting_value)
-	`, key, value)
+		`+upsert, key, value)
 	return err
 }
 

--- a/pkg/storage/mysqlstore/storage.go
+++ b/pkg/storage/mysqlstore/storage.go
@@ -35,11 +35,11 @@ func New(db *sql.DB) *Storage {
 		tasks:           &taskStore{db: db},
 		applyLogs:       &applyLogStore{db: db},
 		controlRequests: &controlRequestStore{db: db},
-		applyComments:   &applyCommentStore{db: db},
+		applyComments:   &applyCommentStore{db: db, dialect: MySQLDialect{}},
 		planComments:    &planCommentStore{db: db},
 		applyOperations: &applyOperationStore{db: db},
-		checks:          &checkStore{db: db},
-		settings:        &settingsStore{db: db},
+		checks:          &checkStore{db: db, dialect: MySQLDialect{}},
+		settings:        &settingsStore{db: db, dialect: MySQLDialect{}},
 		webhookEvents:   &webhookEventStore{db: db},
 	}
 }


### PR DESCRIPTION
## Summary

Introduce a `Dialect` seam in `pkg/storage/mysqlstore` and route the store's `ON DUPLICATE KEY UPDATE` upserts through it. This is a no-behavior-change refactor: the MySQL SQL produced is equivalent to the hand-written statements it replaces. It's the first step toward reusing the state-store logic against a Postgres backend, where upserts use `INSERT … ON CONFLICT (…) DO UPDATE SET … EXCLUDED.col`.

## What

- Add `Dialect` (interface) + `MySQLDialect` with:
  - `UpsertClause(conflictColumns, assignments)` — builds the trailing conflict clause.
  - `ExcludedValue(col)` — references the proposed row value (`VALUES(col)` on MySQL).
- Migrate the 4 upsert sites onto the seam: `settings`, `checks`, and both `apply_comments` writes.
- Wire a `MySQLDialect` into the three sub-stores via the constructor.

`conflictColumns` are captured now even though MySQL resolves conflicts against the table's unique keys and ignores them — Postgres needs them for the `ON CONFLICT` target, so recording them keeps the abstraction portable.

## Why

The upsert clause is the most structurally divergent piece of SQL between MySQL and Postgres, so abstracting it first de-risks the eventual Postgres state store the most, while touching a small, self-contained set of call sites.

## Before / after

```text
before                                   after
──────                                   ─────
store method                             store method
  │                                        │
  │ inline SQL string:                     │ s.dialect.UpsertClause(
  │  "... ON DUPLICATE KEY UPDATE          │      conflictCols, assignments)
  │       col = VALUES(col) ..."           │
  ▼                                        ▼
ExecContext                          ┌──────────────┐
                                     │ MySQLDialect │→ "ON DUPLICATE KEY UPDATE
                                     └──────────────┘    col = VALUES(col) ..."
                                        │
                                        ▼
                                     ExecContext  (identical SQL)
```

## Proposed next steps

This is the first slice of the store dialect abstraction. Follow-ups (each a small, no-behavior-change refactor) will move the remaining MySQL-specific syntax onto the same seam:

1. **Timestamp / `INTERVAL` syntax** — `NOW()` / `CURRENT_TIMESTAMP` and date arithmetic.
2. **Row-claim + identity** — `FOR UPDATE SKIP LOCKED` claims and last-insert-id / auto-increment retrieval.

Named-lock syntax (`GET_LOCK` / `RELEASE_LOCK` → advisory locks) is tracked separately, since it needs a strategy change rather than a syntax swap. A Postgres implementation of `Dialect` and the storage factory that selects it come later, once the seam covers all the dialect-specific SQL.
