### PR TITLE
fix(github): respond to commands with invalid or unknown -e values instead of ignoring them

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -593,14 +593,14 @@ spoof from a chain member missing from the list.
 **Command routing across instances.** Every instance receives every PR comment
 through its own App's webhook. A command whose `-e` value is in the instance's
 `allowed_environments` is handled; one owned by a peer instance is silently
-left for that peer to answer. A command environment that appears nowhere in
-the configuration — not in `allowed_environments`, `environment_order`, or any
-database's routing environments — belongs to no instance, so it is rejected
-with an unknown-environment comment listing the configured environments. A
-malformed `-e` value (typically a flag glued on by a missing space, like
-`-e production--allow-unsafe`) is rejected with a usage comment. Both
-rejections follow the `respond_to_unscoped` policy so exactly one instance
-responds, and are acknowledged with an eyes reaction. Because
+left for that peer to answer. An `-e` value that names no configured
+environment — whether malformed (typically a flag glued on by a missing
+space, like `-e production--allow-unsafe`) or simply absent from
+`allowed_environments`, `environment_order`, and every database's routing
+environments — belongs to no instance, so it is rejected with an
+invalid-environment comment listing the configured environments. The
+rejection follows the `respond_to_unscoped` policy so exactly one instance
+responds, and is acknowledged with an eyes reaction. Because
 `environment_order` doubles as the fleet-wide environment roster for this
 routing decision, keep it complete on every instance.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -590,6 +590,20 @@ gate sees an aggregate-named check from an untrusted app, it blocks as usual
 and emits a warning log and metric so operators can distinguish a check-name
 spoof from a chain member missing from the list.
 
+**Command routing across instances.** Every instance receives every PR comment
+through its own App's webhook. A command whose `-e` value is in the instance's
+`allowed_environments` is handled; one owned by a peer instance is silently
+left for that peer to answer. A command environment that appears nowhere in
+the configuration — not in `allowed_environments`, `environment_order`, or any
+database's routing environments — belongs to no instance, so it is rejected
+with an unknown-environment comment listing the configured environments. A
+malformed `-e` value (typically a flag glued on by a missing space, like
+`-e production--allow-unsafe`) is rejected with a usage comment. Both
+rejections follow the `respond_to_unscoped` policy so exactly one instance
+responds, and are acknowledged with an eyes reaction. Because
+`environment_order` doubles as the fleet-wide environment roster for this
+routing decision, keep it complete on every instance.
+
 ### Environment-local gRPC targets
 
 For remote Tern deployments, keep the target registry environment-local too. The staging instance only needs staging target identifiers:

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -1816,9 +1816,26 @@ func (c *ServerConfig) KnownEnvironments() []string {
 }
 
 // IsEnvironmentKnown reports whether the environment appears anywhere in this
