### PR TITLE
fix(tern): route dispatched applies with no local plan by request fields

### DIFF
--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -1546,7 +1546,7 @@ func (c *LocalClient) planForApplyRequest(ctx context.Context, req *ternv1.Apply
 	if plan != nil {
 		return plan, nil
 	}
-	if len(req.DdlChanges) == 0 && len(req.SchemaFiles) == 0 {
+	if !applyRequestCarriesPlanPayload(req) {
 		return nil, nil
 	}
 	return c.materializeApplyRequestPlan(ctx, req)

--- a/pkg/tern/target_router.go
+++ b/pkg/tern/target_router.go
@@ -139,12 +139,19 @@ func (r *TargetRouter) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*te
 	if req == nil {
 		return nil, fmt.Errorf("apply request is required")
 	}
-	// An apply executes a previously created plan, so the plan is authoritative
-	// for routing: it carries the execution target, namespace, type, and
-	// environment chosen at plan time. Derive the route from the plan and reject
-	// a request that contradicts it. Never treat req.Database as the target — the
-	// opaque execution target and the schema namespace are distinct, and that is
-	// the whole point of this router.
+	// An apply executes a previously created plan, so a locally stored plan is
+	// authoritative for routing: it carries the execution target, namespace,
+	// type, and environment chosen at plan time. Derive the route from the plan
+	// and reject a request that contradicts it. Never treat req.Database as the
+	// target — the opaque execution target and the schema namespace are
+	// distinct, and that is the whole point of this router.
+	//
+	// A non-primary deployment of a multi-deployment environment never planned
+	// locally — the plan row lives on the primary deployment's Tern — so no
+	// local plan exists here. The dispatch request carries the plan's
+	// authoritative DDL changes and schema files, so routing proceeds on the
+	// request's own route fields and the deployment-local client materializes
+	// (and re-verifies against the live schema) the plan before applying.
 	target := req.Target
 	if target == "" && req.Options != nil {
 		target = req.Options["target"]
@@ -158,20 +165,29 @@ func (r *TargetRouter) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*te
 		if err != nil {
 			return nil, fmt.Errorf("load plan %q for apply target routing: %w", req.PlanId, err)
 		}
-		if plan == nil {
-			return nil, fmt.Errorf("plan %q not found for apply target routing", req.PlanId)
-		}
-		if target, err = planAuthoritativeField("target", req.PlanId, target, plan.Target); err != nil {
-			return nil, err
-		}
-		if namespace, err = planAuthoritativeField("database", req.PlanId, namespace, plan.Database); err != nil {
-			return nil, err
-		}
-		if databaseType, err = planAuthoritativeField("type", req.PlanId, databaseType, plan.DatabaseType); err != nil {
-			return nil, err
-		}
-		if environment, err = planAuthoritativeField("environment", req.PlanId, environment, plan.Environment); err != nil {
-			return nil, err
+		switch {
+		case plan != nil:
+			if target, err = planAuthoritativeField("target", req.PlanId, target, plan.Target); err != nil {
+				return nil, err
+			}
+			if namespace, err = planAuthoritativeField("database", req.PlanId, namespace, plan.Database); err != nil {
+				return nil, err
+			}
+			if databaseType, err = planAuthoritativeField("type", req.PlanId, databaseType, plan.DatabaseType); err != nil {
+				return nil, err
+			}
+			if environment, err = planAuthoritativeField("environment", req.PlanId, environment, plan.Environment); err != nil {
+				return nil, err
+			}
+		case applyRequestCarriesPlanPayload(req):
+			r.logger.Info("apply target routing: no local plan; routing dispatch by request fields so the deployment-local client can materialize the plan",
+				"plan_id", req.PlanId,
+				"database", namespace,
+				"environment", environment,
+				"target", target,
+			)
+		default:
+			return nil, fmt.Errorf("plan %q not found for apply target routing and the request carries no DDL changes or schema files to materialize it", req.PlanId)
 		}
 	}
 	if target == "" {
@@ -195,6 +211,14 @@ func (r *TargetRouter) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*te
 	}
 	routedReq.Options["target"] = resolved.Target
 	return client.Apply(ctx, routedReq)
+}
+
+// applyRequestCarriesPlanPayload reports whether a dispatched apply request
+// carries the plan's authoritative content — DDL changes or schema files —
+// which lets a deployment that never planned locally materialize the plan
+// before applying.
+func applyRequestCarriesPlanPayload(req *ternv1.ApplyRequest) bool {
+	return len(req.DdlChanges) > 0 || len(req.SchemaFiles) > 0
 }
 
 // planAuthoritativeField resolves one routing field where the stored plan is

--- a/pkg/tern/target_router.go
+++ b/pkg/tern/target_router.go
@@ -183,6 +183,7 @@ func (r *TargetRouter) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*te
 			r.logger.Info("apply target routing: no local plan; routing dispatch by request fields so the deployment-local client can materialize the plan",
 				"plan_id", req.PlanId,
 				"database", namespace,
+				"database_type", databaseType,
 				"environment", environment,
 				"target", target,
 			)

--- a/pkg/tern/target_router_test.go
+++ b/pkg/tern/target_router_test.go
@@ -391,6 +391,70 @@ func TestTargetRouterApplyRoutesByPlanTargetWhenRequestOmitsTarget(t *testing.T)
 	assert.Equal(t, "production", client.applyReq.Environment)
 }
 
+// A dispatched apply for a non-primary deployment references a plan created on
+// the primary deployment's Tern, so no local plan row exists. When the request
+// carries the plan's authoritative DDL changes and schema files, routing must
+// proceed on the request's own route fields so the deployment-local client can
+// materialize the plan, rather than rejecting the dispatch.
+func TestTargetRouterApplyRoutesMissingPlanWithMaterializationPayload(t *testing.T) {
+	resolver := newStaticResolver(t)
+	created := make(map[string]*targetRouterRecordingClient)
+	planStore := targetRouterPlanStore{byIdentifier: map[string]*storage.Plan{}}
+	router := newTargetRouterForTest(t, resolver, nil, planStore, created)
+
+	resp, err := router.Apply(t.Context(), &ternv1.ApplyRequest{
+		PlanId:      "plan-7",
+		Database:    "orders",
+		Type:        storage.DatabaseTypeMySQL,
+		Environment: "production",
+		Target:      "dsid-orders-prod",
+		DdlChanges: []*ternv1.TableChange{{
+			Namespace: "orders",
+			TableName: "customers",
+			Ddl:       "ALTER TABLE `customers` ADD COLUMN `region_code` CHAR(2) NULL",
+		}},
+		SchemaFiles: map[string]*ternv1.SchemaFiles{
+			"orders": {Files: map[string]string{"customers.sql": "CREATE TABLE `customers` (`id` BIGINT UNSIGNED)"}},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.True(t, resp.Accepted)
+	client := created["orders"]
+	require.NotNil(t, client)
+	require.NotNil(t, client.applyReq)
+	assert.Equal(t, "plan-7", client.applyReq.PlanId)
+	assert.Equal(t, "orders", client.applyReq.Database)
+	assert.Equal(t, "dsid-orders-prod", client.applyReq.Target)
+	assert.Equal(t, "dsid-orders-prod", client.applyReq.Options["target"])
+	assert.Equal(t, storage.DatabaseTypeMySQL, client.applyReq.Type)
+	assert.Equal(t, "production", client.applyReq.Environment)
+	assert.Len(t, client.applyReq.DdlChanges, 1, "the routed request must keep the DDL changes for materialization")
+	assert.Len(t, client.applyReq.SchemaFiles, 1, "the routed request must keep the schema files for materialization")
+}
+
+// A request for a plan that exists nowhere and carries nothing to materialize
+// it from — a stale apply, or a local-mode apply for a plan that was never
+// stored here — must fail closed rather than route on unverifiable fields.
+func TestTargetRouterApplyFailsClosedOnMissingPlanWithoutPayload(t *testing.T) {
+	resolver := newStaticResolver(t)
+	created := make(map[string]*targetRouterRecordingClient)
+	planStore := targetRouterPlanStore{byIdentifier: map[string]*storage.Plan{}}
+	router := newTargetRouterForTest(t, resolver, nil, planStore, created)
+
+	_, err := router.Apply(t.Context(), &ternv1.ApplyRequest{
+		PlanId:      "plan-7",
+		Database:    "orders",
+		Type:        storage.DatabaseTypeMySQL,
+		Environment: "production",
+		Target:      "dsid-orders-prod",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `plan "plan-7" not found for apply target routing`)
+	assert.Empty(t, created, "no client should be created when the plan is missing and there is nothing to materialize")
+}
+
 // The plan is authoritative: a request that supplies a Target contradicting the
 // stored plan target must fail closed rather than silently override the
 // plan-time route.


### PR DESCRIPTION
## Summary
A non-primary deployment of a multi-deployment environment never plans locally — the plan row lives on the primary deployment's Tern. `TargetRouter.Apply` loaded the plan row for routing and hard-failed with `plan not found for apply target routing` when it wasn't in local storage, so the dispatch was rejected before `LocalClient.Apply` could materialize the plan from the request's authoritative DDL changes and schema files. Every multi-deployment apply failed on its second deployment.

## What
When the plan row is missing but the dispatch carries the materialization payload (`DdlChanges`/`SchemaFiles`), route on the request's own fields (target/type/environment) and let the deployment-local client materialize the plan — which still re-verifies the dispatched DDL against the live schema before applying. A request with neither a local plan nor a payload still fails closed, now with an error that says what was missing.

## Why
The materialize path (`planForApplyRequest` → `materializeApplyRequestPlan`) already exists exactly for this case but was unreachable: the router in front of it required the plan row unconditionally. Plan-authoritative routing (fail closed on target/database/type/environment mismatch) is unchanged when the plan row exists.

```
Before ──────────────────────────────────────────────────────────────

  control plane                     non-primary deployment
╭───────────────╮  Apply{plan_id, ╭──────────────────────────────╮
│ dispatch op 2 │──ddl, files}───▶│ TargetRouter.Apply           │
╰───────────────╯                 │  Plans().Get(plan_id) = nil  │
                                  │  ✗ "plan not found for apply │
                                  │     target routing"          │
                                  ╰──────────────────────────────╯
                                   LocalClient.Apply never reached;
                                   materialize path unreachable

After ───────────────────────────────────────────────────────────────

  control plane                     non-primary deployment
╭───────────────╮  Apply{plan_id, ╭──────────────────────────────╮
│ dispatch op 2 │──ddl, files}───▶│ TargetRouter.Apply           │
╰───────────────╯                 │  Plans().Get(plan_id) = nil  │
                                  │  payload present → route by  │
                                  │  request target/type/env     │
                                  ╰──────────────┬───────────────╯
                                                 ▼
                                  ╭──────────────────────────────╮
                                  │ LocalClient.Apply            │
                                  │  materialize plan from       │
                                  │  dispatched DDL/schema files │
                                  │  → verify vs live schema     │
                                  │  → apply ✓                   │
                                  ╰──────────────────────────────╯
```

## Found by
First true two-deployment rolling apply in a live multi-region rollout: the primary deployment applied cleanly, then every dispatch to the second deployment was rejected with `plan "plan-…" not found for apply target routing` until the retry budget was exhausted and the apply terminal-failed. Deployment ordering and `on_failure: halt` behaved correctly throughout — only the missing-plan routing rejection was at fault - ref: test-schema-migrations/pull/8