### PR TITLE
feat(observability): durable webhook inbox depth and backlog metrics

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -29,7 +29,8 @@ import (
 
 // mockStorage implements storage.Storage for testing.
 type mockStorage struct {
-	pingErr error
+	pingErr       error
+	webhookEvents storage.WebhookEventStore
 }
 
 func (m *mockStorage) Locks() storage.LockStore                     { return nil }
@@ -43,7 +44,7 @@ func (m *mockStorage) PlanComments() storage.PlanCommentStore       { return nil
 func (m *mockStorage) ApplyOperations() storage.ApplyOperationStore { return nil }
 func (m *mockStorage) Checks() storage.CheckStore                   { return nil }
 func (m *mockStorage) Settings() storage.SettingsStore              { return nil }
-func (m *mockStorage) WebhookEvents() storage.WebhookEventStore     { return nil }
+func (m *mockStorage) WebhookEvents() storage.WebhookEventStore     { return m.webhookEvents }
 func (m *mockStorage) Ping(ctx context.Context) error               { return m.pingErr }
 func (m *mockStorage) Close() error                                 { return nil }
 

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -152,6 +152,12 @@ type Service struct {
 	remoteHealthWg       sync.WaitGroup
 	remoteHealthInterval time.Duration
 
+	// Webhook inbox metrics monitor loop management.
+	webhookInboxMu       sync.Mutex
+	webhookInboxCancel   context.CancelFunc
+	webhookInboxWg       sync.WaitGroup
+	webhookInboxInterval time.Duration
+
 	// Pending drops cleaner loop management.
 	pendingDropsMu     sync.Mutex
 	pendingDropsCancel context.CancelFunc
@@ -254,6 +260,7 @@ func New(st storage.Storage, config *ServerConfig, ternClients map[string]tern.C
 		clock:                clock.Real{},
 		operatorPollInterval: OperatorPollInterval,
 		remoteHealthInterval: RemoteDeploymentHealthCheckInterval,
+		webhookInboxInterval: WebhookInboxMetricsInterval,
 		pendingObservers:     make(map[pendingObserverKey]tern.ProgressObserver),
 	}
 }
@@ -744,6 +751,7 @@ func (s *Service) Close() error {
 	// Stop background drivers first.
 	s.StopOperator()
 	s.StopRemoteDeploymentHealthMonitor()
+	s.StopWebhookInboxMonitor()
 
 	s.ternMu.Lock()
 	var errs []error

--- a/pkg/api/webhook_inbox_metrics.go
+++ b/pkg/api/webhook_inbox_metrics.go
@@ -1,0 +1,128 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/block/schemabot/pkg/metrics"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+const (
+	// WebhookInboxMetricsInterval is how often SchemaBot snapshots the durable
+	// webhook inbox for steady-state depth/backlog metrics. With durable
+	// dispatch, backpressure shows up as inbox depth rather than request
+	// latency, so this cadence must be tight enough to catch a growing backlog
+	// well within the dispatch expectation.
+	WebhookInboxMetricsInterval = 30 * time.Second
+
+	// WebhookInboxMetricsTimeout bounds a single inbox snapshot so a slow or
+	// contended database cannot stall the monitor loop.
+	WebhookInboxMetricsTimeout = 5 * time.Second
+)
+
+// StartWebhookInboxMonitor starts a background loop that periodically snapshots
+// the durable webhook inbox and emits depth, backlog-age, and stuck-processing
+// gauges. It is a no-op when webhook storage is unavailable (nothing to
+// observe).
+func (s *Service) StartWebhookInboxMonitor(ctx context.Context) {
+	if s.storage == nil {
+		s.logger.Debug("webhook inbox monitor not started because storage is unavailable")
+		return
+	}
+
+	s.webhookInboxMu.Lock()
+	if s.webhookInboxCancel != nil {
+		s.webhookInboxMu.Unlock()
+		s.logger.Info("webhook inbox monitor already running")
+		return
+	}
+	monitorCtx, cancel := context.WithCancel(ctx)
+	s.webhookInboxCancel = cancel
+	interval := s.webhookInboxInterval
+	s.webhookInboxMu.Unlock()
+
+	s.webhookInboxWg.Go(func() {
+		s.webhookInboxMonitor(monitorCtx, interval)
+	})
+	s.logger.Info("webhook inbox monitor started", "interval", interval, "timeout", WebhookInboxMetricsTimeout)
+}
+
+// StopWebhookInboxMonitor stops the background webhook inbox monitor. Safe to
+// call multiple times.
+func (s *Service) StopWebhookInboxMonitor() {
+	s.webhookInboxMu.Lock()
+	cancel := s.webhookInboxCancel
+	if cancel == nil {
+		s.webhookInboxMu.Unlock()
+		return
+	}
+	s.webhookInboxCancel = nil
+	s.webhookInboxMu.Unlock()
+
+	cancel()
+	s.webhookInboxWg.Wait()
+}
+
+// SetWebhookInboxMetricsInterval sets the inbox snapshot interval. Call before
+// StartWebhookInboxMonitor.
+func (s *Service) SetWebhookInboxMetricsInterval(interval time.Duration) error {
+	if interval <= 0 {
+		return fmt.Errorf("webhook inbox metrics interval must be positive")
+	}
+	s.webhookInboxMu.Lock()
+	defer s.webhookInboxMu.Unlock()
+	if s.webhookInboxCancel != nil {
+		return fmt.Errorf("webhook inbox monitor already running")
+	}
+	s.webhookInboxInterval = interval
+	return nil
+}
+
+func (s *Service) webhookInboxMonitor(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	s.CollectWebhookInboxMetrics(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.logger.Debug("webhook inbox monitor stopping", "error", ctx.Err())
+			return
+		case <-ticker.C:
+			s.CollectWebhookInboxMetrics(ctx)
+		}
+	}
+}
+
+// CollectWebhookInboxMetrics snapshots the inbox once and records its gauges. It
+// is exported so tests and diagnostics can run a single synchronous collection
+// without starting the background monitor.
+func (s *Service) CollectWebhookInboxMetrics(ctx context.Context) {
+	if err := ctx.Err(); err != nil {
+		s.logger.Debug("webhook inbox metrics collection skipped because context is done", "error", err)
+		return
+	}
+
+	collectCtx, cancel := context.WithTimeout(ctx, WebhookInboxMetricsTimeout)
+	defer cancel()
+
+	stats, err := s.storage.WebhookEvents().InboxStats(collectCtx)
+	if err != nil {
+		s.logger.Warn("webhook inbox metrics collection failed", "error", err)
+		return
+	}
+
+	for _, state := range storage.WebhookEventStatesAll {
+		metrics.RecordWebhookInboxDepth(ctx, state, stats.CountsByState[state])
+	}
+	metrics.RecordWebhookInboxOldestClaimableAge(ctx, stats.OldestClaimableAge)
+	metrics.RecordWebhookInboxStuckProcessing(ctx, stats.StuckProcessing)
+
+	if stats.StuckProcessing > 0 {
+		s.logger.Warn("durable webhook inbox has rows stuck in processing past the attempt cap",
+			"stuck_processing", stats.StuckProcessing)
+	}
+}

--- a/pkg/api/webhook_inbox_metrics.go
+++ b/pkg/api/webhook_inbox_metrics.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/block/schemabot/pkg/metrics"
@@ -65,21 +64,6 @@ func (s *Service) StopWebhookInboxMonitor() {
 	s.webhookInboxWg.Wait()
 }
 
-// SetWebhookInboxMetricsInterval sets the inbox snapshot interval. Call before
-// StartWebhookInboxMonitor.
-func (s *Service) SetWebhookInboxMetricsInterval(interval time.Duration) error {
-	if interval <= 0 {
-		return fmt.Errorf("webhook inbox metrics interval must be positive")
-	}
-	s.webhookInboxMu.Lock()
-	defer s.webhookInboxMu.Unlock()
-	if s.webhookInboxCancel != nil {
-		return fmt.Errorf("webhook inbox monitor already running")
-	}
-	s.webhookInboxInterval = interval
-	return nil
-}
-
 func (s *Service) webhookInboxMonitor(ctx context.Context, interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -105,18 +89,41 @@ func (s *Service) CollectWebhookInboxMetrics(ctx context.Context) {
 		s.logger.Debug("webhook inbox metrics collection skipped because context is done", "error", err)
 		return
 	}
+	if s.storage == nil || s.storage.WebhookEvents() == nil {
+		s.logger.Debug("webhook inbox metrics collection skipped because webhook storage is unavailable")
+		return
+	}
 
 	collectCtx, cancel := context.WithTimeout(ctx, WebhookInboxMetricsTimeout)
 	defer cancel()
 
 	stats, err := s.storage.WebhookEvents().InboxStats(collectCtx)
 	if err != nil {
+		// The depth/backlog gauges are last-value instruments: leaving them
+		// untouched here re-exports the last-good values with fresh timestamps,
+		// which reads as a healthy inbox. The failure counter is the liveness
+		// signal that tells operators the gauges are stale.
+		metrics.RecordWebhookInboxStatsCollectionFailure(ctx)
 		s.logger.Warn("webhook inbox metrics collection failed", "error", err)
 		return
 	}
 
+	recorded := make(map[string]bool, len(stats.CountsByState))
 	for _, state := range storage.WebhookEventStatesAll {
 		metrics.RecordWebhookInboxDepth(ctx, state, stats.CountsByState[state])
+		recorded[state] = true
+	}
+	// The state column is a free-form varchar, not an enum, so a value outside
+	// the canonical set could appear. Sum any such rows into a single unknown
+	// series rather than dropping them, so an unexpected state still surfaces.
+	var unknownCount int64
+	for state, count := range stats.CountsByState {
+		if !recorded[state] {
+			unknownCount += count
+		}
+	}
+	if unknownCount > 0 {
+		metrics.RecordWebhookInboxDepth(ctx, "unknown", unknownCount)
 	}
 	metrics.RecordWebhookInboxOldestClaimableAge(ctx, stats.OldestClaimableAge)
 	metrics.RecordWebhookInboxStuckProcessing(ctx, stats.StuckProcessing)

--- a/pkg/api/webhook_inbox_metrics.go
+++ b/pkg/api/webhook_inbox_metrics.go
@@ -122,9 +122,11 @@ func (s *Service) CollectWebhookInboxMetrics(ctx context.Context) {
 			unknownCount += count
 		}
 	}
-	if unknownCount > 0 {
-		metrics.RecordWebhookInboxDepth(ctx, "unknown", unknownCount)
-	}
+	// Always record unknown, including 0, like the canonical states above:
+	// inbox_depth is a last-value gauge, so skipping the record when the count
+	// drops back to 0 would leave the gauge re-exporting its last nonzero value
+	// forever, showing a phantom unknown-state population that never resolves.
+	metrics.RecordWebhookInboxDepth(ctx, "unknown", unknownCount)
 	metrics.RecordWebhookInboxOldestClaimableAge(ctx, stats.OldestClaimableAge)
 	metrics.RecordWebhookInboxStuckProcessing(ctx, stats.StuckProcessing)
 

--- a/pkg/api/webhook_inbox_metrics_test.go
+++ b/pkg/api/webhook_inbox_metrics_test.go
@@ -130,11 +130,73 @@ func TestCollectWebhookInboxMetricsRecordsGauges(t *testing.T) {
 		"failed_retryable": 2,
 		"completed":        10,
 		"failed":           4,
+		"unknown":          0,
 	}, depthByState)
 	assert.True(t, oldestFound)
 	assert.Equal(t, int64(90), oldestAge)
 	assert.True(t, stuckFound)
 	assert.Equal(t, int64(2), stuck)