-// instance's configuration (see KnownEnvironments).
+// instance's configuration — the same set KnownEnvironments returns — checked
+// by direct membership so the webhook command path does not materialize and
+// sort the full list on every lookup.
 func (c *ServerConfig) IsEnvironmentKnown(env string) bool {
-	return slices.Contains(c.KnownEnvironments(), env)
+	if c == nil || env == "" {
+		return false
+	}
+	order := c.EnvironmentOrder
+	if len(order) == 0 {
+		order = defaultEnvironmentOrder
+	}
+	if slices.Contains(c.AllowedEnvironments, env) || slices.Contains(order, env) {
+		return true
+	}
+	for _, db := range c.Databases {
+		if _, ok := db.Environments[env]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // PromotionEnvironmentOrder returns the server-owned environment promotion

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -1782,6 +1782,45 @@ func isValidTenantName(tenant string) bool {
 	return true
 }
 
+// KnownEnvironments returns every environment name visible in this instance's
+// configuration: its own allowed environments, the server-owned promotion
+// order (which lists peer-owned environments in environment-isolated
+// deployments), and each database's routing environments. The result is
+// sorted and deduplicated. A command environment outside this set belongs to
+// no SchemaBot instance and can be rejected instead of deferred to a peer.
+func (c *ServerConfig) KnownEnvironments() []string {
+	if c == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	add := func(envs ...string) {
+		for _, env := range envs {
+			if env != "" {
+				seen[env] = struct{}{}
+			}
+		}
+	}
+	add(c.AllowedEnvironments...)
+	add(c.PromotionEnvironmentOrder()...)
+	for _, db := range c.Databases {
+		for env := range db.Environments {
+			add(env)
+		}
+	}
+	envs := make([]string, 0, len(seen))
+	for env := range seen {
+		envs = append(envs, env)
+	}
+	slices.Sort(envs)
+	return envs
+}
+
+// IsEnvironmentKnown reports whether the environment appears anywhere in this
+// instance's configuration (see KnownEnvironments).
+func (c *ServerConfig) IsEnvironmentKnown(env string) bool {
+	return slices.Contains(c.KnownEnvironments(), env)
+}
+
 // PromotionEnvironmentOrder returns the server-owned environment promotion
 // order used by PR apply gating.
 func (c *ServerConfig) PromotionEnvironmentOrder() []string {

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -3464,3 +3464,33 @@ func TestSchemaDirHintsForRepoNoMatches(t *testing.T) {
 	assert.Empty(t, hints)
 	assert.True(t, exhaustive, "no repo-eligible database means no policy-valid config location exists")
 }
+
+func TestKnownEnvironments(t *testing.T) {
+	t.Run("defaults to the promotion order", func(t *testing.T) {
+		cfg := &ServerConfig{}
+		assert.Equal(t, []string{"production", "staging"}, cfg.KnownEnvironments())
+		assert.True(t, cfg.IsEnvironmentKnown("staging"))
+		assert.True(t, cfg.IsEnvironmentKnown("production"))
+		assert.False(t, cfg.IsEnvironmentKnown("prodction"))
+	})
+
+	t.Run("unions allowed environments, environment order, and database routing environments", func(t *testing.T) {
+		cfg := &ServerConfig{
+			AllowedEnvironments: []string{"qa"},
+			EnvironmentOrder:    []string{"staging", "production"},
+			Databases: map[string]DatabaseConfig{
+				"payments": {Environments: map[string]EnvironmentConfig{"load": {}}},
+			},
+		}
+		assert.Equal(t, []string{"load", "production", "qa", "staging"}, cfg.KnownEnvironments())
+		assert.True(t, cfg.IsEnvironmentKnown("load"))
+		assert.True(t, cfg.IsEnvironmentKnown("qa"))
+		assert.False(t, cfg.IsEnvironmentKnown("dev"))
+	})
+
+	t.Run("nil config knows no environments", func(t *testing.T) {
+		var cfg *ServerConfig
+		assert.Nil(t, cfg.KnownEnvironments())
+		assert.False(t, cfg.IsEnvironmentKnown("staging"))
+	})
+}

--- a/pkg/webhook/check_runs_test.go
+++ b/pkg/webhook/check_runs_test.go
@@ -465,6 +465,30 @@ func TestRespondToUnscoped(t *testing.T) {
 		assert.Contains(t, rr.Body.String(), "unscoped command skipped")
 	})
 
+	t.Run("unknown environment skipped when respond_to_unscoped is false", func(t *testing.T) {
+		service := api.New(nil, &api.ServerConfig{
+			RespondToUnscoped:   &falseVal,
+			AllowedEnvironments: []string{"staging"},
+			Repos:               map[string]api.RepoConfig{},
+		}, nil, testLogger())
+
+		h := &Handler{
+			service: service,
+			logger:  testLogger(),
+		}
+
+		req := buildWebhookRequest(t, webhookPayloadOpts{
+			comment: "schemabot apply -e prodction",
+			isPR:    true,
+		}, nil)
+
+		rr := httpResponseRecorder()
+		h.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		assert.Contains(t, rr.Body.String(), "unscoped command skipped")
+	})
+
 	t.Run("targeted command skipped by non-matching tenant", func(t *testing.T) {
 		service := api.New(nil, &api.ServerConfig{
 			Tenant:            "alpha",

--- a/pkg/webhook/check_runs_test.go
+++ b/pkg/webhook/check_runs_test.go
@@ -442,6 +442,29 @@ func TestRespondToUnscoped(t *testing.T) {
 		assert.Contains(t, rr.Body.String(), "unscoped command skipped")
 	})
 
+	t.Run("invalid environment value skipped when respond_to_unscoped is false", func(t *testing.T) {
+		service := api.New(nil, &api.ServerConfig{
+			RespondToUnscoped: &falseVal,
+			Repos:             map[string]api.RepoConfig{},
+		}, nil, testLogger())
+
+		h := &Handler{
+			service: service,
+			logger:  testLogger(),
+		}
+
+		req := buildWebhookRequest(t, webhookPayloadOpts{
+			comment: "schemabot apply -e production--allow-unsafe",
+			isPR:    true,
+		}, nil)
+
+		rr := httpResponseRecorder()
+		h.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		assert.Contains(t, rr.Body.String(), "unscoped command skipped")
+	})
+
 	t.Run("targeted command skipped by non-matching tenant", func(t *testing.T) {
 		service := api.New(nil, &api.ServerConfig{
 			Tenant:            "alpha",

--- a/pkg/webhook/commands.go
+++ b/pkg/webhook/commands.go
@@ -112,39 +112,41 @@ func commandNamePattern() string {
 
 // CommandParser parses SchemaBot commands from PR comments.
 type CommandParser struct {
-	commandRegex      *regexp.Regexp
-	mentionRegex      *regexp.Regexp
-	helpRegex         *regexp.Regexp
-	applyIDRegex      *regexp.Regexp
-	environmentRegex  *regexp.Regexp
-	databaseRegex     *regexp.Regexp
-	tenantRegex       *regexp.Regexp
-	tenantFlagRegex   *regexp.Regexp
-	skipRevertRegex   *regexp.Regexp
-	deferCutoverRegex *regexp.Regexp
-	allowUnsafeRegex  *regexp.Regexp
-	forceRegex        *regexp.Regexp
-	autoConfirmRegex  *regexp.Regexp
-	volumeFlagRegex   *regexp.Regexp
+	commandRegex         *regexp.Regexp
+	mentionRegex         *regexp.Regexp
+	helpRegex            *regexp.Regexp
+	applyIDRegex         *regexp.Regexp
+	environmentRegex     *regexp.Regexp
+	environmentNameRegex *regexp.Regexp
+	databaseRegex        *regexp.Regexp
+	tenantRegex          *regexp.Regexp
+	tenantFlagRegex      *regexp.Regexp
+	skipRevertRegex      *regexp.Regexp
+	deferCutoverRegex    *regexp.Regexp
+	allowUnsafeRegex     *regexp.Regexp
+	forceRegex           *regexp.Regexp
+	autoConfirmRegex     *regexp.Regexp
+	volumeFlagRegex      *regexp.Regexp
 }
 
 // NewCommandParser creates a new command parser.
 func NewCommandParser() *CommandParser {
 	return &CommandParser{
-		commandRegex:      regexp.MustCompile(`(?im)^ {0,3}schemabot[ \t]+(` + commandNamePattern() + `)\b`),
-		mentionRegex:      regexp.MustCompile(`(?im)^ {0,3}schemabot(?:[ \t]+|$)`),
-		helpRegex:         regexp.MustCompile(`(?im)^ {0,3}schemabot[ \t]+help\b`),
-		applyIDRegex:      regexp.MustCompile(`(?i)\b(apply[_-][a-f0-9]+)\b`),
-		environmentRegex:  regexp.MustCompile(`(?i)-e\s+([a-z0-9][a-z0-9_-]*)`),
-		databaseRegex:     regexp.MustCompile(`(?i)-d\s+([a-zA-Z0-9_-]+)`),
-		tenantRegex:       regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`),
-		tenantFlagRegex:   regexp.MustCompile(`(?i)(?:^|\s)(?:--tenant|-t)(?:[ \t]+([^\s]+))?`),
-		skipRevertRegex:   regexp.MustCompile(`(?i)--skip-revert\b`),
-		deferCutoverRegex: regexp.MustCompile(`(?i)--defer-cutover\b`),
-		allowUnsafeRegex:  regexp.MustCompile(`(?i)--allow-unsafe\b`),
-		forceRegex:        regexp.MustCompile(`(?i)--force\b`),
-		autoConfirmRegex:  regexp.MustCompile(`(?i)(?:--yes\b|-y\b)`),
-		volumeFlagRegex:   regexp.MustCompile(`(?i)(?:^|\s)(?:--volume|-v)(?:[ \t]+([^\s]+))?(?:\s|$)`),
+		commandRegex:         regexp.MustCompile(`(?im)^ {0,3}schemabot[ \t]+(` + commandNamePattern() + `)\b`),
+		mentionRegex:         regexp.MustCompile(`(?im)^ {0,3}schemabot(?:[ \t]+|$)`),
+		helpRegex:            regexp.MustCompile(`(?im)^ {0,3}schemabot[ \t]+help\b`),
+		applyIDRegex:         regexp.MustCompile(`(?i)\b(apply[_-][a-f0-9]+)\b`),
+		environmentRegex:     regexp.MustCompile(`(?i)-e\s+([^-\s][^\s]*)`),
+		environmentNameRegex: regexp.MustCompile(`^[a-z0-9][a-z0-9_]*(?:-[a-z0-9_]+)*$`),
+		databaseRegex:        regexp.MustCompile(`(?i)-d\s+([a-zA-Z0-9_-]+)`),
+		tenantRegex:          regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`),
+		tenantFlagRegex:      regexp.MustCompile(`(?i)(?:^|\s)(?:--tenant|-t)(?:[ \t]+([^\s]+))?`),
+		skipRevertRegex:      regexp.MustCompile(`(?i)--skip-revert\b`),
+		deferCutoverRegex:    regexp.MustCompile(`(?i)--defer-cutover\b`),
+		allowUnsafeRegex:     regexp.MustCompile(`(?i)--allow-unsafe\b`),
+		forceRegex:           regexp.MustCompile(`(?i)--force\b`),
+		autoConfirmRegex:     regexp.MustCompile(`(?i)(?:--yes\b|-y\b)`),
+		volumeFlagRegex:      regexp.MustCompile(`(?i)(?:^|\s)(?:--volume|-v)(?:[ \t]+([^\s]+))?(?:\s|$)`),
 	}
 }
 
@@ -176,6 +178,12 @@ type CommandResult struct {
 	IsHelp           bool
 	IsMention        bool
 	MissingEnv       bool
+	// EnvironmentError is true when `-e` is present but its value is not a
+	// valid environment name (for example a flag glued onto the value:
+	// `-e production--allow-unsafe`). The dispatcher posts a usage comment;
+	// such a command must never fall back to missing-env handling, which
+	// would run `plan` against every configured environment.
+	EnvironmentError bool
 }
 
 // ParseCommand parses a SchemaBot command from a comment body.
@@ -316,11 +324,24 @@ func (p *CommandParser) applySpec(spec CommandSpec, body, tenant string, tenantE
 		result.VolumeLevel, result.VolumeLevelError = p.extractVolumeLevel(body)
 	}
 
+	// The -e capture takes the whole token (any non-flag word) and validity is
+	// checked separately: a malformed value like `production--allow-unsafe`
+	// must be rejected as a whole, never reinterpreted as an environment plus
+	// a glued-on flag.
 	if m := p.environmentRegex.FindStringSubmatch(body); len(m) >= 2 {
-		result.Environment = strings.ToLower(m[1])
+		env := strings.ToLower(m[1])
+		if p.environmentNameRegex.MatchString(env) {
+			result.Environment = env
+		} else {
+			result.EnvironmentError = true
+		}
 	}
 
 	switch {
+	case result.EnvironmentError:
+		// The command is recognized; the dispatcher rejects it with a usage
+		// comment instead of treating the environment as missing.
+		result.Found = true
 	case !spec.RequiresEnv:
 		result.Found = true
 	case result.Environment != "":

--- a/pkg/webhook/commands_test.go
+++ b/pkg/webhook/commands_test.go
@@ -461,6 +461,47 @@ func TestParseCommand(t *testing.T) {
 			},
 		},
 		{
+			name: "flag glued onto the environment value is invalid, not reinterpreted",
+			body: "schemabot apply -e production--allow-unsafe",
+			expected: CommandResult{
+				Action:           "apply",
+				EnvironmentError: true,
+				AllowUnsafe:      true,
+				Found:            true,
+				IsMention:        true,
+			},
+		},
+		{
+			name: "environment value with a trailing dash is invalid",
+			body: "schemabot apply -e staging-",
+			expected: CommandResult{
+				Action:           "apply",
+				EnvironmentError: true,
+				Found:            true,
+				IsMention:        true,
+			},
+		},
+		{
+			name: "plan with an invalid environment value is not a multi-env plan",
+			body: "schemabot plan -e production--allow-unsafe",
+			expected: CommandResult{
+				Action:           "plan",
+				EnvironmentError: true,
+				Found:            true,
+				IsMention:        true,
+			},
+		},
+		{
+			name: "environment value with single dashes is valid",
+			body: "schemabot apply -e prod-us-east",
+			expected: CommandResult{
+				Action:      "apply",
+				Environment: "prod-us-east",
+				Found:       true,
+				IsMention:   true,
+			},
+		},
+		{
 			name: "plan with database flag",
 			body: "schemabot plan -e staging -d my-database",
 			expected: CommandResult{

--- a/pkg/webhook/handler_test.go
+++ b/pkg/webhook/handler_test.go
@@ -441,7 +441,7 @@ func TestWebhookInvalidEnvValue(t *testing.T) {
 	select {
 	case body := <-comments:
 		assert.Contains(t, body, "Invalid Environment")
-		assert.Contains(t, body, "missing space")
+		assert.Contains(t, body, "**Available environments**: `production`, `staging`")
 		assert.Contains(t, body, "schemabot apply -e <environment>")
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for the invalid environment comment")
@@ -456,7 +456,7 @@ func TestWebhookInvalidEnvValue(t *testing.T) {
 }
 
 // In an environment-isolated deployment, an environment no instance handles
-// is rejected with an eyes acknowledgment and an unknown-environment comment
+// is rejected with an eyes acknowledgment and an invalid-environment comment
 // listing the configured environments, instead of every instance silently
 // deferring to a peer that does not exist.
 func TestWebhookUnknownEnvironmentRejected(t *testing.T) {
@@ -476,12 +476,11 @@ func TestWebhookUnknownEnvironmentRejected(t *testing.T) {
 
 	select {
 	case body := <-comments:
-		assert.Contains(t, body, "Unknown Environment")
-		assert.Contains(t, body, "`prodction`")
+		assert.Contains(t, body, "Invalid Environment")
 		assert.Contains(t, body, "`staging`")
 		assert.Contains(t, body, "`production`")
 	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for the unknown environment comment")
+		t.Fatal("timed out waiting for the invalid environment comment")
 	}
 
 	select {

--- a/pkg/webhook/handler_test.go
+++ b/pkg/webhook/handler_test.go
@@ -455,6 +455,70 @@ func TestWebhookInvalidEnvValue(t *testing.T) {
 	}
 }
 
+// In an environment-isolated deployment, an environment no instance handles
+// is rejected with an eyes acknowledgment and an unknown-environment comment
+// listing the configured environments, instead of every instance silently
+// deferring to a peer that does not exist.
+func TestWebhookUnknownEnvironmentRejected(t *testing.T) {
+	h, comments, reactions := newTestHandler(t)
+	h.service.Config().AllowedEnvironments = []string{"staging"}
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot apply -e prodction",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "unknown environment")
+
+	select {
+	case body := <-comments:
+		assert.Contains(t, body, "Unknown Environment")
+		assert.Contains(t, body, "`prodction`")
+		assert.Contains(t, body, "`staging`")
+		assert.Contains(t, body, "`production`")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the unknown environment comment")
+	}
+
+	select {
+	case reaction := <-reactions:
+		assert.Equal(t, "eyes", reaction)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the acknowledgment reaction")
+	}
+}
+
+// An environment owned by a peer instance stays silent here: the peer
+// processes the command from its own webhook delivery, and a reaction or
+// comment from this instance would be noise next to the peer's real response.
+func TestWebhookPeerEnvironmentStaysSilent(t *testing.T) {
+	h, comments, reactions := newTestHandler(t)
+	h.service.Config().AllowedEnvironments = []string{"staging"}
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot apply -e production",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "environment handled by another instance")
+
+	select {
+	case body := <-comments:
+		t.Fatalf("unexpected comment posted for a peer-owned environment: %s", body)
+	case reaction := <-reactions:
+		t.Fatalf("unexpected reaction for a peer-owned environment: %s", reaction)
+	default:
+	}
+}
+
 func TestWebhookYesFlagRejectedOnNonApply(t *testing.T) {
 	h, comments, _ := newTestHandler(t)
 

--- a/pkg/webhook/handler_test.go
+++ b/pkg/webhook/handler_test.go
@@ -420,6 +420,41 @@ func TestWebhookMissingEnvForApply(t *testing.T) {
 	}
 }
 
+// A malformed -e value — typically a flag glued onto the environment by a
+// missing space — can never match any instance's allowed environments, so the
+// command is rejected with a usage comment and an eyes acknowledgment rather
+// than left unanswered.
+func TestWebhookInvalidEnvValue(t *testing.T) {
+	h, comments, reactions := newTestHandler(t)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot apply -e production--allow-unsafe",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "invalid environment value")
+
+	select {
+	case body := <-comments:
+		assert.Contains(t, body, "Invalid Environment")
+		assert.Contains(t, body, "missing space")
+		assert.Contains(t, body, "schemabot apply -e <environment>")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the invalid environment comment")
+	}
+
+	select {
+	case reaction := <-reactions:
+		assert.Equal(t, "eyes", reaction)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the acknowledgment reaction")
+	}
+}
+
 func TestWebhookYesFlagRejectedOnNonApply(t *testing.T) {
 	h, comments, _ := newTestHandler(t)
 

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -230,11 +230,29 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 		return
 	}
 
-	// When allowed_environments is configured, silently ignore commands targeting
-	// environments handled by another instance. The other SchemaBot instance will
-	// process the command from its own webhook delivery.
+	// When allowed_environments is configured, commands targeting environments
+	// handled by another instance are silently ignored — that instance will
+	// process the command from its own webhook delivery. An environment that
+	// appears nowhere in the configuration belongs to no instance, so deferring
+	// would leave the command unanswered everywhere; reject it under the
+	// respond_to_unscoped policy so exactly one instance corrects the caller.
 	if result.Found && result.Environment != "" && h.service != nil && !h.service.Config().IsEnvironmentAllowed(result.Environment) {
-		h.logger.Info("ignoring command for non-allowed environment",
+		if !h.service.Config().IsEnvironmentKnown(result.Environment) {
+			if result.Tenant == "" && !h.service.Config().ShouldRespondToUnscoped() {
+				h.logger.Debug("skipping unknown environment response (respond_to_unscoped is false)",
+					"repo", repo, "pr", pr, "environment", result.Environment, "action", result.Action)
+				h.writeJSON(w, http.StatusOK, map[string]string{"message": "unscoped command skipped"})
+				return
+			}
+			h.logger.Info("rejecting command for unknown environment",
+				"repo", repo, "pr", pr, "environment", result.Environment, "action", result.Action)
+			h.acknowledgeCommand(repo, pr, installationID, result.CommentID)
+			h.postComment(repo, pr, installationID,
+				templates.RenderUnknownEnv(result.Action, result.Environment, h.service.Config().KnownEnvironments()))
+			h.writeJSON(w, http.StatusOK, map[string]string{"message": "unknown environment"})
+			return
+		}
+		h.logger.Info("ignoring command for environment owned by another instance",
 			"repo", repo, "pr", pr, "environment", result.Environment, "action", result.Action)
 		h.writeJSON(w, http.StatusOK, map[string]string{
 			"message": "environment handled by another instance",

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -187,7 +187,8 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 		h.logger.Info("rejecting command with invalid environment value",
 			"repo", repo, "pr", pr, "action", result.Action)
 		h.acknowledgeCommand(repo, pr, installationID, result.CommentID)
-		h.postComment(repo, pr, installationID, templates.RenderInvalidEnv(result.Action))
+		h.postComment(repo, pr, installationID,
+			templates.RenderInvalidEnv(result.Action, h.knownEnvironments()))
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "invalid environment value"})
 		return
 	}
@@ -248,7 +249,7 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 				"repo", repo, "pr", pr, "environment", result.Environment, "action", result.Action)
 			h.acknowledgeCommand(repo, pr, installationID, result.CommentID)
 			h.postComment(repo, pr, installationID,
-				templates.RenderUnknownEnv(result.Action, result.Environment, h.service.Config().KnownEnvironments()))
+				templates.RenderInvalidEnv(result.Action, h.knownEnvironments()))
 			h.writeJSON(w, http.StatusOK, map[string]string{"message": "unknown environment"})
 			return
 		}
@@ -640,6 +641,15 @@ func (h *Handler) acknowledgeCommandEarlyIfOwned(ctx context.Context, client *gh
 	}
 	h.acknowledgeCommand(repo, pr, installationID, commentID)
 	return true
+}
+
+// knownEnvironments returns the configured environment roster for error
+// comments, or nil when the handler has no service configuration.
+func (h *Handler) knownEnvironments() []string {
+	if h.service == nil {
+		return nil
+	}
+	return h.service.Config().KnownEnvironments()
 }
 
 // acknowledgeCommand adds the eyes reaction to the command comment,

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -174,6 +174,24 @@ func (h *Handler) handleIssueComment(ctx context.Context, metricApp string, w ht
 		return
 	}
 
+	// Reject an invalid -e value. It can never match any instance's
+	// allowed_environments, so no instance would act on it; answer under the
+	// respond_to_unscoped policy so exactly one instance corrects the caller.
+	if result.EnvironmentError {
+		if result.Tenant == "" && h.service != nil && !h.service.Config().ShouldRespondToUnscoped() {
+			h.logger.Debug("skipping invalid environment response (respond_to_unscoped is false)",
+				"repo", repo, "pr", pr, "action", result.Action)
+			h.writeJSON(w, http.StatusOK, map[string]string{"message": "unscoped command skipped"})
+			return
+		}
+		h.logger.Info("rejecting command with invalid environment value",
+			"repo", repo, "pr", pr, "action", result.Action)
+		h.acknowledgeCommand(repo, pr, installationID, result.CommentID)
+		h.postComment(repo, pr, installationID, templates.RenderInvalidEnv(result.Action))
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "invalid environment value"})
+		return
+	}
+
 	// Handle missing -e flag
 	if result.MissingEnv {
 		if result.Action == action.Plan {

--- a/pkg/webhook/templates/errors.go
+++ b/pkg/webhook/templates/errors.go
@@ -193,6 +193,24 @@ schemabot %s -e staging
 `+"```", action, action)
 }
 
+// RenderUnknownEnv generates an error message when the -e value is a
+// well-formed environment name that no SchemaBot instance handles. The value
+// is safe to render: the parser only accepts environment names made of
+// lowercase alphanumerics, underscores, and single dashes.
+func RenderUnknownEnv(action, env string, available []string) string {
+	quoted := make([]string, len(available))
+	for i, name := range available {
+		quoted[i] = "`" + name + "`"
+	}
+	return fmt.Sprintf(`## ❌ Unknown Environment
+
+`+"`%s`"+` isn't a configured environment.
+
+**Available environments**: %s
+
+**Usage**: `+"`schemabot %s -e <environment>`", env, strings.Join(quoted, ", "), action)
+}
+
 // RenderMissingEnv generates an error message when -e flag is missing.
 func RenderMissingEnv(action string) string {
 	return fmt.Sprintf(`## ❌ Missing Argument

--- a/pkg/webhook/templates/errors.go
+++ b/pkg/webhook/templates/errors.go
@@ -177,6 +177,22 @@ func RenderInvalidCommand() string {
 	return "## ❌ Invalid Command\n\nThat command wasn't recognized. Available commands:\n\n" + commandReference()
 }
 
+// RenderInvalidEnv generates an error message when the -e flag value is not a
+// valid environment name — most commonly a flag glued onto the value by a
+// missing space (`-e production--allow-unsafe`).
+func RenderInvalidEnv(action string) string {
+	return fmt.Sprintf(`## ❌ Invalid Environment
+
+The value after `+"`-e`"+` isn't a valid environment name. Check for a missing space between the environment and any flags that follow it.
+
+**Usage**: `+"`schemabot %s -e <environment> [flags]`"+`
+
+**Example**:
+`+"```"+`
+schemabot %s -e staging
+`+"```", action, action)
+}
+
 // RenderMissingEnv generates an error message when -e flag is missing.
 func RenderMissingEnv(action string) string {
 	return fmt.Sprintf(`## ❌ Missing Argument

--- a/pkg/webhook/templates/errors.go
+++ b/pkg/webhook/templates/errors.go
@@ -177,38 +177,25 @@ func RenderInvalidCommand() string {
 	return "## ❌ Invalid Command\n\nThat command wasn't recognized. Available commands:\n\n" + commandReference()
 }
 
-// RenderInvalidEnv generates an error message when the -e flag value is not a
-// valid environment name — most commonly a flag glued onto the value by a
-// missing space (`-e production--allow-unsafe`).
-func RenderInvalidEnv(action string) string {
-	return fmt.Sprintf(`## ❌ Invalid Environment
-
-The value after `+"`-e`"+` isn't a valid environment name. Check for a missing space between the environment and any flags that follow it.
-
-**Usage**: `+"`schemabot %s -e <environment> [flags]`"+`
-
-**Example**:
-`+"```"+`
-schemabot %s -e staging
-`+"```", action, action)
-}
-
-// RenderUnknownEnv generates an error message when the -e value is a
-// well-formed environment name that no SchemaBot instance handles. The
-// rejected value and the configured environment names are both normalized for
-// markdown display so an unexpected character cannot break the comment.
-func RenderUnknownEnv(action, env string, available []string) string {
+// RenderInvalidEnv generates an error message when the -e value does not name
+// a configured environment — whether malformed (e.g. a flag glued onto the
+// value by a missing space) or simply not an environment any instance
+// handles. The configured environment names are normalized for markdown
+// display so an unexpected character cannot break the comment.
+func RenderInvalidEnv(action string, available []string) string {
 	quoted := make([]string, len(available))
 	for i, name := range available {
 		quoted[i] = markdownInlineCode(name)
 	}
-	return fmt.Sprintf(`## ❌ Unknown Environment
+	availableLine := ""
+	if len(quoted) > 0 {
+		availableLine = "\n**Available environments**: " + strings.Join(quoted, ", ") + "\n"
+	}
+	return fmt.Sprintf(`## ❌ Invalid Environment
 
-%s isn't a configured environment.
-
-**Available environments**: %s
-
-**Usage**: `+"`schemabot %s -e <environment>`", markdownInlineCode(env), strings.Join(quoted, ", "), action)
+`+"`-e`"+` must name one of the configured environments.
+%s
+**Usage**: `+"`schemabot %s -e <environment> [flags]`", availableLine, action)
 }
 
 // markdownInlineCode renders a value as a markdown inline code span,

--- a/pkg/webhook/templates/errors.go
+++ b/pkg/webhook/templates/errors.go
@@ -194,21 +194,29 @@ schemabot %s -e staging
 }
 
 // RenderUnknownEnv generates an error message when the -e value is a
-// well-formed environment name that no SchemaBot instance handles. The value
-// is safe to render: the parser only accepts environment names made of
-// lowercase alphanumerics, underscores, and single dashes.
+// well-formed environment name that no SchemaBot instance handles. The
+// rejected value and the configured environment names are both normalized for
+// markdown display so an unexpected character cannot break the comment.
 func RenderUnknownEnv(action, env string, available []string) string {
 	quoted := make([]string, len(available))
 	for i, name := range available {
-		quoted[i] = "`" + name + "`"
+		quoted[i] = markdownInlineCode(name)
 	}
 	return fmt.Sprintf(`## ❌ Unknown Environment
 
-`+"`%s`"+` isn't a configured environment.
+%s isn't a configured environment.
 
 **Available environments**: %s
 
-**Usage**: `+"`schemabot %s -e <environment>`", env, strings.Join(quoted, ", "), action)
+**Usage**: `+"`schemabot %s -e <environment>`", markdownInlineCode(env), strings.Join(quoted, ", "), action)
+}
+
+// markdownInlineCode renders a value as a markdown inline code span,
+// normalizing characters that would break the span: backticks are stripped
+// and whitespace (including newlines) collapses to single spaces.
+func markdownInlineCode(s string) string {
+	s = strings.ReplaceAll(s, "`", "")
+	return "`" + strings.Join(strings.Fields(s), " ") + "`"
 }
 
 // RenderMissingEnv generates an error message when -e flag is missing.

--- a/pkg/webhook/templates/errors_test.go
+++ b/pkg/webhook/templates/errors_test.go
@@ -6,18 +6,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRenderUnknownEnv(t *testing.T) {
+func TestRenderInvalidEnv(t *testing.T) {
 	t.Run("lists the configured environments", func(t *testing.T) {
-		body := RenderUnknownEnv("apply", "prodction", []string{"production", "staging"})
-		assert.Contains(t, body, "Unknown Environment")
-		assert.Contains(t, body, "`prodction` isn't a configured environment")
+		body := RenderInvalidEnv("apply", []string{"production", "staging"})
+		assert.Contains(t, body, "Invalid Environment")
+		assert.Contains(t, body, "must name one of the configured environments")
 		assert.Contains(t, body, "**Available environments**: `production`, `staging`")
-		assert.Contains(t, body, "`schemabot apply -e <environment>`")
+		assert.Contains(t, body, "`schemabot apply -e <environment> [flags]`")
+	})
+
+	t.Run("omits the available line when no environments are configured", func(t *testing.T) {
+		body := RenderInvalidEnv("apply", nil)
+		assert.Contains(t, body, "Invalid Environment")
+		assert.NotContains(t, body, "Available environments")
 	})
 
 	t.Run("normalizes names that would break markdown code spans", func(t *testing.T) {
-		body := RenderUnknownEnv("apply", "we`ird", []string{"pro`duction", "sta\nging"})
-		assert.Contains(t, body, "`weird` isn't a configured environment")
+		body := RenderInvalidEnv("apply", []string{"pro`duction", "sta\nging"})
 		assert.Contains(t, body, "`production`")
 		assert.Contains(t, body, "`sta ging`")
 		assert.NotContains(t, body, "``")

--- a/pkg/webhook/templates/errors_test.go
+++ b/pkg/webhook/templates/errors_test.go
@@ -1,0 +1,25 @@
+package templates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderUnknownEnv(t *testing.T) {
+	t.Run("lists the configured environments", func(t *testing.T) {
+		body := RenderUnknownEnv("apply", "prodction", []string{"production", "staging"})
+		assert.Contains(t, body, "Unknown Environment")
+		assert.Contains(t, body, "`prodction` isn't a configured environment")
+		assert.Contains(t, body, "**Available environments**: `production`, `staging`")
+		assert.Contains(t, body, "`schemabot apply -e <environment>`")
+	})
+
+	t.Run("normalizes names that would break markdown code spans", func(t *testing.T) {
+		body := RenderUnknownEnv("apply", "we`ird", []string{"pro`duction", "sta\nging"})
+		assert.Contains(t, body, "`weird` isn't a configured environment")
+		assert.Contains(t, body, "`production`")
+		assert.Contains(t, body, "`sta ging`")
+		assert.NotContains(t, body, "``")
+	})
+}


### PR DESCRIPTION
**Why this matters:** In environment-isolated deployments, every instance silently defers commands for non-allowed environments to the peer that owns them. A typo'd environment is owned by nobody, so every instance deferred and the command vanished — no comment, no reaction. The most common shape is a missing space gluing a flag onto the value (`-e production--allow-unsafe`), which parsed as an environment name that matches no instance.

**What it does:**

- **Malformed `-e` value** (contains `--`, trailing dash, etc.): the parser captures the whole token and validates it as an environment name, flagging failures as `EnvironmentError` — deliberately not reinterpreted as environment-plus-flag (a corrected reading of a malformed token must never execute, especially one carrying `--allow-unsafe`), and deliberately not missing-env (a `plan` with a bad `-e` must not fan out to every environment).
- **Well-formed but unknown environment** (`-e prodction`): the configuration already carries a fleet-wide roster — `environment_order` lists peer-owned environments for promotion gating, alongside `allowed_environments` and each database's routing environments. An environment outside that union belongs to no instance. Environments in the roster but owned by a peer keep today's silent deferral.

Both failure shapes get the same generic invalid-environment comment listing the server-side configured environments, plus an eyes reaction so the caller sees the command was received:

> ## ❌ Invalid Environment
>
> `-e` must name one of the configured environments.
>
> **Available environments**: `production`, `staging`
>
> **Usage**: `schemabot apply -e <environment> [flags]`

```
-e <value>
  ├─ malformed name ─────────────→ reject: invalid-environment comment + 👀
  ├─ allowed here ───────────────→ handle
  ├─ known, owned by a peer ─────→ silent (peer answers from its own delivery)
  └─ unknown to the fleet ───────→ reject: invalid-environment comment + 👀
```

The rejection follows the `respond_to_unscoped` policy so exactly one instance answers.

**Northstar:** every `schemabot` command gets a response — silence always means "another instance is on it," never "nobody heard you."

🤖 Generated with [Claude Code](https://claude.com/claude-code)