### PR TITLE
feat(github): announce rollback applies with rollback vocabulary

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -3570,6 +3570,64 @@ ALTER TABLE `events` ADD INDEX `idx_created_at`(`created_at`);
 ```
 
 </details>
+
+</details>
+
+<details>
+<summary><a name="rollback-status-running"></a><strong>Rollback Status: Running</strong></summary>
+
+
+## Rollback Status — Staging
+
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
+
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: In Progress
+
+**Schema `testapp`**
+
+**`users`**: 🟦🟦🟦🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 45%
+
+```sql
+ALTER TABLE `users` DROP INDEX `idx_email`;
+```
+Rows: 45,000 / 100,000
+
+
+---
+
+To stop this schema change:
+```
+schemabot stop apply-a1b2c3d4e5f6 -e staging
+```
+
+_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
+
+</details>
+
+<details>
+<summary><a name="summary-rollback-complete"></a><strong>Summary: Rollback Complete</strong></summary>
+
+
+## ⏪ Rollback Complete — Staging
+
+**Database**: `testapp`
+
+
+> Rolled back successfully — the schema change has been reverted.
+
+<details><summary>Apply details (1 table)</summary>
+
+_Apply ID: `apply-a1b2c3d4e5f6`_
+
+
+**`users`**
+```sql
+ALTER TABLE `users` DROP INDEX `idx_email`;
+```
+
+</details>
 </details>
 
 ### CLI Output

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -88,6 +88,8 @@ func previewCommentAllOutput() {
 		{"SUMMARY: FAILED (LARGE)", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryFailedLarge()) }},
 		{"SUMMARY: MULTI-NAMESPACE FAILED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryMultiNamespaceFailed()) }},
 		{"SUMMARY: MULTI-NAMESPACE COMPLETED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryMultiNamespaceCompleted()) }},
+		{"ROLLBACK STATUS: RUNNING", func() { fmt.Print(webhooktemplates.PreviewCommentRollbackStatus()) }},
+		{"SUMMARY: ROLLBACK COMPLETE", func() { fmt.Print(webhooktemplates.PreviewCommentRollbackSummaryCompleted()) }},
 	}
 
 	for i, s := range sections {
@@ -276,6 +278,8 @@ func previewCommentApplyFlowAllOutput() {
 		{"SUMMARY: FAILED (LARGE)", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryFailedLarge()) }},
 		{"SUMMARY: MULTI-NAMESPACE FAILED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryMultiNamespaceFailed()) }},
 		{"SUMMARY: MULTI-NAMESPACE COMPLETED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryMultiNamespaceCompleted()) }},
+		{"ROLLBACK STATUS: RUNNING", func() { fmt.Print(webhooktemplates.PreviewCommentRollbackStatus()) }},
+		{"SUMMARY: ROLLBACK COMPLETE", func() { fmt.Print(webhooktemplates.PreviewCommentRollbackSummaryCompleted()) }},
 	}
 	printSections(sections)
 }

--- a/pkg/webhook/apply.go
+++ b/pkg/webhook/apply.go
@@ -36,6 +36,7 @@ func buildApplyCommentData(apply *storage.Apply, tasks []*storage.Task, display 
 		RevertExpiresAt:  display.RevertExpiresAt,
 		Volume:           apply.GetOptions().Volume,
 		Tenant:           tenant,
+		Rollback:         apply.IsRollback(),
 	}
 	if apply.StartedAt != nil {
 		data.StartedAt = apply.StartedAt.Format(time.RFC3339)

--- a/pkg/webhook/multi_apply.go
+++ b/pkg/webhook/multi_apply.go
@@ -101,6 +101,7 @@ func buildMultiApplyData(apply *storage.Apply, ops []*storage.ApplyOperation, re
 		Environment: apply.Environment,
 		Details:     details,
 		Tenant:      tenant,
+		Rollback:    apply.IsRollback(),
 	}
 	if apply.StartedAt != nil {
 		data.StartedAt = apply.StartedAt.Format(time.RFC3339)
@@ -164,6 +165,7 @@ func buildDeploymentDetail(apply *storage.Apply, op *storage.ApplyOperation, tas
 		DeployRequestURL: display.DeployRequestURL,
 		RevertExpiresAt:  display.RevertExpiresAt,
 		Tenant:           tenant,
+		Rollback:         apply.IsRollback(),
 	}
 	if apply.StartedAt != nil {
 		data.StartedAt = apply.StartedAt.Format(time.RFC3339)

--- a/pkg/webhook/rollback_integration_test.go
+++ b/pkg/webhook/rollback_integration_test.go
@@ -339,20 +339,25 @@ func TestE2ERollbackConfirmExecutesAndPostsComments(t *testing.T) {
 	h.ServeHTTP(rr, req)
 	require.Equal(t, http.StatusOK, rr.Code)
 
-	// Step 5: Verify that the summary comment arrives on the PR.
-	// This is the critical assertion — if repo/PR/installationID are wrong,
-	// the comment goes to the wrong URL and never reaches the channel.
+	// Step 5: Verify that the summary comment arrives on the PR with rollback
+	// vocabulary — a completed rollback announces "Rollback Complete", never a
+	// green-check applied schema change. This is also the critical delivery
+	// assertion — if repo/PR/installationID are wrong, the comment goes to the
+	// wrong URL and never reaches the channel.
 	gotSummary := false
 	deadline := time.After(webhookIntegrationPollDeadline)
 	for !gotSummary {
 		select {
 		case body := <-result.comments:
-			if strings.Contains(body, "Schema Change") && (strings.Contains(body, "Applied") || strings.Contains(body, "Complete") || strings.Contains(body, "Failed")) {
+			if strings.Contains(body, "Rollback Complete") {
 				gotSummary = true
+				assert.Contains(t, body, "⏪", "the rollback summary carries the rewind emoji, not the green check")
+				assert.Contains(t, body, "Rolled back successfully")
 				assert.Contains(t, body, "DROP INDEX", "rollback should drop the index")
+				assert.NotContains(t, body, "Schema Change Applied")
 			}
 		case <-deadline:
-			t.Fatal("timed out waiting for rollback summary comment — " +
+			t.Fatal("timed out waiting for the rollback summary comment — " +
 				"watchApplyProgress may have lost repo/PR/installationID context")
 		}
 	}

--- a/pkg/webhook/sharded_apply.go
+++ b/pkg/webhook/sharded_apply.go
@@ -129,6 +129,7 @@ func buildShardedApplyData(apply *storage.Apply, ops []*storage.ApplyOperation, 
 		Shards:      shardStatuses(shardOrder, opsByShard, released, tasksByOp),
 		Cells:       cells,
 		Tenant:      tenant,
+		Rollback:    apply.IsRollback(),
 	}
 	if apply.StartedAt != nil {
 		data.StartedAt = apply.StartedAt.Format(time.RFC3339)

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -95,6 +95,12 @@ type ApplyStatusCommentData struct {
 	// pasteable command hint so copied commands address this deployment in
 	// tenant mode. Empty on single-tenant deployments, leaving hints unchanged.
 	Tenant string
+
+	// Rollback reports whether this apply reverts a previously applied schema
+	// change (the apply's durable rollback option). It switches the headline and
+	// status vocabulary from "apply" to "rollback" so a completed rollback is
+	// announced as "Rollback Complete", never as a freshly applied schema change.
+	Rollback bool
 }
 
 // RenderApplyStatusComment renders a PR comment for the current apply status.
@@ -153,21 +159,30 @@ func renderApplyStatusComment(data ApplyStatusCommentData, includeLastUpdated bo
 }
 
 // writeApplyStatusHeader writes the headline for an in-place apply status
-// comment. The title is intentionally state-independent — always "Schema Change
-// Status — <env>" — so the headline stays stable as the apply moves through its
-// states (running → revert window → applied); the current state is conveyed by
-// the Status line and the per-table progress, not the headline. The single-,
-// multi-deployment, and sharded status comments all use this so their headline
-// vocabulary is identical. Terminal summary/notification comments use
-// writeApplyHeader, which keeps a state-specific title.
+// comment. The title is intentionally state-independent — "Schema Change
+// Status — <env>" (or "Rollback Status — <env>" for a rollback apply, which is
+// fixed for the apply's lifetime) — so the headline stays stable as the apply
+// moves through its states (running → revert window → applied); the current
+// state is conveyed by the Status line and the per-table progress, not the
+// headline. The single-, multi-deployment, and sharded status comments all use
+// this so their headline vocabulary is identical. Terminal summary/notification
+// comments use writeApplyHeader, which keeps a state-specific title.
 func writeApplyStatusHeader(sb *strings.Builder, data ApplyStatusCommentData) {
-	writeEnvironmentTitle(sb, "Schema Change Status", data.Environment)
+	title := "Schema Change Status"
+	if data.Rollback {
+		title = "Rollback Status"
+	}
+	writeEnvironmentTitle(sb, title, data.Environment)
 }
 
 // writeApplyHeader writes the state-specific title for a terminal summary or
 // notification comment (the separate comment posted when an apply reaches a
 // terminal state), distinct from the stable in-place status headline.
 func writeApplyHeader(sb *strings.Builder, data ApplyStatusCommentData) {
+	if data.Rollback {
+		writeRollbackHeader(sb, data)
+		return
+	}
 	switch data.State {
 	case state.Apply.Completed:
 		writeEnvironmentTitle(sb, "✅ Schema Change Applied", data.Environment)
@@ -181,6 +196,25 @@ func writeApplyHeader(sb *strings.Builder, data ApplyStatusCommentData) {
 		writeEnvironmentTitle(sb, "🚫 Schema Change Cancelled", data.Environment)
 	default:
 		writeEnvironmentTitle(sb, fmt.Sprintf("Schema Change: %s", humanizeState(data.State)), data.Environment)
+	}
+}
+
+// writeRollbackHeader writes the terminal title for a rollback apply. A
+// completed rollback is announced with rollback vocabulary and a rewind emoji —
+// never the green-check "Schema Change Applied" — so a PR reader cannot mistake
+// the revert for the schema change landing.
+func writeRollbackHeader(sb *strings.Builder, data ApplyStatusCommentData) {
+	switch data.State {
+	case state.Apply.Completed:
+		writeEnvironmentTitle(sb, "⏪ Rollback Complete", data.Environment)
+	case state.Apply.Failed:
+		writeEnvironmentTitle(sb, "❌ Rollback Failed", data.Environment)
+	case state.Apply.Stopped:
+		writeEnvironmentTitle(sb, "⏹️ Rollback Stopped", data.Environment)
+	case state.Apply.Cancelled:
+		writeEnvironmentTitle(sb, "🚫 Rollback Cancelled", data.Environment)
+	default:
+		writeEnvironmentTitle(sb, fmt.Sprintf("Rollback: %s", humanizeState(data.State)), data.Environment)
 	}
 }
 
@@ -212,6 +246,9 @@ func startedAtDisplay(startedAt, fallback string) string {
 
 func writeApplyStatusDetail(sb *strings.Builder, data ApplyStatusCommentData) {
 	detail := applyStatusDetail(data.State)
+	if data.Rollback && state.IsState(data.State, state.Apply.Completed) {
+		detail = "Rolled Back"
+	}
 	if detail == "" {
 		return
 	}
@@ -1008,9 +1045,16 @@ func writeSummaryCompleted(sb *strings.Builder, data ApplyStatusCommentData, tot
 	writeSummaryCompletedMetadata(sb, data)
 	// A VSchema update counts as a schema change alongside table changes, so the
 	// singular/plural wording reflects the total operation count.
+	singular := totalTables+len(data.VSchemaChanges) == 1
 	msg := "Applied successfully — your schema changes are live!"
-	if totalTables+len(data.VSchemaChanges) == 1 {
+	if singular {
 		msg = "Applied successfully — your schema change is live!"
+	}
+	if data.Rollback {
+		msg = "Rolled back successfully — the schema changes have been reverted."
+		if singular {
+			msg = "Rolled back successfully — the schema change has been reverted."
+		}
 	}
 	writeSuccessBlock(sb, msg)
 	writeCompletedSummaryDetails(sb, data)

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -1936,3 +1936,66 @@ func TestRenderApplyStatusComment_RevertWindowDeadline(t *testing.T) {
 	pastDue.RevertExpiresAt = time.Now().Add(-1 * time.Minute).UTC().Format(time.RFC3339)
 	assert.NotContains(t, RenderApplyStatusComment(pastDue), "Closes in")
 }
+
+// TestRenderApplyStatusComment_Rollback verifies that a rollback apply's
+// in-place status comment uses rollback vocabulary: the stable headline reads
+// "Rollback Status" for the apply's whole lifetime, and the Status line reads
+// "Rolled Back" once it completes, so a PR reader always sees the comment as
+// reverting a change rather than applying one.
+func TestRenderApplyStatusComment_Rollback(t *testing.T) {
+	data := ApplyStatusCommentData{
+		Database:    "testapp",
+		Environment: "staging",
+		State:       state.Apply.Running,
+		Rollback:    true,
+		Tables: []TableProgressData{
+			{TableName: "users", DDL: "ALTER TABLE `users` DROP INDEX `idx_email`", Status: "running"},
+		},
+	}
+
+	running := RenderApplyStatusComment(data)
+	assert.Contains(t, running, "## Rollback Status")
+	assert.Contains(t, running, "— Staging")
+	assert.NotContains(t, running, "Schema Change Status")
+
+	data.State = state.Apply.Completed
+	completed := RenderApplyStatusComment(data)
+	assert.Contains(t, completed, "## Rollback Status")
+	assert.Contains(t, completed, "**Status**: Rolled Back")
+	assert.NotContains(t, completed, "**Status**: Applied")
+}
+
+// TestRenderApplySummaryComment_Rollback verifies the terminal summary for a
+// rollback apply: a completed rollback is announced as "Rollback Complete" with
+// a rewind emoji and revert wording — never as a green-check applied schema
+// change — and a failed rollback is announced as "Rollback Failed".
+func TestRenderApplySummaryComment_Rollback(t *testing.T) {
+	data := ApplyStatusCommentData{
+		ApplyID:     "apply-123",
+		Database:    "testapp",
+		Environment: "staging",
+		State:       state.Apply.Completed,
+		Rollback:    true,
+		Tables: []TableProgressData{
+			{TableName: "users", DDL: "ALTER TABLE `users` DROP INDEX `idx_email`", Status: "completed"},
+		},
+	}
+
+	completed := RenderApplySummaryComment(data)
+	assert.Contains(t, completed, "## ⏪ Rollback Complete")
+	assert.Contains(t, completed, "— Staging")
+	assert.Contains(t, completed, "Rolled back successfully — the schema change has been reverted.")
+	assert.NotContains(t, completed, "Schema Change Applied")
+
+	plural := data
+	plural.Tables = append(plural.Tables,
+		TableProgressData{TableName: "orders", DDL: "ALTER TABLE `orders` DROP INDEX `idx_user_id`", Status: "completed"})
+	assert.Contains(t, RenderApplySummaryComment(plural),
+		"Rolled back successfully — the schema changes have been reverted.")
+
+	data.State = state.Apply.Failed
+	data.ErrorMessage = "copy interrupted"
+	failed := RenderApplySummaryComment(data)
+	assert.Contains(t, failed, "## ❌ Rollback Failed")
+	assert.NotContains(t, failed, "Schema Change Failed")
+}

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -1968,7 +1968,9 @@ func TestRenderApplyStatusComment_Rollback(t *testing.T) {
 // TestRenderApplySummaryComment_Rollback verifies the terminal summary for a
 // rollback apply: a completed rollback is announced as "Rollback Complete" with
 // a rewind emoji and revert wording — never as a green-check applied schema
-// change — and a failed rollback is announced as "Rollback Failed".
+// change — and a failed rollback is announced as "Rollback Failed". The
+// vocabulary switch must not drop the collapsible apply details: the apply ID
+// and the reverse DDL statements stay in the comment for triage.
 func TestRenderApplySummaryComment_Rollback(t *testing.T) {
 	data := ApplyStatusCommentData{
 		ApplyID:     "apply-123",
@@ -1986,6 +1988,9 @@ func TestRenderApplySummaryComment_Rollback(t *testing.T) {
 	assert.Contains(t, completed, "— Staging")
 	assert.Contains(t, completed, "Rolled back successfully — the schema change has been reverted.")
 	assert.NotContains(t, completed, "Schema Change Applied")
+	assert.Contains(t, completed, "<details><summary>Apply details (1 table)</summary>")
+	assert.Contains(t, completed, "_Apply ID: `apply-123`_")
+	assert.Contains(t, completed, "ALTER TABLE `users` DROP INDEX `idx_email`")
 
 	plural := data
 	plural.Tables = append(plural.Tables,

--- a/pkg/webhook/templates/multi_apply.go
+++ b/pkg/webhook/templates/multi_apply.go
@@ -46,6 +46,12 @@ type MultiDeploymentApplyData struct {
 	// pasteable command hint so copied commands address this deployment in
 	// tenant mode. Empty on single-tenant deployments, leaving hints unchanged.
 	Tenant string
+
+	// Rollback reports whether this apply reverts a previously applied schema
+	// change (the apply's durable rollback option). It switches the aggregate
+	// headline vocabulary from "apply" to "rollback", matching the
+	// single-deployment comment.
+	Rollback bool
 }
 
 // RenderMultiDeploymentApplyComment renders the PR comment for an apply that
@@ -63,7 +69,7 @@ func RenderMultiDeploymentApplyComment(data MultiDeploymentApplyData) string {
 
 	// Aggregate header: the stable in-place status title, identical to the
 	// single-deployment comment so the headline vocabulary stays shared.
-	writeApplyStatusHeader(&sb, ApplyStatusCommentData{State: data.Model.State, Environment: data.Environment})
+	writeApplyStatusHeader(&sb, ApplyStatusCommentData{State: data.Model.State, Environment: data.Environment, Rollback: data.Rollback})
 	writeAggregateMetadata(&sb, data, renderedAt)
 	writeDeploymentCounts(&sb, data.Model.Counts)
 	writeAggregateFirstFailure(&sb, data.Model.FirstFailure)
@@ -94,7 +100,7 @@ func RenderMultiDeploymentApplyComment(data MultiDeploymentApplyData) string {
 func RenderMultiDeploymentApplySummaryComment(data MultiDeploymentApplyData) string {
 	var sb strings.Builder
 
-	writeApplyHeader(&sb, ApplyStatusCommentData{State: data.Model.State, Environment: data.Environment})
+	writeApplyHeader(&sb, ApplyStatusCommentData{State: data.Model.State, Environment: data.Environment, Rollback: data.Rollback})
 	writeAggregateMetadata(&sb, data, currentTimestamp())
 	writeDeploymentCounts(&sb, data.Model.Counts)
 	writeAggregateFirstFailure(&sb, data.Model.FirstFailure)

--- a/pkg/webhook/templates/multi_apply_test.go
+++ b/pkg/webhook/templates/multi_apply_test.go
@@ -386,3 +386,28 @@ func TestRenderMultiDeploymentApplyComment_EscapesSummaryHTML(t *testing.T) {
 	assert.Contains(t, out, "us&amp;ca")
 	assert.NotContains(t, out, "<summary>🔄 eu<b>")
 }
+
+// A rollback apply that fans out across deployments carries rollback vocabulary
+// on the aggregate headline of both the in-place status comment and the
+// terminal summary, matching the single-deployment comments.
+func TestRenderMultiDeploymentApplyComment_Rollback(t *testing.T) {
+	model := presentation.Derive([]presentation.Operation{
+		rollingOp("eu", so.Running),
+		rollingOp("us", so.Pending),
+	})
+	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{
+		Model: model, ApplyID: "apply-123", Environment: "production", Rollback: true,
+	})
+	assert.Contains(t, out, "## Rollback Status")
+	assert.NotContains(t, out, "Schema Change Status")
+
+	completedModel := presentation.Derive([]presentation.Operation{
+		rollingOp("eu", so.Completed),
+		rollingOp("us", so.Completed),
+	})
+	summary := RenderMultiDeploymentApplySummaryComment(MultiDeploymentApplyData{
+		Model: completedModel, ApplyID: "apply-123", Environment: "production", Rollback: true,
+	})
+	assert.Contains(t, summary, "## ⏪ Rollback Complete")
+	assert.NotContains(t, summary, "Schema Change Applied")
+}

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -1499,6 +1499,40 @@ func PreviewCommentSummaryCompleted() string {
 	return RenderApplySummaryComment(sampleSummaryData(state.Apply.Completed, tables))
 }
 
+// sampleRollbackTables returns reverse-DDL table rows for rollback previews.
+func sampleRollbackTables(status string) []TableProgressData {
+	return []TableProgressData{
+		{
+			Namespace: "testapp",
+			TableName: "users",
+			DDL:       "ALTER TABLE `users` DROP INDEX `idx_email`",
+			Status:    status,
+		},
+	}
+}
+
+// PreviewCommentRollbackStatus renders the in-place status comment for a
+// running rollback apply — the headline carries rollback vocabulary for the
+// apply's whole lifetime.
+func PreviewCommentRollbackStatus() string {
+	tables := sampleRollbackTables(state.Task.Running)
+	tables[0].RowsCopied = 45000
+	tables[0].RowsTotal = 100000
+	tables[0].PercentComplete = 45
+	data := sampleApplyData(state.Apply.Running, tables)
+	data.Rollback = true
+	return RenderApplyStatusComment(data)
+}
+
+// PreviewCommentRollbackSummaryCompleted renders the terminal summary for a
+// completed rollback apply — announced as a rollback, never as an applied
+// schema change.
+func PreviewCommentRollbackSummaryCompleted() string {
+	data := sampleSummaryData(state.Apply.Completed, sampleRollbackTables(state.Task.Completed))
+	data.Rollback = true
+	return RenderApplySummaryComment(data)
+}
+
 // PreviewCommentSummaryCompletedVitessDDLWithVSchema renders a completed Vitess
 // summary where the schema change included both table work and VSchema updates.
 func PreviewCommentSummaryCompletedVitessDDLWithVSchema() string {

--- a/pkg/webhook/templates/sharded_apply.go
+++ b/pkg/webhook/templates/sharded_apply.go
@@ -42,6 +42,12 @@ type ShardedApplyData struct {
 	// pasteable command hint so copied commands address this deployment in
 	// tenant mode. Empty on single-tenant deployments, leaving hints unchanged.
 	Tenant string
+
+	// Rollback reports whether this apply reverts a previously applied schema
+	// change (the apply's durable rollback option). It switches the headline
+	// vocabulary from "apply" to "rollback", matching the single-deployment
+	// comment.
+	Rollback bool
 }
 
 // ShardStatus is one shard's aggregate status. Emoji/Label come from the same
@@ -89,7 +95,7 @@ func RenderShardedApplyComment(data ShardedApplyData) string {
 	var sb strings.Builder
 	renderedAt := currentTimestamp()
 
-	writeApplyStatusHeader(&sb, ApplyStatusCommentData{State: data.State, Environment: data.Environment})
+	writeApplyStatusHeader(&sb, ApplyStatusCommentData{State: data.State, Environment: data.Environment, Rollback: data.Rollback})
 	writeShardedMetadata(&sb, data, renderedAt)
 
 	writeShardCounts(&sb, data.Shards)

--- a/pkg/webhook/templates/sharded_apply_test.go
+++ b/pkg/webhook/templates/sharded_apply_test.go
@@ -118,3 +118,20 @@ func TestRenderShardedApplyComment_UniformMultiTableIsOneGroup(t *testing.T) {
 	assert.Contains(t, out, "| Shard | Status |")
 	assert.NotContains(t, out, "```sql", "the applied comment shows status only, not DDL")
 }