+}
+
+// A non-canonical state row folds into the unknown depth series, and once it is
+// cleaned up the series must return to 0. inbox_depth is a last-value gauge, so
+// the collector records unknown on every pass (including 0); otherwise the
+// gauge would freeze at its last nonzero value and show a phantom unknown
+// population that never resolves.
+func TestCollectWebhookInboxMetricsUnknownReturnsToZeroAfterCleanup(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prevMP := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	t.Cleanup(func() {
+		otel.SetMeterProvider(prevMP)
+		require.NoError(t, mp.Shutdown(t.Context()))
+	})
+
+	store := &fakeWebhookEventStore{stats: &storage.WebhookInboxStats{
+		CountsByState: map[string]int64{
+			storage.WebhookEventPending: 1,
+			"bogus":                     5,
+		},
+	}}
+	svc := newInboxMetricsTestService(t, store)
+
+	svc.CollectWebhookInboxMetrics(t.Context())
+	require.Equal(t, int64(5), inboxDepthForState(t, reader, "unknown"),
+		"a non-canonical state row should fold into the unknown series")
+
+	// The bogus row is cleaned up; the next pass must drive unknown back to 0.
+	store.stats = &storage.WebhookInboxStats{
+		CountsByState: map[string]int64{storage.WebhookEventPending: 1},
+	}
+	svc.CollectWebhookInboxMetrics(t.Context())
+	require.Equal(t, int64(0), inboxDepthForState(t, reader, "unknown"),
+		"unknown must return to 0 once the non-canonical row is gone")
+}
+
+// inboxDepthForState collects the current metrics and returns the inbox_depth
+// gauge value for the given state, or -1 if no data point for that state exists.
+func inboxDepthForState(t *testing.T, reader sdkmetric.Reader, state string) int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "schemabot.webhook.inbox_depth" {
+				continue
+			}
+			gauge, ok := m.Data.(metricdata.Gauge[int64])
+			require.True(t, ok)
+			for _, dp := range gauge.DataPoints {
+				v, ok := dp.Attributes.Value(attribute.Key("state"))
+				require.True(t, ok)
+				if v.AsString() == state {
+					return dp.Value
+				}
+			}
+		}
+	}
+	return -1
 }
 
 // A store failure must not emit the depth/backlog gauges: they are last-value

