### PR TITLE
fix(ddl): bound statement text in Split parse errors

### DIFF
--- a/pkg/ddl/helpers.go
+++ b/pkg/ddl/helpers.go
@@ -32,11 +32,14 @@ func ClassifyStatement(stmt string) (statement.StatementType, string, error) {
 func statementPreview(stmt string) string {
 	const maxPreview = 80
 	s := strings.TrimSpace(stmt)
-	runes := []rune(s)
-	if len(runes) <= maxPreview {
-		return s
+	count := 0
+	for i := range s {
+		if count == maxPreview {
+			return s[:i] + "..."
+		}
+		count++
 	}
-	return string(runes[:maxPreview]) + "..."
+	return s
 }
 
 // ClassifyStatementOp is like ClassifyStatement but returns the operation as a

--- a/pkg/ddl/helpers_test.go
+++ b/pkg/ddl/helpers_test.go
@@ -91,7 +91,7 @@ func TestSplitStatements_Content(t *testing.T) {
 func TestSplitStatements_ParseErrorIncludesPreview(t *testing.T) {
 	_, err := SplitStatements("this is not valid SQL @@@")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "this is not valid SQL")
+	assert.Contains(t, err.Error(), `failed to parse SQL statements "this is not valid SQL @@@"`)
 }
 
 // TestClassifyStatement verifies the single-statement contract: each DDL type

--- a/pkg/ddl/helpers_test.go
+++ b/pkg/ddl/helpers_test.go
@@ -86,6 +86,14 @@ func TestSplitStatements_Content(t *testing.T) {
 	assert.Contains(t, stmts[1], "t2")
 }
 
+// A parse failure identifies the offending input (bounded) so an operator can
+// see which statement failed without the full blob flooding logs.
+func TestSplitStatements_ParseErrorIncludesPreview(t *testing.T) {
+	_, err := SplitStatements("this is not valid SQL @@@")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "this is not valid SQL")
+}
+
 // TestClassifyStatement verifies the single-statement contract: each DDL type
 // classifies to its typed StatementType and table, while compound input —
 // where a destructive statement could ride behind the first statement's

--- a/pkg/ddl/parser.go
+++ b/pkg/ddl/parser.go
@@ -56,7 +56,7 @@ func (tidbStatementParser) Split(content string) ([]string, error) {
 		AllowMixedStatementTypes: true,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse SQL statements: %w", err)
+		return nil, fmt.Errorf("failed to parse SQL statements %q: %w", statementPreview(content), err)
 	}
 	var stmts []string
 	for _, s := range parsed {


### PR DESCRIPTION
## Summary
Follow-up to #716. The `StatementParser` seam bounded statement text in the two `Classify` error paths (commit 2 of #716) but left `Split`'s parse error carrying no content identifier. This lands that last consistency item, which was staged-but-uncommitted when #716 merged and so never shipped.

## What
- `Split` parse error now includes a bounded `statementPreview(content)` preview, matching the `Classify` error paths.
- Adds `TestSplitStatements_ParseErrorIncludesPreview`.

## Why
An operator hitting a `Split` failure otherwise gets `failed to parse SQL statements: <driver err>` with no indication of *which* input failed. Using the existing bounded `statementPreview` helper identifies the offending statement without flooding logs with the full blob.

## Before / after

```diagram
                        Split(content) parse error

  before                              after
  ╭───────────────────────────────╮  ╭────────────────────────────────────────╮
  │ failed to parse SQL           │  │ failed to parse SQL statements         │
  │ statements: <driver err>      │  │ "CREATE TABL...": <driver err>         │
  │  → which statement? unknown   │  │  → offending input shown (bounded)     │
  ╰───────────────────────────────╯  ╰────────────────────────────────────────╯
```
