### PR TITLE
refactor(storage): route timestamp/interval SQL through the dialect

### DIFF
--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -53,7 +53,8 @@ const (
 
 // applyStore implements storage.ApplyStore using MySQL.
 type applyStore struct {
-	db *sql.DB
+	db      *sql.DB
+	dialect Dialect
 }
 
 type applyWriteTx struct {
@@ -1167,6 +1168,9 @@ func (s *applyStore) FindNextApply(ctx context.Context, owner string) (*storage.
 		state.Apply.WaitingForDeploy,
 		storage.ControlOperationStart, storage.ControlRequestPending)
 
+	staleClaimCutoff := s.dialect.RelativeTime(TimestampPrecisionDefault, BeforeCurrentTime, LiteralIntervalAmount(uint64(storage.ApplyLeaseStaleAfter.Microseconds())), IntervalMicrosecond)
+	retryFreshnessCutoff := s.dialect.RelativeTime(TimestampPrecisionDefault, BeforeCurrentTime, ParameterIntervalAmount(), IntervalDay)
+
 	// Apply creation/update enforces at most one active apply per
 	// database/type/environment. The claim query only needs to find stale work;
 	// FOR UPDATE SKIP LOCKED prevents concurrent drivers from claiming the same row.
@@ -1183,8 +1187,8 @@ func (s *applyStore) FindNextApply(ctx context.Context, owner string) (*storage.
 					EXISTS (SELECT 1 FROM tasks t WHERE t.apply_id = a.id)
 					OR EXISTS (SELECT 1 FROM apply_operations ao WHERE ao.apply_id = a.id)
 				))
-				OR (a.state IN (%s) AND a.updated_at < NOW() - INTERVAL %s)
-				OR (a.state = ? AND a.attempt < ? AND a.updated_at >= NOW() - INTERVAL ? DAY)
+				OR (a.state IN (%s) AND a.updated_at < %s)
+				OR (a.state = ? AND a.attempt < ? AND a.updated_at >= %s)
 				OR (
 					a.state = ?
 					AND EXISTS (
@@ -1210,7 +1214,7 @@ func (s *applyStore) FindNextApply(ctx context.Context, owner string) (*storage.
 						AND (
 							a.lease_acquired_at IS NULL
 							OR a.lease_acquired_at < cr.updated_at
-							OR a.updated_at < NOW() - INTERVAL %s
+							OR a.updated_at < %s
 						)
 					)
 				)
@@ -1218,7 +1222,7 @@ func (s *applyStore) FindNextApply(ctx context.Context, owner string) (*storage.
 		ORDER BY a.created_at
 		LIMIT 1
 		FOR UPDATE SKIP LOCKED
-	`, applyColumns, activeStatePlaceholders, applyLeaseStalenessSQL, applyLeaseStalenessSQL), queryArgs...)
+	`, applyColumns, activeStatePlaceholders, staleClaimCutoff, retryFreshnessCutoff, staleClaimCutoff), queryArgs...)
 
 	apply, err := scanApplyInto(row)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -1280,6 +1284,9 @@ func (s *applyStore) ClaimApplyByID(ctx context.Context, applyID int64, owner st
 		state.Apply.WaitingForDeploy,
 		storage.ControlOperationStart, storage.ControlRequestPending)
 
+	staleClaimCutoff := s.dialect.RelativeTime(TimestampPrecisionDefault, BeforeCurrentTime, LiteralIntervalAmount(uint64(storage.ApplyLeaseStaleAfter.Microseconds())), IntervalMicrosecond)
+	retryFreshnessCutoff := s.dialect.RelativeTime(TimestampPrecisionDefault, BeforeCurrentTime, ParameterIntervalAmount(), IntervalDay)
+
 	row := tx.QueryRowContext(ctx, fmt.Sprintf(`
 		SELECT %s
 		FROM applies a
@@ -1289,8 +1296,8 @@ func (s *applyStore) ClaimApplyByID(ctx context.Context, applyID int64, owner st
 					EXISTS (SELECT 1 FROM tasks t WHERE t.apply_id = a.id)
 					OR EXISTS (SELECT 1 FROM apply_operations ao WHERE ao.apply_id = a.id)
 				))
-				OR (a.state IN (%s) AND a.updated_at < NOW() - INTERVAL %s)
-				OR (a.state = ? AND a.attempt < ? AND a.updated_at >= NOW() - INTERVAL ? DAY)
+				OR (a.state IN (%s) AND a.updated_at < %s)
+				OR (a.state = ? AND a.attempt < ? AND a.updated_at >= %s)
 				OR (
 					a.state = ?
 					AND EXISTS (
@@ -1316,14 +1323,14 @@ func (s *applyStore) ClaimApplyByID(ctx context.Context, applyID int64, owner st
 						AND (
 							a.lease_acquired_at IS NULL
 							OR a.lease_acquired_at < cr.updated_at
-							OR a.updated_at < NOW() - INTERVAL %s
+							OR a.updated_at < %s
 						)
 					)
 				)
 			)
 		LIMIT 1
 		FOR UPDATE SKIP LOCKED
-	`, applyColumns, activeStatePlaceholders, applyLeaseStalenessSQL, applyLeaseStalenessSQL), queryArgs...)
+	`, applyColumns, activeStatePlaceholders, staleClaimCutoff, retryFreshnessCutoff, staleClaimCutoff), queryArgs...)
 
 	apply, err := scanApplyInto(row)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -1735,7 +1742,7 @@ func (s *applyStore) ExpireRetryable(ctx context.Context) ([]*storage.RetryableA
 		FROM applies
 		WHERE state = ? AND (
 			attempt >= ?
-			OR updated_at < NOW() - INTERVAL ? DAY
+			OR updated_at < `+s.dialect.RelativeTime(TimestampPrecisionDefault, BeforeCurrentTime, ParameterIntervalAmount(), IntervalDay)+`
 		)
 		FOR UPDATE
 	`, state.Apply.FailedRetryable, maxRecoveryAttempts, retryableRecoveryFreshnessDays)
