### PR TITLE
fix(github): fold superseded progress comments on resume rotation

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -3085,6 +3085,43 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 </details>
 
 <details>
+<summary><a name="resumed-superseded-progress-comment"></a><strong>Resumed: Superseded Progress Comment</strong></summary>
+
+
+▶️ Schema change resumed — progress continues in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
+
+<details>
+<summary>Progress before the stop</summary>
+
+## Schema Change Status — Staging
+
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
+
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: Stopped
+
+**`users`**: 🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 32%
+
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+```
+Rows: 2,300,000 / 7,200,000
+
+
+---
+
+Paused — to resume from where it stopped:
+```
+schemabot start apply-a1b2c3d4e5f6 -e staging
+```
+
+
+</details>
+
+</details>
+
+<details>
 <summary><a name="summary-completed"></a><strong>Summary: Completed</strong></summary>
 
 
@@ -5681,6 +5718,44 @@ schemabot stop apply-a1b2c3d4e5f6 -e staging
 ```
 
 _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
+
+
+</details>
+
+
+</details>
+
+<details>
+<summary><a name="resumed-superseded-progress-comment"></a><strong>Resumed: Superseded Progress Comment</strong></summary>
+
+
+▶️ Schema change resumed — progress continues in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
+
+<details>
+<summary>Progress before the stop</summary>
+
+## Schema Change Status — Staging
+
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
+
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: Stopped
+
+**`users`**: 🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 32%
+
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+```
+Rows: 2,300,000 / 7,200,000
+
+
+---
+
+Paused — to resume from where it stopped:
+```
+schemabot start apply-a1b2c3d4e5f6 -e staging
+```
 
 
 </details>

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -3122,6 +3122,43 @@ schemabot start apply-a1b2c3d4e5f6 -e staging
 </details>
 
 <details>
+<summary><a name="retry-superseded-progress-comment-generic"></a><strong>Retry: Superseded Progress Comment (Generic)</strong></summary>
+
+
+⏭️ Progress comment superseded — progress continues in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
+
+<details>
+<summary>Earlier progress</summary>
+
+## Schema Change Status — Staging
+
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
+
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: Stopped
+
+**`users`**: 🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 32%
+
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+```
+Rows: 2,300,000 / 7,200,000
+
+
+---
+
+Paused — to resume from where it stopped:
+```
+schemabot start apply-a1b2c3d4e5f6 -e staging
+```
+
+
+</details>
+
+</details>
+
+<details>
 <summary><a name="summary-completed"></a><strong>Summary: Completed</strong></summary>
 
 
@@ -5733,6 +5770,44 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 <details>
 <summary>Progress before the stop</summary>