--- a/pkg/api/webhook_inbox_metrics_test.go
+++ b/pkg/api/webhook_inbox_metrics_test.go
@@ -1,0 +1,163 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// fakeWebhookEventStore serves a fixed InboxStats snapshot; every other method
+// is unused by the inbox metrics monitor.
+type fakeWebhookEventStore struct {
+	stats *storage.WebhookInboxStats
+	err   error
+}
+
+func (f *fakeWebhookEventStore) InboxStats(context.Context) (*storage.WebhookInboxStats, error) {
+	return f.stats, f.err
+}
+
+func (f *fakeWebhookEventStore) Create(context.Context, *storage.WebhookEvent) (bool, error) {
+	return false, errors.New("unused")
+}
+
+func (f *fakeWebhookEventStore) GetByDeliveryID(context.Context, string, string) (*storage.WebhookEvent, error) {
+	return nil, errors.New("unused")
+}
+
+func (f *fakeWebhookEventStore) FindNext(context.Context, string, time.Duration) (*storage.WebhookEvent, error) {
+	return nil, errors.New("unused")
+}
+
+func (f *fakeWebhookEventStore) Heartbeat(context.Context, int64, string, time.Duration) error {
+	return errors.New("unused")
+}
+
+func (f *fakeWebhookEventStore) MarkCompleted(context.Context, int64, string) error {
+	return errors.New("unused")
+}
+
+func (f *fakeWebhookEventStore) MarkFailed(context.Context, int64, string, string, *time.Time) error {
+	return errors.New("unused")
+}
+
+func (f *fakeWebhookEventStore) Release(context.Context, int64, string) error {
+	return errors.New("unused")
+}
+
+func newInboxMetricsTestService(t *testing.T, store storage.WebhookEventStore) *Service {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	return New(&mockStorage{webhookEvents: store}, &ServerConfig{}, nil, logger)
+}
+
+// The webhook inbox monitor emits one depth gauge per canonical state (even when
+// a state is empty), a backlog-age gauge, and a stuck-processing gauge, so an
+// operator can see inbox pressure without any schema change running.
+func TestCollectWebhookInboxMetricsRecordsGauges(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prevMP := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	t.Cleanup(func() {
+		otel.SetMeterProvider(prevMP)
+		require.NoError(t, mp.Shutdown(t.Context()))
+	})
+
+	store := &fakeWebhookEventStore{stats: &storage.WebhookInboxStats{
+		CountsByState: map[string]int64{
+			storage.WebhookEventPending:         3,
+			storage.WebhookEventProcessing:      1,
+			storage.WebhookEventFailedRetryable: 2,
+			storage.WebhookEventCompleted:       10,
+			storage.WebhookEventFailed:          4,
+		},
+		OldestClaimableAge: 90 * time.Second,
+		StuckProcessing:    2,
+	}}
+	svc := newInboxMetricsTestService(t, store)
+
+	svc.CollectWebhookInboxMetrics(t.Context())
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+
+	depthByState := map[string]int64{}
+	var oldestAge, stuck int64
+	var oldestFound, stuckFound bool
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			switch m.Name {
+			case "schemabot.webhook.inbox_depth":
+				gauge, ok := m.Data.(metricdata.Gauge[int64])
+				require.True(t, ok)
+				for _, dp := range gauge.DataPoints {
+					state, ok := dp.Attributes.Value(attribute.Key("state"))
+					require.True(t, ok)
+					depthByState[state.AsString()] = dp.Value
+				}
+			case "schemabot.webhook.inbox_oldest_claimable_age_seconds":
+				gauge, ok := m.Data.(metricdata.Gauge[int64])
+				require.True(t, ok)
+				require.Len(t, gauge.DataPoints, 1)
+				oldestAge = gauge.DataPoints[0].Value
+				oldestFound = true
+			case "schemabot.webhook.inbox_stuck_processing":
+				gauge, ok := m.Data.(metricdata.Gauge[int64])
+				require.True(t, ok)
+				require.Len(t, gauge.DataPoints, 1)
+				stuck = gauge.DataPoints[0].Value
+				stuckFound = true
+			}
+		}
+	}
+
+	assert.Equal(t, map[string]int64{
+		"pending":          3,
+		"processing":       1,
+		"failed_retryable": 2,
+		"completed":        10,
+		"failed":           4,
+	}, depthByState)
+	assert.True(t, oldestFound)
+	assert.Equal(t, int64(90), oldestAge)
+	assert.True(t, stuckFound)
+	assert.Equal(t, int64(2), stuck)
+}
+
+// A store failure must not emit gauges (stale values are worse than a gap) and
+// must not panic the monitor loop.
+func TestCollectWebhookInboxMetricsSkipsOnStoreError(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prevMP := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	t.Cleanup(func() {
+		otel.SetMeterProvider(prevMP)
+		require.NoError(t, mp.Shutdown(t.Context()))
+	})
+
+	svc := newInboxMetricsTestService(t, &fakeWebhookEventStore{err: errors.New("db down")})
+
+	svc.CollectWebhookInboxMetrics(t.Context())
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			assert.NotContains(t, m.Name, "schemabot.webhook.inbox_")
+		}
+	}
+}

