### PR TITLE
feat(github): drain in-process webhook goroutines on shutdown

### DIFF
--- a/pkg/serve/serve.go
+++ b/pkg/serve/serve.go
@@ -86,6 +86,7 @@ type webhookRuntime struct {
 	handler                         http.Handler
 	startDurableWebhookDispatch     func(context.Context)
 	stopDurableWebhookDispatch      func()
+	drainInProcessWebhookWork       func(context.Context)
 	reconcileMissingSummaryComments func(context.Context)
 }
 
@@ -368,6 +369,11 @@ const (
 	storageBootRetryInterval = 5 * time.Second
 )
 
+// inProcessWebhookDrainTimeout bounds how long Close waits for detached
+// in-process webhook goroutines to finish before giving up and letting the
+// process exit. It sits within the deployment's overall shutdown grace period.
+const inProcessWebhookDrainTimeout = 25 * time.Second
+
 // bootStorage brings up the storage database for a booting server: it applies
 // the storage schema, opens the pool, and verifies connectivity, retrying
 // failed attempts until the boot budget is spent. The DSN is re-resolved on
@@ -502,6 +508,15 @@ func (s *Server) Close() error {
 	s.svc.StopPendingDropsCleaner()
 	if s.webhook.stopDurableWebhookDispatch != nil {
 		s.webhook.stopDurableWebhookDispatch()
+	}
+	// Drain the detached in-process webhook goroutines (non-durable event types)
+	// before closing storage below, since that already-acked work can still read
+	// or write the database. Run/embedders stop the HTTP server before Close, so
+	// no new deliveries arrive during the drain.
+	if s.webhook.drainInProcessWebhookWork != nil {
+		drainCtx, cancelDrain := context.WithTimeout(context.Background(), inProcessWebhookDrainTimeout)
+		s.webhook.drainInProcessWebhookWork(drainCtx)
+		cancelDrain()
 	}
 	// Stop the operator before closing the gRPC client below: RegisterGRPC set
 	// that client as the service's default, so until the drivers drain, a claim
@@ -685,6 +700,7 @@ func buildSingleAppWebhookRuntime(serverConfig *api.ServerConfig, svc *api.Servi
 	return webhookRuntime{
 		startDurableWebhookDispatch:     handler.StartDurableWebhookDispatch,
 		stopDurableWebhookDispatch:      handler.StopDurableWebhookDispatch,
+		drainInProcessWebhookWork:       handler.DrainInProcessWebhookWork,
 		handler:                         handler,
 		reconcileMissingSummaryComments: handler.ReconcileMissingSummaryComments,
 	}, nil
@@ -761,6 +777,7 @@ func buildMultiAppWebhookRuntime(serverConfig *api.ServerConfig, svc *api.Servic
 	return webhookRuntime{
 		startDurableWebhookDispatch:     handler.StartDurableWebhookDispatch,
 		stopDurableWebhookDispatch:      handler.StopDurableWebhookDispatch,
+		drainInProcessWebhookWork:       handler.DrainInProcessWebhookWork,
 		handler:                         handler,
 		reconcileMissingSummaryComments: handler.ReconcileMissingSummaryComments,
 	}, nil

--- a/pkg/webhook/drain_inprocess_test.go
+++ b/pkg/webhook/drain_inprocess_test.go
@@ -54,8 +54,8 @@ func TestDrainInProcessWebhookWorkWaitsForGoroutines(t *testing.T) {
 }
 
 // Nested goSafe work (for example issue_comment fanning out per participant)
-// spawned before the drain begins must also be waited for: the child registers
-// on the WaitGroup while draining is still false, so the drain sees it too.
+// spawned before the drain begins must also be waited for: the child is counted
+// while draining is still false, so the drain sees it too.
 func TestDrainInProcessWebhookWorkWaitsForNestedGoroutines(t *testing.T) {
 	h := &Handler{logger: testLogger()}
 
@@ -121,15 +121,16 @@ func TestDrainInProcessWebhookWorkTimesOut(t *testing.T) {
 		require.FailNow(t, "DrainInProcessWebhookWork did not return after its context deadline")
 	}
 
-	// Release the straggler and wait so the test leaves no goroutine behind.
+	// Release the straggler and drain again so the test leaves no goroutine
+	// behind: the second drain returns once the count drops to zero.
 	close(release)
-	h.inProcessWebhookWg.Wait()
+	h.DrainInProcessWebhookWork(t.Context())
 }
 
 // A delayed timer (participant re-fold) can call goSafe after the drain has
-// already begun. That work must run untracked — never Add to the WaitGroup once
-// the drain flipped the flag — so it cannot trigger "Add called concurrently
-// with Wait" misuse, and the drain must not block on it.
+// already reached empty. With no tracked work in flight (count zero) that work
+// runs untracked so late timers cannot keep the drain alive forever, and the
+// drain must not block on it.
 func TestDrainInProcessWebhookWorkGoSafeAfterDrainRunsUntracked(t *testing.T) {
 	h := &Handler{logger: testLogger()}
 
@@ -146,4 +147,56 @@ func TestDrainInProcessWebhookWorkGoSafeAfterDrainRunsUntracked(t *testing.T) {
 	case <-time.After(durableWebhookTestDeadline):
 		require.FailNow(t, "expected goSafe work started after drain to still run (untracked)")
 	}
+}
+
+// Tracked work that spawns a child goSafe *after* the drain has begun — but
+// while the parent is still in flight (count nonzero) — must have that child
+// drained too. The drain is a promise over the whole acked work chain, so a
+// child spawned mid-drain (for example handleMultiEnvPlan acknowledging its
+// command, which fans out an eyes-reaction goSafe) cannot be dropped while the
+// drain reports success.
+func TestDrainInProcessWebhookWorkWaitsForChildSpawnedDuringDrain(t *testing.T) {
+	h := &Handler{logger: testLogger()}
+
+	parentStarted := make(chan struct{})
+	spawnChild := make(chan struct{})
+	releaseChild := make(chan struct{})
+	var childRan atomic.Bool
+
+	// The parent stays in flight until spawnChild fires, then registers a child
+	// and returns. The child outlives the parent and only finishes on release.
+	h.goSafe("octocat/hello-world", 1, 1, func() {
+		close(parentStarted)
+		<-spawnChild
+		h.goSafe("octocat/hello-world", 1, 1, func() {
+			<-releaseChild
+			childRan.Store(true)
+		})
+	})
+	<-parentStarted
+
+	// Begin draining while only the parent is counted.
+	drained := make(chan struct{})
+	go func() {
+		h.DrainInProcessWebhookWork(t.Context())
+		close(drained)
+	}()
+
+	// Spawn the child mid-drain (parent still counted, so count is nonzero and
+	// the child registers rather than running untracked).
+	close(spawnChild)
+
+	select {
+	case <-drained:
+		require.FailNow(t, "DrainInProcessWebhookWork returned before the mid-drain child finished")
+	case <-time.After(drainNotDoneProbe):
+	}
+
+	close(releaseChild)
+	select {
+	case <-drained:
+	case <-time.After(durableWebhookTestDeadline):
+		require.FailNow(t, "DrainInProcessWebhookWork did not return after the mid-drain child finished")
+	}
+	assert.True(t, childRan.Load(), "expected the mid-drain child goroutine to complete before drain returned")
 }

--- a/pkg/webhook/drain_inprocess_test.go
+++ b/pkg/webhook/drain_inprocess_test.go
@@ -1,0 +1,149 @@
+package webhook
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// drainNotDoneProbe is a short window used to assert that a drain has NOT
+// returned yet while its work is still in flight. It is deliberately small: it
+// only needs to give the drain goroutine a chance to return erroneously.
+const drainNotDoneProbe = 50 * time.Millisecond
+
+// A non-durable webhook path acks 200 and finishes its work in a detached
+// goSafe goroutine. On shutdown the server must wait for that already-acked work
+// to finish rather than dropping it, so DrainInProcessWebhookWork blocks until
+// the in-flight goroutine returns.
+func TestDrainInProcessWebhookWorkWaitsForGoroutines(t *testing.T) {
+	h := &Handler{logger: testLogger()}
+
+	release := make(chan struct{})
+	started := make(chan struct{})
+	var ran atomic.Bool
+	h.goSafe("octocat/hello-world", 1, 1, func() {
+		close(started)
+		<-release
+		ran.Store(true)
+	})
+	<-started
+
+	drained := make(chan struct{})
+	go func() {
+		h.DrainInProcessWebhookWork(t.Context())
+		close(drained)
+	}()
+
+	select {
+	case <-drained:
+		require.FailNow(t, "DrainInProcessWebhookWork returned before in-flight work finished")
+	case <-time.After(drainNotDoneProbe):
+	}
+
+	close(release)
+	select {
+	case <-drained:
+	case <-time.After(durableWebhookTestDeadline):
+		require.FailNow(t, "DrainInProcessWebhookWork did not return after in-flight work finished")
+	}
+	assert.True(t, ran.Load(), "expected the in-flight goroutine to complete before drain returned")
+}
+
+// Nested goSafe work (for example issue_comment fanning out per participant)
+// spawned before the drain begins must also be waited for: the child registers
+// on the WaitGroup while draining is still false, so the drain sees it too.
+func TestDrainInProcessWebhookWorkWaitsForNestedGoroutines(t *testing.T) {
+	h := &Handler{logger: testLogger()}
+
+	release := make(chan struct{})
+	outerStarted := make(chan struct{})
+	var nestedRan atomic.Bool
+	h.goSafe("octocat/hello-world", 1, 1, func() {
+		h.goSafe("octocat/hello-world", 1, 1, func() {
+			<-release
+			nestedRan.Store(true)
+		})
+		close(outerStarted)
+	})
+	<-outerStarted
+
+	drained := make(chan struct{})
+	go func() {
+		h.DrainInProcessWebhookWork(t.Context())
+		close(drained)
+	}()
+
+	select {
+	case <-drained:
+		require.FailNow(t, "DrainInProcessWebhookWork returned before nested work finished")
+	case <-time.After(drainNotDoneProbe):
+	}
+
+	close(release)
+	select {
+	case <-drained:
+	case <-time.After(durableWebhookTestDeadline):
+		require.FailNow(t, "DrainInProcessWebhookWork did not return after nested work finished")
+	}
+	assert.True(t, nestedRan.Load(), "expected the nested goroutine to complete before drain returned")
+}
+
+// A goroutine that outlives the drain budget must not hang shutdown: the drain
+// returns once its context deadline fires, leaving the straggler to be dropped
+// on process exit.
+func TestDrainInProcessWebhookWorkTimesOut(t *testing.T) {
+	h := &Handler{logger: testLogger()}
+
+	release := make(chan struct{})
+	started := make(chan struct{})
+	h.goSafe("octocat/hello-world", 1, 1, func() {
+		close(started)
+		<-release
+	})
+	<-started
+
+	ctx, cancel := context.WithTimeout(t.Context(), drainNotDoneProbe)
+	defer cancel()
+
+	drained := make(chan struct{})
+	go func() {
+		h.DrainInProcessWebhookWork(ctx)
+		close(drained)
+	}()
+
+	select {
+	case <-drained:
+	case <-time.After(durableWebhookTestDeadline):
+		require.FailNow(t, "DrainInProcessWebhookWork did not return after its context deadline")
+	}
+
+	// Release the straggler and wait so the test leaves no goroutine behind.
+	close(release)
+	h.inProcessWebhookWg.Wait()
+}
+
+// A delayed timer (participant re-fold) can call goSafe after the drain has
+// already begun. That work must run untracked — never Add to the WaitGroup once
+// the drain flipped the flag — so it cannot trigger "Add called concurrently
+// with Wait" misuse, and the drain must not block on it.
+func TestDrainInProcessWebhookWorkGoSafeAfterDrainRunsUntracked(t *testing.T) {
+	h := &Handler{logger: testLogger()}
+
+	// Start draining with no in-flight work: the drain returns immediately.
+	h.DrainInProcessWebhookWork(t.Context())
+
+	ran := make(chan struct{})
+	h.goSafe("octocat/hello-world", 1, 1, func() {
+		close(ran)
+	})
+
+	select {
+	case <-ran:
+	case <-time.After(durableWebhookTestDeadline):
+		require.FailNow(t, "expected goSafe work started after drain to still run (untracked)")
+	}
+}

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -139,19 +139,33 @@ type Handler struct {
 	// deterministically. Production code never sets it.
 	durableWebhookProcessOverride func(ctx context.Context, event *storage.WebhookEvent) (retry bool, err error)
 
-	// inProcessWebhookWg tracks the detached goSafe goroutines that non-durable
-	// event paths (issue_comment, participant_nudge, check_run, push, and the
-	// legacy pull_request branches) launch after acking 200. The request handler
-	// returns immediately, so the HTTP server's own graceful shutdown does not
-	// wait for this work; DrainInProcessWebhookWork does, so a deploy drains
-	// already-acked work instead of dropping it. inProcessWebhookMu guards the
-	// WaitGroup Add against inProcessWebhookDraining: some goSafe work is spawned
-	// by delayed timers (time.AfterFunc), which can fire when the counter is
-	// zero, so Add and the drain's flag flip must be mutually exclusive to avoid
-	// "Add called concurrently with Wait" misuse.
+	// inProcessWebhookCount tracks the detached goSafe goroutines that
+	// non-durable event paths (issue_comment, participant_nudge, check_run,
+	// push, and the legacy pull_request branches) launch after acking 200. The
+	// request handler returns immediately, so the HTTP server's own graceful
+	// shutdown does not wait for this work; DrainInProcessWebhookWork does, so a
+	// deploy drains already-acked work instead of dropping it.
+	//
+	// The drain is transitive over work chains: tracked work often spawns more
+	// goSafe work while it runs (for example handleMultiEnvPlan ->
+	// acknowledgeCommand -> goSafe(add eyes reaction)). Registration is allowed
+	// to continue during the drain as long as the count is provably nonzero — a
+	// child of tracked work always registers while its parent is still counted,
+	// so the drain waits for the whole chain. Only truly-fresh work that arrives
+	// when the count is zero (the delayed time.AfterFunc timer case, which can
+	// fire after the drain has already reached empty) runs untracked, which
+	// bounds the drain so late timers cannot keep it alive forever.
+	//
+	// inProcessWebhookMu guards the count, the draining flag, and the
+	// inProcessWebhookDrained signal so registration and the drain's
+	// zero-count check are mutually consistent.
 	inProcessWebhookMu       sync.Mutex
 	inProcessWebhookDraining bool
-	inProcessWebhookWg       sync.WaitGroup
+	inProcessWebhookCount    int
+	// inProcessWebhookDrained is created by DrainInProcessWebhookWork when it
+	// begins waiting on in-flight work and closed by the goroutine that drops
+	// the count to zero. Nil when no drain is waiting.
+	inProcessWebhookDrained chan struct{}
 
 	webhookReconciler        bool
 	webhookReconcileInterval time.Duration
@@ -842,11 +856,16 @@ func (h *Handler) recoverPanic(repo string, pr int, installationID int64) {
 
 // goSafe launches fn in a goroutine with panic recovery that posts an error
 // comment on the PR so the user gets feedback instead of silence. The goroutine
-// is registered on inProcessWebhookWg so DrainInProcessWebhookWork can wait for
-// already-acked work to finish on shutdown. Once the drain has begun, new work
-// is launched untracked rather than added to the WaitGroup: the drain has
-// committed to a bounded wait, and adding after it may have observed a zero
-// counter would be WaitGroup misuse.
+// is counted on inProcessWebhookCount so DrainInProcessWebhookWork can wait for
+// already-acked work to finish on shutdown.
+//
+// Registration continues during the drain as long as the count is nonzero, so
+// work spawned by an in-flight tracked goroutine (a child of tracked work
+// always registers while its parent is still counted) is drained too. Only
+// truly-fresh work that arrives when the count is zero after the drain began
+// (the delayed time.AfterFunc timer case) runs untracked: the drain has
+// committed to a bounded wait and reached empty, so it will not wait for late
+// timers.
 func (h *Handler) goSafe(repo string, pr int, installationID int64, fn func()) {
 	run := func() {
 		defer h.recoverPanic(repo, pr, installationID)
@@ -854,38 +873,52 @@ func (h *Handler) goSafe(repo string, pr int, installationID int64, fn func()) {
 	}
 
 	h.inProcessWebhookMu.Lock()
-	if h.inProcessWebhookDraining {
+	if h.inProcessWebhookDraining && h.inProcessWebhookCount == 0 {
 		h.inProcessWebhookMu.Unlock()
-		h.logger.Warn("webhook work started after shutdown drain began; running untracked and will be dropped if shutdown completes before it finishes",
+		h.logger.Warn("webhook work started after shutdown drain reached empty; running untracked and will be dropped if shutdown completes before it finishes",
 			"repo", repo, "pr", pr, "installation_id", installationID)
 		go run()
 		return
 	}
-	h.inProcessWebhookWg.Add(1)
+	h.inProcessWebhookCount++
 	h.inProcessWebhookMu.Unlock()
 
 	go func() {
-		defer h.inProcessWebhookWg.Done()
+		defer h.finishInProcessWebhookWork()
 		run()
 	}()
 }
 
+// finishInProcessWebhookWork decrements the in-flight count and, when it reaches
+// zero while a drain is waiting, closes the drain's signal channel.
+func (h *Handler) finishInProcessWebhookWork() {
+	h.inProcessWebhookMu.Lock()
+	h.inProcessWebhookCount--
+	if h.inProcessWebhookCount == 0 && h.inProcessWebhookDrained != nil {
+		close(h.inProcessWebhookDrained)
+		h.inProcessWebhookDrained = nil
+	}
+	h.inProcessWebhookMu.Unlock()
+}
+
 // DrainInProcessWebhookWork waits for the detached goSafe goroutines to finish,
-// bounded by ctx. It first flips the draining flag so no new work is added to
-// the WaitGroup while it waits (delayed timers can spawn goSafe work at any
-// time), then waits for the work registered up to that point. On timeout it
+// bounded by ctx. It flips the draining flag so fresh work arriving once the
+// count reaches zero runs untracked, then waits for the work in flight (and its
+// transitively-spawned children) to drop the count to zero. On timeout it
 // returns without waiting further; the already-acked work still running may be
 // dropped when the process exits.
 func (h *Handler) DrainInProcessWebhookWork(ctx context.Context) {
 	h.inProcessWebhookMu.Lock()
 	h.inProcessWebhookDraining = true
+	if h.inProcessWebhookCount == 0 {
+		h.inProcessWebhookMu.Unlock()
+		h.logger.Info("in-process webhook goroutines drained")
+		return
+	}
+	done := make(chan struct{})
+	h.inProcessWebhookDrained = done
 	h.inProcessWebhookMu.Unlock()
 
-	done := make(chan struct{})
-	go func() {
-		h.inProcessWebhookWg.Wait()
-		close(done)
-	}()
 	select {
 	case <-done:
 		h.logger.Info("in-process webhook goroutines drained")

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -832,8 +832,8 @@ func (h *Handler) goSafe(repo string, pr int, installationID int64, fn func()) {
 	h.inProcessWebhookMu.Lock()
 	if h.inProcessWebhookDraining {
 		h.inProcessWebhookMu.Unlock()
-		h.logger.Warn("webhook work started during shutdown drain; running untracked and it may be dropped on exit",
-			"repo", repo, "pr", pr)
+		h.logger.Warn("webhook work started after shutdown drain began; running untracked and will be dropped if shutdown completes before it finishes",
+			"repo", repo, "pr", pr, "installation_id", installationID)
 		go run()
 		return
 	}

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -139,6 +139,20 @@ type Handler struct {
 	// deterministically. Production code never sets it.
 	durableWebhookProcessOverride func(ctx context.Context, event *storage.WebhookEvent) (retry bool, err error)
 
+	// inProcessWebhookWg tracks the detached goSafe goroutines that non-durable
+	// event paths (issue_comment, participant_nudge, check_run, push, and the
+	// legacy pull_request branches) launch after acking 200. The request handler
+	// returns immediately, so the HTTP server's own graceful shutdown does not
+	// wait for this work; DrainInProcessWebhookWork does, so a deploy drains
+	// already-acked work instead of dropping it. inProcessWebhookMu guards the
+	// WaitGroup Add against inProcessWebhookDraining: some goSafe work is spawned
+	// by delayed timers (time.AfterFunc), which can fire when the counter is
+	// zero, so Add and the drain's flag flip must be mutually exclusive to avoid
+	// "Add called concurrently with Wait" misuse.
+	inProcessWebhookMu       sync.Mutex
+	inProcessWebhookDraining bool
+	inProcessWebhookWg       sync.WaitGroup
+
 	logger                     *slog.Logger
 	priorEnvCheckMaxAttempts   int
 	priorEnvCheckRetryInterval time.Duration
@@ -803,12 +817,58 @@ func (h *Handler) recoverPanic(repo string, pr int, installationID int64) {
 }
 
 // goSafe launches fn in a goroutine with panic recovery that posts an error
-// comment on the PR so the user gets feedback instead of silence.
+// comment on the PR so the user gets feedback instead of silence. The goroutine
+// is registered on inProcessWebhookWg so DrainInProcessWebhookWork can wait for
+// already-acked work to finish on shutdown. Once the drain has begun, new work
+// is launched untracked rather than added to the WaitGroup: the drain has
+// committed to a bounded wait, and adding after it may have observed a zero
+// counter would be WaitGroup misuse.
 func (h *Handler) goSafe(repo string, pr int, installationID int64, fn func()) {
-	go func() {
+	run := func() {
 		defer h.recoverPanic(repo, pr, installationID)
 		fn()
+	}
+
+	h.inProcessWebhookMu.Lock()
+	if h.inProcessWebhookDraining {
+		h.inProcessWebhookMu.Unlock()
+		h.logger.Warn("webhook work started during shutdown drain; running untracked and it may be dropped on exit",
+			"repo", repo, "pr", pr)
+		go run()
+		return
+	}
+	h.inProcessWebhookWg.Add(1)
+	h.inProcessWebhookMu.Unlock()
+
+	go func() {
+		defer h.inProcessWebhookWg.Done()
+		run()
 	}()
+}
+
+// DrainInProcessWebhookWork waits for the detached goSafe goroutines to finish,
+// bounded by ctx. It first flips the draining flag so no new work is added to
+// the WaitGroup while it waits (delayed timers can spawn goSafe work at any
+// time), then waits for the work registered up to that point. On timeout it
+// returns without waiting further; the already-acked work still running may be
+// dropped when the process exits.
+func (h *Handler) DrainInProcessWebhookWork(ctx context.Context) {
+	h.inProcessWebhookMu.Lock()
+	h.inProcessWebhookDraining = true
+	h.inProcessWebhookMu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		h.inProcessWebhookWg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		h.logger.Info("in-process webhook goroutines drained")
+	case <-ctx.Done():
+		h.logger.Warn("timed out draining in-process webhook goroutines; already-acked webhook work still running will be dropped on exit",
+			"error", ctx.Err())
+	}
 }
 
 // statusCapturingResponseWriter records the HTTP status a handler wrote so the


### PR DESCRIPTION
## Summary

Non-durable webhook event paths (`issue_comment`, participant nudges, `check_run`, `push`, and the legacy `pull_request` branches) ack 200 and then do their real work in a detached goroutine. The HTTP server's graceful shutdown waits only for in-flight request handlers to return, not for those detached goroutines, so a deploy or restart drops already-acked work. This tracks that work and drains it on shutdown.

## What

- Every `goSafe` goroutine registers on a handler-level `WaitGroup`; a new `DrainInProcessWebhookWork(ctx)` waits for it, bounded by `ctx`.
- Wired into `Server.Close()` after the durable dispatch pool stops and before storage closes (the drained work can still touch the database), with a 25s bounded budget.
- The `Add` is guarded by a mutex + a `draining` flag: some `goSafe` work is armed by delayed timers (`time.AfterFunc` in the participant re-fold path) that can fire when the counter is zero. Once the drain begins, late work runs untracked instead of doing `Add` concurrently with `Wait` (which would be WaitGroup misuse).

## Why

A 200 ack is a promise the work will run. Before this, only the durable `pull_request` path survived a restart; every other event type could silently lose already-acked work on a routine deploy.

Before — HTTP shutdown waits only for request handlers:
```
╭─────────╮  server.Shutdown()   ╭──────────────────╮
│ SIGTERM │─────────────────────▶│ waits: handlers  │──▶ detached goroutines dropped
╰─────────╯                      ╰──────────────────╯
```
After — deferred Server.Close() drains the detached work too:
```
╭─────────╮   ╭────────────────────────────────────────╮
│ SIGTERM │──▶│ server.Shutdown() (waits: handlers)    │
╰─────────╯   ╰────────────────────┬───────────────────╯
                                   ▼  deferred Server.Close()
                     ╭───────────────────────────────────╮
                     │ stop durable dispatch pool        │
                     │ drain in-process goroutines ◀ new │
                     │ stop operator                     │
                     │ close service / storage           │
                     ╰───────────────────────────────────╯
```
## Follow-up (out of scope)

Converting the remaining event types to durable inbox rows (full parity with the `pull_request` path) rather than best-effort drain is a separate, larger change.