@@ -2003,12 +2010,12 @@ func (s *applyStore) FindMissingSummaryComment(ctx context.Context) ([]*storage.
 		  AND a.pull_request > 0
 		  AND a.installation_id > 0
 		  AND (
-			(a.state IN (?, ?, ?, ?) AND a.completed_at > NOW() - INTERVAL 1 HOUR)
-			OR (a.state = ? AND a.updated_at > NOW() - INTERVAL 1 HOUR)
+			(a.state IN (?, ?, ?, ?) AND a.completed_at > `+s.dialect.RelativeTime(TimestampPrecisionDefault, BeforeCurrentTime, LiteralIntervalAmount(1), IntervalHour)+`)
+			OR (a.state = ? AND a.updated_at > `+s.dialect.RelativeTime(TimestampPrecisionDefault, BeforeCurrentTime, LiteralIntervalAmount(1), IntervalHour)+`)
 		  )
 		  AND (
 			acs.id IS NULL
-			OR (acs.github_comment_id = 0 AND acs.updated_at < NOW() - INTERVAL ? SECOND)
+			OR (acs.github_comment_id = 0 AND acs.updated_at < `+s.dialect.RelativeTime(TimestampPrecisionDefault, BeforeCurrentTime, ParameterIntervalAmount(), IntervalSecond)+`)
 		  )
 		ORDER BY a.updated_at DESC
 	`, state.Apply.Completed, state.Apply.Failed, state.Apply.Reverted, state.Apply.Cancelled,

--- a/pkg/storage/mysqlstore/apply_comments.go
+++ b/pkg/storage/mysqlstore/apply_comments.go
@@ -253,7 +253,7 @@ func (s *applyCommentStore) ReclaimStaleSummaryClaim(ctx context.Context, applyI
 		SET updated_at = NOW()
 		WHERE apply_id = ? AND comment_state = ?
 		  AND github_comment_id = 0
-		  AND updated_at < NOW() - INTERVAL ? SECOND
+		  AND updated_at < `+s.dialect.RelativeTime(TimestampPrecisionDefault, BeforeCurrentTime, ParameterIntervalAmount(), IntervalSecond)+`
 	`, applyID, state.Comment.Summary, int64(storage.SummaryClaimStaleAfter.Seconds()))
 	if err != nil {
 		return false, fmt.Errorf("reclaim stale summary claim for apply %d: %w", applyID, err)

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -25,7 +25,8 @@ const applyOperationColumns = `id, apply_id, deployment, operation_key, operatio
 
 // applyOperationStore implements storage.ApplyOperationStore using MySQL.
 type applyOperationStore struct {
-	db *sql.DB
+	db      *sql.DB
+	dialect Dialect
 }
 
 // Insert stores a new apply_operations row and returns its ID.
@@ -805,6 +806,8 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 	// non-completed, and
 	// a gated one would be redundant with the pending clause below. Start
 	// requests resume eligible work; they do not reorder the rollout.
+	staleClaimCutoff := s.dialect.RelativeTime(TimestampPrecisionDefault, BeforeCurrentTime, LiteralIntervalAmount(uint64(storage.ApplyLeaseStaleAfter.Microseconds())), IntervalMicrosecond)
+	retryFreshnessCutoff := s.dialect.RelativeTime(TimestampPrecisionDefault, BeforeCurrentTime, ParameterIntervalAmount(), IntervalDay)
 	row := tx.QueryRowContext(ctx, fmt.Sprintf(`
 		SELECT %s
 		FROM apply_operations
@@ -856,7 +859,7 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 			)
 			OR (
 				state IN (%s)
-				AND updated_at < NOW() - INTERVAL %s
+				AND updated_at < %s
 				AND NOT (
 					state = ?
 					AND cutover_policy IN (?, ?)
@@ -895,7 +898,7 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 						AND (
 							apply_operations.lease_acquired_at IS NULL
 							OR apply_operations.lease_acquired_at < cr.updated_at
-							OR apply_operations.updated_at < NOW() - INTERVAL %s
+							OR apply_operations.updated_at < %s
 						)
 				)
 			)
