### PR TITLE
fix(github): attribute rollback applies to the confirming user, not the lock owner

### DIFF
--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -390,12 +390,14 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment 
 	})
 	h.service.SetPendingObserver(database, rollbackPlan.Deployment, environment, observer)
 
-	// Execute apply with the rollback plan
+	// Execute apply with the rollback plan. The caller attributes the apply to
+	// the user who confirmed the rollback, not the lock owner (repo#pr), so
+	// history and progress views show who acted.
 	applyReq := api.ApplyRequest{
 		PlanID:         rollbackPlan.PlanIdentifier,
 		Environment:    environment,
 		Options:        options,
-		Caller:         lockOwner,
+		Caller:         formatGitHubCaller(requestedBy, repo, pr),
 		InstallationID: installationID,
 	}
 

--- a/pkg/webhook/rollback_integration_test.go
+++ b/pkg/webhook/rollback_integration_test.go
@@ -364,7 +364,8 @@ func TestE2ERollbackConfirmExecutesAndPostsComments(t *testing.T) {
 	require.NoError(t, err)
 	var rollbackApply *storage.Apply
 	for _, a := range applies {
-		if a.ID != applyID {
+		if a.IsRollback() {
+			require.Nil(t, rollbackApply, "expected exactly one rollback apply row")
 			rollbackApply = a
 		}
 	}

--- a/pkg/webhook/rollback_integration_test.go
+++ b/pkg/webhook/rollback_integration_test.go
@@ -356,6 +356,20 @@ func TestE2ERollbackConfirmExecutesAndPostsComments(t *testing.T) {
 				"watchApplyProgress may have lost repo/PR/installationID context")
 		}
 	}
+
+	// Step 6: The rollback apply is attributed to the user who confirmed it,
+	// in the same caller format as any other PR command, so history and
+	// progress views show who acted rather than the lock owner.
+	applies, err := svc.Storage().Applies().GetByDatabase(ctx, dbName, "mysql", "staging")
+	require.NoError(t, err)
+	var rollbackApply *storage.Apply
+	for _, a := range applies {
+		if a.ID != applyID {
+			rollbackApply = a
+		}
+	}
+	require.NotNil(t, rollbackApply, "rollback apply row should exist")
+	assert.Equal(t, "github:testuser@octocat/hello-world#1", rollbackApply.Caller)
 }
 
 // checkWriteRecorder wraps the service's storage so a test can observe every


### PR DESCRIPTION
**Why this matters:** A confirmed rollback stored the rollback lock owner (`repo#pr`) as the apply's caller, so `status` and history views showed the PR instead of the person who confirmed the rollback — every other command attributes its apply to the acting user.

**What it does:** The rollback apply request now builds its caller with the same structured format as every other PR command — `github:<user>@<repo>#<pr>` from the user who issued `rollback-confirm`. Lock acquisition and release still key on `repo#pr`. This also makes actor extraction (`actorFromCaller`) work for sharded rollback applies, which previously got an empty actor from the unstructured caller.

**Northstar:** every apply is attributable to the human who triggered it, in one canonical caller format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)