+
+## Schema Change Status — Staging
+
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
+
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: Stopped
+
+**`users`**: 🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 32%
+
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+```
+Rows: 2,300,000 / 7,200,000
+
+
+---
+
+Paused — to resume from where it stopped:
+```
+schemabot start apply-a1b2c3d4e5f6 -e staging
+```
+
+
+</details>
+
+
+</details>
+
+<details>
+<summary><a name="retry-superseded-progress-comment-generic"></a><strong>Retry: Superseded Progress Comment (Generic)</strong></summary>
+
+
+⏭️ Progress comment superseded — progress continues in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
+
+<details>
+<summary>Earlier progress</summary>
 
 ## Schema Change Status — Staging
 

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -79,6 +79,7 @@ func previewCommentAllOutput() {
 		{"VOLUME COMMAND ACCEPTED", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeCommandAccepted()) }},
 		{"VOLUME COMMAND INVALID LEVEL", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeInvalidLevel()) }},
 		{"VOLUME CHANGED: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeSupersededProgress()) }},
+		{"RESUMED: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentResumeSupersededProgress()) }},
 		{"SUMMARY: COMPLETED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryCompleted()) }},
 		{"SUMMARY: FAILED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryFailed()) }},
 		{"SUMMARY: STOPPED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryStopped()) }},
@@ -132,6 +133,7 @@ func previewApplyCommandAllOutput() {
 		{"VOLUME COMMAND ACCEPTED", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeCommandAccepted()) }},
 		{"VOLUME COMMAND INVALID LEVEL", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeInvalidLevel()) }},
 		{"VOLUME CHANGED: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeSupersededProgress()) }},
+		{"RESUMED: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentResumeSupersededProgress()) }},
 		{"CHECKS GATE: NOT PASSING", func() {
 			fmt.Print(webhooktemplates.RenderApplyBlockedByNonPassingChecks("staging", []webhooktemplates.BlockingCheck{
 				{Name: "CI / unit-tests", State: "failure"},
@@ -267,6 +269,7 @@ func previewCommentApplyFlowAllOutput() {
 		{"VOLUME COMMAND ACCEPTED", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeCommandAccepted()) }},
 		{"VOLUME COMMAND INVALID LEVEL", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeInvalidLevel()) }},
 		{"VOLUME CHANGED: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeSupersededProgress()) }},
+		{"RESUMED: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentResumeSupersededProgress()) }},
 		// Summaries
 		{"SUMMARY: COMPLETED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryCompleted()) }},
 		{"SUMMARY: FAILED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryFailed()) }},

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -80,6 +80,7 @@ func previewCommentAllOutput() {
 		{"VOLUME COMMAND INVALID LEVEL", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeInvalidLevel()) }},
 		{"VOLUME CHANGED: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeSupersededProgress()) }},
 		{"RESUMED: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentResumeSupersededProgress()) }},
+		{"RETRY: SUPERSEDED PROGRESS COMMENT (GENERIC)", func() { fmt.Print(webhooktemplates.PreviewCommentSupersededProgress()) }},
 		{"SUMMARY: COMPLETED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryCompleted()) }},
 		{"SUMMARY: FAILED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryFailed()) }},
 		{"SUMMARY: STOPPED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryStopped()) }},
@@ -134,6 +135,7 @@ func previewApplyCommandAllOutput() {
 		{"VOLUME COMMAND INVALID LEVEL", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeInvalidLevel()) }},
 		{"VOLUME CHANGED: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeSupersededProgress()) }},
 		{"RESUMED: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentResumeSupersededProgress()) }},
+		{"RETRY: SUPERSEDED PROGRESS COMMENT (GENERIC)", func() { fmt.Print(webhooktemplates.PreviewCommentSupersededProgress()) }},
 		{"CHECKS GATE: NOT PASSING", func() {
 			fmt.Print(webhooktemplates.RenderApplyBlockedByNonPassingChecks("staging", []webhooktemplates.BlockingCheck{
 				{Name: "CI / unit-tests", State: "failure"},
@@ -270,6 +272,7 @@ func previewCommentApplyFlowAllOutput() {
 		{"VOLUME COMMAND INVALID LEVEL", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeInvalidLevel()) }},
 		{"VOLUME CHANGED: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeSupersededProgress()) }},
 		{"RESUMED: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentResumeSupersededProgress()) }},
+		{"RETRY: SUPERSEDED PROGRESS COMMENT (GENERIC)", func() { fmt.Print(webhooktemplates.PreviewCommentSupersededProgress()) }},
 		// Summaries
 		{"SUMMARY: COMPLETED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryCompleted()) }},
 		{"SUMMARY: FAILED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryFailed()) }},

--- a/pkg/webhook/apply_comment_integration_test.go
+++ b/pkg/webhook/apply_comment_integration_test.go
@@ -453,7 +453,9 @@ func TestE2EResumeRotatesProgressComment(t *testing.T) {
 // comment. A resume rotation also reconciles a freeze that a prior drive owed
 // but never landed: the first tick after the second resume freezes both the
 // leftover comment and the one this resume supersedes, each pointing at its
-// successor.
+// successor. The owed fold uses the generic superseded rendering — the marker
+// records which comment is owed, not which rotation superseded it — while the
+// fold this resume performs itself carries the resume headline.
 func TestE2EResumeRotationFreezesAcrossIterations(t *testing.T) {
 	ctx := t.Context()
 
@@ -493,7 +495,8 @@ func TestE2EResumeRotationFreezesAcrossIterations(t *testing.T) {
 	select {
 	case edited := <-capture.edits:
 		assert.Equal(t, firstProgressID, edited.CommentID, "the reconciled freeze lands on the first cycle's comment")
-		assert.Contains(t, edited.Body, "Schema change resumed")
+		assert.Contains(t, edited.Body, "Progress comment superseded",
+			"the owed fold uses the generic rendering since the superseding rotation is not recorded")
 		assert.Contains(t, edited.Body, fmt.Sprintf("#issuecomment-%d", secondProgressID), "the frozen comment links to its successor")
 		assert.Contains(t, edited.Body, "Stopped at 21%", "the superseded body is preserved inside the fold")
 	case <-time.After(5 * time.Second):
@@ -954,7 +957,9 @@ func TestE2EVolumeRotationUntrackedFreshCommentAdoptedWhenStorageHeals(t *testin
 // landed leaves the pending-freeze marker on the tracked row. A later drive's
 // observer — with no in-memory state from the rotation — reconciles it on its
 // first volume check: the superseded comment is frozen pointing at its
-// successor and the marker is cleared, without posting anything new.
+// successor and the marker is cleared, without posting anything new. The fold
+// uses the generic superseded rendering — the marker records which comment is
+// owed, not which rotation superseded it.
 func TestE2EVolumeRotationReconcilesPendingFreezeFromPriorDrive(t *testing.T) {
 	ctx := t.Context()
 
@@ -996,7 +1001,8 @@ func TestE2EVolumeRotationReconcilesPendingFreezeFromPriorDrive(t *testing.T) {
 	select {
 	case edited := <-capture.edits:
 		assert.Equal(t, supersededID, edited.CommentID, "the reconciled freeze lands on the superseded comment")
-		assert.Contains(t, edited.Body, "Volume changed to **5/11**")
+		assert.Contains(t, edited.Body, "Progress comment superseded",
+			"the owed fold uses the generic rendering since the superseding rotation is not recorded")
 		assert.Contains(t, edited.Body, fmt.Sprintf("#issuecomment-%d", freshID), "the frozen comment links to its successor")
 		assert.Contains(t, edited.Body, "Copying at volume 3", "the superseded body is preserved inside the fold")
 	case created := <-capture.creates:

--- a/pkg/webhook/apply_comment_integration_test.go
+++ b/pkg/webhook/apply_comment_integration_test.go
@@ -354,9 +354,10 @@ func TestE2EApplyCommentLifecycle(t *testing.T) {
 
 // When a stopped apply resumes, the observer posts a fresh progress comment and
 // tracks that as the live one, rather than re-editing the comment frozen at
-// "Stopped". The prior progress comment is left in place as the record of where
-// the apply paused, the stopped summary marker is consumed, and later progress
-// edits land on the new comment.
+// "Stopped". The prior progress comment is folded into a collapsed details
+// block pointing at its successor — keeping the pre-stop record on the PR
+// without looking live — the stopped summary marker is consumed, and later
+// progress edits land on the new comment.
 func TestE2EResumeRotatesProgressComment(t *testing.T) {
 	ctx := t.Context()
 
@@ -402,13 +403,27 @@ func TestE2EResumeRotatesProgressComment(t *testing.T) {
 	}
 	assert.NotEqual(t, stoppedProgressID, newProgressID, "resume must post a new comment, not reuse the stopped one")
 
-	// The progress row now tracks the new comment; the stopped-summary marker is
-	// consumed by being superseded — the row and its GitHub comment are kept, not
-	// deleted.
+	// The prior comment is frozen into a collapsed details block pointing at
+	// its successor, with the pre-stop body preserved inside the fold.
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, stoppedProgressID, edited.CommentID, "the freeze edit lands on the superseded comment")
+		assert.Contains(t, edited.Body, "Schema change resumed")
+		assert.Contains(t, edited.Body, fmt.Sprintf("#issuecomment-%d", newProgressID), "the frozen comment links to its successor")
+		assert.Contains(t, edited.Body, "<details>")
+		assert.Contains(t, edited.Body, "Stopped at 21%", "the pre-stop body is preserved inside the fold")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the superseded progress comment to be frozen")
+	}
+
+	// The progress row now tracks the new comment with no freeze left owing;
+	// the stopped-summary marker is consumed by being superseded — the row and
+	// its GitHub comment are kept, not deleted.
 	prog, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Progress)
 	require.NoError(t, err)
 	require.NotNil(t, prog)
 	assert.Equal(t, newProgressID, prog.GitHubCommentID)
+	assert.Nil(t, prog.PendingFreezeCommentID)
 	summary, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Summary)
 	require.NoError(t, err)
 	require.NotNil(t, summary, "the stopped-summary row is retired, not deleted")
@@ -431,6 +446,91 @@ func TestE2EResumeRotatesProgressComment(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("expected an in-place edit of the new progress comment on the next tick")
 	}
+}
+
+// Across repeated stop/start iterations, each resume folds the progress
+// comment it supersedes, so the PR timeline keeps exactly one live progress
+// comment. A resume rotation also reconciles a freeze that a prior drive owed
+// but never landed: the first tick after the second resume freezes both the
+// leftover comment and the one this resume supersedes, each pointing at its
+// successor.
+func TestE2EResumeRotationFreezesAcrossIterations(t *testing.T) {
+	ctx := t.Context()
+
+	f := setupApplyCommentFixture(t, applyCommentFixtureParams{
+		repo:       "org/repo-rotate-iterations",
+		pr:         146,
+		database:   "e2e_rotate_iterations_db",
+		applyState: state.Apply.Resuming,
+	})
+	st, apply, task, capture, h := f.st, f.apply, f.task, f.capture, f.handler
+
+	// Seed the comments left by a first stop/start cycle whose drive died
+	// before its freeze edit landed: the first cycle's progress comment (still
+	// unfolded), the fresh comment that resume rotated to — now frozen at
+	// "Stopped" by a second stop — and the second stop's summary marker.
+	h.postAndTrackComment(ctx, "org/repo-rotate-iterations", 146, 12345, apply, state.Comment.Progress, "Stopped at 21%")
+	firstProgressID := requireCommentCreate(t, capture)
+	h.postAndTrackComment(ctx, "org/repo-rotate-iterations", 146, 12345, apply, state.Comment.Progress, "Stopped at 63%")
+	secondProgressID := requireCommentCreate(t, capture)
+	require.NoError(t, st.ApplyComments().Upsert(ctx, &storage.ApplyComment{
+		ApplyID:                apply.ID,
+		CommentState:           state.Comment.Progress,
+		GitHubCommentID:        secondProgressID,
+		PendingFreezeCommentID: &firstProgressID,
+	}))
+	h.postAndTrackComment(ctx, "org/repo-rotate-iterations", 146, 12345, apply, state.Comment.Summary, "Schema Change Stopped")
+	requireCommentCreate(t, capture)
+
+	fake := clock.NewFake(task.CreatedAt)
+	obs := f.newObserver(st, fake)
+
+	// The first tick after the second resume reconciles the owed freeze before
+	// rotating: the first cycle's comment folds pointing at the comment that
+	// superseded it.
+	obs.OnProgress(apply, []*storage.Task{task})
+
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, firstProgressID, edited.CommentID, "the reconciled freeze lands on the first cycle's comment")
+		assert.Contains(t, edited.Body, "Schema change resumed")
+		assert.Contains(t, edited.Body, fmt.Sprintf("#issuecomment-%d", secondProgressID), "the frozen comment links to its successor")
+		assert.Contains(t, edited.Body, "Stopped at 21%", "the superseded body is preserved inside the fold")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the owed freeze from the prior drive to be reconciled")
+	}
+
+	// The same tick rotates for the second resume: a fresh progress comment is
+	// posted and the second cycle's comment folds pointing at it.
+	var thirdProgressID int64
+	select {
+	case created := <-capture.creates:
+		thirdProgressID = created.ID
+		assert.Contains(t, created.Body, "Schema Change Status — Staging")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected a new progress comment on the second resume")
+	}
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, secondProgressID, edited.CommentID, "the freeze edit lands on the second cycle's comment")
+		assert.Contains(t, edited.Body, "Schema change resumed")
+		assert.Contains(t, edited.Body, fmt.Sprintf("#issuecomment-%d", thirdProgressID), "the frozen comment links to its successor")
+		assert.Contains(t, edited.Body, "Stopped at 63%", "the superseded body is preserved inside the fold")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the second cycle's progress comment to be frozen")
+	}
+
+	// The tracked row points at the live comment with no freeze left owing, and
+	// the stopped-summary marker is consumed.
+	prog, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Progress)
+	require.NoError(t, err)
+	require.NotNil(t, prog)
+	assert.Equal(t, thirdProgressID, prog.GitHubCommentID)
+	assert.Nil(t, prog.PendingFreezeCommentID)
+	summary, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Summary)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.NotNil(t, summary.SupersededAt, "the stopped-summary marker is superseded after rotation")
 }
 
 // requireCommentCreate returns the next captured comment-create id, failing if

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -632,10 +632,11 @@ func (o *CommentObserver) editTrackedComment(apply *storage.Apply, commentState 
 // cross-pod safe: OnTerminal writes a summary comment when an apply stops, so an
 // active apply with a summary comment present has resumed. On rotation it posts a
 // new progress comment — postAndTrackComment overwrites the tracked progress
-// comment id, so later progress edits land on the new comment while the prior one
-// stays frozen as the record — and consumes the summary marker so it rotates
-// exactly once and the eventual terminal summary is posted fresh. Returns true
-// when it rotated.
+// comment id, so later progress edits land on the new comment while the prior
+// one is folded into a details block pointing at its successor (with the freeze
+// it owes recorded in the same tracking write, mirroring the volume rotation) —
+// and consumes the summary marker so it rotates exactly once and the eventual
+// terminal summary is posted fresh. Returns true when it rotated.
 func (o *CommentObserver) rotateProgressCommentForResume(apply *storage.Apply, tasks []*storage.Task) bool {
 	if o.resumeRotated {
 		// This observer already rotated for the current resume. Guard against
@@ -661,8 +662,26 @@ func (o *CommentObserver) rotateProgressCommentForResume(apply *storage.Apply, t
 		return false
 	}
 
+	tracked, err := o.stor.ApplyComments().Get(ctx, o.applyID, state.Comment.Progress)
+	if err != nil {
+		o.logError(apply, "observer: failed to load tracked progress comment before resume rotation", "error", err)
+		return false
+	}
+	var pendingFreeze *int64
+	if tracked != nil {
+		if tracked.PendingFreezeCommentID != nil {
+			// A superseded comment from an earlier rotation is still owed its
+			// frozen rendering — the freeze edit failed or the pod died before it
+			// landed. Retry it now; on success the marker is cleared.
+			o.freezeSupersededProgressComment(apply, *tracked.PendingFreezeCommentID, tracked.GitHubCommentID,
+				supersededByResume, 0)
+		}
+		pendingFreeze = &tracked.GitHubCommentID
+	}
+
 	body := o.formatStatusComment(apply, tasks)
-	if _, posted, _ := o.postAndTrackComment(apply, state.Comment.Progress, body, nil); !posted {
+	newCommentID, posted, trackedNew := o.postAndTrackComment(apply, state.Comment.Progress, body, pendingFreeze)
+	if !posted {
 		// postAndTrackComment logged the failure. The summary marker is left in
 		// place — it is the durable signal that a resume rotation is owed — so
 		// the next tick retries instead of consuming the marker for a comment
@@ -671,6 +690,14 @@ func (o *CommentObserver) rotateProgressCommentForResume(apply *storage.Apply, t
 	}
 	o.resumeRotated = true
 
+	if trackedNew && tracked != nil {
+		o.freezeSupersededProgressComment(apply, tracked.GitHubCommentID, newCommentID, supersededByResume, 0)
+	}
+	// When the fresh comment posted but its tracking write failed
+	// (postAndTrackComment logged it), the prior comment is still the tracked
+	// live one, so it must not be folded; no freeze marker was recorded either,
+	// since the marker rides the tracking write.
+
 	if err := o.stor.ApplyComments().Supersede(o.contextWithApplyLease(ctx, apply), o.applyID, state.Comment.Summary); err != nil {
 		o.logError(apply, "observer: failed to consume summary marker after resume rotation", "error", err)
 		return true
@@ -678,6 +705,36 @@ func (o *CommentObserver) rotateProgressCommentForResume(apply *storage.Apply, t
 	o.logger.Info("observer: posted fresh progress comment for resumed apply",
 		"apply_id", o.applyID, "repo", o.repo, "pr", o.pr, "state", apply.State)
 	return true
+}
+
+// supersededProgressReason names why a tracked progress comment was rotated
+// away from, selecting the frozen rendering written over it.
+type supersededProgressReason int
+
+const (
+	supersededByVolumeChange supersededProgressReason = iota
+	supersededByResume
+)
+
+// frozenSupersededProgressBody renders the folded body written over a
+// superseded progress comment, headlined by the reason it was rotated away
+// from. volume is read only for the volume-change rendering.
+func (o *CommentObserver) frozenSupersededProgressBody(reason supersededProgressReason, volume int, newCommentID int64, previousBody string) string {
+	if reason == supersededByResume {
+		return templates.RenderResumeSupersededProgressComment(templates.ResumeSupersededProgressData{
+			Repo:         o.repo,
+			PR:           o.pr,
+			NewCommentID: newCommentID,
+			PreviousBody: previousBody,
+		})
+	}
+	return templates.RenderVolumeSupersededProgressComment(templates.VolumeSupersededProgressData{
+		Volume:       volume,
+		Repo:         o.repo,
+		PR:           o.pr,
+		NewCommentID: newCommentID,
+		PreviousBody: previousBody,
+	})
 }
 
 // rotateProgressCommentForVolumeChange posts a fresh progress comment when the
@@ -758,7 +815,8 @@ func (o *CommentObserver) rotateProgressCommentForVolumeChange(apply *storage.Ap
 		// A superseded comment from an earlier rotation is still owed its
 		// frozen rendering — the freeze edit failed or the pod died before it
 		// landed. Retry it now; on success the marker is cleared.
-		o.freezeSupersededProgressComment(apply, *tracked.PendingFreezeCommentID, tracked.GitHubCommentID, *tracked.PostedVolume)
+		o.freezeSupersededProgressComment(apply, *tracked.PendingFreezeCommentID, tracked.GitHubCommentID,
+			supersededByVolumeChange, *tracked.PostedVolume)
 	}
 	o.trackedPostedVolume = *tracked.PostedVolume
 	o.trackedPostedVolumeKnown = true
@@ -792,7 +850,7 @@ func (o *CommentObserver) rotateProgressCommentForVolumeChange(apply *storage.Ap
 	o.volumeRotatedTo = currentVolume
 	o.logInfo(apply, "observer: posted fresh progress comment for volume change",
 		"previous_volume", *tracked.PostedVolume, "volume", currentVolume)
-	o.freezeSupersededProgressComment(apply, tracked.GitHubCommentID, newCommentID, currentVolume)
+	o.freezeSupersededProgressComment(apply, tracked.GitHubCommentID, newCommentID, supersededByVolumeChange, currentVolume)
 	return true
 }
 
@@ -824,7 +882,7 @@ func (o *CommentObserver) adoptPendingRotationComment(apply *storage.Apply) bool
 	o.volumeRotatedTo = p.volume
 	o.logInfo(apply, "observer: adopted posted-but-untracked progress comment; progress edits now land on it",
 		"github_comment_id", p.commentID, "volume", p.volume)
-	o.freezeSupersededProgressComment(apply, p.supersededCommentID, p.commentID, p.volume)
+	o.freezeSupersededProgressComment(apply, p.supersededCommentID, p.commentID, supersededByVolumeChange, p.volume)
 	return true
 }
 
@@ -833,11 +891,12 @@ func (o *CommentObserver) adoptPendingRotationComment(apply *storage.Apply) bool
 // the comment that replaced it. Collapsing rather than deleting keeps the
 // pre-change progress on the PR as a record while decluttering the timeline;
 // without the fold a reader has no way to tell a frozen comment from a live
-// one. A failure leaves the tracked row's pending-freeze marker in place (it
-// is written alongside the successor's tracking), so a later tick or a later
-// drive's observer retries; the marker is cleared only once the frozen
-// rendering is on GitHub.
-func (o *CommentObserver) freezeSupersededProgressComment(apply *storage.Apply, oldCommentID, newCommentID int64, volume int) {
+// one. reason selects the fold's headline (volume is read only for the
+// volume-change rendering). A failure leaves the tracked row's pending-freeze
+// marker in place (it is written alongside the successor's tracking), so a
+// later tick or a later drive's observer retries; the marker is cleared only
+// once the frozen rendering is on GitHub.
+func (o *CommentObserver) freezeSupersededProgressComment(apply *storage.Apply, oldCommentID, newCommentID int64, reason supersededProgressReason, volume int) {
 	if !o.leaseStillOwnsObserver(apply, "create GitHub client before freezing superseded comment") {
 		return
 	}
@@ -855,19 +914,13 @@ func (o *CommentObserver) freezeSupersededProgressComment(apply *storage.Apply, 
 			"error", err, "github_comment_id", oldCommentID)
 		return
 	}
-	if !templates.IsVolumeSupersededProgressComment(oldBody) {
+	if !templates.IsSupersededProgressComment(oldBody) {
 		// A retry after a failed marker clear sees the frozen body already on
 		// GitHub; re-rendering would fold the frozen body inside another fold.
 		if !o.leaseStillOwnsObserver(apply, "freeze superseded progress comment") {
 			return
 		}
-		frozen := templates.RenderVolumeSupersededProgressComment(templates.VolumeSupersededProgressData{
-			Volume:       volume,
-			Repo:         o.repo,
-			PR:           o.pr,
-			NewCommentID: newCommentID,
-			PreviousBody: oldBody,
-		})
+		frozen := o.frozenSupersededProgressBody(reason, volume, newCommentID, oldBody)
 		if err := client.EditIssueComment(ctx, o.repo, oldCommentID, frozen); err != nil {
 			o.logError(apply, "observer: failed to freeze superseded progress comment; the pending-freeze marker stays set and the next observer pass that reads the tracked row retries",
 				"error", err, "github_comment_id", oldCommentID)

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -674,7 +674,7 @@ func (o *CommentObserver) rotateProgressCommentForResume(apply *storage.Apply, t
 			// frozen rendering — the freeze edit failed or the pod died before it
 			// landed. Retry it now; on success the marker is cleared.
 			o.freezeSupersededProgressComment(apply, *tracked.PendingFreezeCommentID, tracked.GitHubCommentID,
-				supersededByResume, 0)
+				supersededByPriorRotation, 0)
 		}
 		pendingFreeze = &tracked.GitHubCommentID
 	}
@@ -714,14 +714,26 @@ type supersededProgressReason int
 const (
 	supersededByVolumeChange supersededProgressReason = iota
 	supersededByResume
+	// supersededByPriorRotation is the retry reason: the pending-freeze marker
+	// records which comment is owed a fold but not which rotation superseded
+	// it, so a retry renders the generic fold instead of guessing a headline.
+	supersededByPriorRotation
 )
 
 // frozenSupersededProgressBody renders the folded body written over a
 // superseded progress comment, headlined by the reason it was rotated away
 // from. volume is read only for the volume-change rendering.
 func (o *CommentObserver) frozenSupersededProgressBody(reason supersededProgressReason, volume int, newCommentID int64, previousBody string) string {
-	if reason == supersededByResume {
+	switch reason {
+	case supersededByResume:
 		return templates.RenderResumeSupersededProgressComment(templates.ResumeSupersededProgressData{
+			Repo:         o.repo,
+			PR:           o.pr,
+			NewCommentID: newCommentID,
+			PreviousBody: previousBody,
+		})
+	case supersededByPriorRotation:
+		return templates.RenderSupersededProgressComment(templates.SupersededProgressData{
 			Repo:         o.repo,
 			PR:           o.pr,
 			NewCommentID: newCommentID,
@@ -816,7 +828,7 @@ func (o *CommentObserver) rotateProgressCommentForVolumeChange(apply *storage.Ap
 		// frozen rendering — the freeze edit failed or the pod died before it
 		// landed. Retry it now; on success the marker is cleared.
 		o.freezeSupersededProgressComment(apply, *tracked.PendingFreezeCommentID, tracked.GitHubCommentID,
-			supersededByVolumeChange, *tracked.PostedVolume)
+			supersededByPriorRotation, 0)
 	}
 	o.trackedPostedVolume = *tracked.PostedVolume
 	o.trackedPostedVolumeKnown = true
@@ -914,9 +926,10 @@ func (o *CommentObserver) freezeSupersededProgressComment(apply *storage.Apply, 
 			"error", err, "github_comment_id", oldCommentID)
 		return
 	}
+	// A retry after a failed marker clear finds the frozen body already on
+	// GitHub; re-rendering it would fold the frozen body inside another fold,
+	// so only a still-live body is edited.
 	if !templates.IsSupersededProgressComment(oldBody) {
-		// A retry after a failed marker clear sees the frozen body already on
-		// GitHub; re-rendering would fold the frozen body inside another fold.
 		if !o.leaseStillOwnsObserver(apply, "freeze superseded progress comment") {
 			return
 		}

--- a/pkg/webhook/templates/issue_comment.go
+++ b/pkg/webhook/templates/issue_comment.go
@@ -310,9 +310,9 @@ type VolumeSupersededProgressData struct {
 	PreviousBody string
 }
 
-// volumeSupersededPrefix opens every frozen superseded-progress body;
-// IsVolumeSupersededProgressComment keys on it so a freeze retry can tell an
-// already-frozen comment from a live one.
+// volumeSupersededPrefix opens every frozen body written when a volume change
+// superseded a progress comment; IsSupersededProgressComment keys on it so a
+// freeze retry can tell an already-frozen comment from a live one.
 const volumeSupersededPrefix = "⏩ Volume changed to"
 
 // RenderVolumeSupersededProgressComment renders the frozen body written over a
@@ -326,11 +326,44 @@ func RenderVolumeSupersededProgressComment(data VolumeSupersededProgressData) st
 		data.Volume, storage.MaxVolume, data.Repo, data.PR, data.NewCommentID, data.PreviousBody)
 }
 
-// IsVolumeSupersededProgressComment reports whether a comment body is already
-// the frozen rendering written by RenderVolumeSupersededProgressComment, so a
-// freeze retry does not wrap a frozen body in a second fold.
-func IsVolumeSupersededProgressComment(body string) bool {
-	return strings.HasPrefix(body, volumeSupersededPrefix)
+// ResumeSupersededProgressData contains data for freezing a progress comment
+// that a resume has superseded.
+type ResumeSupersededProgressData struct {
+	// Repo is the "owner/name" repository, used to link the successor comment.
+	Repo string
+	// PR is the pull request number, used to link the successor comment.
+	PR int
+	// NewCommentID is the GitHub comment ID of the fresh progress comment now
+	// tracking the schema change.
+	NewCommentID int64
+	// PreviousBody is the superseded comment's last rendered body, preserved
+	// inside the folded details block.
+	PreviousBody string
+}
+
+// resumeSupersededPrefix opens every frozen body written when a resume
+// superseded a progress comment; IsSupersededProgressComment keys on it so a
+// freeze retry can tell an already-frozen comment from a live one.
+const resumeSupersededPrefix = "▶️ Schema change resumed"
+
+// RenderResumeSupersededProgressComment renders the frozen body written over a
+// progress comment once a resumed apply rotates in a fresh one. The old
+// comment's final pre-stop progress stays on the PR as a record, collapsed
+// into a details block, with a pointer to the comment where progress
+// continues.
+func RenderResumeSupersededProgressComment(data ResumeSupersededProgressData) string {
+	return fmt.Sprintf(
+		resumeSupersededPrefix+" — progress continues in [a new progress comment](https://github.com/%s/pull/%d#issuecomment-%d).\n\n"+
+			"<details>\n<summary>Progress before the stop</summary>\n\n%s\n\n</details>\n",
+		data.Repo, data.PR, data.NewCommentID, data.PreviousBody)
+}
+
+// IsSupersededProgressComment reports whether a comment body is already a
+// frozen superseded-progress rendering — either flavor — so a freeze retry
+// does not wrap a frozen body in a second fold.
+func IsSupersededProgressComment(body string) bool {
+	return strings.HasPrefix(body, volumeSupersededPrefix) ||
+		strings.HasPrefix(body, resumeSupersededPrefix)
 }
 
 // RenderCutoverCommandAccepted renders the acknowledgement posted when a PR

--- a/pkg/webhook/templates/issue_comment.go
+++ b/pkg/webhook/templates/issue_comment.go
@@ -358,12 +358,47 @@ func RenderResumeSupersededProgressComment(data ResumeSupersededProgressData) st
 		data.Repo, data.PR, data.NewCommentID, data.PreviousBody)
 }
 
+// SupersededProgressData contains data for freezing a progress comment when
+// the rotation that superseded it is no longer known — the retry path for a
+// freeze owed by an earlier rotation, where only the owed comment ID was
+// recorded.
+type SupersededProgressData struct {
+	// Repo is the "owner/name" repository, used to link the successor comment.
+	Repo string
+	// PR is the pull request number, used to link the successor comment.
+	PR int
+	// NewCommentID is the GitHub comment ID of the fresh progress comment now
+	// tracking the schema change.
+	NewCommentID int64
+	// PreviousBody is the superseded comment's last rendered body, preserved
+	// inside the folded details block.
+	PreviousBody string
+}
+
+// genericSupersededPrefix opens every frozen body written when the superseding
+// rotation is no longer known; IsSupersededProgressComment keys on it so a
+// freeze retry can tell an already-frozen comment from a live one.
+const genericSupersededPrefix = "⏭️ Progress comment superseded"
+
+// RenderSupersededProgressComment renders the frozen body written over a
+// progress comment when a fresh one has replaced it but the rotation that did
+// so is no longer known. The old comment's final progress stays on the PR as
+// a record, collapsed into a details block, with a pointer to the comment
+// where progress continues.
+func RenderSupersededProgressComment(data SupersededProgressData) string {
+	return fmt.Sprintf(
+		genericSupersededPrefix+" — progress continues in [a new progress comment](https://github.com/%s/pull/%d#issuecomment-%d).\n\n"+
+			"<details>\n<summary>Earlier progress</summary>\n\n%s\n\n</details>\n",
+		data.Repo, data.PR, data.NewCommentID, data.PreviousBody)
+}
+
 // IsSupersededProgressComment reports whether a comment body is already a
 // frozen superseded-progress rendering — either flavor — so a freeze retry
 // does not wrap a frozen body in a second fold.
 func IsSupersededProgressComment(body string) bool {
 	return strings.HasPrefix(body, volumeSupersededPrefix) ||
-		strings.HasPrefix(body, resumeSupersededPrefix)
+		strings.HasPrefix(body, resumeSupersededPrefix) ||
+		strings.HasPrefix(body, genericSupersededPrefix)
 }
 
 // RenderCutoverCommandAccepted renders the acknowledgement posted when a PR

--- a/pkg/webhook/templates/issue_comment_test.go
+++ b/pkg/webhook/templates/issue_comment_test.go
@@ -210,6 +210,41 @@ func TestRenderVolumeSupersededProgressComment(t *testing.T) {
 		"the superseded body is preserved inside the fold")
 }
 
+// TestRenderResumeSupersededProgressComment verifies the frozen body written
+// over an old progress comment after a resume: it links the successor comment
+// and folds the final pre-stop progress into a details block so the record
+// stays on the PR without looking live.
+func TestRenderResumeSupersededProgressComment(t *testing.T) {
+	rendered := RenderResumeSupersededProgressComment(ResumeSupersededProgressData{
+		Repo:         "acme/testapp",
+		PR:           42,
+		NewCommentID: 2222222222,
+		PreviousBody: "## Schema Change Progress\n\nStopped at 21%",
+	})
+	assert.Contains(t, rendered, "Schema change resumed")
+	assert.Contains(t, rendered, "https://github.com/acme/testapp/pull/42#issuecomment-2222222222")
+	assert.Contains(t, rendered, "<details>")
+	assert.Contains(t, rendered, "<summary>Progress before the stop</summary>")
+	assert.Contains(t, rendered, "Stopped at 21%",
+		"the superseded body is preserved inside the fold")
+}
+
+// TestIsSupersededProgressComment verifies the frozen-body predicate accepts
+// both frozen flavors — so a freeze retry never folds a frozen body inside a
+// second fold — and rejects a live progress body.
+func TestIsSupersededProgressComment(t *testing.T) {
+	volume := RenderVolumeSupersededProgressComment(VolumeSupersededProgressData{
+		Volume: 8, Repo: "acme/testapp", PR: 42, NewCommentID: 1, PreviousBody: "old",
+	})
+	resume := RenderResumeSupersededProgressComment(ResumeSupersededProgressData{
+		Repo: "acme/testapp", PR: 42, NewCommentID: 1, PreviousBody: "old",
+	})
+	assert.True(t, IsSupersededProgressComment(volume), "a volume-frozen body is recognized as frozen")
+	assert.True(t, IsSupersededProgressComment(resume), "a resume-frozen body is recognized as frozen")
+	assert.False(t, IsSupersededProgressComment("## Schema Change Status — Staging"),
+		"a live progress body is not frozen")
+}
+
 func TestRenderRevertCommandAccepted(t *testing.T) {
 	rendered := RenderRevertCommandAccepted(RevertCommandAcceptedData{
 		ApplyID:     "apply-957642f96d634694",

--- a/pkg/webhook/templates/issue_comment_test.go
+++ b/pkg/webhook/templates/issue_comment_test.go
@@ -229,8 +229,31 @@ func TestRenderResumeSupersededProgressComment(t *testing.T) {
 		"the superseded body is preserved inside the fold")
 }
 
+// TestRenderSupersededProgressComment verifies the frozen body written over a
+// progress comment when the superseding rotation is no longer known: it links
+// the successor comment and folds the final progress into a details block
+// without claiming a specific rotation caused it.
+func TestRenderSupersededProgressComment(t *testing.T) {
+	rendered := RenderSupersededProgressComment(SupersededProgressData{
+		Repo:         "acme/testapp",
+		PR:           42,
+		NewCommentID: 2222222222,
+		PreviousBody: "## Schema Change Progress\n\nStopped at 21%",
+	})
+	assert.Contains(t, rendered, "Progress comment superseded")
+	assert.Contains(t, rendered, "https://github.com/acme/testapp/pull/42#issuecomment-2222222222")
+	assert.Contains(t, rendered, "<details>")
+	assert.Contains(t, rendered, "<summary>Earlier progress</summary>")
+	assert.Contains(t, rendered, "Stopped at 21%",
+		"the superseded body is preserved inside the fold")
+	assert.NotContains(t, rendered, "Volume changed",
+		"the generic fold does not claim a volume change caused it")
+	assert.NotContains(t, rendered, "resumed",
+		"the generic fold does not claim a resume caused it")
+}
+
 // TestIsSupersededProgressComment verifies the frozen-body predicate accepts
-// both frozen flavors — so a freeze retry never folds a frozen body inside a
+// every frozen flavor — so a freeze retry never folds a frozen body inside a
 // second fold — and rejects a live progress body.
 func TestIsSupersededProgressComment(t *testing.T) {
 	volume := RenderVolumeSupersededProgressComment(VolumeSupersededProgressData{
@@ -239,8 +262,12 @@ func TestIsSupersededProgressComment(t *testing.T) {
 	resume := RenderResumeSupersededProgressComment(ResumeSupersededProgressData{
 		Repo: "acme/testapp", PR: 42, NewCommentID: 1, PreviousBody: "old",
 	})
+	generic := RenderSupersededProgressComment(SupersededProgressData{
+		Repo: "acme/testapp", PR: 42, NewCommentID: 1, PreviousBody: "old",
+	})
 	assert.True(t, IsSupersededProgressComment(volume), "a volume-frozen body is recognized as frozen")
 	assert.True(t, IsSupersededProgressComment(resume), "a resume-frozen body is recognized as frozen")
+	assert.True(t, IsSupersededProgressComment(generic), "a generic-frozen body is recognized as frozen")
 	assert.False(t, IsSupersededProgressComment("## Schema Change Status — Staging"),
 		"a live progress body is not frozen")
 }

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -1464,6 +1464,25 @@ func PreviewCommentResumeSupersededProgress() string {
 	})
 }
 
+// PreviewCommentSupersededProgress renders an old progress comment after a
+// freeze retry folded it without knowing which rotation superseded it: the
+// final progress collapses into a details block under a pointer to the fresh
+// comment now tracking the apply.
+func PreviewCommentSupersededProgress() string {
+	table := sampleSingleTable()
+	table.Status = state.Task.Stopped
+	table.RowsCopied = 2300000
+	table.RowsTotal = 7200000
+	table.PercentComplete = 32
+	data := sampleSingleApplyData(state.Apply.Stopped, table)
+	return RenderSupersededProgressComment(SupersededProgressData{
+		Repo:         "acme/testapp",
+		PR:           42,
+		NewCommentID: 2222222222,
+		PreviousBody: RenderApplyStatusComment(data),
+	})
+}
+
 // PreviewCommentApplySingleCompleted renders a single-table apply completed.
 func PreviewCommentApplySingleCompleted() string {
 	table := sampleSingleTable()

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -1446,6 +1446,24 @@ func PreviewCommentVolumeSupersededProgress() string {
 	})
 }
 
+// PreviewCommentResumeSupersededProgress renders an old progress comment after
+// a resume froze it: the final pre-stop progress collapses into a details
+// block under a pointer to the fresh comment now tracking the apply.
+func PreviewCommentResumeSupersededProgress() string {
+	table := sampleSingleTable()
+	table.Status = state.Task.Stopped
+	table.RowsCopied = 2300000
+	table.RowsTotal = 7200000
+	table.PercentComplete = 32
+	data := sampleSingleApplyData(state.Apply.Stopped, table)
+	return RenderResumeSupersededProgressComment(ResumeSupersededProgressData{
+		Repo:         "acme/testapp",
+		PR:           42,
+		NewCommentID: 2222222222,
+		PreviousBody: RenderApplyStatusComment(data),
+	})
+}
+
 // PreviewCommentApplySingleCompleted renders a single-table apply completed.
 func PreviewCommentApplySingleCompleted() string {
 	table := sampleSingleTable()


### PR DESCRIPTION
## Why this matters

Repeated stop/start cycles leave every prior progress comment fully expanded on the PR, each frozen at "Stopped" and indistinguishable from the live one. A reader scrolling the timeline has no way to tell which comment is tracking the schema change. The volume-change rotation already solved this — its superseded comment collapses into a details block pointing at its successor — but the resume rotation left its predecessor untouched.

## What it does

Resume rotation now folds the progress comment it supersedes, the same way the volume rotation does, so the PR keeps exactly one live progress comment no matter how many stop/start cycles occur:

```
before                            after
──────                            ─────
Progress (frozen at "Stopped")    ▸ ▶️ Schema change resumed — progress continues in …
⏹️ Stopped summary                 ⏹️ Stopped summary
Progress (frozen at "Stopped")    ▸ ▶️ Schema change resumed — progress continues in …
⏹️ Stopped summary                 ⏹️ Stopped summary
Progress (live)                   Progress (live)
```

- The freeze owed to the prior comment rides the fresh comment's tracking write (`pending_freeze_github_comment_id`), so a pod dying between the post and the fold leaves a durable retry instead of a stranded unfolded comment; a resume also reconciles a freeze a prior drive recorded but never landed.
- Stopped summaries stay expanded — they are the compact record of each pause.
- The frozen-body predicate is shared across both rotation flavors so a freeze retry never wraps an already-folded body in a second fold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)