--- a/pkg/api/webhook_inbox_metrics_test.go
+++ b/pkg/api/webhook_inbox_metrics_test.go
@@ -137,9 +137,12 @@ func TestCollectWebhookInboxMetricsRecordsGauges(t *testing.T) {
 	assert.Equal(t, int64(2), stuck)
 }
 
-// A store failure must not emit gauges (stale values are worse than a gap) and
-// must not panic the monitor loop.
-func TestCollectWebhookInboxMetricsSkipsOnStoreError(t *testing.T) {
+// A store failure must not emit the depth/backlog gauges: they are last-value
+// instruments, so leaving them untouched re-exports the last-good values and
+// reads as a healthy inbox. Instead it increments the collection-failure
+// counter — the liveness signal that the gauges are stale — and must not panic
+// the monitor loop.
+func TestCollectWebhookInboxMetricsSkipsGaugesAndCountsFailureOnStoreError(t *testing.T) {
 	reader := sdkmetric.NewManualReader()
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	prevMP := otel.GetMeterProvider()
@@ -155,9 +158,14 @@ func TestCollectWebhookInboxMetricsSkipsOnStoreError(t *testing.T) {
 
 	var rm metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(t.Context(), &rm))
+	names := map[string]bool{}
 	for _, sm := range rm.ScopeMetrics {
 		for _, m := range sm.Metrics {
-			assert.NotContains(t, m.Name, "schemabot.webhook.inbox_")
+			names[m.Name] = true
 		}
 	}
+	assert.NotContains(t, names, "schemabot.webhook.inbox_depth", "gauges must not be re-emitted on error")
+	assert.NotContains(t, names, "schemabot.webhook.inbox_oldest_claimable_age_seconds")
+	assert.NotContains(t, names, "schemabot.webhook.inbox_stuck_processing")
+	assert.Contains(t, names, "schemabot.webhook.inbox_stats_collection_failures", "a failed snapshot must increment the failure counter")
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -11,6 +11,8 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	otelmetric "go.opentelemetry.io/otel/metric"
+
+	"github.com/block/schemabot/pkg/storage"
 )
 
 // Meter name used for all SchemaBot metrics.
@@ -1132,15 +1134,16 @@ func RecordUnregisteredRepositoryWebhook(ctx context.Context, appName, eventType
 }
 
 // knownWebhookInboxStates allowlists the canonical durable webhook inbox states
-// so the depth gauge's cardinality stays bounded. Mirrors the states in
-// storage; an unrecognized value is folded to "unknown".
-var knownWebhookInboxStates = map[string]bool{
-	"pending":          true,
-	"processing":       true,
-	"failed_retryable": true,
-	"completed":        true,
-	"failed":           true,
-}
+// so the depth gauge's cardinality stays bounded. It is derived from the
+// storage state list so the two cannot drift; an unrecognized value is folded to
+// "unknown".
+var knownWebhookInboxStates = func() map[string]bool {
+	states := make(map[string]bool, len(storage.WebhookEventStatesAll))
+	for _, state := range storage.WebhookEventStatesAll {
+		states[state] = true
+	}
+	return states
+}()
 
 // RecordWebhookInboxDepth records the number of durable webhook inbox rows in a
 // given state. A rising pending/processing depth means dispatch is falling
@@ -1176,6 +1179,18 @@ func RecordWebhookInboxOldestClaimableAge(ctx context.Context, age time.Duration
 func RecordWebhookInboxStuckProcessing(ctx context.Context, count int64) {
 	recordGauge(ctx, "schemabot.webhook.inbox_stuck_processing", count,
 		"Number of durable webhook inbox rows stuck in processing past the attempt cap", "{row}",
+		EnvironmentAttribute(""),
+	)
+}
+
+// RecordWebhookInboxStatsCollectionFailure counts failed inbox snapshots. The
+// inbox depth/backlog gauges are last-value instruments, so a failed snapshot
+// leaves them frozen at their last-good values — indistinguishable from a
+// healthy inbox. This counter is the liveness signal for the gauges: a nonzero
+// rate means the depth/backlog/stuck values are stale and must not be trusted.
+func RecordWebhookInboxStatsCollectionFailure(ctx context.Context) {
+	addCounter(ctx, "schemabot.webhook.inbox_stats_collection_failures",
+		"Total number of failed durable webhook inbox metric snapshots", "{failure}",
 		EnvironmentAttribute(""),
 	)
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1131,6 +1131,55 @@ func RecordUnregisteredRepositoryWebhook(ctx context.Context, appName, eventType
 		attrs...)
 }
 
+// knownWebhookInboxStates allowlists the canonical durable webhook inbox states
+// so the depth gauge's cardinality stays bounded. Mirrors the states in
+// storage; an unrecognized value is folded to "unknown".
+var knownWebhookInboxStates = map[string]bool{
+	"pending":          true,
+	"processing":       true,
+	"failed_retryable": true,
+	"completed":        true,
+	"failed":           true,
+}
+
+// RecordWebhookInboxDepth records the number of durable webhook inbox rows in a
+// given state. A rising pending/processing depth means dispatch is falling
+// behind ingestion; a rising failed_retryable depth means deliveries are
+// retrying; a rising completed/failed depth means terminal rows are accumulating
+// and retention has not reclaimed them.
+func RecordWebhookInboxDepth(ctx context.Context, state string, count int64) {
+	if !knownWebhookInboxStates[state] {
+		state = "unknown"
+	}
+	recordGauge(ctx, "schemabot.webhook.inbox_depth", count,
+		"Number of durable webhook inbox rows by state", "{row}",
+		EnvironmentAttribute(""),
+		attribute.String("state", state),
+	)
+}
+
+// RecordWebhookInboxOldestClaimableAge records how long the oldest
+// ready-to-claim-but-unclaimed inbox row has been waiting, in seconds. It is the
+// inbox's backlog latency: a value climbing past the dispatch cadence means work
+// is acked but not being picked up.
+func RecordWebhookInboxOldestClaimableAge(ctx context.Context, age time.Duration) {
+	recordGauge(ctx, "schemabot.webhook.inbox_oldest_claimable_age_seconds", int64(age.Seconds()),
+		"Age in seconds of the oldest ready-to-claim durable webhook inbox row", "s",
+		EnvironmentAttribute(""),
+	)
+}
+
+// RecordWebhookInboxStuckProcessing records the number of inbox rows wedged in
+// processing with an expired lease at the attempt cap — deliveries no driver can
+// reclaim. A nonzero value means auto-plans are being lost to crashes
+// mid-processing until the reconciler terminalizes them.
+func RecordWebhookInboxStuckProcessing(ctx context.Context, count int64) {
+	recordGauge(ctx, "schemabot.webhook.inbox_stuck_processing", count,
+		"Number of durable webhook inbox rows stuck in processing past the attempt cap", "{row}",
+		EnvironmentAttribute(""),
+	)
+}
+
 var knownStatusCheckOperations = map[string]bool{
 	"plan_check_recorded":                  true,
 	"apply_started":                        true,

--- a/pkg/metrics/webhook_inbox_metrics_test.go
+++ b/pkg/metrics/webhook_inbox_metrics_test.go
@@ -1,0 +1,85 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// An unrecognized inbox state must fold to "unknown" so a typo or a future
+// unhandled state can't blow up the depth gauge's cardinality.
+func TestRecordWebhookInboxDepthFoldsUnknownState(t *testing.T) {
+	reader := metric.NewManualReader()
+	mp := metric.NewMeterProvider(metric.WithReader(reader))
+	previousProvider := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	defer func() {
+		otel.SetMeterProvider(previousProvider)
+		require.NoError(t, mp.Shutdown(t.Context()))
+	}()
+
+	RecordWebhookInboxDepth(t.Context(), "pending", 3)
+	RecordWebhookInboxDepth(t.Context(), "not_a_real_state", 7)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+
+	depthByState := map[string]int64{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "schemabot.webhook.inbox_depth" {
+				continue
+			}
+			gauge, ok := m.Data.(metricdata.Gauge[int64])
+			require.True(t, ok)
+			for _, dp := range gauge.DataPoints {
+				state, ok := dp.Attributes.Value(attribute.Key("state"))
+				require.True(t, ok)
+				depthByState[state.AsString()] = dp.Value
+			}
+		}
+	}
+
+	assert.Equal(t, int64(3), depthByState["pending"])
+	assert.Equal(t, int64(7), depthByState["unknown"])
+	assert.NotContains(t, depthByState, "not_a_real_state")
+}
+
+// The backlog-age gauge reports whole seconds.
+func TestRecordWebhookInboxOldestClaimableAge(t *testing.T) {
+	reader := metric.NewManualReader()
+	mp := metric.NewMeterProvider(metric.WithReader(reader))
+	previousProvider := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	defer func() {
+		otel.SetMeterProvider(previousProvider)
+		require.NoError(t, mp.Shutdown(t.Context()))
+	}()
+
+	RecordWebhookInboxOldestClaimableAge(t.Context(), 90*time.Second)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+
+	var found bool
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "schemabot.webhook.inbox_oldest_claimable_age_seconds" {
+				continue
+			}
+			found = true
+			gauge, ok := m.Data.(metricdata.Gauge[int64])
+			require.True(t, ok)
+			require.Len(t, gauge.DataPoints, 1)
+			assert.Equal(t, int64(90), gauge.DataPoints[0].Value)
+		}
+	}
+	assert.True(t, found)
+}

