### PR TITLE
Serve Prometheus metrics on a dedicated listener (default :9102)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -364,6 +364,7 @@ test-e2e-local-down: ## Tear down e2e local environment
 #        Tern-Staging-HTTP=15380, Tern-Staging-gRPC=15390, Tern-Production-HTTP=15382, Tern-Production-gRPC=15392
 E2E_GRPC_ENV := SCHEMABOT_PORT=15370 \
 	SCHEMABOT_MYSQL_PORT=15371 \
+	SCHEMABOT_METRICS_PORT=15376 \
 	TERN_STAGING_MYSQL_PORT=15372 \
 	TERN_PRODUCTION_MYSQL_PORT=15373 \
 	TERN_STAGING_PORT=15380 \
@@ -394,6 +395,7 @@ test-e2e-grpc: build ## Run gRPC e2e tests in isolated environment
 	done
 	@echo "Running gRPC e2e tests..."
 	@E2E_SCHEMABOT_URL=http://localhost:15370 \
+	E2E_SCHEMABOT_METRICS_URL=http://localhost:15376 \
 	E2E_SCHEMABOT_MYSQL_DSN="root:testpassword@tcp(localhost:15371)/schemabot" \
 	E2E_TERN_STAGING_MYSQL_DSN="root:testpassword@tcp(localhost:15372)/testapp" \
 	E2E_TERN_PRODUCTION_MYSQL_DSN="root:testpassword@tcp(localhost:15373)/testapp" \
@@ -412,6 +414,7 @@ test-e2e-grpc: build ## Run gRPC e2e tests in isolated environment
 #        EU-HTTP=15380, EU-gRPC=15390, US-HTTP=15382, US-gRPC=15392
 E2E_GRPC_MD_ENV := SCHEMABOT_PORT=15370 \
 	SCHEMABOT_MYSQL_PORT=15371 \
+	SCHEMABOT_METRICS_PORT=15376 \
 	TERN_EU_MYSQL_PORT=15372 \
 	TERN_US_MYSQL_PORT=15373 \
 	TERN_EU_PORT=15380 \
@@ -444,6 +447,7 @@ test-e2e-grpc-multideploy: build ## Run multi-deployment fan-out gRPC e2e fixtur
 	@echo "Running multi-deployment gRPC e2e tests..."
 	@E2E_MULTIDEPLOY=1 \
 	E2E_SCHEMABOT_URL=http://localhost:15370 \
+	E2E_SCHEMABOT_METRICS_URL=http://localhost:15376 \
 	E2E_SCHEMABOT_MYSQL_DSN="root:testpassword@tcp(localhost:15371)/schemabot" \
 	E2E_TERN_EU_MYSQL_DSN="root:testpassword@tcp(localhost:15372)/testapp" \
 	E2E_TERN_US_MYSQL_DSN="root:testpassword@tcp(localhost:15373)/testapp" \

--- a/charts/schemabot/Chart.yaml
+++ b/charts/schemabot/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: schemabot
 description: GitOps for database schemas
 type: application
-version: 0.1.7
+version: 0.1.8
 appVersion: "v0.1.3"
 maintainers:
   - name: aparajon

--- a/charts/schemabot/templates/deployment.yaml
+++ b/charts/schemabot/templates/deployment.yaml
@@ -46,6 +46,9 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+              protocol: TCP
             {{- if .Values.grpc.enabled }}
             - name: grpc
               containerPort: {{ .Values.grpc.port }}

--- a/charts/schemabot/values.yaml
+++ b/charts/schemabot/values.yaml
@@ -26,6 +26,12 @@ grpc:
   enabled: false
   port: 13370
 
+# The dedicated Prometheus metrics listener. Must match the server's
+# metrics_port config (defaults to 9102 in both places); /metrics is not
+# served on the API port.
+metrics:
+  port: 9102
+
 # SchemaBot config file contents. Rendered into a ConfigMap and mounted
 # at /config/config.yaml. See docs/configuration.md for all options.
 #

--- a/deploy/local/docker-compose.grpc-multideploy.yml
+++ b/deploy/local/docker-compose.grpc-multideploy.yml
@@ -157,6 +157,7 @@ services:
       - ./config:/config:ro
     ports:
       - "${SCHEMABOT_PORT:-13380}:8080"
