### PR TITLE
fix(github): recover crash-wedged and shutdown-interrupted webhook deliveries

### DIFF
--- a/pkg/storage/mysqlstore/webhook_events.go
+++ b/pkg/storage/mysqlstore/webhook_events.go
@@ -105,7 +105,7 @@ func (s *webhookEventStore) reopenTerminalWebhookEvent(ctx context.Context, prov
 	`, storage.WebhookEventPending, payload, receivedAt, provider, deliveryID,
 		storage.WebhookEventFailed, storage.WebhookEventCompleted, storage.WebhookEventProcessing)
 	if err != nil {
-		return false, fmt.Errorf("reopen terminally failed webhook delivery (provider=%s, delivery_id=%s): %w", provider, deliveryID, err)
+		return false, fmt.Errorf("reopen webhook delivery for redelivery (provider=%s, delivery_id=%s): %w", provider, deliveryID, err)
 	}
 	rows, err := result.RowsAffected()
 	if err != nil {

--- a/pkg/storage/mysqlstore/webhook_events.go
+++ b/pkg/storage/mysqlstore/webhook_events.go
@@ -78,21 +78,32 @@ func (s *webhookEventStore) Create(ctx context.Context, event *storage.WebhookEv
 // reopenTerminalWebhookEvent handles the duplicate-GUID branch of Create.
 // GitHub's "Redeliver" reuses the original delivery GUID, so plain dedup would
 // make redelivery a permanent no-op for a terminal row — the one case where an
-// operator most needs it to work. Re-open both terminal states (failed and
-// completed): a completed row can still have lost its follow-on work if the
-// process died after the delivery was marked completed but before the detached
-// plan goroutines durably recorded their plans, and re-running auto-plan on the
-// same head SHA is idempotent, so a redeliver is a safe recovery lever.
-// pending/retryable/processing rows are genuinely in flight (dedup, return
-// false). last_error is kept for forensics until the next attempt overwrites it.
+// operator most needs it to work. Re-open:
+//   - failed and completed rows: a completed row can still have lost its
+//     follow-on work if the process died after the delivery was marked completed
+//     but before the detached plan goroutines durably recorded their plans, and
+//     re-running auto-plan on the same head SHA is idempotent.
+//   - processing rows whose lease has expired: a driver hard-killed on its final
+//     attempt leaves the row parked in processing with attempts at the cap,
+//     which FindNext never reclaims — so it would otherwise be recoverable only
+//     by the reconciler's periodic sweep. Matching it here makes Redeliver an
+//     immediate recovery lever. An expired lease means no live owner, so the
+//     reopen can't race a real driver, and the lease-token guard on
+//     MarkCompleted/MarkFailed still rejects a returning zombie driver.
+//
+// pending/retryable rows and processing rows with a live (unexpired) lease are
+// genuinely in flight, so they dedup (return false). last_error is kept for
+// forensics until the next attempt overwrites it.
 func (s *webhookEventStore) reopenTerminalWebhookEvent(ctx context.Context, provider, deliveryID, payload string, receivedAt time.Time) (bool, error) {
 	result, err := s.db.ExecContext(ctx, `
 		UPDATE webhook_events
 		SET state = ?, attempts = 0, payload = ?, received_at = ?,
 			lease_owner = NULL, lease_token = NULL, lease_expires_at = NULL,
 			retry_after = NULL, completed_at = NULL, started_at = NULL, updated_at = NOW()
-		WHERE provider = ? AND delivery_id = ? AND state IN (?, ?)
-	`, storage.WebhookEventPending, payload, receivedAt, provider, deliveryID, storage.WebhookEventFailed, storage.WebhookEventCompleted)
+		WHERE provider = ? AND delivery_id = ?
+			AND (state IN (?, ?) OR (state = ? AND lease_expires_at <= NOW(6)))
+	`, storage.WebhookEventPending, payload, receivedAt, provider, deliveryID,
+		storage.WebhookEventFailed, storage.WebhookEventCompleted, storage.WebhookEventProcessing)
 	if err != nil {
 		return false, fmt.Errorf("reopen terminally failed webhook delivery (provider=%s, delivery_id=%s): %w", provider, deliveryID, err)
 	}

--- a/pkg/storage/mysqlstore/webhook_events_test.go
+++ b/pkg/storage/mysqlstore/webhook_events_test.go
@@ -248,6 +248,77 @@ func TestWebhookEventStore_CreateReopensTerminalDelivery(t *testing.T) {
 	assert.JSONEq(t, `{"attempt":3}`, string(reopenedAgain.Payload))
 }
 