+
+// A sharded rollback apply carries rollback vocabulary on the stable headline,
+// matching the single-deployment status comment.
+func TestRenderShardedApplyComment_Rollback(t *testing.T) {
+	out := RenderShardedApplyComment(ShardedApplyData{
+		State: state.Apply.Running, Environment: "staging", Database: "cdb_resolute",
+		Keyspace: "cdb_resolute_sharded", ApplyID: "apply-x", RequestedBy: "morgo",
+		Rollback: true,
+		Shards: []ShardStatus{
+			{Shard: "-40", Emoji: "🔄", Label: "running table copy", State: state.ApplyOperation.Running},
+		},
+		Cells: []ShardCell{mutesCell("-40")},
+	})
+
+	assert.Contains(t, out, "## Rollback Status")
+	assert.NotContains(t, out, "Schema Change Status")
+}


### PR DESCRIPTION
**Why this matters:** A completed rollback's PR comments read like a fresh apply — the terminal summary said "✅ Schema Change Applied" and the status comment said "Schema Change Status / Applied" — so a reader could mistake the revert for the schema change landing.

**What it does:** Rollback applies (identified by the durable rollback option, `Apply.IsRollback()`) now carry rollback vocabulary on every comment surface. The terminal summary announces the outcome with a rewind emoji instead of the green check:

> ## ⏪ Rollback Complete — Staging
>
> **Database**: `mydb`
>
> Rolled back successfully — the schema change has been reverted.

A failed rollback announces "❌ Rollback Failed". The in-place status comment's stable headline reads "Rollback Status" for the apply's whole lifetime, with a "Rolled Back" terminal status line. The single-deployment, multi-deployment aggregate, and sharded comments all share the same headline vocabulary. Ordinary applies render unchanged.

**Northstar:** a PR comment always says what actually happened to the target — a revert is never announced as an applied schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)