--- a/pkg/serve/serve.go
+++ b/pkg/serve/serve.go
@@ -474,7 +474,8 @@ func (s *Server) Handler() http.Handler {
 
 // Start launches the server's background work: the operator driver pool
 // (dispatches queued applies and recovers stale ones), the remote-deployment
-// health monitor, and the pending-drops cleaner — all of which run until ctx is
+// health monitor, the webhook inbox monitor (emits durable-inbox depth/backlog
+// metrics), and the pending-drops cleaner — all of which run until ctx is
 // canceled or Close is called. It also kicks off a one-shot missing-summary
 // reconciliation that, once started, runs to completion independently of ctx (it
 // repairs interrupted terminal comments and must not be cut short by a request
@@ -487,6 +488,7 @@ func (s *Server) Start(ctx context.Context) {
 	}
 	s.svc.StartOperator(ctx)
 	s.svc.StartRemoteDeploymentHealthMonitor(ctx)
+	s.svc.StartWebhookInboxMonitor(ctx)
 	s.svc.StartPendingDropsCleaner(ctx)
 }
 

--- a/pkg/storage/mysqlstore/webhook_events.go
+++ b/pkg/storage/mysqlstore/webhook_events.go
@@ -117,6 +117,29 @@ func (s *webhookEventStore) GetByDeliveryID(ctx context.Context, provider, deliv
 	return scanWebhookEvent(row)
 }
 
