### PR TITLE
feat(github): downgrade auto-apply when the schema dir changed on base

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -70,6 +70,13 @@ type ServerConfig struct {
 	// Repos holds per-repository configuration.
 	Repos map[string]RepoConfig `yaml:"repos"`
 
+	// RequireUpToDateWithBase controls whether automatic apply is downgraded to
+	// manual confirmation when the resolved schema directory changed on the PR's
+	// base branch since the branch diverged. It is the global default; a repo may
+	// override it via RepoConfig.RequireUpToDateWithBase. Nil defaults to true
+	// (guard enabled). Resolved via RequiresUpToDateWithBase.
+	RequireUpToDateWithBase *bool `yaml:"require_up_to_date_with_base,omitempty"`
+
 	// PRCommandAuthorization controls which GitHub users may run SchemaBot
 	// apply/apply-confirm PR comment commands. When disabled, existing OSS/local
 	// behavior is preserved.
@@ -715,6 +722,14 @@ type RepoConfig struct {
 	// this repository. Stored check state is still maintained for SchemaBot's
 	// own safety gates. Defaults to true when not configured.
 	EnableChecks *bool `yaml:"enable_checks,omitempty"`
+
+	// RequireUpToDateWithBase overrides ServerConfig.RequireUpToDateWithBase for
+	// this repository. Nil inherits the global setting (which itself defaults to
+	// true). Set it to false as an escape hatch for very high-churn repositories
+	// where the base branch changes the schema directory faster than a PR can
+	// stay current, and where operators accept auto-apply against a base that
+	// may have advanced. Resolved via RequiresUpToDateWithBase.
+	RequireUpToDateWithBase *bool `yaml:"require_up_to_date_with_base,omitempty"`
 
 	// GitHubApp names the App in ServerConfig.Apps that owns webhooks and
 	// outbound GitHub API calls for this repository. Required when Apps is
@@ -1663,6 +1678,24 @@ func (c *ServerConfig) AreChecksEnabled(repo string) bool {
 		return true
 	}
 	return *repoConfig.EnableChecks
+}
+
+// RequiresUpToDateWithBase reports whether automatic apply should be downgraded
+// to manual confirmation when the resolved schema directory changed on the PR's
+// base branch since the branch diverged. Precedence: a non-nil repo override
+// wins, else the non-nil global default, else true (guard enabled). A nil
+// receiver returns the safe default of true.
+func (c *ServerConfig) RequiresUpToDateWithBase(repo string) bool {
+	if c == nil {
+		return true
+	}
+	if repoConfig, ok := c.Repos[repo]; ok && repoConfig.RequireUpToDateWithBase != nil {
+		return *repoConfig.RequireUpToDateWithBase
+	}
+	if c.RequireUpToDateWithBase != nil {
+		return *c.RequireUpToDateWithBase
+	}
+	return true
 }
 
 // ResolvedGitHubApp identifies which configured GitHub App owns a repository.

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -2378,6 +2378,63 @@ func TestServerConfig_AreChecksEnabled(t *testing.T) {
 	})
 }
 
