### PR TITLE
fix(github): drop duplicate headline inside per-deployment details

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -5760,8 +5760,6 @@ schemabot cutover apply-a1b2c3d4e5f6 -e production
 <details open>
 <summary>🟢 eu — ready for cutover — next in order</summary>
 
-## Schema Change Status — Production
-
 **Database**: `payments_eu` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
@@ -5804,8 +5802,6 @@ schemabot cutover apply-a1b2c3d4e5f6 -e production
 
 <details open>
 <summary>🔄 us — running table copy</summary>
-
-## Schema Change Status — Production
 
 **Database**: `payments_us` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
@@ -5893,8 +5889,6 @@ schemabot apply -e production
 <details>
 <summary>✅ eu — completed</summary>
 
-## Schema Change Status — Production
-
 **Database**: `payments_eu` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
@@ -5928,8 +5922,6 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 
 <details open>
 <summary>❌ us — failed</summary>
-
-## Schema Change Status — Production
 
 **Database**: `payments_us` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
@@ -6006,8 +5998,6 @@ _No details available yet._
 <details>
 <summary>✅ eu — completed</summary>
 
-## Schema Change Status — Production
-
 **Database**: `payments_eu` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
@@ -6042,8 +6032,6 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 <details>
 <summary>✅ us — completed</summary>
 
-## Schema Change Status — Production
-
 **Database**: `payments_us` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
 *Applied by @aparajon at 2026-01-01 00:00:00 UTC*
@@ -6077,8 +6065,6 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 
 <details>
 <summary>✅ au — completed</summary>
-
-## Schema Change Status — Production
 
 **Database**: `payments_au` | **Apply ID**: `apply-a1b2c3d4e5f6`
 
@@ -6132,8 +6118,6 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 <details>
 <summary>✅ eu — completed</summary>
 
-## ✅ Schema Change Applied — Production
-
 **Database**: `payments_eu`
 
 
@@ -6168,8 +6152,6 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 <details>
 <summary>✅ us — completed</summary>
 
-## ✅ Schema Change Applied — Production
-
 **Database**: `payments_us`
 
 
@@ -6203,8 +6185,6 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 
 <details>
 <summary>✅ au — completed</summary>
-
-## ✅ Schema Change Applied — Production
 
 **Database**: `payments_au`
 
@@ -6268,8 +6248,6 @@ schemabot apply -e production
 <details>
 <summary>✅ eu — completed</summary>
 
-## ✅ Schema Change Applied — Production
-
 **Database**: `payments_eu`
 
 
@@ -6303,8 +6281,6 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 
 <details open>
 <summary>❌ us — failed</summary>
-
-## ❌ Schema Change Failed — Production
 
 **Database**: `payments_us` | **Apply ID**: `apply-a1b2c3d4e5f6`
 