+// webhookClaimablePredicate matches exactly the rows a driver would claim: a
+// pending row, a retryable row whose retry window has elapsed and is under the
+// attempt cap, or a processing row whose lease has expired and is under the
+// attempt cap. FindNext and the InboxStats backlog-age query derive from this
+// single source so the "ready to claim" definition cannot drift between what a
+// driver picks up and what the backlog gauge measures. Bind its placeholders
+// with webhookClaimableArgs.
+const webhookClaimablePredicate = `(
+			state = ?
+			OR (state = ? AND (retry_after IS NULL OR retry_after <= NOW()) AND attempts < ?)
+			OR (state = ? AND lease_expires_at <= NOW(6) AND attempts < ?)
+		)`
+
+// webhookClaimableArgs returns the placeholder bindings for
+// webhookClaimablePredicate, in order.
+func webhookClaimableArgs() []any {
+	return []any{
+		storage.WebhookEventPending,
+		storage.WebhookEventFailedRetryable, storage.MaxWebhookEventAttempts,
+		storage.WebhookEventProcessing, storage.MaxWebhookEventAttempts,
+	}
+}
+
 func (s *webhookEventStore) FindNext(ctx context.Context, owner string, leaseDuration time.Duration) (*storage.WebhookEvent, error) {
 	if owner == "" {
 		return nil, fmt.Errorf("webhook driver owner is required")
@@ -133,15 +156,11 @@ func (s *webhookEventStore) FindNext(ctx context.Context, owner string, leaseDur
 	row := tx.QueryRowContext(ctx, `
 		SELECT `+webhookEventColumns+`
 		FROM webhook_events
-		WHERE state = ?
-			OR (state = ? AND (retry_after IS NULL OR retry_after <= NOW()) AND attempts < ?)
-			OR (state = ? AND lease_expires_at <= NOW(6) AND attempts < ?)
+		WHERE `+webhookClaimablePredicate+`
 		ORDER BY created_at, id
 		LIMIT 1
 		FOR UPDATE SKIP LOCKED
-	`, storage.WebhookEventPending,
-		storage.WebhookEventFailedRetryable, storage.MaxWebhookEventAttempts,
-		storage.WebhookEventProcessing, storage.MaxWebhookEventAttempts)
+	`, webhookClaimableArgs()...)
 
 	event, err := scanWebhookEventInto(row)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -340,16 +359,18 @@ func (s *webhookEventStore) InboxStats(ctx context.Context) (*storage.WebhookInb
 		return nil, fmt.Errorf("iterate webhook inbox state counts: %w", err)
 	}
 
-	// Oldest ready-to-claim row: pending, or retryable whose retry window has
-	// elapsed. Processing rows are already claimed, so they are excluded. NULL
-	// (nothing waiting) scans into a zero age.
+	// Oldest ready-to-claim row, using the exact predicate a driver claims by
+	// (webhookClaimablePredicate) so the backlog gauge and dispatch agree on
+	// what is claimable: a cap-exhausted retryable row is not counted (a driver
+	// won't take it, so it isn't backlog), and an expired-lease processing row a
+	// driver would reclaim is counted (real backlog when its driver crashed).
+	// NULL (nothing waiting) scans into a zero age.
 	var oldestAgeSeconds sql.NullFloat64
 	err = s.db.QueryRowContext(ctx, `
 		SELECT TIMESTAMPDIFF(MICROSECOND, MIN(received_at), NOW(6)) / 1e6
 		FROM webhook_events
-		WHERE state = ?
-			OR (state = ? AND (retry_after IS NULL OR retry_after <= NOW()))
-	`, storage.WebhookEventPending, storage.WebhookEventFailedRetryable).Scan(&oldestAgeSeconds)
+		WHERE `+webhookClaimablePredicate+`
+	`, webhookClaimableArgs()...).Scan(&oldestAgeSeconds)
 	if err != nil {
 		return nil, fmt.Errorf("measure oldest claimable webhook inbox row: %w", err)
 	}

--- a/pkg/storage/mysqlstore/webhook_events.go
+++ b/pkg/storage/mysqlstore/webhook_events.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/block/spirit/pkg/utils"
+
 	"github.com/block/schemabot/pkg/storage"
 )
 
@@ -308,6 +310,62 @@ func scanWebhookEventInto(row scanner) (*storage.WebhookEvent, error) {
 		event.CompletedAt = &completedAt.Time
 	}
 	return &event, nil
+}
+
+// InboxStats returns a read-only snapshot of the inbox for observability. It
+// runs three cheap aggregates rather than one query: heterogeneous aggregates
+// (grouped counts, a MIN age over a filtered subset, and a filtered count) do
+// not combine into a single index-friendly statement, and each is served by an
+// existing index.
+func (s *webhookEventStore) InboxStats(ctx context.Context) (*storage.WebhookInboxStats, error) {
+	stats := &storage.WebhookInboxStats{CountsByState: make(map[string]int64, len(storage.WebhookEventStatesAll))}
+	for _, state := range storage.WebhookEventStatesAll {
+		stats.CountsByState[state] = 0
+	}
+
+	rows, err := s.db.QueryContext(ctx, `SELECT state, COUNT(*) FROM webhook_events GROUP BY state`)
+	if err != nil {
+		return nil, fmt.Errorf("count webhook inbox rows by state: %w", err)
+	}
+	defer utils.CloseAndLog(rows)
+	for rows.Next() {
+		var state string
+		var count int64
+		if err := rows.Scan(&state, &count); err != nil {
+			return nil, fmt.Errorf("scan webhook inbox state count: %w", err)
+		}
+		stats.CountsByState[state] = count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate webhook inbox state counts: %w", err)
+	}
+
+	// Oldest ready-to-claim row: pending, or retryable whose retry window has
+	// elapsed. Processing rows are already claimed, so they are excluded. NULL
+	// (nothing waiting) scans into a zero age.
+	var oldestAgeSeconds sql.NullFloat64
+	err = s.db.QueryRowContext(ctx, `
+		SELECT TIMESTAMPDIFF(MICROSECOND, MIN(received_at), NOW(6)) / 1e6
+		FROM webhook_events
+		WHERE state = ?
+			OR (state = ? AND (retry_after IS NULL OR retry_after <= NOW()))
+	`, storage.WebhookEventPending, storage.WebhookEventFailedRetryable).Scan(&oldestAgeSeconds)
+	if err != nil {
+		return nil, fmt.Errorf("measure oldest claimable webhook inbox row: %w", err)
+	}
+	if oldestAgeSeconds.Valid && oldestAgeSeconds.Float64 > 0 {
+		stats.OldestClaimableAge = time.Duration(oldestAgeSeconds.Float64 * float64(time.Second))
+	}
+
+	err = s.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM webhook_events
+		WHERE state = ? AND lease_expires_at <= NOW(6) AND attempts >= ?
+	`, storage.WebhookEventProcessing, storage.MaxWebhookEventAttempts).Scan(&stats.StuckProcessing)
+	if err != nil {
+		return nil, fmt.Errorf("count stuck processing webhook inbox rows: %w", err)
+	}
+
+	return stats, nil
 }
 
 func (s *webhookEventStore) checkWebhookEventLeaseResult(ctx context.Context, result sql.Result, id int64, leaseToken string) error {

--- a/pkg/storage/mysqlstore/webhook_events_test.go
+++ b/pkg/storage/mysqlstore/webhook_events_test.go
@@ -495,3 +495,66 @@ func TestWebhookEventStore_SubSecondLeaseIsNotImmediatelyReclaimable(t *testing.
 	require.NoError(t, err)
 	assert.Nil(t, none)
 }
+
+// InboxStats gives operators a steady-state view of the durable inbox: how many
+// rows sit in each state, how long the oldest ready-to-claim delivery has waited
+// (backlog latency), and how many are wedged in processing past the attempt cap.
+func TestWebhookEventStore_InboxStats(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	// Empty inbox: every state present at zero, no backlog, nothing stuck.
+	empty, err := store.WebhookEvents().InboxStats(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, empty)
+	assert.Equal(t, int64(0), empty.CountsByState[storage.WebhookEventPending])
+	assert.Equal(t, int64(0), empty.CountsByState[storage.WebhookEventProcessing])
+	assert.Zero(t, empty.OldestClaimableAge)
+	assert.Equal(t, int64(0), empty.StuckProcessing)
+
+	// Two pending rows; the older one drives the backlog age.
+	insertPending := func(deliveryID string, receivedAgo time.Duration) {
+		t.Helper()
+		inserted, err := store.WebhookEvents().Create(ctx, &storage.WebhookEvent{DeliveryID: deliveryID, Event: "pull_request", Payload: []byte(`{}`)})
+		require.NoError(t, err)
+		require.True(t, inserted)
+		_, err = testDB.ExecContext(ctx, `UPDATE webhook_events SET received_at = NOW(6) - INTERVAL ? SECOND WHERE provider = ? AND delivery_id = ?`,
+			int(receivedAgo.Seconds()), storage.WebhookProviderGitHub, deliveryID)
+		require.NoError(t, err)
+	}
+	insertPending("pending-old", 120*time.Second)
+	insertPending("pending-new", 5*time.Second)
+
+	// A completed row: counts toward completed, never toward backlog. Set its
+	// state directly so the FIFO claim order can't reassign it to another row.
+	completedDelivery, err := store.WebhookEvents().Create(ctx, &storage.WebhookEvent{DeliveryID: "completed-1", Event: "pull_request", Payload: []byte(`{}`)})
+	require.NoError(t, err)
+	require.True(t, completedDelivery)
+	_, err = testDB.ExecContext(ctx, `UPDATE webhook_events SET state = ?, completed_at = NOW() WHERE provider = ? AND delivery_id = ?`,
+		storage.WebhookEventCompleted, storage.WebhookProviderGitHub, "completed-1")
+	require.NoError(t, err)
+
+	// A stuck processing row: at the attempt cap with an expired lease.
+	stuck, err := store.WebhookEvents().Create(ctx, &storage.WebhookEvent{DeliveryID: "stuck-1", Event: "pull_request", Payload: []byte(`{}`)})
+	require.NoError(t, err)
+	require.True(t, stuck)
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE webhook_events
+		SET state = ?, attempts = ?, lease_owner = 'driver', lease_token = 'tok',
+			lease_expires_at = NOW(6) - INTERVAL 1 SECOND
+		WHERE provider = ? AND delivery_id = ?
+	`, storage.WebhookEventProcessing, storage.MaxWebhookEventAttempts, storage.WebhookProviderGitHub, "stuck-1")
+	require.NoError(t, err)
+
+	stats, err := store.WebhookEvents().InboxStats(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+	assert.Equal(t, int64(2), stats.CountsByState[storage.WebhookEventPending])
+	assert.Equal(t, int64(1), stats.CountsByState[storage.WebhookEventProcessing])
+	assert.Equal(t, int64(1), stats.CountsByState[storage.WebhookEventCompleted])
+	assert.Equal(t, int64(1), stats.StuckProcessing)
+	// The oldest pending row is ~120s old; allow slack for execution time.
+	assert.GreaterOrEqual(t, stats.OldestClaimableAge, 110*time.Second)
+	assert.Less(t, stats.OldestClaimableAge, 5*time.Minute)
+}

