### PR TITLE
fix(github): retry GitHub reads generously through transient failures

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -432,9 +432,28 @@ func newGitHubRateLimitTransport(base http.RoundTripper) http.RoundTripper {
 	)
 }
 
-const githubUnavailableReadRetryMaxAttempts = 3
+// GitHub read retries are deliberately generous: transient edge failures
+// (5xx, empty-body 400s, dropped connections, short rate-limit windows) can
+// last several seconds, and a failed read on a webhook path surfaces to the
+// user as a ❌ comment on the PR. The exponential schedule waits roughly
+// fifteen seconds end to end; the caller's context deadline still bounds the
+// total wait, so a short-deadline caller gives up sooner.
+const (
+	githubUnavailableReadRetryMaxAttempts = 6
+	githubUnavailableReadRetryMaxDelay    = 20 * time.Second
+)
 
-var githubUnavailableReadRetryDelay = 200 * time.Millisecond
+var githubUnavailableReadRetryDelay = 500 * time.Millisecond
+
+// SetUnavailableReadRetryDelayForTest shrinks the read-retry backoff base so
+// tests that simulate GitHub failures do not wait out the production
+// schedule. It returns a restore function; a test-binary init may discard it
+// to keep the override for the whole run.
+func SetUnavailableReadRetryDelayForTest(delay time.Duration) (restore func()) {
+	original := githubUnavailableReadRetryDelay
+	githubUnavailableReadRetryDelay = delay
+	return func() { githubUnavailableReadRetryDelay = original }
+}
 
 func retryGitHubUnavailableRead[T any](ctx context.Context, logger *slog.Logger, operation string, logAttrs []any, read func(context.Context) (T, error)) (T, error) {
 	var zero T
@@ -450,7 +469,7 @@ func retryGitHubUnavailableRead[T any](ctx context.Context, logger *slog.Logger,
 		if !IsUnavailableError(err) || attempt == githubUnavailableReadRetryMaxAttempts || ctx.Err() != nil {
 			return zero, err
 		}
-		delay := githubUnavailableReadRetryDelay * time.Duration(attempt)
+		delay := githubReadRetryDelay(attempt, err)
 		if logger != nil {
 			logger.Warn("retrying unavailable GitHub read",
 				append(logAttrs, "operation", operation, "attempt", attempt, "max_attempts", githubUnavailableReadRetryMaxAttempts, "delay", delay, "error", err)...)
@@ -464,6 +483,29 @@ func retryGitHubUnavailableRead[T any](ctx context.Context, logger *slog.Logger,
 		}
 	}
 	return zero, fmt.Errorf("retry GitHub read %s: exhausted attempts", operation)
+}
+
+// githubReadRetryDelay picks the wait before the next read attempt:
+// exponential backoff from the base delay, raised to any rate-limit
+// retry-after hint carried by the error, and capped so a long rate-limit
+// window cannot stall the caller far past what its context deadline would
+// allow anyway.
+func githubReadRetryDelay(attempt int, err error) time.Duration {
+	delay := githubUnavailableReadRetryDelay << (attempt - 1)
+	if hint, ok := githubRateLimitRetryAfter(err); ok && hint > delay {
+		delay = hint
+	}
+	return min(delay, githubUnavailableReadRetryMaxDelay)
+}
+
+// githubRateLimitRetryAfter extracts the Retry-After wait a GitHub
+// secondary rate limit carries, when present.
+func githubRateLimitRetryAfter(err error) (time.Duration, bool) {
+	var abuseErr *gh.AbuseRateLimitError
+	if errors.As(err, &abuseErr) && abuseErr.RetryAfter != nil {
+		return *abuseErr.RetryAfter, true
+	}
+	return 0, false
 }
 
 // AppSlug returns the GitHub App slug associated with this installation
@@ -522,11 +564,13 @@ func isGitHubUnavailable(err error) bool {
 	if errors.Is(err, context.DeadlineExceeded) {
 		return true
 	}
+	if isGitHubSecondaryRateLimited(err) {
+		return true
+	}
 
 	var ghErr *gh.ErrorResponse
 	if errors.As(err, &ghErr) && ghErr.Response != nil {
-		status := ghErr.Response.StatusCode
-		return status >= http.StatusInternalServerError
+		return isTransientGitHubStatus(ghErr)
 	}
 
 	var netErr net.Error
@@ -535,6 +579,39 @@ func isGitHubUnavailable(err error) bool {
 	}
 	var opErr *net.OpError
 	return errors.As(err, &opErr)
+}
+
+// isGitHubSecondaryRateLimited reports whether the error is a GitHub
+// secondary (abuse) rate limit. Secondary limits clear within seconds, so
+// they count as availability failures; the retry delay honors the server's
+// Retry-After hint via githubRateLimitRetryAfter. A primary rate limit
+// (*gh.RateLimitError) is deliberately not retried here: it means the
+// installation's hourly budget is exhausted, the reset is typically far
+// beyond any read's context deadline, and callers with durable retry
+// (webhook deliveries) recover on their own schedule instead.
+func isGitHubSecondaryRateLimited(err error) bool {
+	var abuseErr *gh.AbuseRateLimitError
+	return errors.As(err, &abuseErr)
+}
+
+// isTransientGitHubStatus classifies an HTTP error status from the GitHub
+// API as an availability failure (worth retrying) or a semantic answer
+// about the request (not). 5xx and 429 are availability failures. A 400
+// whose body carries no error message or details is GitHub's edge
+// intermittently rejecting a valid read — a real client error always says
+// what was wrong with the request. 404 stays semantic: config discovery
+// depends on it meaning "this path does not exist".
+func isTransientGitHubStatus(ghErr *gh.ErrorResponse) bool {
+	switch status := ghErr.Response.StatusCode; {
+	case status >= http.StatusInternalServerError:
+		return true
+	case status == http.StatusTooManyRequests:
+		return true
+	case status == http.StatusBadRequest && ghErr.Message == "" && len(ghErr.Errors) == 0:
+		return true
+	default:
+		return false
+	}
 }
 
 // splitRepo splits "owner/repo" into owner and repo parts.
@@ -563,7 +640,13 @@ func (ic *InstallationClient) CreateIssueComment(ctx context.Context, repo strin
 // GetIssueComment returns the current body of an existing PR/issue comment.
 func (ic *InstallationClient) GetIssueComment(ctx context.Context, repo string, commentID int64) (string, error) {
 	owner, repoName := splitRepo(repo)
-	comment, _, err := ic.client.Issues.GetComment(ctx, owner, repoName, commentID)
+	comment, err := retryGitHubUnavailableRead(ctx, ic.logger, "get issue comment", []any{"repo", repo, "comment_id", commentID}, func(ctx context.Context) (*gh.IssueComment, error) {
+		c, _, callErr := ic.client.Issues.GetComment(ctx, owner, repoName, commentID)
+		if callErr != nil {
+			return nil, classifyGitHubAPIError(callErr)
+		}
+		return c, nil
+	})
 	if err != nil {
 		return "", fmt.Errorf("get issue comment %d: %w", commentID, err)
 	}
@@ -1077,7 +1160,15 @@ func (ic *InstallationClient) FindCheckRunByName(ctx context.Context, repo, head
 	var untrustedApps []string
 	seenUntrusted := make(map[string]struct{})
 	for {
-		result, resp, err := ic.client.Checks.ListCheckRunsForRef(ctx, owner, repoName, headSHA, opts)
+		var resp *gh.Response
+		result, err := retryGitHubUnavailableRead(ctx, ic.logger, "list check runs by name", []any{"repo", repo, "head_sha", headSHA, "check_name", checkName}, func(ctx context.Context) (*gh.ListCheckRunsResults, error) {
+			res, listResp, listErr := ic.client.Checks.ListCheckRunsForRef(ctx, owner, repoName, headSHA, opts)
+			if listErr != nil {
+				return nil, classifyGitHubAPIError(listErr)
+			}
+			resp = listResp
+			return res, nil
+		})
 		if err != nil {
 			return nil, nil, fmt.Errorf("list check runs named %q on %s@%s: %w", checkName, repo, headSHA, err)
 		}
@@ -1284,7 +1375,15 @@ func (ic *InstallationClient) fetchCommitStatusRows(ctx context.Context, owner, 
 	opts := &gh.ListOptions{PerPage: 100}
 	var out []CheckStatusRow
 	for {
-		combined, resp, err := ic.client.Repositories.GetCombinedStatus(ctx, owner, repoName, ref, opts)
+		var resp *gh.Response
+		combined, err := retryGitHubUnavailableRead(ctx, ic.logger, "get combined commit status", []any{"repo", repo, "ref", ref}, func(ctx context.Context) (*gh.CombinedStatus, error) {
+			res, statusResp, statusErr := ic.client.Repositories.GetCombinedStatus(ctx, owner, repoName, ref, opts)
+			if statusErr != nil {
+				return nil, classifyGitHubAPIError(statusErr)
+			}
+			resp = statusResp
+			return res, nil
+		})
 		if err != nil {
 			return nil, fmt.Errorf("get combined commit status for %s@%s: %w", repo, ref, err)
 		}
@@ -1312,7 +1411,15 @@ func (ic *InstallationClient) fetchCheckRunRows(ctx context.Context, owner, repo
 	opts := &gh.ListCheckRunsOptions{Filter: &filter, ListOptions: gh.ListOptions{PerPage: 100}}
 	var out []CheckStatusRow
 	for {
-		result, resp, err := ic.client.Checks.ListCheckRunsForRef(ctx, owner, repoName, ref, opts)
+		var resp *gh.Response
+		result, err := retryGitHubUnavailableRead(ctx, ic.logger, "list check runs", []any{"repo", repo, "ref", ref}, func(ctx context.Context) (*gh.ListCheckRunsResults, error) {
+			res, listResp, listErr := ic.client.Checks.ListCheckRunsForRef(ctx, owner, repoName, ref, opts)
+			if listErr != nil {
+				return nil, classifyGitHubAPIError(listErr)
+			}
+			resp = listResp
+			return res, nil
+		})
 		if err != nil {
 			return nil, fmt.Errorf("list check runs for %s@%s: %w", repo, ref, err)
 		}

--- a/pkg/github/retry_test.go
+++ b/pkg/github/retry_test.go
@@ -83,6 +83,7 @@ func TestGitHubReadRetryDelay(t *testing.T) {
 		{name: "delay doubles per attempt", attempt: 3, err: transient, want: 2 * time.Second},
 		{name: "fifth attempt reaches eight seconds", attempt: 5, err: transient, want: 8 * time.Second},
 		{name: "retry-after hint raises the wait", attempt: 1, err: &gh.AbuseRateLimitError{RetryAfter: &longHint}, want: 5 * time.Second},
+		{name: "retry-after hint survives error classification", attempt: 1, err: classifyGitHubAPIError(&gh.AbuseRateLimitError{RetryAfter: &longHint}), want: 5 * time.Second},
 		{name: "schedule wins over a shorter hint", attempt: 3, err: &gh.AbuseRateLimitError{RetryAfter: &shortHint}, want: 2 * time.Second},
 	}
 

--- a/pkg/github/retry_test.go
+++ b/pkg/github/retry_test.go
@@ -1,0 +1,180 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"testing"
+	"time"
+
+	gh "github.com/google/go-github/v86/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func ghErrorResponse(status int, message string) *gh.ErrorResponse {
+	return &gh.ErrorResponse{
+		Response: &http.Response{StatusCode: status},
+		Message:  message,
+	}
+}
+
+// TestIsGitHubUnavailableClassification pins down which GitHub API failures
+// count as availability failures (retryable) versus semantic answers about
+// the request (never retried). The 404 and message-bearing 400 rows are
+// safety-relevant: config discovery treats 404 as "this path does not
+// exist", so retrying it would turn every discovery probe into a slow path.
+func TestIsGitHubUnavailableClassification(t *testing.T) {
+	t.Parallel()
+
+	retryAfter := 5 * time.Second
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "500 internal server error", err: ghErrorResponse(http.StatusInternalServerError, "boom"), want: true},
+		{name: "503 service unavailable", err: ghErrorResponse(http.StatusServiceUnavailable, ""), want: true},
+		{name: "429 too many requests", err: ghErrorResponse(http.StatusTooManyRequests, "slow down"), want: true},
+		{name: "empty-body 400 from the edge", err: ghErrorResponse(http.StatusBadRequest, ""), want: true},
+		{name: "400 with a real validation message", err: ghErrorResponse(http.StatusBadRequest, "invalid request"), want: false},
+		{name: "400 with field errors", err: &gh.ErrorResponse{Response: &http.Response{StatusCode: http.StatusBadRequest}, Errors: []gh.Error{{Code: "invalid"}}}, want: false},
+		{name: "404 not found", err: ghErrorResponse(http.StatusNotFound, "Not Found"), want: false},
+		{name: "401 unauthorized", err: ghErrorResponse(http.StatusUnauthorized, "Bad credentials"), want: false},
+		{name: "403 forbidden", err: ghErrorResponse(http.StatusForbidden, "Resource not accessible"), want: false},
+		{name: "primary rate limit means the hourly budget is exhausted", err: &gh.RateLimitError{Rate: gh.Rate{Reset: gh.Timestamp{Time: time.Now().Add(time.Minute)}}}, want: false},
+		{name: "secondary rate limit clears within seconds", err: &gh.AbuseRateLimitError{RetryAfter: &retryAfter}, want: true},
+		{name: "wrapped 502", err: fmt.Errorf("fetch file: %w", ghErrorResponse(http.StatusBadGateway, "")), want: true},
+		{name: "context deadline exceeded", err: context.DeadlineExceeded, want: true},
+		{name: "plain error", err: errors.New("something else"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, isGitHubUnavailable(tt.err))
+			assert.Equal(t, tt.want, IsUnavailableError(classifyGitHubAPIError(tt.err)))
+		})
+	}
+}
+
+// TestGitHubReadRetryDelay verifies the wait schedule: exponential growth
+// from the base delay, raised to a rate-limit retry-after hint when the
+// server provides one, and always capped so a long rate-limit window cannot
+// stall a caller indefinitely.
+func TestGitHubReadRetryDelay(t *testing.T) {
+	t.Parallel()
+
+	shortHint := 100 * time.Millisecond
+	longHint := 5 * time.Second
+	transient := ghErrorResponse(http.StatusServiceUnavailable, "")
+
+	tests := []struct {
+		name    string
+		attempt int
+		err     error
+		want    time.Duration
+	}{
+		{name: "first attempt uses the base delay", attempt: 1, err: transient, want: 500 * time.Millisecond},
+		{name: "delay doubles per attempt", attempt: 3, err: transient, want: 2 * time.Second},
+		{name: "fifth attempt reaches eight seconds", attempt: 5, err: transient, want: 8 * time.Second},
+		{name: "retry-after hint raises the wait", attempt: 1, err: &gh.AbuseRateLimitError{RetryAfter: &longHint}, want: 5 * time.Second},
+		{name: "schedule wins over a shorter hint", attempt: 3, err: &gh.AbuseRateLimitError{RetryAfter: &shortHint}, want: 2 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, githubReadRetryDelay(tt.attempt, tt.err))
+		})
+	}
+
+	t.Run("a long retry-after hint is capped", func(t *testing.T) {
+		t.Parallel()
+
+		farHint := 10 * time.Minute
+		abuseErr := &gh.AbuseRateLimitError{RetryAfter: &farHint}
+		assert.Equal(t, githubUnavailableReadRetryMaxDelay, githubReadRetryDelay(1, abuseErr))
+	})
+}
+
+// TestGetIssueCommentRetriesEmptyBodyBadRequest exercises the transient
+// empty-body 400 GitHub's edge intermittently returns for valid reads: the
+// read is retried and the caller sees the successful result, not the blip.
+func TestGetIssueCommentRetriesEmptyBodyBadRequest(t *testing.T) {
+	setGitHubUnavailableReadRetryDelay(t, time.Millisecond)
+
+	client, mux := setupConfigTestGitHubServer(t)
+	requests := 0
+	mux.HandleFunc("GET /repos/octocat/hello-world/issues/comments/77", func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		if requests == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		_, err := w.Write([]byte(`{"id": 77, "body": "progress comment body"}`))
+		require.NoError(t, err)
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	body, err := ic.GetIssueComment(t.Context(), "octocat/hello-world", 77)
+
+	require.NoError(t, err)
+	assert.Equal(t, "progress comment body", body)
+	assert.Equal(t, 2, requests)
+}
+
+// TestGetIssueCommentDoesNotRetrySemanticBadRequest verifies a 400 that
+// carries a real validation message fails immediately: it is GitHub's
+// answer about the request, and retrying it would only delay the caller.
+func TestGetIssueCommentDoesNotRetrySemanticBadRequest(t *testing.T) {
+	setGitHubUnavailableReadRetryDelay(t, time.Millisecond)
+
+	client, mux := setupConfigTestGitHubServer(t)
+	requests := 0
+	mux.HandleFunc("GET /repos/octocat/hello-world/issues/comments/77", func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusBadRequest)
+		_, err := w.Write([]byte(`{"message": "problems parsing JSON"}`))
+		require.NoError(t, err)
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	_, err := ic.GetIssueComment(t.Context(), "octocat/hello-world", 77)
+
+	require.Error(t, err)
+	assert.False(t, IsUnavailableError(err))
+	assert.Equal(t, 1, requests)
+}
+
+// TestListReviewsRetriesUnavailableRead verifies the paginated review read
+// that gates approvals survives a transient 5xx on one page.
+func TestListReviewsRetriesUnavailableRead(t *testing.T) {
+	setGitHubUnavailableReadRetryDelay(t, time.Millisecond)
+
+	client, mux := setupConfigTestGitHubServer(t)
+	requests := 0
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/reviews", func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		if requests == 1 {
+			http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		_, err := w.Write([]byte(`[{"user": {"login": "alice"}, "state": "APPROVED"}]`))
+		require.NoError(t, err)
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	reviews, err := ic.ListReviews(t.Context(), "octocat/hello-world", 1)
+
+	require.NoError(t, err)
+	require.Len(t, reviews, 1)
+	assert.Equal(t, "alice", reviews[0].User)
+	assert.Equal(t, ReviewApproved, reviews[0].State)
+	assert.Equal(t, 2, requests)
+}

--- a/pkg/github/reviews.go
+++ b/pkg/github/reviews.go
@@ -37,9 +37,17 @@ func (ic *InstallationClient) ListReviews(ctx context.Context, repo string, pr i
 	var allReviews []*ReviewInfo
 
 	for {
-		reviews, resp, err := ic.client.PullRequests.ListReviews(ctx, owner, repoName, pr, opts)
+		var resp *gh.Response
+		reviews, err := retryGitHubUnavailableRead(ctx, ic.logger, "list PR reviews", []any{"repo", repo, "pr", pr}, func(ctx context.Context) ([]*gh.PullRequestReview, error) {
+			list, listResp, listErr := ic.client.PullRequests.ListReviews(ctx, owner, repoName, pr, opts)
+			if listErr != nil {
+				return nil, classifyGitHubAPIError(listErr)
+			}
+			resp = listResp
+			return list, nil
+		})
 		if err != nil {
-			return nil, fmt.Errorf("list PR reviews: %w", err)
+			return nil, fmt.Errorf("list PR reviews for %s#%d: %w", repo, pr, err)
 		}
 		for _, r := range reviews {
 			allReviews = append(allReviews, &ReviewInfo{
@@ -208,7 +216,15 @@ func (ic *InstallationClient) ListTeamMembers(ctx context.Context, org, slug str
 	var members []string
 
 	for {
-		users, resp, err := ic.client.Teams.ListTeamMembersBySlug(ctx, org, slug, opts)
+		var resp *gh.Response
+		users, err := retryGitHubUnavailableRead(ctx, ic.logger, "list team members", []any{"org", org, "team_slug", slug}, func(ctx context.Context) ([]*gh.User, error) {
+			list, listResp, listErr := ic.client.Teams.ListTeamMembersBySlug(ctx, org, slug, opts)
+			if listErr != nil {
+				return nil, classifyGitHubAPIError(listErr)
+			}
+			resp = listResp
+			return list, nil
+		})
 		if err != nil {
 			return nil, teamMembershipReadError("list team members", org, slug, err)
 		}

--- a/pkg/github/reviews_test.go
+++ b/pkg/github/reviews_test.go
@@ -194,6 +194,7 @@ func TestGetApprovedReviewers(t *testing.T) {
 }
 
 func TestIsTeamMember(t *testing.T) {
+	setGitHubUnavailableReadRetryDelay(t, time.Millisecond)
 	tests := []struct {
 		name            string
 		statusCode      int
@@ -270,6 +271,7 @@ func TestIsTeamMember(t *testing.T) {
 }
 
 func TestListTeamMembersErrorClassification(t *testing.T) {
+	setGitHubUnavailableReadRetryDelay(t, time.Millisecond)
 	tests := []struct {
 		name           string
 		statusCode     int

--- a/pkg/webhook/github_retry_delay_test.go
+++ b/pkg/webhook/github_retry_delay_test.go
@@ -1,0 +1,14 @@
+package webhook
+
+import (
+	"time"
+
+	ghclient "github.com/block/schemabot/pkg/github"
+)
+
+// Webhook tests stub GitHub servers that answer reads with 5xx to exercise
+// failure paths; without shrinking the backoff base every such test would
+// wait out the full production retry schedule.
+func init() {
+	_ = ghclient.SetUnavailableReadRetryDelayForTest(time.Millisecond)
+}


### PR DESCRIPTION
## Why this matters

GitHub's API intermittently fails valid reads — empty-body 400s, 5xx blips, dropped connections, short secondary rate-limit windows. Today a single such blip surfaces to the user as a ❌ failed plan or apply comment on their PR, even though retrying seconds later would have succeeded. The previous retry policy (3 attempts, ~0.6s of total wait, 5xx/network errors only) was too narrow and too short to ride out real-world GitHub flakiness.

## What it does

- **Generous schedule**: reads now retry up to 6 attempts with exponential backoff (500ms → 8s, ~15.5s total wait), each wait capped and always bounded by the caller's context deadline.
- **Broader transient classification**: empty-body 400s (a real client error always carries an error message), 429s, and secondary rate limits now retry; secondary rate limits honor the server's `Retry-After` hint up to the cap.
- **Semantic answers still fail fast**: 404 (config discovery depends on it meaning "path does not exist"), message-bearing 400s, auth failures, and primary rate-limit exhaustion (the hourly budget is gone — the durable webhook layer recovers on its own schedule) are never retried.
- **Remaining read sites wrapped**: issue comment fetch, check-run lookups, combined commit status, PR reviews, and team members now go through the retry wrapper. Writes stay unwrapped (duplicate-comment risk), as does the post-failure permissions diagnostic probe.

```
read ──► attempt 1 ──500ms──► 2 ──1s──► 3 ──2s──► 4 ──4s──► 5 ──8s──► 6 ──► error
           │ transient? (5xx / empty-body 400 / 429 / secondary limit / network)
           └─ semantic (404, 400-with-message, auth, primary limit) ──► error immediately
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)