### PR TITLE
fix(github): detect plan drift on change identity, not DDL text alone

### DIFF
--- a/pkg/webhook/apply_execute.go
+++ b/pkg/webhook/apply_execute.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/block/schemabot/pkg/api"
 	"github.com/block/schemabot/pkg/apitypes"
@@ -217,28 +218,84 @@ func (h *Handler) executeApply(
 	}
 }
 
-// ddlMatchesStoredPlan compares the re-plan DDL against a previously stored plan.
-// Uses order-independent comparison since FlatTables() and FlatDDLChanges() may
-// return statements in different order.
-func ddlMatchesStoredPlan(planResp *apitypes.PlanResponse, storedPlan *storage.Plan) bool {
-	newDDL := planResp.FlatTables()
-	storedDDL := storedPlan.FlatDDLChanges()
+// planChangeIdentity is the drift-comparison key for a single table change. A
+// bare DDL string is not enough: the same DDL text can move between namespaces,
+// tables, or operations (e.g. one keyspace dropping a table and another creating
+// it), which a DDL-only multiset would treat as unchanged and auto-apply. The
+// full identity is what the operator reviewed, so drift must be judged on it.
+type planChangeIdentity struct {
+	namespace string
+	table     string
+	operation string
+	ddl       string
+}
 
-	if len(newDDL) != len(storedDDL) {
+// ddlMatchesStoredPlan reports whether the re-plan describes the same set of
+// table changes the operator reviewed in storedPlan. Comparison is
+// order-independent (the flattening helpers may emit changes in different order)
+// and keyed on the full change identity, not DDL text alone. Any mismatch means
+// drift, and the caller downgrades an automatic apply to manual confirmation —
+// so this errs toward requiring re-review, never toward silently applying a
+// changed plan.
+func ddlMatchesStoredPlan(planResp *apitypes.PlanResponse, storedPlan *storage.Plan) bool {
+	newChanges := responsePlanIdentities(planResp)
+	storedChanges := storedPlanIdentities(storedPlan)
+
+	if len(newChanges) != len(storedChanges) {
 		return false
 	}
 
-	// Build a set of DDL strings from the stored plan
-	storedSet := make(map[string]int, len(storedDDL))
-	for _, s := range storedDDL {
-		storedSet[s.DDL]++
-	}
-
-	for _, n := range newDDL {
-		if storedSet[n.DDL] <= 0 {
+	for identity, count := range newChanges {
+		if storedChanges[identity] != count {
 			return false
 		}
-		storedSet[n.DDL]--
 	}
 	return true
+}
+
+// responsePlanIdentities builds the change-identity multiset from a re-plan
+// response. Namespace comes from the SchemaChangeResponse grouping (the
+// authoritative source; FlatTables() does not carry it onto each change) and is
+// normalized the same way the stored plan is — an empty namespace becomes
+// "default" — so the two multisets are keyed identically.
+func responsePlanIdentities(planResp *apitypes.PlanResponse) map[planChangeIdentity]int {
+	identities := make(map[planChangeIdentity]int)
+	for _, sc := range planResp.Changes {
+		namespace := normalizePlanNamespace(sc.Namespace)
+		for _, tc := range sc.TableChanges {
+			identities[planChangeIdentity{
+				namespace: namespace,
+				table:     tc.TableName,
+				operation: strings.ToLower(tc.ChangeType),
+				ddl:       tc.DDL,
+			}]++
+		}
+	}
+	return identities
+}
+
+// storedPlanIdentities builds the change-identity multiset from a stored plan.
+// FlatDDLChanges backfills each change's namespace from its map key, which the
+// store already normalized (empty → "default"), so it matches the response side.
+func storedPlanIdentities(storedPlan *storage.Plan) map[planChangeIdentity]int {
+	identities := make(map[planChangeIdentity]int)
+	for _, tc := range storedPlan.FlatDDLChanges() {
+		identities[planChangeIdentity{
+			namespace: normalizePlanNamespace(tc.Namespace),
+			table:     tc.Table,
+			operation: strings.ToLower(tc.Operation),
+			ddl:       tc.DDL,
+		}]++
+	}
+	return identities
+}
+
+// normalizePlanNamespace mirrors the store's namespace handling so a plan whose
+// proto namespace is empty (persisted as "default") compares equal to the
+// re-plan response that still carries the empty grouping namespace.
+func normalizePlanNamespace(namespace string) string {
+	if namespace == "" {
+		return "default"
+	}
+	return namespace
 }

--- a/pkg/webhook/apply_execute_test.go
+++ b/pkg/webhook/apply_execute_test.go
@@ -16,37 +16,37 @@ func TestDDLMatchesStoredPlan(t *testing.T) {
 		wantMatch  bool
 	}{
 		{
-			name: "identical DDL matches",
+			name: "identical change matches",
 			planResp: &apitypes.PlanResponse{
 				Changes: []*apitypes.SchemaChangeResponse{
-					{TableChanges: []*apitypes.TableChangeResponse{
-						{DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
+					{Namespace: "mydb", TableChanges: []*apitypes.TableChangeResponse{
+						{TableName: "users", ChangeType: "alter", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
 					}},
 				},
 			},
 			storedPlan: &storage.Plan{
 				Namespaces: map[string]*storage.NamespacePlanData{
 					"mydb": {Tables: []storage.TableChange{
-						{DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
+						{Table: "users", Operation: "alter", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
 					}},
 				},
 			},
 			wantMatch: true,
 		},
 		{
-			name: "different DDL does not match",
+			name: "extra change does not match",
 			planResp: &apitypes.PlanResponse{
 				Changes: []*apitypes.SchemaChangeResponse{
-					{TableChanges: []*apitypes.TableChangeResponse{
-						{DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
-						{DDL: "ALTER TABLE `users` DROP COLUMN `old_field`"},
+					{Namespace: "mydb", TableChanges: []*apitypes.TableChangeResponse{
+						{TableName: "users", ChangeType: "alter", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
+						{TableName: "users", ChangeType: "alter", DDL: "ALTER TABLE `users` DROP COLUMN `old_field`"},
 					}},
 				},
 			},
 			storedPlan: &storage.Plan{
 				Namespaces: map[string]*storage.NamespacePlanData{
 					"mydb": {Tables: []storage.TableChange{
-						{DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
+						{Table: "users", Operation: "alter", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
 					}},
 				},
 			},
@@ -56,35 +56,125 @@ func TestDDLMatchesStoredPlan(t *testing.T) {
 			name: "different DDL content does not match",
 			planResp: &apitypes.PlanResponse{
 				Changes: []*apitypes.SchemaChangeResponse{
-					{TableChanges: []*apitypes.TableChangeResponse{
-						{DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(500)"},
+					{Namespace: "mydb", TableChanges: []*apitypes.TableChangeResponse{
+						{TableName: "users", ChangeType: "alter", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(500)"},
 					}},
 				},
 			},
 			storedPlan: &storage.Plan{
 				Namespaces: map[string]*storage.NamespacePlanData{
 					"mydb": {Tables: []storage.TableChange{
-						{DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
+						{Table: "users", Operation: "alter", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
 					}},
 				},
 			},
 			wantMatch: false,
 		},
 		{
-			name: "same DDL in different order matches",
+			name: "same changes in different order match",
 			planResp: &apitypes.PlanResponse{
 				Changes: []*apitypes.SchemaChangeResponse{
-					{TableChanges: []*apitypes.TableChangeResponse{
-						{DDL: "ALTER TABLE `orders` ADD INDEX `idx_status` (`status`)"},
-						{DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
+					{Namespace: "mydb", TableChanges: []*apitypes.TableChangeResponse{
+						{TableName: "orders", ChangeType: "alter", DDL: "ALTER TABLE `orders` ADD INDEX `idx_status` (`status`)"},
+						{TableName: "users", ChangeType: "alter", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
 					}},
 				},
 			},
 			storedPlan: &storage.Plan{
 				Namespaces: map[string]*storage.NamespacePlanData{
 					"mydb": {Tables: []storage.TableChange{
-						{DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
-						{DDL: "ALTER TABLE `orders` ADD INDEX `idx_status` (`status`)"},
+						{Table: "users", Operation: "alter", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
+						{Table: "orders", Operation: "alter", DDL: "ALTER TABLE `orders` ADD INDEX `idx_status` (`status`)"},
+					}},
+				},
+			},
+			wantMatch: true,
+		},
+		{
+			name: "same DDL under a different namespace does not match",
+			planResp: &apitypes.PlanResponse{
+				Changes: []*apitypes.SchemaChangeResponse{
+					{Namespace: "keyspace_b", TableChanges: []*apitypes.TableChangeResponse{
+						{TableName: "accounts", ChangeType: "create", DDL: "CREATE TABLE `accounts` (`id` bigint)"},
+					}},
+				},
+			},
+			storedPlan: &storage.Plan{
+				Namespaces: map[string]*storage.NamespacePlanData{
+					"keyspace_a": {Tables: []storage.TableChange{
+						{Table: "accounts", Operation: "create", DDL: "CREATE TABLE `accounts` (`id` bigint)"},
+					}},
+				},
+			},
+			wantMatch: false,
+		},
+		{
+			name: "same DDL against a different table does not match",
+			planResp: &apitypes.PlanResponse{
+				Changes: []*apitypes.SchemaChangeResponse{
+					{Namespace: "mydb", TableChanges: []*apitypes.TableChangeResponse{
+						{TableName: "customers", ChangeType: "alter", DDL: "ALTER TABLE `t` ADD COLUMN `email` varchar(255)"},
+					}},
+				},
+			},
+			storedPlan: &storage.Plan{
+				Namespaces: map[string]*storage.NamespacePlanData{
+					"mydb": {Tables: []storage.TableChange{
+						{Table: "users", Operation: "alter", DDL: "ALTER TABLE `t` ADD COLUMN `email` varchar(255)"},
+					}},
+				},
+			},
+			wantMatch: false,
+		},
+		{
+			name: "same DDL with a different operation does not match",
+			planResp: &apitypes.PlanResponse{
+				Changes: []*apitypes.SchemaChangeResponse{
+					{Namespace: "mydb", TableChanges: []*apitypes.TableChangeResponse{
+						{TableName: "events", ChangeType: "drop", DDL: "-- events"},
+					}},
+				},
+			},
+			storedPlan: &storage.Plan{
+				Namespaces: map[string]*storage.NamespacePlanData{
+					"mydb": {Tables: []storage.TableChange{
+						{Table: "events", Operation: "create", DDL: "-- events"},
+					}},
+				},
+			},
+			wantMatch: false,
+		},
+		{
+			name: "operation comparison is case-insensitive",
+			planResp: &apitypes.PlanResponse{
+				Changes: []*apitypes.SchemaChangeResponse{
+					{Namespace: "mydb", TableChanges: []*apitypes.TableChangeResponse{
+						{TableName: "users", ChangeType: "ALTER", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
+					}},
+				},
+			},
+			storedPlan: &storage.Plan{
+				Namespaces: map[string]*storage.NamespacePlanData{
+					"mydb": {Tables: []storage.TableChange{
+						{Table: "users", Operation: "alter", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
+					}},
+				},
+			},
+			wantMatch: true,
+		},
+		{
+			name: "empty response namespace matches default-normalized stored namespace",
+			planResp: &apitypes.PlanResponse{
+				Changes: []*apitypes.SchemaChangeResponse{
+					{Namespace: "", TableChanges: []*apitypes.TableChangeResponse{
+						{TableName: "users", ChangeType: "alter", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
+					}},
+				},
+			},
+			storedPlan: &storage.Plan{
+				Namespaces: map[string]*storage.NamespacePlanData{
+					"default": {Tables: []storage.TableChange{
+						{Table: "users", Operation: "alter", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
 					}},
 				},
 			},


### PR DESCRIPTION
## Summary

The automatic-apply drift check downgrades to manual confirmation when the re-plan differs from the auto-plan the operator reviewed. It compared only a multiset of DDL strings, so a re-plan that kept the same DDL text but moved it to a different namespace, table, or operation was treated as unchanged and applied without re-review.

## What

`ddlMatchesStoredPlan` now compares on the full change identity `(namespace, table, operation, ddl)` instead of DDL text alone:

- Namespace is normalized the same way the store normalizes it (empty → `default`), so default-namespace plans don't report false drift.
- Operation is compared case-insensitively (`ChangeType` vs `Operation`).
- Comparison stays order-independent and count-aware; it only ever gets *stricter*, so the failure direction remains the safe one — downgrade to manual confirm, never auto-apply on uncertainty.

## Why

DDL-text equality is not identity. The same statement can legitimately move between keyspaces/tables/operations between the auto-plan and the apply re-plan; the operator reviewed the specific change, so drift must be judged on the whole change, not just its text.

## Before / after (example)

Sharded DB with two keyspaces. The operator reviews an auto-plan that drops `events` from keyspace `orders`. Between review and apply, the schema is re-planned and now drops `events` from keyspace `archive` — the DDL text `DROP TABLE events` is byte-identical, only the keyspace changed.

Before (DDL-text-only multiset):
```
reviewed : { "DROP TABLE events": 1 }
re-plan  : { "DROP TABLE events": 1 }
→ multisets equal → auto-apply proceeds, dropping from the WRONG keyspace
without any re-review
```
After (change-identity multiset):
```
reviewed : { (orders,  events, drop, "DROP TABLE events"): 1 }
re-plan  : { (archive, events, drop, "DROP TABLE events"): 1 }
→ multisets differ → downgrade to manual confirm, operator re-reviews

The same holds when only the `table` or `operation` differs while the DDL text is unchanged.
```

## Follow-up (intentionally out of scope)

The drift comparison traverses only `Plan.Namespaces`, not `Plan.Shards`, so per-shard changes in sharded (Vitess) plans are still not compared. This is pre-existing behavior, unchanged by this PR, and tracked as a separate follow-up — it should not be raised as a new issue against this change.
