### PR TITLE
feat(observability): log what diverged in review-time drift

### DIFF
--- a/pkg/api/plan_review_drift.go
+++ b/pkg/api/plan_review_drift.go
@@ -7,6 +7,7 @@ import (
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 
 	"github.com/block/schemabot/pkg/metrics"
+	"github.com/block/schemabot/pkg/tern"
 )
 
 // RollupReviewTimeDrift computes the review-time drift rollup for a
@@ -62,13 +63,15 @@ func (s *Service) RollupReviewTimeDrift(ctx context.Context, req PlanRequest, pr
 		switch entry.Class {
 		case DeploymentDiverged:
 			s.logger.Warn("review-time drift: deployment diverged from the reviewed plan; the plan check will block the PR until reconciled",
-				"repository", req.Repository,
-				"pr", pr,
-				"head_sha", headSHA,
-				"database", req.Database,
-				"environment", req.Environment,
-				"deployment", entry.Deployment,
-				"target", entry.Target)
+				append([]any{
+					"repository", req.Repository,
+					"pr", pr,
+					"head_sha", headSHA,
+					"database", req.Database,
+					"environment", req.Environment,
+					"deployment", entry.Deployment,
+					"target", entry.Target,
+				}, driftDiffLogAttrs(entry.Diff)...)...)
 		case DeploymentErrored:
 			s.logger.Warn("review-time drift: deployment could not be diffed or compared; the plan check will block the PR closed",
 				"repository", req.Repository,
@@ -83,4 +86,61 @@ func (s *Service) RollupReviewTimeDrift(ctx context.Context, req PlanRequest, pr
 	}
 
 	return rollup, nil
+}
+
+// maxDriftDiffLogItems caps how many diff items a diverged deployment's warn log
+// renders per list, so a badly drifted deployment cannot flood the log line.
+// The omitted remainder is summarized as a "+N more" tail.
+const maxDriftDiffLogItems = 5
+
+// driftDiffLogAttrs renders a diverged deployment's change-set diff as log
+// attributes so an operator can tell from the warn log alone what the
+// deployment would run that the reviewed plan does not say (and vice versa).
+// Each item names the namespace, shard when set, table, and operation — never
+// the DDL body, which can be long and belongs on the producer's own logs.
+// Empty lists are omitted.
+func driftDiffLogAttrs(diff tern.ChangeSetDiff) []any {
+	var attrs []any
+	if items := formatDriftDiffItems(diff.MissingFromCandidate); len(items) > 0 {
+		attrs = append(attrs, "diff_missing", items)
+	}
+	if items := formatDriftDiffItems(diff.UnexpectedInCandidate); len(items) > 0 {
+		attrs = append(attrs, "diff_unexpected", items)
+	}
+	if ns := capDriftList(diff.MissingVSchema); len(ns) > 0 {
+		attrs = append(attrs, "diff_missing_vschema", ns)
+	}
+	if ns := capDriftList(diff.UnexpectedVSchema); len(ns) > 0 {
+		attrs = append(attrs, "diff_unexpected_vschema", ns)
+	}
+	return attrs
+}
+
+// formatDriftDiffItems renders diff items as "namespace[/shard].table operation"
+// strings, capped to maxDriftDiffLogItems with a "+N more" overflow entry.
+func formatDriftDiffItems(items []tern.ChangeSetDiffItem) []string {
+	formatted := make([]string, 0, min(len(items), maxDriftDiffLogItems+1))
+	for _, item := range items[:min(len(items), maxDriftDiffLogItems)] {
+		loc := item.Namespace
+		if item.Shard != "" {
+			loc += "/" + item.Shard
+		}
+		formatted = append(formatted, fmt.Sprintf("%s.%s %s", loc, item.Table, item.Operation))
+	}
+	if overflow := len(items) - maxDriftDiffLogItems; overflow > 0 {
+		formatted = append(formatted, fmt.Sprintf("+%d more", overflow))
+	}
+	return formatted
+}
+
+// capDriftList caps a namespace list to maxDriftDiffLogItems with a "+N more"
+// overflow entry.
+func capDriftList(values []string) []string {
+	if len(values) <= maxDriftDiffLogItems {
+		return values
+	}
+	capped := make([]string, 0, maxDriftDiffLogItems+1)
+	capped = append(capped, values[:maxDriftDiffLogItems]...)
+	capped = append(capped, fmt.Sprintf("+%d more", len(values)-maxDriftDiffLogItems))
+	return capped
 }

--- a/pkg/api/plan_review_drift_test.go
+++ b/pkg/api/plan_review_drift_test.go
@@ -2,12 +2,15 @@ package api
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+
+	"github.com/block/schemabot/pkg/tern"
 )
 
 func reviewedUsersPlan(ddl string) *ternv1.PlanResponse {
@@ -90,4 +93,73 @@ func TestRollupReviewTimeDrift_UnresolvedTargetsError(t *testing.T) {
 	req.Database = "unknown"
 	_, err := svc.RollupReviewTimeDrift(t.Context(), req, reviewedUsersPlan("ALTER TABLE `users` ADD COLUMN `email` varchar(255)"), "eu")
 	require.Error(t, err)
+}
+
+// A diverged deployment's warn log carries the comparator's diff so an operator
+// can tell what the deployment would run that the reviewed plan does not say —
+// table and operation per item, never the DDL body, capped with a "+N more"
+// overflow so a badly drifted deployment cannot flood the log line.
+func TestDriftDiffLogAttrs(t *testing.T) {
+	diff := tern.ChangeSetDiff{
+		MissingFromCandidate: []tern.ChangeSetDiffItem{
+			{Namespace: "testapp", Table: "users", Operation: "alter_table", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
+		},
+		UnexpectedInCandidate: []tern.ChangeSetDiffItem{
+			{Namespace: "testapp", Shard: "-80", Table: "orders", Operation: "create_table", DDL: "CREATE TABLE `orders` (`id` bigint)"},
+		},
+		MissingVSchema:    []string{"testapp"},
+		UnexpectedVSchema: []string{"other"},
+	}
+
+	attrs := driftDiffLogAttrs(diff)
+	require.Equal(t, []any{
+		"diff_missing", []string{"testapp.users alter_table"},
+		"diff_unexpected", []string{"testapp/-80.orders create_table"},
+		"diff_missing_vschema", []string{"testapp"},
+		"diff_unexpected_vschema", []string{"other"},
+	}, attrs)
+	for _, attr := range attrs {
+		if items, ok := attr.([]string); ok {
+			for _, item := range items {
+				assert.NotContains(t, item, "ADD COLUMN", "diff log items must never carry DDL bodies")
+			}
+		}
+	}
+}
+
+// Empty diff lists are omitted from the log attributes so a warn line only
+// names the directions that actually differ.
+func TestDriftDiffLogAttrs_OmitsEmptyLists(t *testing.T) {
+	diff := tern.ChangeSetDiff{
+		UnexpectedInCandidate: []tern.ChangeSetDiffItem{
+			{Namespace: "testapp", Table: "orders", Operation: "drop_table"},
+		},
+	}
+
+	assert.Equal(t, []any{
+		"diff_unexpected", []string{"testapp.orders drop_table"},
+	}, driftDiffLogAttrs(diff))
+}
+
+// A diff with more items than the log cap renders the first items and
+// summarizes the remainder as "+N more" instead of flooding the log line.
+func TestDriftDiffLogAttrs_CapsWithOverflow(t *testing.T) {
+	var items []tern.ChangeSetDiffItem
+	for i := range maxDriftDiffLogItems + 3 {
+		items = append(items, tern.ChangeSetDiffItem{
+			Namespace: "testapp",
+			Table:     fmt.Sprintf("t%02d", i),
+			Operation: "create_table",
+		})
+	}
+
+	attrs := driftDiffLogAttrs(tern.ChangeSetDiff{MissingFromCandidate: items})
+	require.Len(t, attrs, 2)
+	require.Equal(t, "diff_missing", attrs[0])
+	rendered, ok := attrs[1].([]string)
+	require.True(t, ok)
+	require.Len(t, rendered, maxDriftDiffLogItems+1)
+	assert.Equal(t, "testapp.t00 create_table", rendered[0])
+	assert.Equal(t, fmt.Sprintf("testapp.t%02d create_table", maxDriftDiffLogItems-1), rendered[maxDriftDiffLogItems-1])
+	assert.Equal(t, "+3 more", rendered[maxDriftDiffLogItems])
 }

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -1318,6 +1318,28 @@ func (c *LocalClient) PlanDiff(ctx context.Context, req *ternv1.PlanRequest) (*t
 	}
 
 	changes, violations, protoShards := c.planResultToProtoChanges(result)
+	// Log the resulting change set so a diverged deployment is triageable from
+	// this side's logs alone: change count plus one line per table change, with
+	// DDL length instead of the DDL body.
+	changeCount := 0
+	for _, ch := range changes {
+		changeCount += len(ch.TableChanges)
+	}
+	c.logger.Info("LocalClient.PlanDiff: plan diff response",
+		"database", c.config.Database,
+		"change_count", changeCount,
+	)
+	for _, ch := range changes {
+		for _, tc := range ch.TableChanges {
+			c.logger.Info("LocalClient.PlanDiff: table change",
+				"database", c.config.Database,
+				"namespace", tc.Namespace,
+				"table", tc.TableName,
+				"change_type", tc.ChangeType.String(),
+				"ddl_len", len(tc.Ddl),
+			)
+		}
+	}
 	return &ternv1.PlanDiffResponse{
 		Engine:         c.protoEngine(),
 		Changes:        changes,


### PR DESCRIPTION
## Summary
When the review-time drift rollup classifies a deployment as diverged, neither side of the system logged *what* diverged — the control plane warn named the deployment but not the differing change-set items, and the worker's `PlanDiff` never logged its resulting change set. Triaging a divergence meant connecting to the deployment's database and diffing it by hand.

## What
- Worker: `LocalClient.PlanDiff` logs its result mirroring the `ExecutePlan` convention — a response line with `change_count`, plus one line per table change with namespace/table/change type/DDL length (no DDL bodies).
- Control plane: the diverged warn in the rollup now carries the comparator's diff items as structured attrs (`diff_missing`, `diff_unexpected`, and the vschema lists) — `namespace[/shard].table operation` per item, capped with a `+N more` overflow, empty lists omitted.

## Why
With both, the triage question "what would the diverged deployment run that the reviewed plan doesn't say?" is answerable from either side's logs alone, keeping raw DDL bodies out of log lines per the existing convention.