+func TestServerConfig_RequiresUpToDateWithBase(t *testing.T) {
+	boolPtr := func(b bool) *bool { return &b }
+
+	t.Run("nil config defaults to enabled", func(t *testing.T) {
+		var cfg *ServerConfig
+		assert.True(t, cfg.RequiresUpToDateWithBase("org/repo"))
+	})
+
+	t.Run("unset global and repo default to enabled", func(t *testing.T) {
+		cfg := ServerConfig{Repos: map[string]RepoConfig{"org/repo": {}}}
+		assert.True(t, cfg.RequiresUpToDateWithBase("org/repo"))
+	})
+
+	t.Run("global false applies to repos without override", func(t *testing.T) {
+		cfg := ServerConfig{
+			RequireUpToDateWithBase: boolPtr(false),
+			Repos:                   map[string]RepoConfig{"org/repo": {}},
+		}
+		assert.False(t, cfg.RequiresUpToDateWithBase("org/repo"))
+	})
+
+	t.Run("global false applies to unlisted repos", func(t *testing.T) {
+		cfg := ServerConfig{RequireUpToDateWithBase: boolPtr(false)}
+		assert.False(t, cfg.RequiresUpToDateWithBase("org/other-repo"))
+	})
+
+	t.Run("repo override wins over global", func(t *testing.T) {
+		cfg := ServerConfig{
+			RequireUpToDateWithBase: boolPtr(true),
+			Repos: map[string]RepoConfig{
+				"org/repo": {RequireUpToDateWithBase: boolPtr(false)},
+			},
+		}
+		assert.False(t, cfg.RequiresUpToDateWithBase("org/repo"))
+	})
+
+	t.Run("repo override enables when global disables", func(t *testing.T) {
+		cfg := ServerConfig{
+			RequireUpToDateWithBase: boolPtr(false),
+			Repos: map[string]RepoConfig{
+				"org/repo": {RequireUpToDateWithBase: boolPtr(true)},
+			},
+		}
+		assert.True(t, cfg.RequiresUpToDateWithBase("org/repo"))
+	})
+
+	t.Run("nil repo override inherits global", func(t *testing.T) {
+		cfg := ServerConfig{
+			RequireUpToDateWithBase: boolPtr(false),
+			Repos: map[string]RepoConfig{
+				"org/repo": {RequireUpToDateWithBase: nil},
+			},
+		}
+		assert.False(t, cfg.RequiresUpToDateWithBase("org/repo"))
+	})
+}
+
 func TestServerConfig_IsEnvironmentAllowed(t *testing.T) {
 	t.Run("nil allowed_environments allows all", func(t *testing.T) {
 		cfg := ServerConfig{AllowedEnvironments: nil}

--- a/pkg/github/base_drift.go
+++ b/pkg/github/base_drift.go
@@ -1,0 +1,184 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"slices"
+	"strings"
+
+	gh "github.com/google/go-github/v86/github"
+)
+
+// SchemaDirChangedOnBase reports whether the resolved schema directory
+// schemaPath changed on the PR's base branch since the branch diverged. It
+// compares the git tree SHA of schemaPath at the merge base of baseSHA/headSHA
+// against its tree SHA at the current baseSHA — so a base branch that advanced
+// by thousands of commits without touching schemaPath reports no change, while
+// any change under schemaPath (including the directory being added or removed on
+// base) reports changed.
+//
+// changed is the safety-relevant signal: callers downgrade automatic apply to
+// manual confirmation when it is true. changedFiles is a best-effort list of the
+// files under schemaPath that changed on base, for operator-facing display; it
+// may be empty even when changed is true (for example when the compare file list
+// is unavailable or truncated), and callers must not treat an empty list as
+// "nothing changed". err is returned only for failures that leave the change
+// decision unknown; callers must fail closed (downgrade) on a non-nil err.
+//
+// Comparison uses recursive git tree SHAs, which commit to entry names, modes,
+// types, and child object SHAs, so equal tree SHAs prove identical directory
+// snapshots. It does not follow schema-namespace symlinks whose targets live
+// outside schemaPath, nor does it detect a base branch repointing the
+// environment-root symlink itself; those are known gaps (see the feature's
+// limitations) where the guard behaves as if no base change occurred.
+func (ic *InstallationClient) SchemaDirChangedOnBase(ctx context.Context, repo, baseSHA, headSHA, schemaPath string) (changed bool, changedFiles []string, err error) {
+	owner, repoName := splitRepo(repo)
+
+	comparison, err := retryGitHubUnavailableRead(ctx, ic.logger, "compare for merge base",
+		[]any{"repo", repo, "base", baseSHA, "head", headSHA},
+		func(ctx context.Context) (*gh.CommitsComparison, error) {
+			cmp, _, cmpErr := ic.client.Repositories.CompareCommits(ctx, owner, repoName, baseSHA, headSHA, nil)
+			if cmpErr != nil {
+				return nil, fmt.Errorf("compare commits %s...%s: %w", baseSHA, headSHA, classifyGitHubAPIError(cmpErr))
+			}
+			return cmp, nil
+		})
+	if err != nil {
+		return false, nil, fmt.Errorf("resolve merge base %s...%s in %s: %w", baseSHA, headSHA, repo, err)
+	}
+	if comparison == nil || comparison.MergeBaseCommit == nil || comparison.MergeBaseCommit.GetSHA() == "" {
+		return false, nil, fmt.Errorf("resolve merge base %s...%s in %s: comparison returned no merge base", baseSHA, headSHA, repo)
+	}
+	mergeBase := comparison.MergeBaseCommit.GetSHA()
+
+	// The current base is already an ancestor of head: no base commits landed
+	// since the branch diverged, so the schema directory cannot have changed on
+	// base relative to what this PR is built on.
+	if mergeBase == baseSHA {
+		return false, nil, nil
+	}
+
+	mergeBaseTreeSHA, mergeBaseFound, err := ic.treeSHAForPath(ctx, repo, mergeBase, schemaPath)
+	if err != nil {
+		return false, nil, fmt.Errorf("resolve schema dir %q tree at merge base %s in %s: %w", schemaPath, mergeBase, repo, err)
+	}
+	baseTreeSHA, baseFound, err := ic.treeSHAForPath(ctx, repo, baseSHA, schemaPath)
+	if err != nil {
+		return false, nil, fmt.Errorf("resolve schema dir %q tree at base %s in %s: %w", schemaPath, baseSHA, repo, err)
+	}
+
+	// Base never had the directory (the PR introduces it): base did not change
+	// a directory it does not contain.
+	if !mergeBaseFound && !baseFound {
+		return false, nil, nil
+	}
+	// Present on both sides with an identical snapshot: unchanged.
+	if mergeBaseFound && baseFound && mergeBaseTreeSHA == baseTreeSHA {
+		return false, nil, nil
+	}
+
+	// Differs, or the directory was added or removed on base since divergence.
+	return true, ic.changedFilesUnderPath(ctx, repo, mergeBase, baseSHA, schemaPath), nil
+}
+
+// treeSHAForPath resolves the git tree SHA of the directory dir at ref. found is
+// false when dir does not exist (or is not a directory) at ref. It walks the
+// path one segment at a time with shallow tree fetches, so it works even when
+// the repository's full recursive listing would be truncated. An empty or "."
+// dir resolves to the ref's root tree SHA.
+func (ic *InstallationClient) treeSHAForPath(ctx context.Context, repo, ref, dir string) (sha string, found bool, err error) {
+	clean := strings.Trim(path.Clean(dir), "/")
+	if clean == "" || clean == "." {
+		root, rootErr := ic.rootTreeSHA(ctx, repo, ref)
+		if rootErr != nil {
+			return "", false, rootErr
+		}
+		return root, true, nil
+	}
+
+	treeSHA := ref
+	for segment := range strings.SplitSeq(clean, "/") {
+		entries, shallowErr := ic.fetchGitTreeShallow(ctx, repo, treeSHA)
+		if shallowErr != nil {
+			return "", false, fmt.Errorf("resolve %q under %q in repo %s ref %s: %w", segment, clean, repo, ref, shallowErr)
+		}
+		next := ""
+		for _, entry := range entries {
+			if entry.Path == segment && entry.Type == "tree" {
+				next = entry.SHA
+				break
+			}
+		}
+		if next == "" {
+			return "", false, nil
+		}
+		treeSHA = next
+	}
+	return treeSHA, true, nil
+}
+
+// rootTreeSHA returns the SHA of the root tree of the commit-ish ref.
+func (ic *InstallationClient) rootTreeSHA(ctx context.Context, repo, ref string) (string, error) {
+	owner, repoName := splitRepo(repo)
+	tree, err := retryGitHubUnavailableRead(ctx, ic.logger, "fetch root tree",
+		[]any{"repo", repo, "ref", ref},
+		func(ctx context.Context) (*gh.Tree, error) {
+			ghTree, _, treeErr := ic.client.Git.GetTree(ctx, owner, repoName, ref, false)
+			if treeErr != nil {
+				return nil, fmt.Errorf("fetch root tree: %w", classifyGitHubAPIError(treeErr))
+			}
+			return ghTree, nil
+		})
+	if err != nil {
+		return "", fmt.Errorf("resolve root tree for repo %s ref %s: %w", repo, ref, err)
+	}
+	if tree.GetSHA() == "" {
+		return "", fmt.Errorf("resolve root tree for repo %s ref %s: empty tree SHA", repo, ref)
+	}
+	return tree.GetSHA(), nil
+}
+
+// changedFilesUnderPath returns, best-effort, the files under schemaPath that
+// changed between base and head, sorted and deduplicated. It is used only for
+// operator-facing display, so any failure (including a truncated compare
+// response) yields an empty list rather than an error: the change decision has
+// already been made from tree SHAs by the caller.
+func (ic *InstallationClient) changedFilesUnderPath(ctx context.Context, repo, base, head, schemaPath string) []string {
+	files, err := ic.FetchChangedFilesBetween(ctx, repo, base, head)
+	if err != nil {
+		ic.logger.Warn("could not list changed schema files for base-drift downgrade; showing a generic message",
+			"repo", repo, "base", base, "head", head, "schema_path", schemaPath, "error", err)
+		return nil
+	}
+
+	seen := make(map[string]struct{}, len(files))
+	var under []string
+	for _, f := range files {
+		for _, name := range []string{f.Filename, f.PreviousFilename} {
+			if name == "" || !pathWithinDir(schemaPath, name) {
+				continue
+			}
+			if _, dup := seen[name]; dup {
+				continue
+			}
+			seen[name] = struct{}{}
+			under = append(under, name)
+		}
+	}
+	slices.Sort(under)
+	return under
+}
+
+// pathWithinDir reports whether the file path p is dir itself or lives beneath
+// dir, matching on path-segment boundaries so "schema/foo" does not match
+// "schema/foobar". An empty or "." dir means the repository root, which contains
+// every path.
+func pathWithinDir(dir, p string) bool {
+	cleanDir := strings.Trim(path.Clean(dir), "/")
+	cleanPath := strings.Trim(path.Clean(p), "/")
+	if cleanDir == "" || cleanDir == "." {
+		return true
+	}
+	return cleanPath == cleanDir || strings.HasPrefix(cleanPath, cleanDir+"/")
+}

--- a/pkg/github/base_drift.go
+++ b/pkg/github/base_drift.go
@@ -12,11 +12,20 @@ import (
 
 // SchemaDirChangedOnBase reports whether the resolved schema directory
 // schemaPath changed on the PR's base branch since the branch diverged. It
-// compares the git tree SHA of schemaPath at the merge base of baseSHA/headSHA
-// against its tree SHA at the current baseSHA — so a base branch that advanced
-// by thousands of commits without touching schemaPath reports no change, while
-// any change under schemaPath (including the directory being added or removed on
-// base) reports changed.
+// compares the git tree SHA of schemaPath at the merge base of baseRef/headSHA
+// against its tree SHA at the current tip of baseRef — so a base branch that
+// advanced by thousands of commits without touching schemaPath reports no
+// change, while any change under schemaPath (including the directory being added
+// or removed on base) reports changed.
+//
+// baseRef must be the base branch *ref name* (e.g. "main"), not a snapshot SHA.
+// The live base tip is resolved from the compare response's BaseCommit rather
+// than from the caller's snapshot: GitHub's pull.base.sha is not guaranteed to
+// track the live base tip and is typically the base tip at PR creation — which
+// for most PRs equals the merge base, so passing it would make the
+// mergeBase == base short-circuit fire (reporting "no drift") in exactly the
+// fast-moving-base scenario this guard exists for. Resolving the tip from the
+// ref keeps the comparison against the branch's current state.
 //
 // changed is the safety-relevant signal: callers downgrade automatic apply to
 // manual confirmation when it is true. changedFiles is a best-effort list of the
@@ -30,27 +39,34 @@ import (
 // types, and child object SHAs, so equal tree SHAs prove identical directory
 // snapshots. It does not follow schema-namespace symlinks whose targets live
 // outside schemaPath, nor does it detect a base branch repointing the
-// environment-root symlink itself; those are known gaps (see the feature's
-// limitations) where the guard behaves as if no base change occurred.
-func (ic *InstallationClient) SchemaDirChangedOnBase(ctx context.Context, repo, baseSHA, headSHA, schemaPath string) (changed bool, changedFiles []string, err error) {
+// environment-root symlink itself; those are known gaps where the guard behaves
+// as if no base change occurred.
+func (ic *InstallationClient) SchemaDirChangedOnBase(ctx context.Context, repo, baseRef, headSHA, schemaPath string) (changed bool, changedFiles []string, err error) {
 	owner, repoName := splitRepo(repo)
 
 	comparison, err := retryGitHubUnavailableRead(ctx, ic.logger, "compare for merge base",
-		[]any{"repo", repo, "base", baseSHA, "head", headSHA},
+		[]any{"repo", repo, "base", baseRef, "head", headSHA},
 		func(ctx context.Context) (*gh.CommitsComparison, error) {
-			cmp, _, cmpErr := ic.client.Repositories.CompareCommits(ctx, owner, repoName, baseSHA, headSHA, nil)
+			cmp, _, cmpErr := ic.client.Repositories.CompareCommits(ctx, owner, repoName, baseRef, headSHA, nil)
 			if cmpErr != nil {
-				return nil, fmt.Errorf("compare commits %s...%s: %w", baseSHA, headSHA, classifyGitHubAPIError(cmpErr))
+				return nil, fmt.Errorf("compare commits %s...%s: %w", baseRef, headSHA, classifyGitHubAPIError(cmpErr))
 			}
 			return cmp, nil
 		})
 	if err != nil {
-		return false, nil, fmt.Errorf("resolve merge base %s...%s in %s: %w", baseSHA, headSHA, repo, err)
+		return false, nil, fmt.Errorf("resolve merge base %s...%s in %s: %w", baseRef, headSHA, repo, err)
 	}
 	if comparison == nil || comparison.MergeBaseCommit == nil || comparison.MergeBaseCommit.GetSHA() == "" {
-		return false, nil, fmt.Errorf("resolve merge base %s...%s in %s: comparison returned no merge base", baseSHA, headSHA, repo)
+		return false, nil, fmt.Errorf("resolve merge base %s...%s in %s: comparison returned no merge base", baseRef, headSHA, repo)
 	}
 	mergeBase := comparison.MergeBaseCommit.GetSHA()
+
+	// Pin the live base tip from the compare response (the tip of baseRef at the
+	// time of this call), not the caller's snapshot SHA. Fail closed if absent.
+	if comparison.BaseCommit == nil || comparison.BaseCommit.GetSHA() == "" {
+		return false, nil, fmt.Errorf("resolve base tip %s...%s in %s: comparison returned no base commit", baseRef, headSHA, repo)
+	}
+	baseSHA := comparison.BaseCommit.GetSHA()
 
 	// The current base is already an ancestor of head: no base commits landed
 	// since the branch diverged, so the schema directory cannot have changed on

--- a/pkg/github/base_drift_test.go
+++ b/pkg/github/base_drift_test.go
@@ -1,0 +1,224 @@
+package github
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	gh "github.com/google/go-github/v86/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// baseDriftFixture models the GitHub API responses SchemaDirChangedOnBase needs:
+// merge-base resolution (compare base...head), per-commit root trees (so a path
+// can be resolved to a tree SHA), and the compare file list used for the
+// operator-facing changed-file display.
+type baseDriftFixture struct {
+	// mergeBase is returned as merge_base_commit.sha for compare base...head.
+	mergeBase string
+	// rootTrees maps a commit SHA to the entries of its root tree.
+	rootTrees map[string][]driftEntry
+	// compareFiles maps a "base...head" key to the files that compare returns.
+	compareFiles map[string][]*gh.CommitFile
+}
+
+// driftEntry is a directory entry in a fixture root tree.
+type driftEntry struct {
+	path string
+	sha  string
+}
+
+func newBaseDriftClient(t *testing.T, fx baseDriftFixture) *InstallationClient {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("GET /repos/octo/repo/compare/{basehead}", func(w http.ResponseWriter, r *http.Request) {
+		basehead := r.PathValue("basehead")
+		parts := strings.SplitN(basehead, "...", 2)
+		require.Len(t, parts, 2, "compare basehead must be base...head")
+		base, head := parts[0], parts[1]
+
+		cmp := &gh.CommitsComparison{}
+		// The merge-base query is always base...head where head is the PR head.
+		// For any compare we serve the recorded merge base and any recorded files.
+		if base == "" || head == "" {
+			http.Error(w, "bad compare", http.StatusBadRequest)
+			return
+		}
+		if fx.mergeBase != "" {
+			cmp.MergeBaseCommit = &gh.RepositoryCommit{SHA: new(fx.mergeBase)}
+		}
+		if files, ok := fx.compareFiles[basehead]; ok {
+			cmp.Files = files
+		}
+		writeJSON(t, w, cmp)
+	})
+
+	mux.HandleFunc("GET /repos/octo/repo/git/trees/{sha}", func(w http.ResponseWriter, r *http.Request) {
+		sha := r.PathValue("sha")
+		entries, ok := fx.rootTrees[sha]
+		if !ok {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		tree := &gh.Tree{SHA: new(sha), Truncated: new(false)}
+		for i := range entries {
+			tree.Entries = append(tree.Entries, &gh.TreeEntry{
+				Path: new(entries[i].path),
+				Mode: new("040000"),
+				Type: new("tree"),
+				SHA:  new(entries[i].sha),
+			})
+		}
+		writeJSON(t, w, tree)
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	ghc := gh.NewClient(nil)
+	ghc.BaseURL, _ = url.Parse(server.URL + "/")
+	return &InstallationClient{
+		client: ghc,
+		logger: slog.New(slog.NewTextHandler(prDiscardWriter{}, &slog.HandlerOptions{Level: slog.LevelError})),
+	}
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	require.NoError(t, json.NewEncoder(w).Encode(v))
+}
+
+func treeEntry(pathName, sha string) driftEntry {
+	return driftEntry{path: pathName, sha: sha}
+}
+
+func TestSchemaDirChangedOnBase(t *testing.T) {
+	const (
+		headSHA = "headsha"
+		baseSHA = "basesha"
+	)
+
+	t.Run("merge base equals base means base has not advanced", func(t *testing.T) {
+		ic := newBaseDriftClient(t, baseDriftFixture{mergeBase: baseSHA})
+		changed, files, err := ic.SchemaDirChangedOnBase(t.Context(), "octo/repo", baseSHA, headSHA, "schemas")
+		require.NoError(t, err)
+		assert.False(t, changed)
+		assert.Empty(t, files)
+	})
+
+	t.Run("base advanced but schema dir unchanged", func(t *testing.T) {
+		ic := newBaseDriftClient(t, baseDriftFixture{
+			mergeBase: "mergebase",
+			rootTrees: map[string][]driftEntry{
+				"mergebase": {treeEntry("schemas", "schematree"), treeEntry("docs", "docstree_old")},
+				baseSHA:     {treeEntry("schemas", "schematree"), treeEntry("docs", "docstree_new")},
+			},
+		})
+		changed, files, err := ic.SchemaDirChangedOnBase(t.Context(), "octo/repo", baseSHA, headSHA, "schemas")
+		require.NoError(t, err)
+		assert.False(t, changed, "only docs changed on base, not the schema dir")
+		assert.Empty(t, files)
+	})
+
+	t.Run("schema dir changed on base lists changed files", func(t *testing.T) {
+		ic := newBaseDriftClient(t, baseDriftFixture{
+			mergeBase: "mergebase",
+			rootTrees: map[string][]driftEntry{
+				"mergebase": {treeEntry("schemas", "schematree_old")},
+				baseSHA:     {treeEntry("schemas", "schematree_new")},
+			},
+			compareFiles: map[string][]*gh.CommitFile{
+				"mergebase..." + baseSHA: {
+					{Filename: new("schemas/orders.sql"), Status: new("modified")},
+					{Filename: new("schemas/users.sql"), Status: new("added")},
+					{Filename: new("docs/readme.md"), Status: new("modified")},
+				},
+			},
+		})
+		changed, files, err := ic.SchemaDirChangedOnBase(t.Context(), "octo/repo", baseSHA, headSHA, "schemas")
+		require.NoError(t, err)
+		assert.True(t, changed)
+		assert.Equal(t, []string{"schemas/orders.sql", "schemas/users.sql"}, files,
+			"only files under the schema dir are listed, sorted")
+	})
+
+	t.Run("schema dir added on base", func(t *testing.T) {
+		ic := newBaseDriftClient(t, baseDriftFixture{
+			mergeBase: "mergebase",
+			rootTrees: map[string][]driftEntry{
+				"mergebase": {treeEntry("docs", "docstree")},
+				baseSHA:     {treeEntry("schemas", "schematree"), treeEntry("docs", "docstree")},
+			},
+		})
+		changed, _, err := ic.SchemaDirChangedOnBase(t.Context(), "octo/repo", baseSHA, headSHA, "schemas")
+		require.NoError(t, err)
+		assert.True(t, changed)
+	})
+
+	t.Run("schema dir removed on base", func(t *testing.T) {
+		ic := newBaseDriftClient(t, baseDriftFixture{
+			mergeBase: "mergebase",
+			rootTrees: map[string][]driftEntry{
+				"mergebase": {treeEntry("schemas", "schematree")},
+				baseSHA:     {treeEntry("docs", "docstree")},
+			},
+		})
+		changed, _, err := ic.SchemaDirChangedOnBase(t.Context(), "octo/repo", baseSHA, headSHA, "schemas")
+		require.NoError(t, err)
+		assert.True(t, changed)
+	})
+
+	t.Run("schema dir absent on both base refs is a PR-introduced dir", func(t *testing.T) {
+		ic := newBaseDriftClient(t, baseDriftFixture{
+			mergeBase: "mergebase",
+			rootTrees: map[string][]driftEntry{
+				"mergebase": {treeEntry("docs", "docstree")},
+				baseSHA:     {treeEntry("docs", "docstree")},
+			},
+		})
+		changed, _, err := ic.SchemaDirChangedOnBase(t.Context(), "octo/repo", baseSHA, headSHA, "schemas")
+		require.NoError(t, err)
+		assert.False(t, changed, "base never had the schema dir, so base did not change it")
+	})
+
+	t.Run("missing merge base is an error so callers fail closed", func(t *testing.T) {
+		ic := newBaseDriftClient(t, baseDriftFixture{mergeBase: ""})
+		_, _, err := ic.SchemaDirChangedOnBase(t.Context(), "octo/repo", baseSHA, headSHA, "schemas")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "merge base")
+	})
+
+	t.Run("unavailable changed-file list still reports changed with no files", func(t *testing.T) {
+		ic := newBaseDriftClient(t, baseDriftFixture{
+			mergeBase: "mergebase",
+			rootTrees: map[string][]driftEntry{
+				"mergebase": {treeEntry("schemas", "schematree_old")},
+				baseSHA:     {treeEntry("schemas", "schematree_new")},
+			},
+			// No compareFiles entry for mergebase...basesha, so the file list
+			// compare returns nothing; the change decision still holds.
+		})
+		changed, files, err := ic.SchemaDirChangedOnBase(t.Context(), "octo/repo", baseSHA, headSHA, "schemas")
+		require.NoError(t, err)
+		assert.True(t, changed)
+		assert.Empty(t, files)
+	})
+}
+
+func TestPathWithinDir(t *testing.T) {
+	assert.True(t, pathWithinDir("schema", "schema/foo.sql"))
+	assert.True(t, pathWithinDir("schema", "schema"))
+	assert.False(t, pathWithinDir("schema", "schemafoo/bar.sql"), "must match on segment boundary")
+	assert.False(t, pathWithinDir("schema", "other/foo.sql"))
+	assert.True(t, pathWithinDir("db/staging", "db/staging/orders.sql"))
+	assert.False(t, pathWithinDir("db/staging", "db/prod/orders.sql"))
+	assert.True(t, pathWithinDir(".", "anything/at/root.sql"), "root dir contains every path")
+	assert.True(t, pathWithinDir("", "anything.sql"))
+}

--- a/pkg/github/base_drift_test.go
+++ b/pkg/github/base_drift_test.go
@@ -15,12 +15,19 @@ import (
 )
 
 // baseDriftFixture models the GitHub API responses SchemaDirChangedOnBase needs:
-// merge-base resolution (compare base...head), per-commit root trees (so a path
-// can be resolved to a tree SHA), and the compare file list used for the
+// merge-base resolution (compare baseRef...head), per-commit root trees (so a
+// path can be resolved to a tree SHA), and the compare file list used for the
 // operator-facing changed-file display.
 type baseDriftFixture struct {
-	// mergeBase is returned as merge_base_commit.sha for compare base...head.
+	// mergeBase is returned as merge_base_commit.sha for compare baseRef...head.
 	mergeBase string
+	// baseTip is returned as base_commit.sha for compare baseRef...head — the
+	// live tip of the base ref, which the gate uses as the base SHA. When empty
+	// it falls back to the compare's base path segment (the ref name).
+	baseTip string
+	// omitBaseCommit suppresses base_commit in the compare response so tests can
+	// exercise the "no base commit" fail-closed path.
+	omitBaseCommit bool
 	// rootTrees maps a commit SHA to the entries of its root tree.
 	rootTrees map[string][]driftEntry
 	// compareFiles maps a "base...head" key to the files that compare returns.
@@ -44,14 +51,25 @@ func newBaseDriftClient(t *testing.T, fx baseDriftFixture) *InstallationClient {
 		base, head := parts[0], parts[1]
 
 		cmp := &gh.CommitsComparison{}
-		// The merge-base query is always base...head where head is the PR head.
-		// For any compare we serve the recorded merge base and any recorded files.
+		// The merge-base query is always baseRef...head where head is the PR
+		// head. For any compare we serve the recorded merge base, the live base
+		// tip, and any recorded files.
 		if base == "" || head == "" {
 			http.Error(w, "bad compare", http.StatusBadRequest)
 			return
 		}
 		if fx.mergeBase != "" {
 			cmp.MergeBaseCommit = &gh.RepositoryCommit{SHA: new(fx.mergeBase)}
+		}
+		// base_commit.sha is the resolved live tip of the base ref. Default to
+		// the base path segment so callers that pass a concrete SHA see it
+		// echoed back; tests that model a moving base set baseTip explicitly.
+		if !fx.omitBaseCommit {
+			baseTip := fx.baseTip
+			if baseTip == "" {
+				baseTip = base
+			}
+			cmp.BaseCommit = &gh.RepositoryCommit{SHA: new(baseTip)}
 		}
 		if files, ok := fx.compareFiles[basehead]; ok {
 			cmp.Files = files
@@ -125,6 +143,41 @@ func TestSchemaDirChangedOnBase(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, changed, "only docs changed on base, not the schema dir")
 		assert.Empty(t, files)
+	})
+
+	t.Run("resolves the live base tip so a stale snapshot does not mask drift", func(t *testing.T) {
+		// GitHub's pull.base.sha snapshot for a fast-moving base is typically
+		// the base tip at PR creation, which equals the merge base — so passing
+		// it would short-circuit as "no drift". The gate passes the base ref and
+		// resolves the live tip from base_commit, catching drift the snapshot
+		// would hide. Here the merge base still has the old schema tree while the
+		// live base tip has a new one.
+		ic := newBaseDriftClient(t, baseDriftFixture{
+			mergeBase: "mergebase",
+			baseTip:   "livebasetip",
+			rootTrees: map[string][]driftEntry{
+				"mergebase":   {treeEntry("schemas", "schematree_old")},
+				"livebasetip": {treeEntry("schemas", "schematree_new")},
+			},
+			compareFiles: map[string][]*gh.CommitFile{
+				"mergebase...livebasetip": {
+					{Filename: new("schemas/orders.sql"), Status: new("modified")},
+				},
+			},
+		})
+		changed, files, err := ic.SchemaDirChangedOnBase(t.Context(), "octo/repo", "main", headSHA, "schemas")
+		require.NoError(t, err)
+		assert.True(t, changed, "drift on the live base tip must be detected")
+		assert.Equal(t, []string{"schemas/orders.sql"}, files)
+	})
+
+	t.Run("missing base commit is an error so callers fail closed", func(t *testing.T) {
+		// A compare response with a merge base but no base_commit leaves the live
+		// base tip unknown; the gate must fail closed rather than guess.
+		ic := newBaseDriftClient(t, baseDriftFixture{mergeBase: "mergebase", omitBaseCommit: true})
+		_, _, err := ic.SchemaDirChangedOnBase(t.Context(), "octo/repo", "main", headSHA, "schemas")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no base commit")
 	})
 
 	t.Run("schema dir changed on base lists changed files", func(t *testing.T) {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -283,6 +283,34 @@ func RecordStalePlanRejected(ctx context.Context, environment string) {
 	)
 }
 
+// knownAutoApplyDowngradeReasons limits metric cardinality on the
+// schemabot.auto_apply.downgraded counter to the reasons an automatic apply is
+// downgraded to manual confirmation before it is queued.
+var knownAutoApplyDowngradeReasons = map[string]bool{
+	"base_drift":            true,
+	"base_drift_unverified": true,
+	"plan_load_failed":      true,
+}
+
+// RecordAutoApplyDowngrade increments the counter for automatic applies
+// downgraded to manual confirmation before the apply was queued. reason is
+// base_drift (the schema dir changed on base), base_drift_unverified (the
+// base-drift check could not be completed and failed closed), or
+// plan_load_failed (the stored plan could not be loaded for DDL comparison).
+// A spike in base_drift_unverified points at a GitHub API degradation
+// downgrading applies fleet-wide; base_drift tracks how often base advances
+// under reviewed plans; plan_load_failed points at storage trouble.
+func RecordAutoApplyDowngrade(ctx context.Context, reason, environment string) {
+	if !knownAutoApplyDowngradeReasons[reason] {
+		reason = "unknown"
+	}
+	addCounter(ctx, "schemabot.auto_apply.downgraded.total",
+		"Automatic applies downgraded to manual confirmation before being queued", "{downgrade}",
+		attribute.String("reason", reason),
+		EnvironmentAttribute(environment),
+	)
+}
+
 // RecordTransientPlanRetry increments the counter for webhook plan retries
 // after transient remote deployment unavailability. A spike with
 // outcome="exhausted" for one environment means the network path to that

--- a/pkg/webhook/apply_base_drift_integration_test.go
+++ b/pkg/webhook/apply_base_drift_integration_test.go
@@ -43,8 +43,15 @@ func TestE2EApplyDowngradesWhenBaseSchemaChanged(t *testing.T) {
 
 	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
 	// Base advanced past the PR's fork point (distinct merge base) and the
-	// change touched the resolved schema directory.
+	// change touched the resolved schema directory: the merge base serves a
+	// different users.sql than the base tip, so the content-addressed schema
+	// subtree SHA genuinely differs and the gate detects drift.
 	result.MergeBaseSHA = "mergebase111"
+	result.TreeContentByCommit = map[string]map[string]string{
+		"mergebase111": {
+			"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+		},
+	}
 	result.BaseDriftChangedFiles = []string{"schema/orders.sql"}
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
@@ -74,7 +81,7 @@ func TestE2EApplyDowngradesWhenBaseSchemaChanged(t *testing.T) {
 		assert.Contains(t, body, "schema files changed on `main`")
 		assert.Contains(t, body, "`schema/orders.sql`")
 		assert.NotContains(t, body, "Applying automatically")
-	case <-time.After(30 * time.Second):
+	case <-time.After(webhookIntegrationPollDeadline):
 		t.Fatal("timed out waiting for base-drift downgrade comment")
 	}
 
@@ -84,7 +91,66 @@ func TestE2EApplyDowngradesWhenBaseSchemaChanged(t *testing.T) {
 		assert.Contains(t, cr.Name, "SchemaBot")
 		assert.Equal(t, "completed", cr.Status)
 		assert.Equal(t, "action_required", cr.Conclusion)
-	case <-time.After(10 * time.Second):
+	case <-time.After(webhookIntegrationCheckRunDeadline):
 		t.Fatal("timed out waiting for check run")
+	}
+}
+
+// TestE2EApplyProceedsWhenBaseAdvancedButSchemaUnchanged exercises the
+// path-scoped nature of the base-branch drift gate: when the base branch
+// advanced past the PR's fork point (a distinct merge base and base tip) but the
+// resolved schema directory is byte-identical at the merge base and the base
+// tip, automatic apply proceeds. The gate must not downgrade merely because the
+// branch is behind base on unrelated files.
+func TestE2EApplyProceedsWhenBaseAdvancedButSchemaUnchanged(t *testing.T) {
+	dbName := "webhook_apply_base_no_drift"
+	svc := setupE2EService(t, dbName)
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+
+	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
+	// Base advanced (distinct merge base and base tip) but no per-commit content
+	// override, so the merge base and base tip serve byte-identical schema
+	// content: the content-addressed schema subtree SHAs match and the gate
+	// reports no drift.
+	result.MergeBaseSHA = "mergebase222"
+	result.BaseTipSHA = "basetip333"
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	installClient := ghclient.NewInstallationClient(client, logger)
+	factory := &fakeClientFactory{client: installClient}
+
+	h := NewHandler(svc, factory, nil, logger)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot apply -e staging",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	t.Cleanup(func() {
+		_ = svc.Storage().Locks().ForceRelease(context.WithoutCancel(t.Context()), dbName, "mysql")
+	})
+
+	select {
+	case body := <-result.comments:
+		assert.NotContains(t, body, "Automatic apply paused",
+			"base advanced on unrelated files must not downgrade automatic apply")
+		assert.Contains(t, body, "Applying automatically")
+	case <-time.After(webhookIntegrationPollDeadline):
+		t.Fatal("timed out waiting for automatic apply plan comment")
 	}
 }

--- a/pkg/webhook/apply_base_drift_integration_test.go
+++ b/pkg/webhook/apply_base_drift_integration_test.go
@@ -1,0 +1,90 @@
+//go:build integration
+
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	gh "github.com/google/go-github/v86/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ghclient "github.com/block/schemabot/pkg/github"
+)
+
+// TestE2EApplyDowngradesWhenBaseSchemaChanged exercises the base-branch drift
+// gate: when the schema directory changed on the base branch since the PR
+// diverged, automatic apply is downgraded to manual confirmation — the plan
+// comment names the changed base files and tells the operator to update the
+// branch or run apply-confirm, and nothing is applied automatically.
+func TestE2EApplyDowngradesWhenBaseSchemaChanged(t *testing.T) {
+	dbName := "webhook_apply_base_drift"
+	svc := setupE2EService(t, dbName)
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+
+	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
+	// Base advanced past the PR's fork point (distinct merge base) and the
+	// change touched the resolved schema directory.
+	result.MergeBaseSHA = "mergebase111"
+	result.BaseDriftChangedFiles = []string{"schema/orders.sql"}
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	installClient := ghclient.NewInstallationClient(client, logger)
+	factory := &fakeClientFactory{client: installClient}
+
+	h := NewHandler(svc, factory, nil, logger)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot apply -e staging",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// The lock is acquired during the downgrade path; release it so it doesn't
+	// leak to other tests sharing the same PR.
+	t.Cleanup(func() {
+		_ = svc.Storage().Locks().ForceRelease(context.WithoutCancel(t.Context()), dbName, "mysql")
+	})
+
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "Automatic apply paused")
+		assert.Contains(t, body, "schema files changed on `main`")
+		assert.Contains(t, body, "`schema/orders.sql`")
+		assert.NotContains(t, body, "Applying automatically")
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for base-drift downgrade comment")
+	}
+
+	// The apply plan check is recorded as action_required, like other downgrades.
+	select {
+	case cr := <-result.checkRuns:
+		assert.Contains(t, cr.Name, "SchemaBot")
+		assert.Equal(t, "completed", cr.Status)
+		assert.Equal(t, "action_required", cr.Conclusion)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for check run")
+	}
+}

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/block/schemabot/pkg/api"
+	"github.com/block/schemabot/pkg/apitypes"
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
@@ -267,6 +268,30 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		return
 	}
 
+	// Base-branch drift gate: if the schema directory changed on the base
+	// branch since this PR diverged, the plan may no longer reflect the base
+	// it will apply against. Downgrade automatic apply to manual confirmation
+	// so the operator reviews it. The lock stays held so apply-confirm can
+	// proceed. apply-confirm (the deliberate override) does not run this gate.
+	// Repositories can disable it via RequireUpToDateWithBase. Fail closed:
+	// any uncertainty downgrades rather than auto-applying against an
+	// unverified base.
+	if h.service.Config().RequiresUpToDateWithBase(repo) {
+		changed, changedFiles, driftErr := client.SchemaDirChangedOnBase(ctx, repo, prInfo.BaseSHA, prInfo.HeadSHA, schemaResult.SchemaPath)
+		switch {
+		case driftErr != nil:
+			h.logger.Warn("automatic apply downgraded: could not verify branch is current with base",
+				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "environment", environment, "schema_path", schemaResult.SchemaPath, "error", driftErr)
+			h.postAutoApplyDowngrade(ctx, client, repo, pr, installationID, schemaResult, planResp, environment, commentData, baseDriftUnknownDowngradeReason(prInfo.BaseRef))
+			return
+		case changed:
+			h.logger.Info("automatic apply downgraded: schema directory changed on base branch",
+				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "environment", environment, "schema_path", schemaResult.SchemaPath, "base_ref", prInfo.BaseRef, "changed_file_count", len(changedFiles))
+			h.postAutoApplyDowngrade(ctx, client, repo, pr, installationID, schemaResult, planResp, environment, commentData, baseDriftDowngradeReason(prInfo.BaseRef, changedFiles))
+			return
+		}
+	}
+
 	// Look up the plan we just created for DDL comparison in executeApply.
 	// Fail closed: if we can't load the plan, downgrade to manual confirmation
 	// rather than skipping the DDL drift check entirely.
@@ -274,15 +299,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	if planErr != nil || storedPlan == nil {
 		h.logger.Info("automatic apply downgraded: could not load plan for DDL comparison",
 			"repo", repo, "pr", pr, "planID", planResp.PlanID, "error", planErr)
-		commentData.AutoConfirmDowngradeReason = "Could not verify plan — confirm manually"
-		h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
-		headSHA, checkRunErr := h.storeApplyPlanCheckRecord(ctx, client, repo, pr, schemaResult, planResp, environment)
-		if checkRunErr != nil {
-			h.logger.Error("failed to create apply plan check run", "repo", repo, "pr", pr, "error", checkRunErr)
-		}
-		if headSHA != "" {
-			h.updateAggregateCheck(ctx, client, repo, pr, headSHA)
-		}
+		h.postAutoApplyDowngrade(ctx, client, repo, pr, installationID, schemaResult, planResp, environment, commentData, "Could not verify plan — confirm manually")
 		return
 	}
 
@@ -297,6 +314,27 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 
 	// Check 2 (DDL drift) happens inside executeApply after re-plan
 	h.executeApply(ctx, client, repo, pr, schemaResult, environment, installationID, requestedBy, result, storedPlan)
+}
+
+// postAutoApplyDowngrade is the shared tail for automatic-apply downgrades that
+// happen before the apply is queued (base drift, plan-load failure). It posts
+// the manual-confirmation plan comment and records the apply plan check,
+// leaving the lock held so the operator can review and run apply-confirm.
+func (h *Handler) postAutoApplyDowngrade(
+	ctx context.Context, client *ghclient.InstallationClient,
+	repo string, pr int, installationID int64,
+	schemaResult *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse,
+	environment string, commentData templates.PlanCommentData, reason string,
+) {
+	commentData.AutoConfirmDowngradeReason = reason
+	h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
+	headSHA, checkErr := h.storeApplyPlanCheckRecord(ctx, client, repo, pr, schemaResult, planResp, environment)
+	if checkErr != nil {
+		h.logger.Error("failed to create apply plan check run", "repo", repo, "pr", pr, "error", checkErr)
+	}
+	if headSHA != "" {
+		h.updateAggregateCheck(ctx, client, repo, pr, headSHA)
+	}
 }
 
 // handleApplyConfirmCommand handles the "schemabot apply-confirm -e <env>" PR comment command.

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/block/schemabot/pkg/api"
 	"github.com/block/schemabot/pkg/apitypes"
 	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/metrics"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/webhook/action"
@@ -277,17 +278,17 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	// any uncertainty downgrades rather than auto-applying against an
 	// unverified base.
 	if h.service.Config().RequiresUpToDateWithBase(repo) {
-		changed, changedFiles, driftErr := client.SchemaDirChangedOnBase(ctx, repo, prInfo.BaseSHA, prInfo.HeadSHA, schemaResult.SchemaPath)
+		changed, changedFiles, driftErr := client.SchemaDirChangedOnBase(ctx, repo, prInfo.BaseRef, prInfo.HeadSHA, schemaResult.SchemaPath)
 		switch {
 		case driftErr != nil:
 			h.logger.Warn("automatic apply downgraded: could not verify branch is current with base",
 				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "environment", environment, "schema_path", schemaResult.SchemaPath, "error", driftErr)
-			h.postAutoApplyDowngrade(ctx, client, repo, pr, installationID, schemaResult, planResp, environment, commentData, baseDriftUnknownDowngradeReason(prInfo.BaseRef))
+			h.postAutoApplyDowngrade(ctx, client, repo, pr, installationID, schemaResult, planResp, environment, commentData, "base_drift_unverified", baseDriftUnknownDowngradeReason(prInfo.BaseRef))
 			return
 		case changed:
 			h.logger.Info("automatic apply downgraded: schema directory changed on base branch",
 				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "environment", environment, "schema_path", schemaResult.SchemaPath, "base_ref", prInfo.BaseRef, "changed_file_count", len(changedFiles))
-			h.postAutoApplyDowngrade(ctx, client, repo, pr, installationID, schemaResult, planResp, environment, commentData, baseDriftDowngradeReason(prInfo.BaseRef, changedFiles))
+			h.postAutoApplyDowngrade(ctx, client, repo, pr, installationID, schemaResult, planResp, environment, commentData, "base_drift", baseDriftDowngradeReason(prInfo.BaseRef, changedFiles))
 			return
 		}
 	}
@@ -299,7 +300,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	if planErr != nil || storedPlan == nil {
 		h.logger.Info("automatic apply downgraded: could not load plan for DDL comparison",
 			"repo", repo, "pr", pr, "planID", planResp.PlanID, "error", planErr)
-		h.postAutoApplyDowngrade(ctx, client, repo, pr, installationID, schemaResult, planResp, environment, commentData, "Could not verify plan — confirm manually")
+		h.postAutoApplyDowngrade(ctx, client, repo, pr, installationID, schemaResult, planResp, environment, commentData, "plan_load_failed", "Could not verify plan — confirm manually")
 		return
 	}
 
@@ -317,15 +318,19 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 }
 
 // postAutoApplyDowngrade is the shared tail for automatic-apply downgrades that
-// happen before the apply is queued (base drift, plan-load failure). It posts
-// the manual-confirmation plan comment and records the apply plan check,
-// leaving the lock held so the operator can review and run apply-confirm.
+// happen before the apply is queued (base drift, plan-load failure). It records
+// the downgrade metric, posts the manual-confirmation plan comment, and records
+// the apply plan check, leaving the lock held so the operator can review and run
+// apply-confirm. metricReason is the low-cardinality label for the downgrade
+// counter (see metrics.RecordAutoApplyDowngrade); reason is the operator-facing
+// comment text.
 func (h *Handler) postAutoApplyDowngrade(
 	ctx context.Context, client *ghclient.InstallationClient,
 	repo string, pr int, installationID int64,
 	schemaResult *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse,
-	environment string, commentData templates.PlanCommentData, reason string,
+	environment string, commentData templates.PlanCommentData, metricReason, reason string,
 ) {
+	metrics.RecordAutoApplyDowngrade(ctx, metricReason, environment)
 	commentData.AutoConfirmDowngradeReason = reason
 	h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
 	headSHA, checkErr := h.storeApplyPlanCheckRecord(ctx, client, repo, pr, schemaResult, planResp, environment)

--- a/pkg/webhook/base_drift_downgrade.go
+++ b/pkg/webhook/base_drift_downgrade.go
@@ -1,0 +1,55 @@
+package webhook
+
+import (
+	"fmt"
+	"strings"
+)
+
+// maxBaseDriftFilesShown caps how many changed base files the downgrade comment
+// lists so a large base change cannot push the PR comment past GitHub's size
+// limit and hide the confirmation instructions.
+const maxBaseDriftFilesShown = 10
+
+// baseDriftDowngradeReason builds the AutoConfirmDowngradeReason shown when
+// automatic apply is paused because the schema directory changed on the base
+// branch since the PR diverged. changedFiles may be empty when the specific
+// files could not be listed; the reason still tells the operator what to do.
+func baseDriftDowngradeReason(baseRef string, changedFiles []string) string {
+	base := baseRef
+	if base == "" {
+		base = "the base branch"
+	} else {
+		base = "`" + base + "`"
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "the schema files changed on %s since this branch diverged, so this plan may not reflect the current base. Update the branch and re-run apply, or review the plan below and run apply-confirm to apply it as-is.", base)
+
+	if len(changedFiles) > 0 {
+		fmt.Fprintf(&b, "\n\nChanged on %s:", base)
+		shown := changedFiles
+		if len(shown) > maxBaseDriftFilesShown {
+			shown = shown[:maxBaseDriftFilesShown]
+		}
+		for _, f := range shown {
+			fmt.Fprintf(&b, "\n- `%s`", f)
+		}
+		if remaining := len(changedFiles) - len(shown); remaining > 0 {
+			fmt.Fprintf(&b, "\n- …and %d more", remaining)
+		}
+	}
+	return b.String()
+}
+
+// baseDriftUnknownDowngradeReason is shown when SchemaBot could not determine
+// whether the base branch changed the schema directory. It fails closed to
+// manual confirmation rather than auto-applying against an unverified base.
+func baseDriftUnknownDowngradeReason(baseRef string) string {
+	base := baseRef
+	if base == "" {
+		base = "the base branch"
+	} else {
+		base = "`" + base + "`"
+	}
+	return fmt.Sprintf("SchemaBot could not verify that this branch is current with %s. Update the branch and re-run apply, or review the plan below and run apply-confirm to apply it as-is.", base)
+}

--- a/pkg/webhook/base_drift_downgrade_test.go
+++ b/pkg/webhook/base_drift_downgrade_test.go
@@ -1,0 +1,45 @@
+package webhook
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBaseDriftDowngradeReason(t *testing.T) {
+	t.Run("lists changed files under the base ref", func(t *testing.T) {
+		reason := baseDriftDowngradeReason("main", []string{"schema/orders.sql", "schema/users.sql"})
+		assert.Contains(t, reason, "`main`")
+		assert.Contains(t, reason, "apply-confirm")
+		assert.Contains(t, reason, "- `schema/orders.sql`")
+		assert.Contains(t, reason, "- `schema/users.sql`")
+	})
+
+	t.Run("omits the file list when none were resolved", func(t *testing.T) {
+		reason := baseDriftDowngradeReason("main", nil)
+		assert.Contains(t, reason, "`main`")
+		assert.NotContains(t, reason, "Changed on")
+	})
+
+	t.Run("caps the displayed file list", func(t *testing.T) {
+		files := make([]string, 0, maxBaseDriftFilesShown+5)
+		for range cap(files) {
+			files = append(files, "schema/table.sql")
+		}
+		reason := baseDriftDowngradeReason("main", files)
+		assert.Equal(t, maxBaseDriftFilesShown, strings.Count(reason, "- `schema/table.sql`"))
+		assert.Contains(t, reason, "…and 5 more")
+	})
+
+	t.Run("falls back to a generic base name when the ref is empty", func(t *testing.T) {
+		reason := baseDriftDowngradeReason("", nil)
+		assert.Contains(t, reason, "the base branch")
+	})
+}
+
+func TestBaseDriftUnknownDowngradeReason(t *testing.T) {
+	assert.Contains(t, baseDriftUnknownDowngradeReason("main"), "could not verify")
+	assert.Contains(t, baseDriftUnknownDowngradeReason("main"), "`main`")
+	assert.Contains(t, baseDriftUnknownDowngradeReason(""), "the base branch")
+}

--- a/pkg/webhook/webhook_integration_test.go
+++ b/pkg/webhook/webhook_integration_test.go
@@ -71,6 +71,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -309,9 +310,16 @@ type planFlowResult struct {
 	// MergeBaseSHA drives the base-branch drift gate's compare response. Empty
 	// (the default) makes the merge base equal the compare base, so the gate
 	// sees no base advance and every existing automatic-apply test proceeds
-	// unchanged. A drift test sets it to a distinct SHA (and provides differing
-	// schema-dir trees) to exercise the manual-confirm downgrade.
+	// unchanged. A drift test sets it to a distinct SHA; because the shallow
+	// tree server salts directory tree SHAs with the commit SHA, a distinct
+	// merge base makes the schema subtree differ from the base and triggers the
+	// manual-confirm downgrade.
 	MergeBaseSHA string
+
+	// BaseDriftChangedFiles are the files a compare returns, so a drift test can
+	// assert the downgrade comment lists them. They should live under the
+	// resolved schema directory to survive the gate's path filter.
+	BaseDriftChangedFiles []string
 }
 
 func (p *planFlowResult) nextHeadSHA() string {
@@ -362,6 +370,95 @@ func setupFakeGitHubForPlan(t *testing.T, mux *http.ServeMux, schemaSQL map[stri
 	return setupFakeGitHubForPlanWithPRFiles(t, mux, schemaSQL, schemabotConfig, ns, nil)
 }
 
+// shallowChild is one entry in a single directory level of a fake git tree.
+type shallowChild struct {
+	name string
+	typ  string // "tree" or "blob"
+	sha  string // blob SHA (only meaningful for blobs)
+}
+
+// serveShallowTree serves a single-level (non-recursive) git tree for a GetTree
+// request, resolved from the flat recursive treeEntries. Directory tree SHAs are
+// encoded as "tree|<commit>|<dirPath>" so that (a) successive shallow fetches
+// can walk into subdirectories, and (b) the same directory reports a different
+// tree SHA at a different commit — which is what lets the base-branch drift gate
+// detect that the schema subtree changed between the merge base and the base.
+// The root fetch uses the commit SHA directly as the requested tree SHA.
+func serveShallowTree(w http.ResponseWriter, requestedSHA string, treeEntries []*gh.TreeEntry) {
+	commit, dir := parseShallowTreeSHA(requestedSHA)
+	var entries []*gh.TreeEntry
+	for _, c := range shallowChildren(treeEntries, dir) {
+		if c.typ == "tree" {
+			childDir := c.name
+			if dir != "" {
+				childDir = dir + "/" + c.name
+			}
+			entries = append(entries, &gh.TreeEntry{
+				Path: new(c.name),
+				Mode: new("040000"),
+				Type: new("tree"),
+				SHA:  new("tree|" + commit + "|" + childDir),
+			})
+			continue
+		}
+		entries = append(entries, &gh.TreeEntry{
+			Path: new(c.name),
+			Mode: new("100644"),
+			Type: new("blob"),
+			SHA:  new(c.sha),
+		})
+	}
+	_ = json.NewEncoder(w).Encode(gh.Tree{SHA: &requestedSHA, Entries: entries, Truncated: new(false)})
+}
+
+// parseShallowTreeSHA decodes a requested tree SHA into the commit it belongs to
+// and the directory path it represents. A synthetic directory SHA has the form
+// "tree|<commit>|<dir>"; any other value is a root commit SHA (empty dir).
+func parseShallowTreeSHA(requestedSHA string) (commit, dir string) {
+	if parts := strings.SplitN(requestedSHA, "|", 3); len(parts) == 3 && parts[0] == "tree" {
+		return parts[1], parts[2]
+	}
+	return requestedSHA, ""
+}
+
+// shallowChildren returns the immediate children of dir (empty dir = root),
+// derived from the flat recursive treeEntries, sorted by name. A name with
+// descendants is a "tree"; otherwise it carries the entry's blob SHA.
+func shallowChildren(treeEntries []*gh.TreeEntry, dir string) []shallowChild {
+	byName := make(map[string]shallowChild)
+	prefix := ""
+	if dir != "" {
+		prefix = dir + "/"
+	}
+	for _, e := range treeEntries {
+		p := e.GetPath()
+		if prefix != "" {
+			if !strings.HasPrefix(p, prefix) {
+				continue
+			}
+			p = p[len(prefix):]
+		}
+		if p == "" {
+			continue
+		}
+		first, rest, hasRest := strings.Cut(p, "/")
+		if hasRest && rest != "" {
+			byName[first] = shallowChild{name: first, typ: "tree"}
+			continue
+		}
+		// A leaf directly under dir keeps its actual type and blob SHA.
+		if _, exists := byName[first]; !exists {
+			byName[first] = shallowChild{name: first, typ: e.GetType(), sha: e.GetSHA()}
+		}
+	}
+	children := make([]shallowChild, 0, len(byName))
+	for _, c := range byName {
+		children = append(children, c)
+	}
+	slices.SortFunc(children, func(a, b shallowChild) int { return strings.Compare(a.name, b.name) })
+	return children
+}
+
 func setupFakeGitHubForPlanWithPRFiles(t *testing.T, mux *http.ServeMux, schemaSQL map[string]string, schemabotConfig, ns string, prFiles []*gh.CommitFile) *planFlowResult {
 	t.Helper()
 
@@ -404,9 +501,13 @@ func setupFakeGitHubForPlanWithPRFiles(t *testing.T, mux *http.ServeMux, schemaS
 		if result.MergeBaseSHA != "" {
 			mergeBase = result.MergeBaseSHA
 		}
-		_ = json.NewEncoder(w).Encode(gh.CommitsComparison{
+		cmp := gh.CommitsComparison{
 			MergeBaseCommit: &gh.RepositoryCommit{SHA: &mergeBase},
-		})
+		}
+		for _, f := range result.BaseDriftChangedFiles {
+			cmp.Files = append(cmp.Files, &gh.CommitFile{Filename: new(f), Status: new("modified")})
+		}
+		_ = json.NewEncoder(w).Encode(cmp)
 	})
 
 	// PR changed files — report schema files changed (in namespace subdir)
@@ -471,11 +572,19 @@ func setupFakeGitHubForPlanWithPRFiles(t *testing.T, mux *http.ServeMux, schemaS
 	})
 	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/", func(w http.ResponseWriter, r *http.Request) {
 		sha := r.URL.Path[len("/repos/octocat/hello-world/git/trees/"):]
-		_ = json.NewEncoder(w).Encode(gh.Tree{
-			SHA:       &sha,
-			Entries:   treeEntries,
-			Truncated: new(false),
-		})
+		// Recursive fetches (schema discovery) get the flat whole-tree listing.
+		// Non-recursive fetches (the base-branch drift gate's per-level path
+		// resolution) get a faithful single-level tree so the gate can walk into
+		// the schema directory and compare its subtree SHA across commits.
+		if r.URL.Query().Get("recursive") == "1" {
+			_ = json.NewEncoder(w).Encode(gh.Tree{
+				SHA:       &sha,
+				Entries:   treeEntries,
+				Truncated: new(false),
+			})
+			return
+		}
+		serveShallowTree(w, sha, treeEntries)
 	})
 
 	// Blob content

--- a/pkg/webhook/webhook_integration_test.go
+++ b/pkg/webhook/webhook_integration_test.go
@@ -305,6 +305,13 @@ type planFlowResult struct {
 	// before issuing the webhook request. Nil preserves the default
 	// "no checks → passing" behavior.
 	CheckStatusNodes atomic.Pointer[func() []checkStatusNode]
+
+	// MergeBaseSHA drives the base-branch drift gate's compare response. Empty
+	// (the default) makes the merge base equal the compare base, so the gate
+	// sees no base advance and every existing automatic-apply test proceeds
+	// unchanged. A drift test sets it to a distinct SHA (and provides differing
+	// schema-dir trees) to exercise the manual-confirm downgrade.
+	MergeBaseSHA string
 }
 
 func (p *planFlowResult) nextHeadSHA() string {
@@ -378,6 +385,27 @@ func setupFakeGitHubForPlanWithPRFiles(t *testing.T, mux *http.ServeMux, schemaS
 				SHA: new("def456"),
 			},
 			User: &gh.User{Login: new("testuser")},
+		})
+	})
+
+	// Compare commits — used by the base-branch drift gate to resolve the merge
+	// base of base...head. By default the merge base equals the compare base
+	// (result.MergeBaseSHA empty), so the gate concludes the base has not
+	// advanced and automatic apply proceeds. The changed-files list for a
+	// mergeBase...base compare is served for drift tests that set MergeBaseSHA.
+	mux.HandleFunc("GET /repos/octocat/hello-world/compare/{basehead}", func(w http.ResponseWriter, r *http.Request) {
+		basehead := r.PathValue("basehead")
+		parts := strings.SplitN(basehead, "...", 2)
+		base := ""
+		if len(parts) == 2 {
+			base = parts[0]
+		}
+		mergeBase := base
+		if result.MergeBaseSHA != "" {
+			mergeBase = result.MergeBaseSHA
+		}
+		_ = json.NewEncoder(w).Encode(gh.CommitsComparison{
+			MergeBaseCommit: &gh.RepositoryCommit{SHA: &mergeBase},
 		})
 	})
 