--- a/pkg/storage/mysqlstore/webhook_events_test.go
+++ b/pkg/storage/mysqlstore/webhook_events_test.go
@@ -496,6 +496,58 @@ func TestWebhookEventStore_SubSecondLeaseIsNotImmediatelyReclaimable(t *testing.
 	assert.Nil(t, none)
 }
 
+// The backlog-age gauge must count exactly the rows a driver would claim: a
+// retryable row past the attempt cap is not backlog (FindNext skips it forever),
+// while an expired-lease processing row under the cap is (a driver reclaims it).
+func TestWebhookEventStore_InboxStatsBacklogMatchesClaimable(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	// A cap-exhausted retryable row whose retry window has long elapsed. FindNext
+	// never reclaims it, so it must not inflate the backlog age.
+	capExhausted, err := store.WebhookEvents().Create(ctx, &storage.WebhookEvent{DeliveryID: "cap-exhausted", Event: "pull_request", Payload: []byte(`{}`)})
+	require.NoError(t, err)
+	require.True(t, capExhausted)
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE webhook_events
+		SET state = ?, attempts = ?, retry_after = NOW() - INTERVAL 1 HOUR,
+			received_at = NOW(6) - INTERVAL 600 SECOND
+		WHERE provider = ? AND delivery_id = ?
+	`, storage.WebhookEventFailedRetryable, storage.MaxWebhookEventAttempts, storage.WebhookProviderGitHub, "cap-exhausted")
+	require.NoError(t, err)
+
+	onlyExhausted, err := store.WebhookEvents().InboxStats(ctx)
+	require.NoError(t, err)
+	assert.Zero(t, onlyExhausted.OldestClaimableAge, "a cap-exhausted retryable row must not count as backlog")
+
+	// An expired-lease processing row under the cap is genuinely reclaimable
+	// backlog: its driver crashed and another will pick it up.
+	reclaimable, err := store.WebhookEvents().Create(ctx, &storage.WebhookEvent{DeliveryID: "reclaimable", Event: "pull_request", Payload: []byte(`{}`)})
+	require.NoError(t, err)
+	require.True(t, reclaimable)
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE webhook_events
+		SET state = ?, attempts = ?, lease_owner = 'driver', lease_token = 'tok',
+			lease_expires_at = NOW(6) - INTERVAL 1 SECOND,
+			received_at = NOW(6) - INTERVAL 200 SECOND
+		WHERE provider = ? AND delivery_id = ?
+	`, storage.WebhookEventProcessing, storage.MaxWebhookEventAttempts-1, storage.WebhookProviderGitHub, "reclaimable")
+	require.NoError(t, err)
+
+	stats, err := store.WebhookEvents().InboxStats(ctx)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, stats.OldestClaimableAge, 190*time.Second, "an expired-lease processing row under the cap is claimable backlog")
+	assert.Less(t, stats.OldestClaimableAge, 300*time.Second, "the 600s cap-exhausted retryable row must not drive the age")
+
+	// FindNext agrees with the gauge: it reclaims the processing row and never
+	// the cap-exhausted retryable one.
+	claimed, err := store.WebhookEvents().FindNext(ctx, "driver-b", time.Minute)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, "reclaimable", claimed.DeliveryID)
+}
+
 // InboxStats gives operators a steady-state view of the durable inbox: how many
 // rows sit in each state, how long the oldest ready-to-claim delivery has waited
 // (backlog latency), and how many are wedged in processing past the attempt cap.

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -245,6 +245,13 @@ type WebhookEventStore interface {
 	// a real processing attempt. Returns ErrWebhookEventLeaseLost when the
 	// lease token is stale.
 	Release(ctx context.Context, id int64, leaseToken string) error
+
+	// InboxStats returns a point-in-time snapshot of the inbox for steady-state
+	// observability: row counts per state, the age of the oldest row that is
+	// ready to claim but not yet claimed (backlog latency), and the count of
+	// rows wedged in processing past the attempt cap with an expired lease. It
+	// is read-only and safe to call on a periodic cadence.
+	InboxStats(ctx context.Context) (*WebhookInboxStats, error)
 }
 
 // PlanStore manages schema change plans.

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -1293,6 +1293,35 @@ const (
 	WebhookEventFailed          = "failed"
 )
 