@@ -909,11 +912,11 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 							(
 								a.state = ?
 								AND a.attempt < ?
-								AND a.updated_at >= NOW() - INTERVAL ? DAY
+								AND a.updated_at >= %s
 							)
 							OR (
 								a.state IN (%s)
-								AND a.updated_at < NOW() - INTERVAL %s
+								AND a.updated_at < %s
 							)
 						)
 				)
@@ -922,7 +925,7 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 		ORDER BY created_at, id
 		LIMIT 1
 		FOR UPDATE SKIP LOCKED
-	`, applyOperationColumns, activeStatePlaceholders, applyLeaseStalenessSQL, activeStatePlaceholders, applyLeaseStalenessSQL, activeStatePlaceholders, applyLeaseStalenessSQL), queryArgs...)
+	`, applyOperationColumns, activeStatePlaceholders, staleClaimCutoff, activeStatePlaceholders, staleClaimCutoff, retryFreshnessCutoff, activeStatePlaceholders, staleClaimCutoff), queryArgs...)
 
 	ad, err := scanApplyOperationInto(row)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -1169,6 +1172,7 @@ func (s *applyOperationStore) FindNextApplyOperationCutover(ctx context.Context,
 		state.ApplyOperation.RevertWindow,
 	)
 
+	staleClaimCutoff := s.dialect.RelativeTime(TimestampPrecisionDefault, BeforeCurrentTime, LiteralIntervalAmount(uint64(storage.ApplyLeaseStaleAfter.Microseconds())), IntervalMicrosecond)
 	row := tx.QueryRowContext(ctx, fmt.Sprintf(`
 		SELECT %s
 		FROM apply_operations
@@ -1204,12 +1208,12 @@ func (s *applyOperationStore) FindNextApplyOperationCutover(ctx context.Context,
 						AND cr.status = ?
 				)
 			)
-			OR (state IN (?, ?) AND updated_at < NOW() - INTERVAL %s)
+			OR (state IN (?, ?) AND updated_at < %s)
 		)
 		ORDER BY created_at, id
 		LIMIT 1
 		FOR UPDATE SKIP LOCKED
-	`, applyOperationColumns, applyLeaseStalenessSQL), queryArgs...)
+	`, applyOperationColumns, staleClaimCutoff), queryArgs...)
 
 	ad, err := scanApplyOperationInto(row)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/pkg/storage/mysqlstore/dialect.go
+++ b/pkg/storage/mysqlstore/dialect.go
@@ -7,9 +7,13 @@ import (
 )
 
 // Dialect abstracts the SQL-syntax differences between database families (MySQL
-// and, in the future, Postgres) that the state store depends on, so the same
-// store logic can target either engine. This package provides the MySQL
-// implementation; a Postgres store provides its own.
+// and, in the future, Postgres) that the state store depends on. This is an
+// incremental seam: the store lives in mysqlstore and still emits MySQL-style
+// "?" placeholders, and only the family-varying syntax (upsert clause,
+// current-time and relative-time expressions) routes through here. When a
+// Postgres store is introduced this interface likely moves to a shared package,
+// and its parameterized SQL will need a "?"-to-"$n" rebind at the store
+// boundary.
 type Dialect interface {
 	// UpsertClause returns the trailing conflict-resolution clause that turns an
 	// INSERT into an upsert. conflictColumns names the unique key that defines a

--- a/pkg/storage/mysqlstore/dialect.go
+++ b/pkg/storage/mysqlstore/dialect.go
@@ -1,13 +1,15 @@
 package mysqlstore
 
-import "strings"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
 
 // Dialect abstracts the SQL-syntax differences between database families (MySQL
 // and, in the future, Postgres) that the state store depends on, so the same
-// store logic can target either engine. It currently lives here alongside its
-// MySQLDialect implementation; when a Postgres store is introduced this
-// interface likely moves to a shared package so neither store depends on the
-// other.
+// store logic can target either engine. This package provides the MySQL
+// implementation; a Postgres store provides its own.
 type Dialect interface {
 	// UpsertClause returns the trailing conflict-resolution clause that turns an
 	// INSERT into an upsert. conflictColumns names the unique key that defines a
@@ -19,6 +21,72 @@ type Dialect interface {
 	// use inside an UpsertAssignment expression (MySQL: VALUES(col); Postgres:
 	// EXCLUDED.col).
 	ExcludedValue(column string) string
+	// CurrentTimestamp returns the expression for the current time at the given
+	// fractional-second precision (MySQL: NOW() / NOW(6)).
+	CurrentTimestamp(precision TimestampPrecision) string
+	// RelativeTime returns an expression for the current time offset by an
+	// interval, for staleness and lease-expiry predicates. amount is either a
+	// build-time literal or a bound query parameter; a parameterized amount emits
+	// exactly one placeholder that the caller supplies as a query argument.
+	RelativeTime(precision TimestampPrecision, direction RelativeTimeDirection, amount IntervalAmount, unit IntervalUnit) string
+}
+
+// TimestampPrecision selects the fractional-second precision of a current-time
+// expression. Only the values the store actually uses are representable.
+type TimestampPrecision uint8
+
+const (
+	// TimestampPrecisionDefault is whole-second precision (MySQL NOW()).
+	TimestampPrecisionDefault TimestampPrecision = iota
+	// TimestampPrecisionMicrosecond is microsecond precision (MySQL NOW(6)).
+	TimestampPrecisionMicrosecond
+)
+
+// RelativeTimeDirection selects whether an interval is subtracted from or added
+// to the current time.
+type RelativeTimeDirection uint8
+
+const (
+	// BeforeCurrentTime yields current time minus the interval.
+	BeforeCurrentTime RelativeTimeDirection = iota
+	// AfterCurrentTime yields current time plus the interval.
+	AfterCurrentTime
+)
+
+// IntervalUnit is the unit of a relative-time interval.
+type IntervalUnit uint8
+
+const (
+	// IntervalMicrosecond is a microsecond interval unit.
+	IntervalMicrosecond IntervalUnit = iota
+	// IntervalSecond is a second interval unit.
+	IntervalSecond
+	// IntervalMinute is a minute interval unit.
+	IntervalMinute
+	// IntervalHour is an hour interval unit.
+	IntervalHour
+	// IntervalDay is a day interval unit.
+	IntervalDay
+)
+
+// IntervalAmount is the magnitude of a relative-time interval: either a literal
+// value known when the query is built or a bound query parameter. Construct it
+// with LiteralIntervalAmount or ParameterIntervalAmount so the parameterized
+// form always emits exactly one placeholder.
+type IntervalAmount struct {
+	literal       uint64
+	parameterized bool
+}
+
+// LiteralIntervalAmount is an interval magnitude fixed at query-build time.
+func LiteralIntervalAmount(value uint64) IntervalAmount {
+	return IntervalAmount{literal: value}
+}
+
+// ParameterIntervalAmount is an interval magnitude bound as a query parameter;
+// the caller supplies the value as a query argument.
+func ParameterIntervalAmount() IntervalAmount {
+	return IntervalAmount{parameterized: true}
 }
 
 // UpsertAssignment describes how one column is updated when an upsert matches an
@@ -49,4 +117,55 @@ func (d MySQLDialect) UpsertClause(_ []string, assignments []UpsertAssignment) s
 		sets[i] = a.Column + " = " + expr
 	}
 	return "ON DUPLICATE KEY UPDATE " + strings.Join(sets, ", ")
+}
+
+// CurrentTimestamp returns MySQL's NOW() at the requested precision.
+func (MySQLDialect) CurrentTimestamp(precision TimestampPrecision) string {
+	switch precision {
+	case TimestampPrecisionDefault:
+		return "NOW()"
+	case TimestampPrecisionMicrosecond:
+		return "NOW(6)"
+	default:
+		panic(fmt.Sprintf("mysqlstore: unknown timestamp precision %d", precision))
+	}
+}
+
+// RelativeTime builds a MySQL current-time-plus-or-minus-interval expression.
+// Subtraction uses the INTERVAL operator (NOW() - INTERVAL n UNIT); addition
+// uses DATE_ADD so it composes with an explicit-precision NOW(6). A
+// parameterized amount emits a single "?" placeholder.
+func (d MySQLDialect) RelativeTime(precision TimestampPrecision, direction RelativeTimeDirection, amount IntervalAmount, unit IntervalUnit) string {
+	magnitude := "?"
+	if !amount.parameterized {
+		magnitude = strconv.FormatUint(amount.literal, 10)
+	}
+	interval := "INTERVAL " + magnitude + " " + mysqlIntervalUnit(unit)
+	now := d.CurrentTimestamp(precision)
+
+	switch direction {
+	case BeforeCurrentTime:
+		return now + " - " + interval
+	case AfterCurrentTime:
+		return "DATE_ADD(" + now + ", " + interval + ")"
+	default:
+		panic(fmt.Sprintf("mysqlstore: unknown relative-time direction %d", direction))
+	}
+}
+
+func mysqlIntervalUnit(unit IntervalUnit) string {
+	switch unit {
+	case IntervalMicrosecond:
+		return "MICROSECOND"
+	case IntervalSecond:
+		return "SECOND"
+	case IntervalMinute:
+		return "MINUTE"
+	case IntervalHour:
+		return "HOUR"
+	case IntervalDay:
+		return "DAY"
+	default:
+		panic(fmt.Sprintf("mysqlstore: unknown interval unit %d", unit))
+	}
 }

--- a/pkg/storage/mysqlstore/dialect_test.go
+++ b/pkg/storage/mysqlstore/dialect_test.go
@@ -62,3 +62,88 @@ func TestMySQLDialectUpsertClause(t *testing.T) {
 		})
 	}
 }
+
+func TestMySQLDialectCurrentTimestamp(t *testing.T) {
+	d := MySQLDialect{}
+	assert.Equal(t, "NOW()", d.CurrentTimestamp(TimestampPrecisionDefault))
+	assert.Equal(t, "NOW(6)", d.CurrentTimestamp(TimestampPrecisionMicrosecond))
+}
+
+// RelativeTime must render the exact MySQL expressions the store used before the
+// dialect seam, including the DATE_ADD form for additions and a single "?"
+// placeholder for parameterized magnitudes.
+func TestMySQLDialectRelativeTime(t *testing.T) {
+	d := MySQLDialect{}
+
+	tests := []struct {
+		name      string
+		precision TimestampPrecision
+		direction RelativeTimeDirection
+		amount    IntervalAmount
+		unit      IntervalUnit
+		want      string
+	}{
+		{
+			name:      "literal minute before",
+			precision: TimestampPrecisionDefault,
+			direction: BeforeCurrentTime,
+			amount:    LiteralIntervalAmount(1),
+			unit:      IntervalMinute,
+			want:      "NOW() - INTERVAL 1 MINUTE",
+		},
+		{
+			name:      "literal hour before",
+			precision: TimestampPrecisionDefault,
+			direction: BeforeCurrentTime,
+			amount:    LiteralIntervalAmount(1),
+			unit:      IntervalHour,
+			want:      "NOW() - INTERVAL 1 HOUR",
+		},
+		{
+			name:      "parameterized second before",
+			precision: TimestampPrecisionDefault,
+			direction: BeforeCurrentTime,
+			amount:    ParameterIntervalAmount(),
+			unit:      IntervalSecond,
+			want:      "NOW() - INTERVAL ? SECOND",
+		},
+		{
+			name:      "parameterized day before",
+			precision: TimestampPrecisionDefault,
+			direction: BeforeCurrentTime,
+			amount:    ParameterIntervalAmount(),
+			unit:      IntervalDay,
+			want:      "NOW() - INTERVAL ? DAY",
+		},
+		{
+			name:      "parameterized microsecond after at microsecond precision",
+			precision: TimestampPrecisionMicrosecond,
+			direction: AfterCurrentTime,
+			amount:    ParameterIntervalAmount(),
+			unit:      IntervalMicrosecond,
+			want:      "DATE_ADD(NOW(6), INTERVAL ? MICROSECOND)",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := d.RelativeTime(tc.precision, tc.direction, tc.amount, tc.unit)
+			assert.Equal(t, tc.want, got)
+			if tc.amount.parameterized {
+				assert.Equal(t, 1, countPlaceholders(got), "parameterized amount must emit exactly one ?")
+			} else {
+				assert.Equal(t, 0, countPlaceholders(got), "literal amount must emit no ?")
+			}
+		})
+	}
+}
+
+func countPlaceholders(s string) int {
+	n := 0
+	for _, r := range s {
+		if r == '?' {
+			n++
+		}
+	}
+	return n
+}

--- a/pkg/storage/mysqlstore/sql_helpers.go
+++ b/pkg/storage/mysqlstore/sql_helpers.go
@@ -5,20 +5,8 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 	"log/slog"
-
-	"github.com/block/schemabot/pkg/storage"
 )
-
-// applyLeaseStalenessSQL is the SQL INTERVAL after which a claimed applies or
-// apply_operations row's lease heartbeat (updated_at) is stale and the row may
-// be re-claimed by another driver. Derived from storage.ApplyLeaseStaleAfter so
-// the reclaim window and the driver-side presumed-lost bound cannot drift
-// apart; microsecond units keep the two windows exactly equal for any
-// duration, so the reclaim window can never round below the presumed-lost
-// bound.
-var applyLeaseStalenessSQL = fmt.Sprintf("%d MICROSECOND", storage.ApplyLeaseStaleAfter.Microseconds())
 
 // rollbackTx rolls back tx, logging a warning if the rollback fails for a
 // reason other than the transaction already being finished. operation is

--- a/pkg/storage/mysqlstore/storage.go
+++ b/pkg/storage/mysqlstore/storage.go
@@ -31,16 +31,16 @@ func New(db *sql.DB) *Storage {
 		db:              db,
 		locks:           &lockStore{db: db},
 		plans:           &planStore{db: db},
-		applies:         &applyStore{db: db},
+		applies:         &applyStore{db: db, dialect: MySQLDialect{}},
 		tasks:           &taskStore{db: db},
 		applyLogs:       &applyLogStore{db: db},
 		controlRequests: &controlRequestStore{db: db},
 		applyComments:   &applyCommentStore{db: db, dialect: MySQLDialect{}},
 		planComments:    &planCommentStore{db: db},
-		applyOperations: &applyOperationStore{db: db},
+		applyOperations: &applyOperationStore{db: db, dialect: MySQLDialect{}},
 		checks:          &checkStore{db: db, dialect: MySQLDialect{}},
 		settings:        &settingsStore{db: db, dialect: MySQLDialect{}},
-		webhookEvents:   &webhookEventStore{db: db},
+		webhookEvents:   &webhookEventStore{db: db, dialect: MySQLDialect{}},
 	}
 }
 

--- a/pkg/storage/mysqlstore/webhook_events.go
+++ b/pkg/storage/mysqlstore/webhook_events.go
@@ -20,7 +20,8 @@ const webhookEventColumns = `id, provider, delivery_id, event, action, repositor
 	received_at, started_at, completed_at, created_at, updated_at`
 
 type webhookEventStore struct {
-	db *sql.DB
+	db      *sql.DB
+	dialect Dialect
 }
 
 func (s *webhookEventStore) Create(ctx context.Context, event *storage.WebhookEvent) (bool, error) {
@@ -103,7 +104,7 @@ func (s *webhookEventStore) reopenTerminalWebhookEvent(ctx context.Context, prov
 			lease_owner = NULL, lease_token = NULL, lease_expires_at = NULL,
 			retry_after = NULL, completed_at = NULL, started_at = NULL, updated_at = NOW()
 		WHERE provider = ? AND delivery_id = ?
-			AND (state IN (?, ?) OR (state = ? AND lease_expires_at <= NOW(6)))
+			AND (state IN (?, ?) OR (state = ? AND lease_expires_at <= `+s.dialect.CurrentTimestamp(TimestampPrecisionMicrosecond)+`))
 	`, storage.WebhookEventPending, payload, receivedAt, provider, deliveryID,
 		storage.WebhookEventFailed, storage.WebhookEventCompleted, storage.WebhookEventProcessing)
 	if err != nil {
@@ -135,11 +136,13 @@ func (s *webhookEventStore) GetByDeliveryID(ctx context.Context, provider, deliv
 // single source so the "ready to claim" definition cannot drift between what a
 // driver picks up and what the backlog gauge measures. Bind its placeholders
 // with webhookClaimableArgs.
-const webhookClaimablePredicate = `(
+func (s *webhookEventStore) webhookClaimablePredicate() string {
+	return `(
 			state = ?
-			OR (state = ? AND (retry_after IS NULL OR retry_after <= NOW()) AND attempts < ?)
-			OR (state = ? AND lease_expires_at <= NOW(6) AND attempts < ?)
+			OR (state = ? AND (retry_after IS NULL OR retry_after <= ` + s.dialect.CurrentTimestamp(TimestampPrecisionDefault) + `) AND attempts < ?)
+			OR (state = ? AND lease_expires_at <= ` + s.dialect.CurrentTimestamp(TimestampPrecisionMicrosecond) + ` AND attempts < ?)
 		)`
+}
 
 // webhookClaimableArgs returns the placeholder bindings for
 // webhookClaimablePredicate, in order.
@@ -190,7 +193,7 @@ func (s *webhookEventStore) FindNext(ctx context.Context, owner string, leaseDur
 	row := tx.QueryRowContext(ctx, `
 		SELECT `+webhookEventColumns+`
 		FROM webhook_events
-		WHERE `+webhookClaimablePredicate+`
+		WHERE `+s.webhookClaimablePredicate()+`
 		ORDER BY created_at, id
 		LIMIT 1
 		FOR UPDATE SKIP LOCKED
@@ -210,7 +213,7 @@ func (s *webhookEventStore) FindNext(ctx context.Context, owner string, leaseDur
 	_, err = tx.ExecContext(ctx, `
 		UPDATE webhook_events
 		SET state = ?, attempts = attempts + 1, lease_owner = ?, lease_token = ?,
-			lease_expires_at = DATE_ADD(NOW(6), INTERVAL ? MICROSECOND),
+			lease_expires_at = `+s.dialect.RelativeTime(TimestampPrecisionMicrosecond, AfterCurrentTime, ParameterIntervalAmount(), IntervalMicrosecond)+`,
 			retry_after = NULL, started_at = COALESCE(started_at, NOW()), updated_at = NOW()
 		WHERE id = ?
 	`, storage.WebhookEventProcessing, owner, leaseToken, leaseDuration.Microseconds(), event.ID)
@@ -250,7 +253,7 @@ func (s *webhookEventStore) Heartbeat(ctx context.Context, id int64, leaseToken 
 	}
 	result, err := s.db.ExecContext(ctx, `
 		UPDATE webhook_events
-		SET lease_expires_at = DATE_ADD(NOW(6), INTERVAL ? MICROSECOND), updated_at = NOW()
+		SET lease_expires_at = `+s.dialect.RelativeTime(TimestampPrecisionMicrosecond, AfterCurrentTime, ParameterIntervalAmount(), IntervalMicrosecond)+`, updated_at = NOW()
 		WHERE id = ? AND lease_token = ?
 	`, leaseDuration.Microseconds(), id, leaseToken)
 	if err != nil {
@@ -343,7 +346,7 @@ func (s *webhookEventStore) TerminateStuckProcessing(ctx context.Context, reason
 		SET state = ?, last_error = ?, completed_at = COALESCE(completed_at, NOW()),
 			lease_owner = NULL, lease_token = NULL, lease_expires_at = NULL,
 			retry_after = NULL, updated_at = NOW()
-		WHERE state = ? AND lease_expires_at <= NOW(6) AND attempts >= ?
+		WHERE state = ? AND lease_expires_at <= `+s.dialect.CurrentTimestamp(TimestampPrecisionMicrosecond)+` AND attempts >= ?
 	`, storage.WebhookEventFailed, nullString(reason),
 		storage.WebhookEventProcessing, storage.MaxWebhookEventAttempts)
 	if err != nil {
@@ -431,9 +434,9 @@ func (s *webhookEventStore) InboxStats(ctx context.Context) (*storage.WebhookInb
 	// NULL (nothing waiting) scans into a zero age.
 	var oldestAgeSeconds sql.NullFloat64
 	err = s.db.QueryRowContext(ctx, `
-		SELECT TIMESTAMPDIFF(MICROSECOND, MIN(received_at), NOW(6)) / 1e6
+		SELECT TIMESTAMPDIFF(MICROSECOND, MIN(received_at), `+s.dialect.CurrentTimestamp(TimestampPrecisionMicrosecond)+`) / 1e6
 		FROM webhook_events
-		WHERE `+webhookClaimablePredicate+`
+		WHERE `+s.webhookClaimablePredicate()+`
 	`, webhookClaimableArgs()...).Scan(&oldestAgeSeconds)
 	if err != nil {
 		return nil, fmt.Errorf("measure oldest claimable webhook inbox row: %w", err)
@@ -444,7 +447,7 @@ func (s *webhookEventStore) InboxStats(ctx context.Context) (*storage.WebhookInb
 
 	err = s.db.QueryRowContext(ctx, `
 		SELECT COUNT(*) FROM webhook_events
-		WHERE state = ? AND lease_expires_at <= NOW(6) AND attempts >= ?
+		WHERE state = ? AND lease_expires_at <= `+s.dialect.CurrentTimestamp(TimestampPrecisionMicrosecond)+` AND attempts >= ?
 	`, storage.WebhookEventProcessing, storage.MaxWebhookEventAttempts).Scan(&stats.StuckProcessing)
 	if err != nil {
 		return nil, fmt.Errorf("count stuck processing webhook inbox rows: %w", err)


### PR DESCRIPTION
## Summary
Continues the state-store dialect abstraction by moving the timestamp and relative-time SQL in `mysqlstore` behind the `Dialect` provider, so a future Postgres store can supply its own syntax. No behavior change for MySQL/Vitess.

## What
- Add `CurrentTimestamp` and `RelativeTime` to `Dialect`, with `MySQLDialect` rendering the exact expressions the store used before (`NOW()`/`NOW(6)`, `NOW() - INTERVAL n UNIT`, `DATE_ADD(NOW(6), INTERVAL ? MICROSECOND)`).
- Route the stale-claim and retry-freshness cutoffs in `applies.go` and `apply_operations.go`, and all four `NOW(6)`/`DATE_ADD` sites in `webhook_events.go` (FindNext claim + predicate, Heartbeat, and the redelivery-reopen predicate), through the provider.
- Wire `MySQLDialect` into the apply, apply-operation, and webhook-event stores.
- Bare `NOW()` wall-clock stamps are intentionally left as-is.

## Why
Relative-time arithmetic is one of the last dialect-specific SQL shapes hardcoded in the state store. Centralizing it on the provider keeps the store logic engine-neutral and lets the Postgres store implement the same intent (`NOW() - INTERVAL`, `now() - make_interval(...)`, etc.) without editing every call site. Unit tests pin the generated SQL and placeholder counts so the MySQL output is provably unchanged.

## Before / after

```diagram
  before                                    after
  ╭────────────────────────────────────╮   ╭─────────────────────────────────────────╮
  │ applies.go / apply_operations.go / │   │ applies.go / apply_operations.go /      │
  │ webhook_events.go                  │   │ webhook_events.go                       │
  │   "… NOW(6) …"          (hardcoded)│   │   "… "+dialect.CurrentTimestamp(µs)+" …"│
  │   "… NOW() - INTERVAL 1 MINUTE …"  │   │   "… "+dialect.RelativeTime(…)+" …"     │
  │   "DATE_ADD(NOW(6), INTERVAL ? …)" │   │                                         │
  ╰────────────────────────────────────╯   ╰──────────────────┬──────────────────────╯
                                                              ▼
                                            ╭─────────────────────────────────────────╮
                                            │ Dialect provider                        │
                                            │   MySQLDialect → identical MySQL SQL    │
                                            │   (future) PostgresDialect → pg syntax  │
                                            ╰─────────────────────────────────────────╯
```
## Known follow-ups (out of scope, deliberately deferred)
- **Placeholder rebinding for Postgres.** The entire `mysqlstore` emits MySQL-style `?` placeholders (e.g. `placeholders()` in `applies.go`, and the parameterized `RelativeTime`). Postgres via `database/sql` needs numbered placeholders (`$1`, `$2`, …). The intended approach is a single `?`→`$n` rebind at the store boundary (e.g. `sqlx.Rebind`) when the Postgres store lands — so the `Dialect` seam deliberately keeps emitting `?` rather than growing an ordinal-placeholder API. Tracked as DB-13 in the DB-agnostic workstream; not part of this MySQL-only, no-behavior-change PR.