--- a/pkg/webhook/templates/multi_apply.go
+++ b/pkg/webhook/templates/multi_apply.go
@@ -226,7 +226,9 @@ func writeDeploymentSummarySections(sb *strings.Builder, data MultiDeploymentApp
 // and problematic deployments default open; completed and queued ones default
 // collapsed (the model's Open flag). The per-deployment body keeps today's
 // single-deployment fidelity — per-table progress, errors, and DDL — scoped to
-// one deployment.
+// one deployment, minus the single-deployment headline: the aggregate header
+// already carries the title and the <summary> line names the deployment, so
+// repeating the headline inside every section is noise.
 func writeDeploymentDetailSections(sb *strings.Builder, data MultiDeploymentApplyData, renderDetail func(ApplyStatusCommentData) string) {
 	for _, d := range data.Model.Deployments {
 		openAttr := ""
@@ -235,12 +237,28 @@ func writeDeploymentDetailSections(sb *strings.Builder, data MultiDeploymentAppl
 		}
 		fmt.Fprintf(sb, "\n<details%s>\n<summary>%s — %s</summary>\n\n", openAttr, deploymentTag(d), html.EscapeString(d.Label))
 		if detail, ok := data.Details[d.Deployment]; ok {
-			sb.WriteString(renderDetail(detail))
+			sb.WriteString(stripLeadingHeading(renderDetail(detail)))
 		} else {
 			sb.WriteString("_No details available yet._\n")
 		}
 		sb.WriteString("\n</details>\n")
 	}
+}
+
+// stripLeadingHeading removes the headline a single-deployment renderer writes
+// as its first line ("## <title>[ — <env>]") plus the blank lines that follow
+// it, so a body embedded in a per-deployment <details> section does not repeat
+// the aggregate comment's header. A body that does not start with a heading is
+// returned unchanged.
+func stripLeadingHeading(body string) string {
+	if !strings.HasPrefix(body, "## ") {
+		return body
+	}
+	_, rest, found := strings.Cut(body, "\n")
+	if !found {
+		return ""
+	}
+	return strings.TrimLeft(rest, "\n")
 }
 
 // deploymentTag renders the "<emoji> <deployment>" prefix, omitting the leading

--- a/pkg/webhook/templates/multi_apply_test.go
+++ b/pkg/webhook/templates/multi_apply_test.go
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/block/schemabot/pkg/presentation"
@@ -311,6 +312,77 @@ func TestRenderMultiDeploymentApplySummaryComment_CompletedReusesSummaryRenderer
 	assert.Contains(t, out, "Applied successfully — your schema change is live!")
 	assert.Contains(t, out, "**Database**: `payments_eu`")
 	assert.Contains(t, out, "**Database**: `payments_us`")
+}
+
+// The comment's headline appears once, on the aggregate header: each
+// deployment's <details> body drops the headline the single-deployment renderer
+// would write, since the <summary> line already names the deployment and
+// repeating the title in every expanded section is noise. The rest of the body
+// (database, tables) is untouched.
+func TestRenderMultiDeploymentApplyComment_DetailsOmitDuplicateHeadline(t *testing.T) {
+	model := presentation.Derive([]presentation.Operation{
+		rollingOp("eu", so.Completed),
+		rollingOp("us", so.Running),
+	})
+	out := RenderMultiDeploymentApplyComment(MultiDeploymentApplyData{
+		Model:       model,
+		ApplyID:     "apply-123",
+		Environment: "production",
+		Details: map[string]ApplyStatusCommentData{
+			"eu": {
+				Database:    "payments_eu",
+				Environment: "production",
+				State:       state.Apply.Completed,
+				Tables:      []TableProgressData{{TableName: "orders", Status: state.Task.Completed}},
+			},
+			"us": {
+				Database:    "payments_us",
+				Environment: "production",
+				State:       state.Apply.Running,
+				Tables:      []TableProgressData{{TableName: "orders", Status: state.Task.Running}},
+			},
+		},
+	})
+
+	assert.Equal(t, 1, strings.Count(out, "## Schema Change Status"),
+		"the headline must appear once, on the aggregate header, not inside each deployment's section")
+	assert.True(t, strings.HasPrefix(out, "## Schema Change Status — Production"))
+	// The section bodies keep their per-deployment content.
+	assert.Contains(t, out, "**Database**: `payments_eu`")
+	assert.Contains(t, out, "**Database**: `payments_us`")
+}
+
+// The terminal summary comment deduplicates the same way: the state-specific
+// headline appears once on the aggregate header, not inside each deployment's
+// expanded terminal summary.
+func TestRenderMultiDeploymentApplySummaryComment_DetailsOmitDuplicateHeadline(t *testing.T) {
+	model := presentation.Derive([]presentation.Operation{
+		rollingOp("eu", so.Completed),
+		rollingOp("us", so.Completed),
+	})
+	out := RenderMultiDeploymentApplySummaryComment(MultiDeploymentApplyData{
+		Model:       model,
+		ApplyID:     "apply-123",
+		Environment: "production",
+		Details: map[string]ApplyStatusCommentData{
+			"eu": {
+				Database:    "payments_eu",
+				Environment: "production",
+				State:       state.Apply.Completed,
+				Tables:      []TableProgressData{{TableName: "orders", Status: state.Task.Completed}},
+			},
+			"us": {
+				Database:    "payments_us",
+				Environment: "production",
+				State:       state.Apply.Completed,
+				Tables:      []TableProgressData{{TableName: "orders", Status: state.Task.Completed}},
+			},
+		},
+	})
+
+	assert.Equal(t, 1, strings.Count(out, "## ✅ Schema Change Applied"),
+		"the terminal headline must appear once, on the aggregate header, not inside each deployment's section")
+	assert.Contains(t, out, "Applied successfully — your schema change is live!")
 }
 
 // A failed multi-deployment summary keeps the aggregate failed header and routes


### PR DESCRIPTION
## Summary
The multi-deployment apply comment embeds the full single-deployment renderer in each per-deployment `<details>` section, so every expanded section repeats the comment's own headline (`## Schema Change Status — <env>`, or the state-specific title on the terminal summary). The headline is pure noise there: the aggregate header already carries the title and the `<summary>` line already names the deployment and its state.

## What
Strip the leading `## …` headline from each embedded per-deployment body at the one seam both comment variants share (`writeDeploymentDetailSections`). Everything else in the body — database line, per-table progress, errors, DDL — is unchanged.

## Why
Expanding a deployment's section should add detail, not repeat the header the reader is already looking at.
```
Before                              After
Schema Change Status — Prod      ## Schema Change Status — Prod
...                                 ...
▾ ✅ eu — completed                 ▾ ✅ eu — completed
Schema Change Status — Prod      Database: db_eu | ...
Database: db_eu | ...         ...
...
```