+// WebhookEventStatesAll lists every canonical webhook inbox state, ordered from
+// earliest to terminal. Use it to enumerate states for metrics and stats so a
+// series is always present even when a state is momentarily empty.
+var WebhookEventStatesAll = []string{
+	WebhookEventPending,
+	WebhookEventProcessing,
+	WebhookEventFailedRetryable,
+	WebhookEventCompleted,
+	WebhookEventFailed,
+}
+
+// WebhookInboxStats is a point-in-time snapshot of the durable webhook inbox
+// used for steady-state observability.
+type WebhookInboxStats struct {
+	// CountsByState is the number of rows in each state. Every canonical state
+	// is present, defaulting to 0, so a gauge series never disappears when a
+	// state momentarily empties.
+	CountsByState map[string]int64
+
+	// OldestClaimableAge is how long the oldest ready-to-claim-but-unclaimed row
+	// (pending, or retryable with an elapsed retry window) has been waiting. It
+	// is the inbox's backlog latency; zero when nothing is waiting.
+	OldestClaimableAge time.Duration
+
+	// StuckProcessing is the number of rows wedged in processing with an expired
+	// lease at the attempt cap — deliveries a driver can no longer reclaim.
+	StuckProcessing int64
+}
+
 // WebhookEvent is a durable inbox row for one SCM/webhook delivery.
 type WebhookEvent struct {
 	ID             int64

--- a/pkg/webhook/durable_dispatch_test.go
+++ b/pkg/webhook/durable_dispatch_test.go
@@ -87,6 +87,10 @@ func (s *recordingWebhookEventStore) Release(context.Context, int64, string) err
 	return errors.New("Release not implemented by recordingWebhookEventStore")
 }
 
+func (s *recordingWebhookEventStore) InboxStats(context.Context) (*storage.WebhookInboxStats, error) {
+	return nil, errors.New("InboxStats not implemented by recordingWebhookEventStore")
+}
+
 func TestDurablePullRequestWebhookQueuesAndAcks(t *testing.T) {
 	events := newRecordingWebhookEventStore()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))


### PR DESCRIPTION
## Summary

Adds steady-state observability for the durable webhook inbox. A background monitor periodically snapshots the inbox and emits gauges for depth by state, backlog latency, and stuck-processing rows — so operators can see webhook backpressure as inbox depth rather than only as request latency.

## What

- New read-only `WebhookEventStore.InboxStats`: row counts per state, the age of the oldest ready-to-claim-but-unclaimed row, and the count of rows wedged in `processing` past the attempt cap with an expired lease.
- A `Service` background monitor (mirrors the remote-deployment health monitor: `Start`/`Stop`, configurable interval, started from the server lifecycle) that snapshots every 30s and records:
  - `schemabot.webhook.inbox_depth{state}` — one series per canonical state, present even at zero.
  - `schemabot.webhook.inbox_oldest_claimable_age_seconds` — backlog latency.
  - `schemabot.webhook.inbox_stuck_processing` — deliveries no driver can reclaim.
- The depth gauge folds unrecognized states to `unknown` to keep cardinality bounded.

## Why

The inbox decouples acknowledgement from processing, so a growing backlog no longer shows up as slow webhook responses — it shows up as rows piling in the table. Without these gauges, an operator has no signal that acked deliveries aren't being drained. The stuck-processing gauge surfaces the crash-on-final-attempt population until the reconciler terminalizes it.

## Before / after

```text
        BEFORE                                AFTER
  inbox depth invisible            monitor snapshots inbox every 30s
  backlog only visible as    ──▶     inbox_depth{state}
  slow requests (which the           inbox_oldest_claimable_age_seconds
  fast-ack path removed)             inbox_stuck_processing
```

### The wedge in-action
```
FindNext claims (attempts 1→5, lease set)
        │
        ▼
   state=processing, attempts=5, lease active
        │   driver OOM-killed before MarkFailed
        ▼
   lease expires  ──────────────────────────────╮
        │                                       │
        ▼                                       ▼
  reclaim predicate:                     redeliver / Create:
  state=processing                       row is non-terminal
  AND lease_expires_at<=NOW()  ✓         → inserted=false (dedup)
  AND attempts < 5             ✗         → GitHub "Redeliver" = no-op
        │
        ▼
  FindNext SKIPS it  →  wedged in `processing` forever
```

Dispatch metrics keyed by delivery GUID (started/finished/failed) and the transport-lag alerts need the dispatch driver pool and are a stacked follow-up.