+func TestWebhookEventStore_CreateReopensStuckProcessingDelivery(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	inserted, err := store.WebhookEvents().Create(ctx, &storage.WebhookEvent{DeliveryID: "delivery-1", Event: "pull_request", Payload: []byte(`{"attempt":1}`)})
+	require.NoError(t, err)
+	require.True(t, inserted)
+
+	// A driver hard-killed on its final attempt leaves the row in processing
+	// with an expired lease at the attempts ceiling. FindNext never reclaims it,
+	// so an operator Redeliver is the only recovery lever.
+	_, err = testDB.ExecContext(ctx, `
+		UPDATE webhook_events
+		SET state = ?, attempts = ?, lease_owner = 'driver-a', lease_token = 'token-a',
+			lease_expires_at = DATE_SUB(NOW(6), INTERVAL 1 HOUR), started_at = NOW(6)
+		WHERE delivery_id = 'delivery-1'
+	`, storage.WebhookEventProcessing, storage.MaxWebhookEventAttempts)
+	require.NoError(t, err)
+
+	stuck, err := store.WebhookEvents().FindNext(ctx, "driver-b", time.Minute)
+	require.NoError(t, err)
+	require.Nil(t, stuck, "cap-exhausted processing row must not be reclaimable by FindNext")
+
+	// Redeliver reuses the delivery GUID; it must re-open the wedged row.
+	inserted, err = store.WebhookEvents().Create(ctx, &storage.WebhookEvent{DeliveryID: "delivery-1", Event: "pull_request", Payload: []byte(`{"attempt":2}`)})
+	require.NoError(t, err)
+	require.True(t, inserted)
+
+	reopened, err := store.WebhookEvents().GetByDeliveryID(ctx, storage.WebhookProviderGitHub, "delivery-1")
+	require.NoError(t, err)
+	require.NotNil(t, reopened)
+	assert.Equal(t, storage.WebhookEventPending, reopened.State)
+	assert.Equal(t, 0, reopened.Attempts)
+	assert.Empty(t, reopened.LeaseToken)
+	assert.Nil(t, reopened.StartedAt)
+	assert.JSONEq(t, `{"attempt":2}`, string(reopened.Payload))
+
+	reclaimed, err := store.WebhookEvents().FindNext(ctx, "driver-c", time.Minute)
+	require.NoError(t, err)
+	require.NotNil(t, reclaimed, "reopened row must be claimable again")
+	assert.Equal(t, 1, reclaimed.Attempts)
+}
+
+func TestWebhookEventStore_CreateDedupesProcessingWithLiveLease(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	inserted, err := store.WebhookEvents().Create(ctx, &storage.WebhookEvent{DeliveryID: "delivery-1", Event: "pull_request", Payload: []byte(`{"attempt":1}`)})
+	require.NoError(t, err)
+	require.True(t, inserted)
+
+	// A live driver owns the row (unexpired lease), so it is genuinely in
+	// flight — a duplicate delivery must dedup rather than yank it away.
+	claimed, err := store.WebhookEvents().FindNext(ctx, "driver-a", time.Minute)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+
+	inserted, err = store.WebhookEvents().Create(ctx, &storage.WebhookEvent{DeliveryID: "delivery-1", Event: "pull_request", Payload: []byte(`{"attempt":2}`)})
+	require.NoError(t, err)
+	require.False(t, inserted, "a processing row with a live lease must dedup, not reopen")
+
+	current, err := store.WebhookEvents().GetByDeliveryID(ctx, storage.WebhookProviderGitHub, "delivery-1")
+	require.NoError(t, err)
+	require.NotNil(t, current)
+	assert.Equal(t, storage.WebhookEventProcessing, current.State)
+	assert.Equal(t, claimed.LeaseToken, current.LeaseToken, "the live driver's lease must be untouched")
+	assert.JSONEq(t, `{"attempt":1}`, string(current.Payload), "payload must not be overwritten while in flight")
+}
+
 func TestWebhookEventStore_ReleaseRefundsAttemptAndRequeues(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/mysqlstore/webhook_events_test.go
+++ b/pkg/storage/mysqlstore/webhook_events_test.go
@@ -259,7 +259,8 @@ func TestWebhookEventStore_CreateReopensStuckProcessingDelivery(t *testing.T) {
 
 	// A driver hard-killed on its final attempt leaves the row in processing
 	// with an expired lease at the attempts ceiling. FindNext never reclaims it,
-	// so an operator Redeliver is the only recovery lever.
+	// so absent the reconciler's periodic sweep an operator Redeliver is the
+	// only immediate recovery lever — which is the path this exercises.
 	_, err = testDB.ExecContext(ctx, `
 		UPDATE webhook_events
 		SET state = ?, attempts = ?, lease_owner = 'driver-a', lease_token = 'token-a',

--- a/pkg/webhook/durable_dispatch.go
+++ b/pkg/webhook/durable_dispatch.go
@@ -210,12 +210,17 @@ func (h *Handler) driveClaimedDurableWebhook(ctx context.Context, driverID int, 
 	finishCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 	defer cancel()
 	if processErr != nil {
-		if heartbeatErr == nil && ctx.Err() != nil && errors.Is(processErr, context.Canceled) {
-			// Shutdown (not lease loss) cancelled the run mid-flight. The claim
-			// consumed an attempt when FindNext incremented the counter, but no
-			// real processing happened — refund it, or deploy-churn restarts
-			// that each claim-and-cancel the same delivery would terminally
-			// fail it without a single genuine attempt.
+		if heartbeatErr == nil && ctx.Err() != nil {
+			// The driver context is cancelled, so the pool is shutting down and
+			// this run was interrupted mid-flight — not lease loss, since the
+			// heartbeat still held. Key the refund off the context cancellation
+			// rather than unwrapping processErr: a client that stringifies the
+			// cancellation drops the context.Canceled sentinel, which would
+			// misroute the interrupted claim into a burned attempt via
+			// MarkFailed. The claim consumed an attempt when FindNext
+			// incremented the counter, but no genuine attempt completed — refund
+			// it, or deploy-churn restarts that each claim-and-cancel the same
+			// delivery would terminally fail it without a single real attempt.
 			if err := store.Release(finishCtx, event.ID, event.LeaseToken); err != nil {
 				h.logger.Warn("durable webhook driver could not release delivery claim on shutdown; lease expiry will hand it to another driver",
 					"driver", driverID, "delivery_id", event.DeliveryID, "event", event.Event,

--- a/pkg/webhook/durable_dispatch_test.go
+++ b/pkg/webhook/durable_dispatch_test.go
@@ -462,6 +462,34 @@ func TestDurableWebhookShutdownReleasesClaim(t *testing.T) {
 	require.Empty(t, store.completed)
 }
 
+func TestDurableWebhookShutdownReleasesClaimWhenCancelErrorIsStringified(t *testing.T) {
+	store := newScriptedWebhookEventStore(durablePullRequestEvent(t))
+	h := newDurableDriverHandler(t, store, nil, nil)
+
+	driverCtx, cancelDriver := context.WithCancel(t.Context())
+	defer cancelDriver()
+	h.durableWebhookProcessOverride = func(ctx context.Context, _ *storage.WebhookEvent) (bool, error) {
+		cancelDriver()
+		<-ctx.Done()
+		// A client that stringifies the cancellation drops the context.Canceled
+		// sentinel from the error chain. The refund must still fire off the
+		// driver-context cancellation rather than an errors.Is unwrap, or the
+		// interrupted claim burns an attempt via MarkFailed.
+		return true, errors.New(ctx.Err().Error())
+	}
+
+	h.driveNextDurableWebhook(driverCtx, 0, "test-host/1/webhook-driver-0")
+
+	select {
+	case released := <-store.released:
+		require.Equal(t, "token-1", released.leaseToken)
+	default:
+		t.Fatal("expected shutdown-cancelled claim to be released even when the cancel error is stringified")
+	}
+	require.Empty(t, store.failed, "shutdown cancellation must not consume the attempt budget")
+	require.Empty(t, store.completed)
+}
+
 func TestDurableWebhookHeartbeatTransientErrorKeepsRunAlive(t *testing.T) {
 	store := newScriptedWebhookEventStore(&storage.WebhookEvent{
 		Provider:   storage.WebhookProviderGitHub,


### PR DESCRIPTION
## Summary
Follow-up to #705 addressing the structural gap and the note-level refund concern from its pre-merge adversarial review. Both are recovery paths for durable webhook deliveries that could otherwise strand or waste an auto-plan.

## What
- `reopenTerminalWebhookEvent` also matches `processing` rows whose lease has expired, so GitHub "Redeliver" recovers a delivery whose driver was hard-killed on its final attempt (parked in `processing`, expired lease, attempts at the cap — a row `FindNext` never reclaims). Rows with a live lease still dedup.
- The durable-dispatch shutdown refund keys off driver-context cancellation instead of `errors.Is(processErr, context.Canceled)`, so an interrupted claim is released (attempt refunded) even if a client stringifies the cancellation and drops the sentinel.

## Why
Without the reopen match, a final-attempt crash left the row invisible to `FindNext` and made Redeliver a silent no-op — recoverable only via the reconciler's periodic sweep (up to one interval later). Keying the refund off the error chain risked burning a delivery's attempt budget under deploy churn, the exact scenario the refund exists to prevent.

## Before / after
```text
Redeliver on a crash-wedged row:
  before → dedup no-op (reopen matched failed|completed only)
  after  → reopen (adds processing + expired lease); live lease still dedups

Shutdown mid-run:
  before → refund only if processErr unwraps to context.Canceled
  after  → refund whenever driver ctx is cancelled and the heartbeat held
```

## Testing / validation
Build + lint green; shutdown-refund unit test passes locally. Two reopen integration tests added (compile locally; run in CI — local Docker is unavailable).