+      - "${SCHEMABOT_METRICS_PORT:-13387}:9102"
     depends_on:
       schemabot-mysql:
         condition: service_healthy

--- a/deploy/local/docker-compose.grpc.yml
+++ b/deploy/local/docker-compose.grpc.yml
@@ -154,6 +154,7 @@ services:
       - ./config:/config:ro
     ports:
       - "${SCHEMABOT_PORT:-13380}:8080"
+      - "${SCHEMABOT_METRICS_PORT:-13386}:9102"
     depends_on:
       schemabot-mysql:
         condition: service_healthy

--- a/deploy/local/telemetry/prometheus.yml
+++ b/deploy/local/telemetry/prometheus.yml
@@ -19,4 +19,6 @@ storage:
 scrape_configs:
   - job_name: schemabot
     static_configs:
-      - targets: ["schemabot:8080"]
+      # The dedicated metrics listener (metrics_port, default 9102) — /metrics
+      # is not served on the API port.
+      - targets: ["schemabot:9102"]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,6 +12,7 @@
 - [Environment Order](#environment-order)
 - [Hybrid Mode](#hybrid-mode)
 - [Drivers](#drivers)
+- [Metrics](#metrics)
 - [Pending Drops](#pending-drops)
 - [Storage Schema Changes](#storage-schema-changes)
 - [Support Channel](#support-channel)
@@ -276,6 +277,16 @@ Increase `drivers` when one SchemaBot server should make operator progress acros
 
 A driver claim means selecting one stale apply and refreshing its heartbeat in the same storage transaction. That heartbeat refresh is the driver's lease while it reloads state and drives the apply to a terminal state.
 
+## Metrics
+
+SchemaBot serves Prometheus metrics at `/metrics` on a dedicated HTTP listener, separate from the API port. A separate port lets scrapers reach metrics without traversing the API port's transport security — for example when a service mesh proxy terminates mutual TLS on the API port — and keeps the endpoint off any externally routed surface.
+
+```yaml
+metrics_port: 9102
+```
+
+The listener binds `:9102` by default; set `metrics_port` to move it. The API port (the `PORT` environment variable) does not serve `/metrics`.
+
 **Sizing:** each driver drives one claimed apply synchronously to a terminal state, and that includes waiting states such as deferred cutovers and revert windows, so a server's effective apply concurrency is `drivers × replicas`. Size that product to the number of applies you expect to be in flight at once, counting parked ones — a deferred cutover holds its driver for the full wait. A control plane that dispatches to remote servers bounds end-to-end concurrency with its own driver pool the same way.
 
 ## Pending Drops
@@ -499,7 +510,7 @@ By default (`auth.type: none` or unset) the SchemaBot API is unauthenticated —
 - **Read tier** — visibility: `status`, `progress`, `logs`, `locks` (list), history, database discovery, and `pull` (read a live schema).
 - **Write tier** — anything that stages or makes a change: `plan`, `apply`, controls (`stop`/`start`/`cutover`/`volume`/`revert`/`skip-revert`/`rollback`), `unlock`, and settings mutation. `plan` is a write because it stages a change against a database.
 
-Any unclassified `/api` route is treated as write (fail-closed). The `/webhook` and health/metrics endpoints are exempt — webhooks authenticate themselves via HMAC. Two authenticators are available.
+Any unclassified `/api` route is treated as write (fail-closed). The `/webhook` and health endpoints are exempt — webhooks authenticate themselves via HMAC. Prometheus metrics are served on a dedicated listener (see [Metrics](#metrics)), not on the API port. Two authenticators are available.
 
 ### OIDC (Bearer tokens)
 

--- a/e2e/grpc/helpers_test.go
+++ b/e2e/grpc/helpers_test.go
@@ -33,6 +33,15 @@ func grpcSchemabotURL(t *testing.T) string {
 	return url
 }
 
+// grpcSchemabotMetricsURL is the base URL of the dedicated metrics listener,
+// which serves /metrics on its own port separate from the API.
+func grpcSchemabotMetricsURL(t *testing.T) string {
+	t.Helper()
+	url := os.Getenv("E2E_SCHEMABOT_METRICS_URL")
+	require.NotEmpty(t, url, "E2E_SCHEMABOT_METRICS_URL environment variable not set")
+	return url
+}
+
 func grpcSchemabotMySQLDSN(t *testing.T) string {
 	t.Helper()
 	dsn := os.Getenv("E2E_SCHEMABOT_MYSQL_DSN")
@@ -281,7 +290,12 @@ func grpcApplyLogs(t *testing.T, applyID string, limit int) []grpcApplyLogEntry 
 // exposition text.
 func grpcMetrics(t *testing.T) string {
 	t.Helper()
-	resp := grpcGet(t, "/metrics")
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, grpcSchemabotMetricsURL(t)+"/metrics", nil)
+	require.NoError(t, err, "create request")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err, "GET /metrics")
 	require.Equalf(t, http.StatusOK, resp.StatusCode, "GET /metrics status")
 	body, err := io.ReadAll(resp.Body)
 	_ = resp.Body.Close()

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -108,6 +108,14 @@ type ServerConfig struct {
 	// SKIP LOCKED to prevent races. Defaults to DefaultDrivers.
 	Drivers int `yaml:"drivers"`
 
+	// MetricsPort is the TCP port of the dedicated HTTP listener serving
+	// Prometheus metrics at /metrics. Metrics are served on their own listener —
+	// not on the main API port — so scrapers can reach them without traversing
+	// the API port's transport security (for example a service mesh proxy
+	// terminating mutual TLS on the API port). Defaults to DefaultMetricsPort.
+	// Read via MetricsListenPort.
+	MetricsPort int `yaml:"metrics_port,omitempty"`
+
 	// OperatorClaimOperations switches drivers to claim work at the
 	// apply_operations (per-deployment) level via FindNextApplyOperation instead
 	// of the apply level via FindNextApply. While every apply still owns exactly
@@ -897,6 +905,9 @@ func (c *ServerConfig) Validate() error {
 
 	if err := validateUniqueNames("environment_order", c.EnvironmentOrder); err != nil {
 		return err
+	}
+	if c.MetricsPort < 0 || c.MetricsPort > 65535 {
+		return fmt.Errorf("metrics_port must be between 0 and 65535, got %d", c.MetricsPort)
 	}
 	if err := validateUniqueNames("required_checks", c.RequiredChecks); err != nil {
 		return err
@@ -1920,6 +1931,19 @@ func (c *ServerConfig) ShouldClaimOperations() bool {
 		return true
 	}
 	return *c.OperatorClaimOperations
+}
+
+// DefaultMetricsPort is the port of the dedicated Prometheus metrics listener
+// when metrics_port is not configured.
+const DefaultMetricsPort = 9102
+
+// MetricsListenPort returns the TCP port of the dedicated /metrics listener:
+// metrics_port when configured, DefaultMetricsPort otherwise.
+func (c *ServerConfig) MetricsListenPort() int {
+	if c == nil || c.MetricsPort == 0 {
+		return DefaultMetricsPort
+	}
+	return c.MetricsPort
 }
 
 // IsCheckRequired returns whether a PR check name is part of the configured

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -747,6 +747,37 @@ func TestServerConfig_ValidateRejectsLocalRemoteRouteCollision(t *testing.T) {
 // A non-empty but unparseable revert_window_duration is a startup config error
 // so a typo (e.g. "30 minutes") fails closed instead of silently reverting to
 // the engine default window.
+// MetricsListenPort defaults to DefaultMetricsPort and honors an explicit
+// metrics_port override.
+func TestServerConfig_MetricsListenPort(t *testing.T) {
+	cfg := ServerConfig{}
+	assert.Equal(t, DefaultMetricsPort, cfg.MetricsListenPort(), "unset metrics_port defaults")
+
+	cfg.MetricsPort = 9464
+	assert.Equal(t, 9464, cfg.MetricsListenPort(), "explicit metrics_port wins")
+}
+
+// A metrics_port outside the TCP port range fails closed at config load.
+func TestServerConfig_ValidateRejectsInvalidMetricsPort(t *testing.T) {
+	for _, port := range []int{-1, 65536} {
+		cfg := ServerConfig{
+			MetricsPort: port,
+			Databases: map[string]DatabaseConfig{
+				"mydb": {
+					Type: "vitess",
+					Environments: map[string]EnvironmentConfig{
+						"staging": {DSN: "root@tcp(localhost)/mydb"},
+					},
+				},
+			},
+		}
+
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "metrics_port")
+	}
+}
+
 func TestServerConfig_ValidateRejectsInvalidRevertWindowDuration(t *testing.T) {
 	cfg := ServerConfig{
 		Databases: map[string]DatabaseConfig{

--- a/pkg/auth/forward_auth_test.go
+++ b/pkg/auth/forward_auth_test.go
@@ -330,17 +330,25 @@ func TestForwardAuth_GroupsFromRepeatedAndDelimitedHeaders(t *testing.T) {
 }
 
 func TestForwardAuth_SkipsInfraPaths(t *testing.T) {
-	// Health/metrics/webhook paths bypass the authorizer entirely.
+	// Health/webhook paths bypass the authorizer entirely.
 	handler, _ := newForwardAuth(t, auth.ForwardAuthConfig{
 		TrustedProxyCIDRs: []string{trustedCIDR},
 		WriteGroups:       []string{"owners"},
 	})
 
-	for _, path := range []string{"/livez", "/health", "/metrics", "/webhook"} {
+	for _, path := range []string{"/livez", "/health", "/webhook"} {
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, path, nil)
 		req.RemoteAddr = untrustedAddr // untrusted, but these paths skip auth
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)
 		assert.Equalf(t, http.StatusOK, rec.Code, "path %s should bypass auth", path)
 	}
+
+	// /metrics is served on a dedicated listener outside the API handler, so it
+	// no longer bypasses the authorizer on the API port.
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/metrics", nil)
+	req.RemoteAddr = untrustedAddr
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code, "/metrics should not bypass auth")
 }

--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -184,17 +184,16 @@ func (a *OIDCAuthorizer) extractGroups(token *oidc.IDToken) ([]string, error) {
 	return nil, fmt.Errorf("parse %s claim as string or string array", a.groupsClaim)
 }
 
-// skipAuth reports paths that bypass OIDC authentication: webhooks have their
-// own HMAC authentication, and the probe and telemetry endpoints (/livez,
-// /health, /tern-health, /metrics) are unauthenticated infrastructure
-// endpoints — kubelet probes and scrapers carry no credentials.
+// skipAuth reports paths that bypass authentication: webhooks have their own
+// HMAC authentication, and the probe endpoints (/livez, /health, /tern-health)
+// are unauthenticated infrastructure endpoints — kubelet probes carry no
+// credentials. Prometheus metrics are served on a dedicated listener outside
+// the API handler, so /metrics needs no bypass here.
 func skipAuth(path string) bool {
 	switch {
 	case path == "/livez":
 		return true
 	case path == "/health":
-		return true
-	case path == "/metrics":
 		return true
 	case strings.HasPrefix(path, "/webhook"):
 		return true

--- a/pkg/auth/oidc_test.go
+++ b/pkg/auth/oidc_test.go
@@ -319,7 +319,7 @@ func TestOIDCAuthorizerBypassesNonAPIPaths(t *testing.T) {
 	p := newTestOIDCProvider(t)
 	authz := newAuthorizer(t, p, auth.OIDCConfig{Audience: "schemabot"})
 
-	for _, path := range []string{"/livez", "/health", "/metrics", "/webhook", "/tern-health/cake/staging"} {
+	for _, path := range []string{"/livez", "/health", "/webhook", "/tern-health/cake/staging"} {
 		t.Run(path, func(t *testing.T) {
 			var ran bool
 			handler := authz.Middleware(okHandler(&ran, nil))
@@ -332,4 +332,17 @@ func TestOIDCAuthorizerBypassesNonAPIPaths(t *testing.T) {
 			assert.True(t, ran)
 		})
 	}
+
+	// /metrics is served on a dedicated listener outside the API handler, so it
+	// no longer bypasses authentication on the API port.
+	t.Run("/metrics requires auth", func(t *testing.T) {
+		var ran bool
+		handler := authz.Middleware(okHandler(&ran, nil))
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/metrics", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.False(t, ran)
+	})
 }

--- a/pkg/serve/serve.go
+++ b/pkg/serve/serve.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/signal"
 	"sort"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -102,9 +103,10 @@ func (r webhookRuntime) StartMissingSummaryReconciliation(ctx context.Context, l
 }
 
 // Run starts the SchemaBot server with the given configuration and blocks until
-// it receives SIGINT/SIGTERM or the HTTP server fails, then shuts down
+// it receives SIGINT/SIGTERM or either HTTP server fails, then shuts down
 // gracefully. The storage DSN is resolved from cfg (falling back to MYSQL_DSN);
-// PORT and GRPC_PORT are read from the environment.
+// PORT and GRPC_PORT are read from the environment. Prometheus metrics are
+// served on a dedicated listener at cfg.MetricsListenPort, not on the API port.
 func Run(ctx context.Context, cfg *api.ServerConfig, opts ...Option) error {
 	port := getEnv("PORT", "8080")
 	grpcPort := os.Getenv("GRPC_PORT")
@@ -162,13 +164,31 @@ func Run(ctx context.Context, cfg *api.ServerConfig, opts ...Option) error {
 		IdleTimeout:  60 * time.Second,
 	}
 
-	errCh := make(chan error, 1)
+	// Metrics get their own listener so scrapers never traverse the API port
+	// (see ServerConfig.MetricsPort).
+	metricsPort := strconv.Itoa(cfg.MetricsListenPort())
+	metricsMux := http.NewServeMux()
+	metricsMux.Handle("GET /metrics", srv.MetricsHandler())
+	metricsServer := &http.Server{
+		Addr:         ":" + metricsPort,
+		Handler:      metricsMux,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	errCh := make(chan error, 2)
 	go func() {
 		srv.logger.Info("starting http server", "port", port)
 		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			errCh <- err
+			errCh <- fmt.Errorf("http server: %w", err)
 		}
-		close(errCh)
+	}()
+	go func() {
+		srv.logger.Info("starting metrics server", "port", metricsPort)
+		if err := metricsServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- fmt.Errorf("metrics server: %w", err)
+		}
 	}()
 
 	// Wait for a shutdown signal, context cancellation (embedded callers), or a
@@ -186,13 +206,13 @@ func Run(ctx context.Context, cfg *api.ServerConfig, opts ...Option) error {
 		return err
 	}
 
-	// Graceful shutdown of the HTTP server; Server.Close (deferred) releases the
-	// rest.
+	// Graceful shutdown of both HTTP servers; Server.Close (deferred) releases
+	// the rest.
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	srv.logger.Info("shutting down server")
-	return server.Shutdown(shutdownCtx)
+	return errors.Join(server.Shutdown(shutdownCtx), metricsServer.Shutdown(shutdownCtx))
 }
 
 // Server is a built but not-yet-listening SchemaBot server. Build constructs it
@@ -332,7 +352,7 @@ func Build(ctx context.Context, cfg *api.ServerConfig, opts ...Option) (*Server,
 	// Authentication middleware. With the default (none) auth this is an
 	// allow-all NoneAuthorizer that lets every request through (attaching an
 	// anonymous user); with "oidc" it validates Bearer JWTs and bypasses
-	// non-API paths (/webhook, /metrics, health) itself.
+	// non-API paths (/webhook, health) itself.
 	authz, err := buildAuthorizer(ctx, cfg.Auth, cfg.PRCommandAuthorization.AdminTeams, logger)
 	if err != nil {
 		return nil, fmt.Errorf("setup auth: %w", err)
@@ -451,13 +471,13 @@ func (s *Server) RegisterGRPC(ctx context.Context, gs *grpc.Server) error {
 	return nil
 }
 
-// Handler returns the SchemaBot HTTP handler: API routes, /metrics, the webhook
-// endpoint, the auth middleware, and OTel instrumentation. An embedder mounts it
-// on its own server; Run serves it directly.
+// Handler returns the SchemaBot HTTP handler: API routes, the webhook endpoint,
+// the auth middleware, and OTel instrumentation. An embedder mounts it on its
+// own server; Run serves it directly. Prometheus metrics are not part of this
+// handler — mount MetricsHandler on a dedicated listener instead.
 func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
 	s.svc.ConfigureRoutes(mux)
-	mux.Handle("GET /metrics", s.telemetry.MetricsHandler)
 	mux.Handle("POST /webhook", s.webhook.handler)
 
 	authedHandler := s.authz.Middleware(mux)
@@ -470,6 +490,13 @@ func (s *Server) Handler() http.Handler {
 		authedHandler.ServeHTTP(w, r)
 	})
 	return otelhttp.NewHandler(metricHandler, "schemabot")
+}
+
+// MetricsHandler returns the Prometheus /metrics handler. Run serves it on the
+// dedicated metrics listener (ServerConfig.MetricsPort); an embedder that owns
+// its listeners mounts it wherever its scraper expects it.
+func (s *Server) MetricsHandler() http.Handler {
+	return s.telemetry.MetricsHandler
 }
 
 // Start launches the server's background work: the operator driver pool

--- a/pkg/serve/serve_build_test.go
+++ b/pkg/serve/serve_build_test.go
@@ -40,10 +40,9 @@ func TestServerRegisterGRPCRegistersTernService(t *testing.T) {
 	assert.True(t, ok, "RegisterGRPC must register the Tern service on the embedder's gRPC server")
 }
 
-// Handler returns the SchemaBot HTTP handler an embedder mounts on its own mux.
-// It exposes /metrics through the auth middleware, so a request reaches the
-// metrics endpoint without Run owning the HTTP server.
-func TestServerHandlerServesMetrics(t *testing.T) {
+// Prometheus metrics live on their own handler (served by Run on the dedicated
+// metrics listener), not on the API handler an embedder mounts on its own mux.
+func TestServerMetricsHandlerSeparateFromAPIHandler(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 	cfg := &api.ServerConfig{}
 	svc := api.New(mysqlstore.New(nil), cfg, nil, logger)
@@ -69,7 +68,14 @@ func TestServerHandlerServesMetrics(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/metrics", nil))
-	assert.Equal(t, http.StatusOK, rec.Code, "the handler serves /metrics through the auth middleware")
+	assert.Equal(t, http.StatusNotFound, rec.Code, "the API handler does not serve /metrics")
+
+	metricsHandler := srv.MetricsHandler()
+	require.NotNil(t, metricsHandler)
+
+	rec = httptest.NewRecorder()
+	metricsHandler.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/metrics", nil))
+	assert.Equal(t, http.StatusOK, rec.Code, "the metrics handler serves /metrics")
 }
 
 // Enabling auth.type: forward_auth wires the forward-auth authorizer into the


### PR DESCRIPTION
## What

Moves `/metrics` off the main API port onto its own HTTP listener, defaulting to port **9102** and overridable with a new `metrics_port` server config key.

## Why

Serving Prometheus metrics on the API port forces the two to share transport security. When the API port sits behind a proxy that terminates mutual TLS (e.g. a service mesh sidecar), plaintext scrapers can't reach `/metrics` without punching exemptions into the proxy's policy for the whole port. A dedicated listener lets operators keep strict transport security on the API port and expose only the metrics port to their scraper.

Discussed with maintainers before implementation; changing the default port (rather than keeping 8080) was agreed since backward compatibility is not a concern here.

## Changes

- **`pkg/api/config.go`**: new `metrics_port` config key (validated 0–65535); `MetricsListenPort()` defaults to `DefaultMetricsPort` (9102).
- **`pkg/serve/serve.go`**: `Run` starts a second `http.Server` serving `GET /metrics`; graceful shutdown drains both servers, and a boot failure of either listener surfaces on the error channel. New `Server.MetricsHandler()` accessor for embedders.
- **`pkg/auth/oidc.go`**: the auth middlewares no longer special-case `/metrics` — it isn't mounted on the API port anymore, so a `/metrics` request there is now 404 (or 401 behind auth), never a metrics response.
- **Helm chart**: exposes the new container port (`metrics.port`, port name `metrics`); chart `0.1.7` → `0.1.8`.
- **Local dev / e2e**: compose files map the metrics port, the local Prometheus scrapes `schemabot:9102`, and the gRPC e2e harness reads `E2E_SCHEMABOT_METRICS_URL`.
- **Docs**: new *Metrics* section in `docs/configuration.md`.

## Deployment note

Upgrading operators must point their scraper at the metrics port (default 9102): after this change the API port never serves `/metrics`. The chart's `metrics.port` value must match the server's `metrics_port` config; both default to 9102.

## Testing

- Full unit + integration suites pass locally; lint clean.
- gRPC e2e (including the multi-deployment matrix) exercises the new listener end-to-end in CI: the harness scrapes `/metrics` via the dedicated port mapping.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

*This PR was authored by an AI agent on behalf of @mpuncel.*