--- a/pkg/webhook/webhook_integration_test.go
+++ b/pkg/webhook/webhook_integration_test.go
@@ -61,18 +61,22 @@ package webhook
 
 import (
 	"context"
+	"crypto/sha1"
 	"database/sql"
 	"embed"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log"
 	"log/slog"
+	"maps"
 	"net/http"
 	"os"
 	"os/exec"
 	"slices"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -308,18 +312,30 @@ type planFlowResult struct {
 	CheckStatusNodes atomic.Pointer[func() []checkStatusNode]
 
 	// MergeBaseSHA drives the base-branch drift gate's compare response. Empty
-	// (the default) makes the merge base equal the compare base, so the gate
-	// sees no base advance and every existing automatic-apply test proceeds
-	// unchanged. A drift test sets it to a distinct SHA; because the shallow
-	// tree server salts directory tree SHAs with the commit SHA, a distinct
-	// merge base makes the schema subtree differ from the base and triggers the
-	// manual-confirm downgrade.
+	// (the default) makes the merge base equal the resolved base tip, so the
+	// gate sees no base advance and every existing automatic-apply test proceeds
+	// unchanged. A drift test sets it to a distinct SHA so the gate walks the
+	// schema subtree at the merge base and the base tip.
 	MergeBaseSHA string
+
+	// BaseTipSHA is the live base tip the compare returns as base_commit.sha —
+	// what the gate resolves the base ref to. Empty defaults to the compare's
+	// base path segment (the ref name), which equals the default merge base, so
+	// the gate short-circuits with no drift. A drift test sets a distinct value
+	// so the merge base and base tip differ.
+	BaseTipSHA string
 
 	// BaseDriftChangedFiles are the files a compare returns, so a drift test can
 	// assert the downgrade comment lists them. They should live under the
 	// resolved schema directory to survive the gate's path filter.
 	BaseDriftChangedFiles []string
+
+	// TreeContentByCommit overrides the schema files served for specific commits
+	// (typically the merge base). Commits absent from the map use the default
+	// schema files. Because tree SHAs are content-addressed, this is what lets a
+	// base-drift test make the schema subtree genuinely differ (drift) or stay
+	// identical (base advanced elsewhere) between the merge base and base tip.
+	TreeContentByCommit map[string]map[string]string
 }
 
 func (p *planFlowResult) nextHeadSHA() string {
@@ -377,48 +393,99 @@ type shallowChild struct {
 	sha  string // blob SHA (only meaningful for blobs)
 }
 
-// serveShallowTree serves a single-level (non-recursive) git tree for a GetTree
-// request, resolved from the flat recursive treeEntries. Directory tree SHAs are
-// encoded as "tree|<commit>|<dirPath>" so that (a) successive shallow fetches
-// can walk into subdirectories, and (b) the same directory reports a different
-// tree SHA at a different commit — which is what lets the base-branch drift gate
-// detect that the schema subtree changed between the merge base and the base.
-// The root fetch uses the commit SHA directly as the requested tree SHA.
-func serveShallowTree(w http.ResponseWriter, requestedSHA string, treeEntries []*gh.TreeEntry) {
-	commit, dir := parseShallowTreeSHA(requestedSHA)
-	var entries []*gh.TreeEntry
-	for _, c := range shallowChildren(treeEntries, dir) {
-		if c.typ == "tree" {
+// contentTreeSHA hashes a directory's immediate children (each child's name,
+// type, and child SHA) into a content-addressed tree SHA. Identical directory
+// contents therefore yield an identical SHA regardless of which commit they
+// appear in — the git property that lets the base-branch drift gate distinguish
+// "the schema subtree actually changed" (different content → different SHA) from
+// "the base advanced elsewhere" (same content → same SHA).
+func contentTreeSHA(children []*gh.TreeEntry) string {
+	var b strings.Builder
+	for _, c := range children {
+		fmt.Fprintf(&b, "%s\x00%s\x00%s\n", c.GetPath(), c.GetType(), c.GetSHA())
+	}
+	sum := sha1.Sum([]byte(b.String()))
+	return "tree:" + hex.EncodeToString(sum[:])
+}
+
+// buildContentTree walks the flat recursive treeEntries and returns the root
+// directory's immediate children (with content-addressed tree SHAs) plus an
+// index from every directory's content SHA to its children. The index lets a
+// per-level shallow fetch resolve a content SHA into its children without
+// knowing which commit produced it, since content SHAs are content-addressed.
+func buildContentTree(treeEntries []*gh.TreeEntry) (root []*gh.TreeEntry, index map[string][]*gh.TreeEntry) {
+	index = map[string][]*gh.TreeEntry{}
+	var walk func(dir string) []*gh.TreeEntry
+	walk = func(dir string) []*gh.TreeEntry {
+		var out []*gh.TreeEntry
+		for _, c := range shallowChildren(treeEntries, dir) {
+			if c.typ != "tree" {
+				out = append(out, &gh.TreeEntry{
+					Path: new(c.name),
+					Mode: new("100644"),
+					Type: new("blob"),
+					SHA:  new(c.sha),
+				})
+				continue
+			}
 			childDir := c.name
 			if dir != "" {
 				childDir = dir + "/" + c.name
 			}
-			entries = append(entries, &gh.TreeEntry{
+			childChildren := walk(childDir)
+			sha := contentTreeSHA(childChildren)
+			index[sha] = childChildren
+			out = append(out, &gh.TreeEntry{
 				Path: new(c.name),
 				Mode: new("040000"),
 				Type: new("tree"),
-				SHA:  new("tree|" + commit + "|" + childDir),
+				SHA:  new(sha),
 			})
-			continue
 		}
-		entries = append(entries, &gh.TreeEntry{
-			Path: new(c.name),
-			Mode: new("100644"),
-			Type: new("blob"),
-			SHA:  new(c.sha),
-		})
+		return out
 	}
-	_ = json.NewEncoder(w).Encode(gh.Tree{SHA: &requestedSHA, Entries: entries, Truncated: new(false)})
+	root = walk("")
+	return root, index
 }
 
-// parseShallowTreeSHA decodes a requested tree SHA into the commit it belongs to
-// and the directory path it represents. A synthetic directory SHA has the form
-// "tree|<commit>|<dir>"; any other value is a root commit SHA (empty dir).
-func parseShallowTreeSHA(requestedSHA string) (commit, dir string) {
-	if parts := strings.SplitN(requestedSHA, "|", 3); len(parts) == 3 && parts[0] == "tree" {
-		return parts[1], parts[2]
+// blobSHAForContent returns a content-addressed blob SHA so identical file
+// content yields an identical blob SHA (and therefore identical enclosing tree
+// SHAs) regardless of which commit it appears in.
+func blobSHAForContent(content string) string {
+	sum := sha1.Sum([]byte(content))
+	return "blob:" + hex.EncodeToString(sum[:])
+}
+
+// buildSchemaTreeEntries builds a flat recursive git tree listing (and its blob
+// content map) for schemaSQL under schema/<ns>/ plus an optional
+// schema/schemabot.yaml config. Names are emitted in sorted order so the listing
+// is deterministic across runs.
+func buildSchemaTreeEntries(schemaSQL map[string]string, schemabotConfig, ns string) ([]*gh.TreeEntry, map[string]string) {
+	var treeEntries []*gh.TreeEntry
+	blobContents := map[string]string{}
+	add := func(pth, content string) {
+		sha := blobSHAForContent(content)
+		blobContents[sha] = content
+		treeEntries = append(treeEntries, &gh.TreeEntry{
+			Path: new(pth),
+			Mode: new("100644"),
+			Type: new("blob"),
+			SHA:  new(sha),
+			Size: new(len(content)),
+		})
 	}
-	return requestedSHA, ""
+	if schemabotConfig != "" {
+		add("schema/schemabot.yaml", schemabotConfig)
+	}
+	names := make([]string, 0, len(schemaSQL))
+	for name := range schemaSQL {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	for _, name := range names {
+		add("schema/"+ns+"/"+name, schemaSQL[name])
+	}
+	return treeEntries, blobContents
 }
 
 // shallowChildren returns the immediate children of dir (empty dir = root),
@@ -486,10 +553,13 @@ func setupFakeGitHubForPlanWithPRFiles(t *testing.T, mux *http.ServeMux, schemaS
 	})
 
 	// Compare commits — used by the base-branch drift gate to resolve the merge
-	// base of base...head. By default the merge base equals the compare base
-	// (result.MergeBaseSHA empty), so the gate concludes the base has not
-	// advanced and automatic apply proceeds. The changed-files list for a
-	// mergeBase...base compare is served for drift tests that set MergeBaseSHA.
+	// base of baseRef...head and the live base tip (base_commit.sha). By default
+	// the base tip equals the merge base (both default to the base path segment,
+	// i.e. the ref name), so the gate concludes the base has not advanced and
+	// automatic apply proceeds. A drift test sets MergeBaseSHA and BaseTipSHA to
+	// distinct values so the gate walks the schema subtree at each. The
+	// changed-files list for a mergeBase...baseTip compare is served for drift
+	// tests via BaseDriftChangedFiles.
 	mux.HandleFunc("GET /repos/octocat/hello-world/compare/{basehead}", func(w http.ResponseWriter, r *http.Request) {
 		basehead := r.PathValue("basehead")
 		parts := strings.SplitN(basehead, "...", 2)
@@ -497,12 +567,17 @@ func setupFakeGitHubForPlanWithPRFiles(t *testing.T, mux *http.ServeMux, schemaS
 		if len(parts) == 2 {
 			base = parts[0]
 		}
-		mergeBase := base
+		baseTip := base
+		if result.BaseTipSHA != "" {
+			baseTip = result.BaseTipSHA
+		}
+		mergeBase := baseTip
 		if result.MergeBaseSHA != "" {
 			mergeBase = result.MergeBaseSHA
 		}
 		cmp := gh.CommitsComparison{
 			MergeBaseCommit: &gh.RepositoryCommit{SHA: &mergeBase},
+			BaseCommit:      &gh.RepositoryCommit{SHA: &baseTip},
 		}
 		for _, f := range result.BaseDriftChangedFiles {
 			cmp.Files = append(cmp.Files, &gh.CommitFile{Filename: new(f), Status: new("modified")})
@@ -526,65 +601,56 @@ func setupFakeGitHubForPlanWithPRFiles(t *testing.T, mux *http.ServeMux, schemaS
 		_ = json.NewEncoder(w).Encode(files)
 	})
 
-	// Build tree entries for all schema files + schemabot.yaml config
-	var treeEntries []*gh.TreeEntry
-	blobIndex := 0
-	blobContents := make(map[string]string) // sha -> content
+	// Build the default flat tree listing + blob contents for the schema files
+	// and schemabot.yaml config. Blob SHAs are content-addressed so identical
+	// content yields identical tree SHAs across commits (see buildContentTree).
+	treeEntries, blobContents := buildSchemaTreeEntries(schemaSQL, schemabotConfig, ns)
 
-	// schemabot.yaml config
-	if schemabotConfig != "" {
-		configSHA := "configsha001"
-		blobContents[configSHA] = schemabotConfig
-		treeEntries = append(treeEntries, &gh.TreeEntry{
-			Path: new("schema/schemabot.yaml"),
-			Mode: new("100644"),
-			Type: new("blob"),
-			SHA:  new(configSHA),
-			Size: new(len(schemabotConfig)),
-		})
+	// treeEntriesForCommit returns the flat tree for a commit, honoring
+	// per-commit schema-content overrides. A base-drift test sets an override on
+	// the merge base so its schema subtree genuinely differs from the base tip;
+	// commits without an override serve the default tree.
+	treeEntriesForCommit := func(commit string) []*gh.TreeEntry {
+		if override, ok := result.TreeContentByCommit[commit]; ok {
+			entries, _ := buildSchemaTreeEntries(override, schemabotConfig, ns)
+			return entries
+		}
+		return treeEntries
 	}
 
-	for name, content := range schemaSQL {
-		sha := fmt.Sprintf("blobsha%03d", blobIndex)
-		blobIndex++
-		blobContents[sha] = content
-		treeEntries = append(treeEntries, &gh.TreeEntry{
-			Path: new("schema/" + ns + "/" + name),
-			Mode: new("100644"),
-			Type: new("blob"),
-			SHA:  new(sha),
-			Size: new(len(content)),
-		})
-	}
+	// Content-addressed directory index, populated as commit root trees are
+	// served. The base-drift gate always fetches a commit's root tree before
+	// walking into subdirectories, so a later per-level fetch of a content SHA
+	// resolves against entries indexed by the earlier root fetch.
+	var treeIndexMu sync.Mutex
+	treeIndex := map[string][]*gh.TreeEntry{}
 
-	// Git tree (recursive). The exact-SHA handler preserves the historical
-	// "abc123" behavior for tests that only exercise one head; the prefix
-	// fallback serves the same tree for any other SHA so tests that simulate
-	// HEAD advancing (e.g. the cross-delivery freshness checks) don't need a
-	// custom fixture per SHA. Go 1.22 ServeMux gives precedence to the more
-	// specific exact path, so existing tests are unaffected.
-	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/abc123", func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(gh.Tree{
-			SHA:       new("abc123"),
-			Entries:   treeEntries,
-			Truncated: new(false),
-		})
-	})
 	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/", func(w http.ResponseWriter, r *http.Request) {
 		sha := r.URL.Path[len("/repos/octocat/hello-world/git/trees/"):]
 		// Recursive fetches (schema discovery) get the flat whole-tree listing.
-		// Non-recursive fetches (the base-branch drift gate's per-level path
-		// resolution) get a faithful single-level tree so the gate can walk into
-		// the schema directory and compare its subtree SHA across commits.
 		if r.URL.Query().Get("recursive") == "1" {
 			_ = json.NewEncoder(w).Encode(gh.Tree{
 				SHA:       &sha,
-				Entries:   treeEntries,
+				Entries:   treeEntriesForCommit(sha),
 				Truncated: new(false),
 			})
 			return
 		}
-		serveShallowTree(w, sha, treeEntries)
+		// Non-recursive (the base-drift gate's per-level path resolution): a
+		// content-addressed subtree SHA resolves via the index; any other value
+		// is a commit whose root tree is built and indexed on demand.
+		treeIndexMu.Lock()
+		children, indexed := treeIndex[sha]
+		treeIndexMu.Unlock()
+		if indexed {
+			_ = json.NewEncoder(w).Encode(gh.Tree{SHA: &sha, Entries: children, Truncated: new(false)})
+			return
+		}
+		root, index := buildContentTree(treeEntriesForCommit(sha))
+		treeIndexMu.Lock()
+		maps.Copy(treeIndex, index)
+		treeIndexMu.Unlock()
+		_ = json.NewEncoder(w).Encode(gh.Tree{SHA: &sha, Entries: root, Truncated: new(false)})
 	})
 
 	// Blob content


### PR DESCRIPTION
## Summary

Adds a default-on, path-scoped "up-to-date-with-base" gate. On the automatic apply path, if the resolved schema directory changed on the PR's base branch since the branch diverged, SchemaBot downgrades to manual confirmation instead of applying against a base that has moved underneath the plan. A PR can be thousands of commits behind and still auto-apply, as long as its schema subtree is unchanged.

## What

- New GitHub primitive `SchemaDirChangedOnBase`: given the base **ref name**, it compares `baseRef...head`, resolves the **live base tip** from the compare response's `BaseCommit` (not the PR's `pull.base.sha` snapshot, which is typically the base tip at PR creation and would defeat the gate), then compares the **git tree SHA of the resolved schema directory** at the merge base vs the live base tip. Equal tree SHAs prove an identical subtree; a difference (or the directory being added/removed) means the base changed it. Path resolution walks one level at a time with shallow tree fetches, so it is truncation-safe and fails closed.
- Gate wired into the automatic apply path (`handleApplyCommand`) only. `apply-confirm` bypasses it because it goes through a different handler (not because of a nil stored plan). On downgrade the lock stays held so the operator can review and confirm.
- Downgrade comment names the base files that changed (capped, with an "…and N more" overflow) and tells the operator to update the branch or run `apply-confirm`.
- Downgrade metric `schemabot.auto_apply.downgraded.total` with a `reason` label (`base_drift`, `base_drift_unverified`, `plan_load_failed`) so a GitHub API degradation that downgrades applies fleet-wide is visible, not silent.
- Config knob `require_up_to_date_with_base`: global default plus a per-repository override. Precedence is repo override → global → default `true`. High-churn repositories can opt out.
- Fail-closed: any uncertainty (compare/tree API error, missing merge base, missing base commit) downgrades to manual confirmation rather than auto-applying against an unverified base.

## Why

Automatic apply re-plans against the PR head, but nothing checked whether the **base branch** had changed the schema directory since the branch diverged. In fast-moving repositories a plan could be auto-applied against a base that already moved, silently applying against a stale view. Whole-branch "commits behind" is unusable when the base changes constantly, so the gate is scoped to the schema subtree: only a change under the resolved schema root matters.

## Before / after

Before: auto-apply
```
re-plan vs stored auto-plan (DDL drift) ── differ ─▶ manual confirm
└─ same ──▶ APPLY   ◀── base may have moved under the schema dir, unseen
```
After: auto-apply
```
compare(baseRef…head) ─▶ merge base + live base tip
merge base == live base tip ............... APPLY (base did not advance)
schema-dir tree(mergeBase) == tree(tip) ... APPLY (base moved elsewhere only)
schema-dir tree differs / added / removed ─▶ manual confirm (names files)
error / unknown ........................... manual confirm (fail closed)
(apply-confirm bypasses this gate)
```
## Known gaps (intentionally out of scope — do not flag as new issues)

These fall back to prior behavior (no gate) rather than regressing anything. The code comment on `SchemaDirChangedOnBase` records the two symlink gaps; the rest are documented in the design doc:

- Namespace symlinks whose targets live outside the schema directory: a tree SHA hashes the symlink blob, not the target's contents. *(In code comment.)*
- A base branch repointing the environment-root symlink itself. *(In code comment.)*
- A PR relocating its schema root while the base changes the old path.
- Check-to-queue TOCTOU: the gate is a best-effort downgrade, not a hard guarantee the base is current at execution time.
- `POST /api/apply` bypasses this gate (operator-authed direct plan execution); pre-existing, by-design entry-point asymmetry.

## Deferred follow-ups (tracked — do not flag as new issues)

Tracked in the design doc's follow-ups (personal-kmuddukrishna: `design-stuff/schemabot-apply-base-drift-gate/follow-ups.md`):

- **BD-1** Root-config (`schemaPath == "."`) makes the gate whole-repo sensitive; needs a changed-file-list path or documented degradation.
- **BD-2** Collapse the gate's API calls with a single reversed `head...base` compare and dedup `treeSHAForPath` against `fetchGitSubtreeCached`.
- **BD-3** Unify the DDL-drift downgrade onto `postAutoApplyDowngrade` so it also records the `action_required` check and refreshes the aggregate (today it does neither).
