### PR TITLE
feat(github): skip repos with checks disabled in the checks backfill sweep

### DIFF
--- a/docs/check-runs.md
+++ b/docs/check-runs.md
@@ -607,7 +607,11 @@ the checks that instance owns:
 - **Repositories.** `--repo` scans one repository; `--all-repos` scans every
   repository declared in the instance's `repos:` config. A legacy single-App
   config declares no repos, so there `--all-repos` is rejected and repositories
-  must be named explicitly.
+  must be named explicitly. Repositories with `enable_checks: false` are
+  skipped, not scanned — the server refuses to create their checks, so every
+  open PR would trivially read as missing one. The skip is reported, never an
+  error: an `--all-repos` sweep keeps going, and naming a disabled repository
+  explicitly returns skip outcomes that say why nothing was created.
 - **Apps.** Each repository resolves to the GitHub App that owns it (see
   [Multi-App Routing](configuration.md#multi-app-routing)); the scan and the
   recreated Check Runs both use that App's installation. An instance hosting

--- a/docs/check-runs.md
+++ b/docs/check-runs.md
@@ -604,14 +604,15 @@ instance scans with its own GitHub App credentials, its own `repos:` config,
 its own `allowed_environments`, and its own storage, so one run converges only
 the checks that instance owns:
 
-- **Repositories.** `--repo` scans one repository; `--all-repos` scans every
-  repository declared in the instance's `repos:` config. A legacy single-App
-  config declares no repos, so there `--all-repos` is rejected and repositories
-  must be named explicitly. Repositories with `enable_checks: false` are
-  skipped, not scanned — the server refuses to create their checks, so every
-  open PR would trivially read as missing one. The skip is reported, never an
-  error: an `--all-repos` sweep keeps going, and naming a disabled repository
-  explicitly returns skip outcomes that say why nothing was created.
+- **Repositories.** Naming a repository (`schemabot checks backfill
+  <owner/name>`) scans just that one; `--all-repos` scans every repository
+  declared in the instance's `repos:` config. A legacy single-App config
+  declares no repos, so there `--all-repos` is rejected and repositories must
+  be named explicitly. Repositories with `enable_checks: false` are skipped,
+  not scanned — the server refuses to create their checks, so every open PR
+  would trivially read as missing one. The skip is reported, never an error:
+  an `--all-repos` sweep keeps going, and naming a disabled repository
+  explicitly reports it as skipped with the reason instead of scanning it.
 - **Apps.** Each repository resolves to the GitHub App that owns it (see
   [Multi-App Routing](configuration.md#multi-app-routing)); the scan and the
   recreated Check Runs both use that App's installation. An instance hosting

--- a/pkg/api/webhook_ops_handlers.go
+++ b/pkg/api/webhook_ops_handlers.go
@@ -98,6 +98,11 @@ type ChecksSynthesizeResult = apitypes.ChecksSynthesizeResult
 // heavy plan work runs asynchronously, so a chunk only pays discovery.
 const checksSynthesizeMaxPRsPerRequest = 10
 
+// checksDisabledSkipOutcome is the per-PR outcome when a synthesize request
+// names a repository whose Check Run publishing is turned off. A skip, not an
+// error: a fleet sweep that includes a disabled repo should keep going.
+const checksDisabledSkipOutcome = "skipped: Check Runs are disabled for this repository (enable_checks: false)"
+
 func (s *Service) handleChecksSynthesize(w http.ResponseWriter, r *http.Request) {
 	var req ChecksSynthesizeRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -132,11 +137,23 @@ func executeChecksSynthesize(ctx context.Context, cfg *ServerConfig, backfiller 
 			return nil, webhookOpsRequestErrorf("pr numbers must be positive; got %d", pr)
 		}
 	}
-	if backfiller == nil {
-		return nil, fmt.Errorf("check run backfill is unavailable: no GitHub webhook runtime is configured")
-	}
 	if logger == nil {
 		logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	}
+	// Backfill exists to create Check Runs; on a repo with publishing turned
+	// off it could only replay auto-plans whose checks the publisher refuses,
+	// leaving plan comments as the sole side effect. Skip per PR rather than
+	// erroring so a fleet sweep that includes a disabled repo keeps going.
+	if !cfg.AreChecksEnabled(req.Repo) {
+		logger.Info("Check Run backfill skipping repository with checks disabled", "repo", req.Repo, "prs", len(req.PRs))
+		response := &ChecksSynthesizeResponse{Repo: req.Repo}
+		for _, pr := range req.PRs {
+			response.Results = append(response.Results, ChecksSynthesizeResult{PR: pr, Outcome: checksDisabledSkipOutcome})
+		}
+		return response, nil
+	}
+	if backfiller == nil {
+		return nil, fmt.Errorf("check run backfill is unavailable: no GitHub webhook runtime is configured")
 	}
 	installationClient, installationID, err := resolveRepoInstallationClient(ctx, cfg, req.Repo, logger)
 	if err != nil {
@@ -297,6 +314,14 @@ func executeChecksScan(ctx context.Context, cfg *ServerConfig, req ChecksScanReq
 	if logger == nil {
 		logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
 	}
+	// With Check Run publishing turned off, every open PR would trivially be
+	// missing a check the server refuses to create — the scan result would be
+	// all noise. Report the repo as disabled instead of scanning, as a normal
+	// response rather than an error so a fleet sweep keeps going.
+	if !cfg.AreChecksEnabled(req.Repo) {
+		logger.Info("checks scan skipping repository with checks disabled", "repo", req.Repo)
+		return &ChecksScanResponse{Repo: req.Repo, ChecksDisabled: true}, nil
+	}
 	installationClient, _, err := resolveRepoInstallationClient(ctx, cfg, req.Repo, logger)
 	if err != nil {
 		return nil, err
@@ -319,9 +344,12 @@ func (s *Service) handleChecksRepos(w http.ResponseWriter, r *http.Request) {
 }
 
 // executeChecksRepos lists the repositories declared in the server's repos
-// config — the inventory a fleet-wide checks scan iterates. A legacy
-// single-App config declares no repos, so a fleet sweep cannot know what to
-// scan; the operator must name repositories explicitly there.
+// config — the inventory a fleet-wide checks scan iterates. Repositories with
+// Check Run publishing turned off are listed separately as disabled: a scan
+// of one would report every open PR as missing a check the server refuses to
+// create, so callers skip them and tell the operator. A legacy single-App
+// config declares no repos, so a fleet sweep cannot know what to scan; the
+// operator must name repositories explicitly there.
 func executeChecksRepos(cfg *ServerConfig) (*ChecksReposResponse, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("server config is nil")
@@ -329,12 +357,17 @@ func executeChecksRepos(cfg *ServerConfig) (*ChecksReposResponse, error) {
 	if len(cfg.Repos) == 0 {
 		return nil, webhookOpsRequestErrorf("this server declares no repos config; name a repository explicitly instead of scanning all repos")
 	}
-	repos := make([]string, 0, len(cfg.Repos))
+	response := &ChecksReposResponse{Repos: make([]string, 0, len(cfg.Repos))}
 	for repo := range cfg.Repos {
-		repos = append(repos, repo)
+		if cfg.AreChecksEnabled(repo) {
+			response.Repos = append(response.Repos, repo)
+		} else {
+			response.Disabled = append(response.Disabled, repo)
+		}
 	}
-	sort.Strings(repos)
-	return &ChecksReposResponse{Repos: repos}, nil
+	sort.Strings(response.Repos)
+	sort.Strings(response.Disabled)
+	return response, nil
 }
 
 // resolveRepoInstallationClient builds an installation-scoped GitHub client

--- a/pkg/api/webhook_ops_handlers_test.go
+++ b/pkg/api/webhook_ops_handlers_test.go
@@ -634,23 +634,98 @@ func TestExecuteChecksScanRejectsInvalidUpdatedSince(t *testing.T) {
 	assert.Contains(t, err.Error(), "updated_since")
 }
 
-// The repos inventory returns the declared repos config sorted, and a legacy
-// single-App config (which declares no repos) is a request error telling the
-// operator to name a repository — a fleet sweep cannot guess what to scan.
+// The repos inventory splits the declared repos config into scannable repos
+// and repos with Check Run publishing turned off, both sorted — a fleet sweep
+// scans the former and reports the latter as skipped. A legacy single-App
+// config (which declares no repos) is a request error telling the operator to
+// name a repository — a fleet sweep cannot guess what to scan.
 func TestExecuteChecksRepos(t *testing.T) {
 	t.Parallel()
 
+	checksOff := false
 	cfg := &ServerConfig{
-		Apps:  map[string]GitHubAppConfig{"main": {AppID: "1", PrivateKey: "key"}},
-		Repos: map[string]RepoConfig{"octo/zebra": {GitHubApp: "main"}, "octo/alpha": {GitHubApp: "main"}},
+		Apps: map[string]GitHubAppConfig{"main": {AppID: "1", PrivateKey: "key"}},
+		Repos: map[string]RepoConfig{
+			"octo/zebra":    {GitHubApp: "main"},
+			"octo/alpha":    {GitHubApp: "main"},
+			"octo/no-check": {GitHubApp: "main", EnableChecks: &checksOff},
+		},
 	}
 	response, err := executeChecksRepos(cfg)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"octo/alpha", "octo/zebra"}, response.Repos)
+	assert.Equal(t, []string{"octo/no-check"}, response.Disabled)
 
 	_, err = executeChecksRepos(&ServerConfig{GitHub: GitHubConfig{AppID: "1", PrivateKey: "key"}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "declares no repos config")
+}
+
+// A repository whose Check Run publishing is turned off ends up entirely in
+// the disabled list; the response says explicitly that nothing is scannable
+// instead of erroring, so a fleet sweep reports the skips and finishes clean.
+func TestExecuteChecksReposAllDisabled(t *testing.T) {
+	t.Parallel()
+
+	checksOff := false
+	cfg := &ServerConfig{
+		Apps: map[string]GitHubAppConfig{"main": {AppID: "1", PrivateKey: "key"}},
+		Repos: map[string]RepoConfig{
+			"octo/one": {GitHubApp: "main", EnableChecks: &checksOff},
+			"octo/two": {GitHubApp: "main", EnableChecks: &checksOff},
+		},
+	}
+	response, err := executeChecksRepos(cfg)
+	require.NoError(t, err)
+	assert.Empty(t, response.Repos)
+	assert.Equal(t, []string{"octo/one", "octo/two"}, response.Disabled)
+}
+
+// Synthesize against a repository with Check Run publishing turned off skips
+// every requested PR without touching GitHub or the auto-plan flow: the
+// publisher would refuse the checks anyway, and replaying auto-plans would
+// leave plan comments as the only side effect. A skip outcome, not an error,
+// so a fleet sweep that includes a disabled repo keeps going.
+func TestExecuteChecksSynthesizeSkipsRepoWithChecksDisabled(t *testing.T) {
+	t.Parallel()
+
+	checksOff := false
+	cfg := &ServerConfig{
+		Apps:  map[string]GitHubAppConfig{"main": {AppID: "1", PrivateKey: "key"}},
+		Repos: map[string]RepoConfig{"octo/repo": {GitHubApp: "main", EnableChecks: &checksOff}},
+	}
+	backfiller := &fakeCheckRunBackfiller{}
+
+	response, err := executeChecksSynthesize(t.Context(), cfg, backfiller, ChecksSynthesizeRequest{Repo: "octo/repo", PRs: []int{1, 2}}, discardLogger())
+	require.NoError(t, err)
+	assert.Empty(t, backfiller.calls)
+	require.Len(t, response.Results, 2)
+	for i, pr := range []int{1, 2} {
+		assert.Equal(t, pr, response.Results[i].PR)
+		assert.Equal(t, checksDisabledSkipOutcome, response.Results[i].Outcome)
+		assert.Empty(t, response.Results[i].Error)
+	}
+}
+
+// Scanning a repository with Check Run publishing turned off reports the repo
+// as disabled instead of scanning: every open PR would trivially be missing a
+// check the server refuses to create. A normal response, not an error, so a
+// fleet sweep that includes a disabled repo keeps going.
+func TestExecuteChecksScanSkipsRepoWithChecksDisabled(t *testing.T) {
+	t.Parallel()
+
+	checksOff := false
+	cfg := &ServerConfig{
+		Apps:  map[string]GitHubAppConfig{"main": {AppID: "1", PrivateKey: "key"}},
+		Repos: map[string]RepoConfig{"octo/repo": {GitHubApp: "main", EnableChecks: &checksOff}},
+	}
+
+	response, err := executeChecksScan(t.Context(), cfg, ChecksScanRequest{Repo: "octo/repo"}, discardLogger())
+	require.NoError(t, err)
+	assert.True(t, response.ChecksDisabled)
+	assert.Equal(t, "octo/repo", response.Repo)
+	assert.Zero(t, response.Scanned)
+	assert.Empty(t, response.Missing)
 }
 
 // A missing check whose name is already taken by an untrusted app's Check Run

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -120,6 +120,11 @@ type ChecksScanResponse struct {
 	CheckNames []string `json:"check_names"`
 	Scanned    int      `json:"scanned"`
 	NextPage   int      `json:"next_page,omitempty"`
+	// ChecksDisabled reports that this repository has Check Run publishing
+	// turned off (enable_checks: false), so the scan was skipped: every open
+	// PR would trivially be missing a check the server refuses to create.
+	// When set, no PRs were scanned and the other fields are zero.
+	ChecksDisabled bool `json:"checks_disabled,omitempty"`
 	// EstimatedOpenPRs is the repository's total open-PR count as GitHub
 	// reports it for this page's listing — an upper bound while more pages
 	// remain, exact on the final page. Recomputed every page so the caller
@@ -150,7 +155,14 @@ type GitHubRateLimit struct {
 // ChecksReposResponse lists the repositories declared in the server's repos
 // config — the inventory a fleet-wide scan iterates.
 type ChecksReposResponse struct {
+	// Repos are the declared repositories with Check Run publishing enabled —
+	// the ones a checks scan or backfill can act on.
 	Repos []string `json:"repos"`
+	// Disabled are declared repositories with Check Run publishing turned off
+	// (enable_checks: false). A scan of these would report every open PR as
+	// missing a check that the server refuses to create; callers skip them
+	// and report the skip to the operator.
+	Disabled []string `json:"disabled,omitempty"`
 }
 
 // ChecksSynthesizeRequest asks the server to recreate missing Check Runs for

--- a/pkg/cmd/commands/checks_backfill.go
+++ b/pkg/cmd/commands/checks_backfill.go
@@ -99,9 +99,13 @@ type checksStuckCheck struct {
 }
 
 type checksBackfillReport struct {
-	Repos      []string `json:"repos"`
-	CheckNames []string `json:"check_names"`
-	Scanned    int      `json:"scanned"`
+	Repos []string `json:"repos"`
+	// SkippedDisabled are repositories the sweep did not scan because their
+	// Check Run publishing is turned off (enable_checks: false) — the server
+	// refuses to create their checks, so every open PR would read as missing.
+	SkippedDisabled []string `json:"skipped_checks_disabled,omitempty"`
+	CheckNames      []string `json:"check_names"`
+	Scanned         int      `json:"scanned"`
 	// Last echoes the --last window bounding the sweep; empty means every
 	// open PR was scanned.
 	Last       string                 `json:"last,omitempty"`
@@ -145,6 +149,7 @@ func (cmd *ChecksBackfillCmd) Run(ctx context.Context, g *Globals) error {
 	defer stopProgress()
 
 	repos := []string{cmd.Repo}
+	var skippedDisabled []string
 	if cmd.AllRepos {
 		updateProgress("listing the repositories declared on the server...")
 		declared, err := cmdclient.ChecksRepos(ctx, endpoint)
@@ -154,10 +159,14 @@ func (cmd *ChecksBackfillCmd) Run(ctx context.Context, g *Globals) error {
 		if err != nil {
 			return fmt.Errorf("list the server's declared repositories: %w", err)
 		}
-		if len(declared.Repos) == 0 {
+		if len(declared.Repos) == 0 && len(declared.Disabled) == 0 {
 			return fmt.Errorf("the server declared no repositories; name a repository explicitly")
 		}
+		// Disabled repos are skipped, not scanned: the server refuses to
+		// create their checks, so every open PR would read as missing. An
+		// empty enabled list leaves nothing to scan; the report says so.
 		repos = declared.Repos
+		skippedDisabled = declared.Disabled
 	}
 
 	// Scan phase: page through each repository's open PRs and ask the two
@@ -165,10 +174,11 @@ func (cmd *ChecksBackfillCmd) Run(ctx context.Context, g *Globals) error {
 	// complete? The listing is newest-updated first, so a --last window stops
 	// each repo's paging as soon as it crosses the window start.
 	report := &checksBackfillReport{
-		Repos:      repos,
-		Last:       cmd.Last,
-		DryRun:     cmd.DryRun,
-		StuckAfter: cmd.StuckAfter,
+		Repos:           repos,
+		SkippedDisabled: skippedDisabled,
+		Last:            cmd.Last,
+		DryRun:          cmd.DryRun,
+		StuckAfter:      cmd.StuckAfter,
 	}
 	checkNamesSeen := map[string]bool{}
 	held := 0
@@ -190,6 +200,13 @@ scanning:
 			}
 			if err != nil {
 				return fmt.Errorf("scan %s open PRs for missing or stuck Check Runs: %w", repo, err)
+			}
+			// The server skips repos whose Check Run publishing is turned
+			// off rather than reporting every open PR as missing; record the
+			// skip for the report and move to the next repo.
+			if chunk.ChecksDisabled {
+				report.SkippedDisabled = append(report.SkippedDisabled, repo)
+				continue scanning
 			}
 			for _, name := range chunk.CheckNames {
 				if !checkNamesSeen[name] {
@@ -444,6 +461,10 @@ func (cmd *ChecksBackfillCmd) write(report *checksBackfillReport) error {
 }
 
 func writeChecksBackfillReport(w io.Writer, report *checksBackfillReport) error {
+	if len(report.Repos) == 0 && len(report.SkippedDisabled) > 0 {
+		_, err := fmt.Fprintf(w, "All %d declared repositories have Check Runs disabled (enable_checks: false); nothing to scan: %s.\n", len(report.SkippedDisabled), strings.Join(report.SkippedDisabled, ", "))
+		return err
+	}
 	repoScope := strings.Join(report.Repos, ", ")
 	if len(report.Repos) > 3 {
 		repoScope = fmt.Sprintf("%d repositories", len(report.Repos))
@@ -452,8 +473,17 @@ func writeChecksBackfillReport(w io.Writer, report *checksBackfillReport) error 
 	if report.Last != "" {
 		window = fmt.Sprintf(" updated in the last %s", report.Last)
 	}
-	if _, err := fmt.Fprintf(w, "Scanned %d open PRs%s in %s for %s.\n", report.Scanned, window, repoScope, strings.Join(report.CheckNames, ", ")); err != nil {
+	checkScope := ""
+	if len(report.CheckNames) > 0 {
+		checkScope = fmt.Sprintf(" for %s", strings.Join(report.CheckNames, ", "))
+	}
+	if _, err := fmt.Fprintf(w, "Scanned %d open PRs%s in %s%s.\n", report.Scanned, window, repoScope, checkScope); err != nil {
 		return err
+	}
+	if len(report.SkippedDisabled) > 0 {
+		if _, err := fmt.Fprintf(w, "Skipped repositories with Check Runs disabled (enable_checks: false): %s.\n", strings.Join(report.SkippedDisabled, ", ")); err != nil {
+			return err
+		}
 	}
 	if err := writeChecksStuckSection(w, report); err != nil {
 		return err

--- a/pkg/cmd/commands/checks_backfill.go
+++ b/pkg/cmd/commands/checks_backfill.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -181,6 +182,7 @@ func (cmd *ChecksBackfillCmd) Run(ctx context.Context, g *Globals) error {
 		StuckAfter:      cmd.StuckAfter,
 	}
 	checkNamesSeen := map[string]bool{}
+	skippedByServer := map[string]bool{}
 	held := 0
 scanning:
 	for i, repo := range repos {
@@ -205,6 +207,7 @@ scanning:
 			// off rather than reporting every open PR as missing; record the
 			// skip for the report and move to the next repo.
 			if chunk.ChecksDisabled {
+				skippedByServer[repo] = true
 				report.SkippedDisabled = append(report.SkippedDisabled, repo)
 				continue scanning
 			}
@@ -260,6 +263,13 @@ scanning:
 		}
 	}
 	sort.Strings(report.CheckNames)
+
+	// The report's scanned-repo list and its skip list stay disjoint: a repo
+	// the server reported as disabled was never scanned, so it belongs only
+	// in the skip list.
+	if len(skippedByServer) > 0 {
+		report.Repos = slices.DeleteFunc(report.Repos, func(r string) bool { return skippedByServer[r] })
+	}
 
 	if !cmd.DryRun {
 		// Act phase: synthesize the missing checks in server-bounded batches
@@ -462,7 +472,11 @@ func (cmd *ChecksBackfillCmd) write(report *checksBackfillReport) error {
 
 func writeChecksBackfillReport(w io.Writer, report *checksBackfillReport) error {
 	if len(report.Repos) == 0 && len(report.SkippedDisabled) > 0 {
-		_, err := fmt.Fprintf(w, "All %d declared repositories have Check Runs disabled (enable_checks: false); nothing to scan: %s.\n", len(report.SkippedDisabled), strings.Join(report.SkippedDisabled, ", "))
+		if len(report.SkippedDisabled) == 1 {
+			_, err := fmt.Fprintf(w, "Repository %s has Check Runs disabled (enable_checks: false); nothing to scan.\n", report.SkippedDisabled[0])
+			return err
+		}
+		_, err := fmt.Fprintf(w, "All %d repositories have Check Runs disabled (enable_checks: false); nothing to scan: %s.\n", len(report.SkippedDisabled), strings.Join(report.SkippedDisabled, ", "))
 		return err
 	}
 	repoScope := strings.Join(report.Repos, ", ")

--- a/pkg/cmd/commands/checks_backfill_test.go
+++ b/pkg/cmd/commands/checks_backfill_test.go
@@ -135,6 +135,46 @@ func TestWriteChecksBackfillReportFleetHeadlineAndHeldPRs(t *testing.T) {
 	assert.Contains(t, rendered, "held: an uncompleted Check Run sits on this head")
 }
 
+// Repositories whose Check Run publishing is turned off are skipped, not
+// scanned, and the report names them so the operator knows the sweep left
+// them out deliberately.
+func TestWriteChecksBackfillReportNamesSkippedDisabledRepos(t *testing.T) {
+	report := &checksBackfillReport{
+		Repos:           []string{"octo/a", "octo/b"},
+		SkippedDisabled: []string{"octo/off", "octo/quiet"},
+		CheckNames:      []string{"SchemaBot (production)"},
+		Scanned:         20,
+		DryRun:          true,
+		StuckAfter:      "1h",
+	}
+
+	var out strings.Builder
+	require.NoError(t, writeChecksBackfillReport(&out, report))
+
+	rendered := out.String()
+	assert.Contains(t, rendered, "Scanned 20 open PRs in octo/a, octo/b")
+	assert.Contains(t, rendered, "Skipped repositories with Check Runs disabled (enable_checks: false): octo/off, octo/quiet.")
+	assert.Contains(t, rendered, "No missing SchemaBot Check Runs found.")
+}
+
+// When every declared repository has Check Run publishing turned off, a fleet
+// sweep has nothing to scan; the report says so plainly instead of rendering
+// an empty scan headline.
+func TestWriteChecksBackfillReportAllReposDisabled(t *testing.T) {
+	report := &checksBackfillReport{
+		SkippedDisabled: []string{"octo/off", "octo/quiet"},
+		DryRun:          true,
+		StuckAfter:      "1h",
+	}
+
+	var out strings.Builder
+	require.NoError(t, writeChecksBackfillReport(&out, report))
+
+	rendered := out.String()
+	assert.Contains(t, rendered, "All 2 declared repositories have Check Runs disabled (enable_checks: false); nothing to scan: octo/off, octo/quiet.")
+	assert.NotContains(t, rendered, "Scanned")
+}
+
 // The pacing decision: pause only when the budget snapshot is below the floor
 // and a future reset exists to wait for. Missing snapshots, disabled pacing,
 // healthy budgets, and already-past resets all proceed without waiting.

--- a/pkg/cmd/commands/checks_backfill_test.go
+++ b/pkg/cmd/commands/checks_backfill_test.go
@@ -1,6 +1,9 @@
 package commands
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -171,8 +174,53 @@ func TestWriteChecksBackfillReportAllReposDisabled(t *testing.T) {
 	require.NoError(t, writeChecksBackfillReport(&out, report))
 
 	rendered := out.String()
-	assert.Contains(t, rendered, "All 2 declared repositories have Check Runs disabled (enable_checks: false); nothing to scan: octo/off, octo/quiet.")
+	assert.Contains(t, rendered, "All 2 repositories have Check Runs disabled (enable_checks: false); nothing to scan: octo/off, octo/quiet.")
 	assert.NotContains(t, rendered, "Scanned")
+}
+
+// A single repository with Check Run publishing turned off — the shape a
+// named-repo invocation produces — reads as a sentence about that repository,
+// not a fleet summary.
+func TestWriteChecksBackfillReportSingleRepoDisabled(t *testing.T) {
+	report := &checksBackfillReport{
+		SkippedDisabled: []string{"octo/off"},
+		DryRun:          true,
+		StuckAfter:      "1h",
+	}
+
+	var out strings.Builder
+	require.NoError(t, writeChecksBackfillReport(&out, report))
+
+	rendered := out.String()
+	assert.Contains(t, rendered, "Repository octo/off has Check Runs disabled (enable_checks: false); nothing to scan.")
+	assert.NotContains(t, rendered, "Scanned")
+}
+
+// Naming a repository whose Check Run publishing is turned off scans nothing:
+// the server reports the repo as disabled and the CLI reports the skip with
+// the reason. The repo appears only in the skip list — not in the scanned-repo
+// scope — so the report never implies a scan that did not happen.
+func TestChecksBackfillRunSkipsNamedDisabledRepo(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/checks/scan", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(apitypes.ChecksScanResponse{Repo: "octo/off", ChecksDisabled: true}))
+	}))
+	t.Cleanup(server.Close)
+
+	cmd := &ChecksBackfillCmd{Repo: "octo/off", DryRun: true, StuckAfter: "1h", JSON: true}
+	var runErr error
+	output := captureStdout(func() {
+		runErr = cmd.Run(t.Context(), &Globals{Endpoint: server.URL})
+	})
+	require.NoError(t, runErr)
+
+	var report checksBackfillReport
+	require.NoError(t, json.Unmarshal([]byte(output), &report))
+	assert.Empty(t, report.Repos, "a repo the server reported as disabled was not scanned and must not appear in the scanned-repo list")
+	assert.Equal(t, []string{"octo/off"}, report.SkippedDisabled)
+	assert.Zero(t, report.Scanned)
+	assert.Empty(t, report.Actions)
 }
 
 // The pacing decision: pause only when the budget snapshot is below the floor


### PR DESCRIPTION
## Why this matters

A repository with `enable_checks: false` publishes no Check Runs — every check write is gated server-side — but the backfill machinery didn't know it. A scan reported every open PR as missing a check the server refuses to create, and a synthesize replayed real auto-plans whose only surviving side effect was duplicate plan comments. On a deployment where checks are deliberately disabled (e.g. a standby control plane awaiting a webhook cutover), a routine `checks backfill --all-repos` was pure noise with a comment-spam side effect.

## What it does

Teaches all three checks-ops layers the flag, with skip semantics — a fleet sweep keeps going, nothing errors:

- `/api/checks/repos` splits the declared inventory into `repos` (enabled, scannable) and a new `disabled` list.
- `/api/checks/scan` returns `checks_disabled` for a disabled repo instead of scanning.
- `/api/checks/synthesize` returns per-PR skip outcomes for a disabled repo before any GitHub call or auto-plan replay.
- The CLI sweep scans only enabled repos, names the skipped ones in its report (`skipped_checks_disabled` in JSON), and says plainly when every declared repo is disabled and there is nothing to scan.

Flipping `enable_checks` back on moves a repo into the scannable inventory automatically, so the next sweep picks it up with no special flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)