### PR TITLE
fix(github): attribute auto-plan failure comments to the automatic trigger

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -962,6 +962,21 @@ type: mysql
 </details>
 
 <details>
+<summary><a name="autoplan-generic-error"></a><strong>Auto-plan: Generic Error</strong></summary>
+
+
+## ❌ Plan Failed
+
+**Environment**: all configured environments
+
+*Triggered automatically by a pull request update at 2026-01-15 14:30:00 UTC*
+
+### Error
+
+> failed to fetch repository contents: API rate limit exceeded
+</details>
+
+<details>
 <summary><a name="missing-e-flag"></a><strong>Missing -e Flag</strong></summary>
 
 

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -967,7 +967,7 @@ type: mysql
 
 ## ❌ Plan Failed
 
-**Environment**: all configured environments
+**Environment**: `staging`
 
 *Triggered automatically by a pull request update at 2026-01-15 14:30:00 UTC*
 

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -17,6 +17,7 @@ func previewCommentErrorsOutput() {
 		{"DATABASE NOT FOUND", webhooktemplates.PreviewCommentErrorNotFound},
 		{"INVALID CONFIG", webhooktemplates.PreviewCommentErrorInvalid},
 		{"GENERIC ERROR", webhooktemplates.PreviewCommentErrorGeneric},
+		{"AUTO-PLAN: GENERIC ERROR", webhooktemplates.PreviewCommentErrorGenericAutoPlan},
 		{"MISSING -e FLAG", webhooktemplates.PreviewCommentMissingEnv},
 		{"INVALID COMMAND", webhooktemplates.PreviewCommentInvalidCmd},
 	}
@@ -64,6 +65,7 @@ func previewCommentAllOutput() {
 		{"DATABASE NOT FOUND", func() { fmt.Print(webhooktemplates.PreviewCommentErrorNotFound()) }},
 		{"INVALID CONFIG", func() { fmt.Print(webhooktemplates.PreviewCommentErrorInvalid()) }},
 		{"GENERIC ERROR", func() { fmt.Print(webhooktemplates.PreviewCommentErrorGeneric()) }},
+		{"AUTO-PLAN: GENERIC ERROR", func() { fmt.Print(webhooktemplates.PreviewCommentErrorGenericAutoPlan()) }},
 		{"MISSING -E FLAG", func() { fmt.Print(webhooktemplates.PreviewCommentMissingEnv()) }},
 		{"INVALID COMMAND", func() { fmt.Print(webhooktemplates.PreviewCommentInvalidCmd()) }},
 		{"APPLY IN PROGRESS", func() { fmt.Print(webhooktemplates.PreviewCommentApplyProgress()) }},
@@ -196,6 +198,7 @@ func previewCommentPlanAllOutput() {
 		{"DATABASE NOT FOUND", func() { fmt.Print(webhooktemplates.PreviewCommentErrorNotFound()) }},
 		{"INVALID CONFIG", func() { fmt.Print(webhooktemplates.PreviewCommentErrorInvalid()) }},
 		{"GENERIC ERROR", func() { fmt.Print(webhooktemplates.PreviewCommentErrorGeneric()) }},
+		{"AUTO-PLAN: GENERIC ERROR", func() { fmt.Print(webhooktemplates.PreviewCommentErrorGenericAutoPlan()) }},
 		{"MISSING -E FLAG", func() { fmt.Print(webhooktemplates.PreviewCommentMissingEnv()) }},
 		{"INVALID COMMAND", func() { fmt.Print(webhooktemplates.PreviewCommentInvalidCmd()) }},
 	}

--- a/pkg/webhook/auto_plan_integration_test.go
+++ b/pkg/webhook/auto_plan_integration_test.go
@@ -709,12 +709,14 @@ func TestE2EGitHubUnavailableDuringAutoPlanDoesNotPublishCheckRun(t *testing.T) 
 // failure comment for an auto-plan that fails after dispatch: config
 // discovery succeeds, but the dispatched plan's own GitHub reads fail. The
 // comment must attribute the plan to the automatic pull request trigger and
-// state the multi-environment scope — an auto-plan has no requesting user
-// and no single target environment, so it must never render a bare @ mention
-// or an empty environment code span.
+// name the deployment's environment scope — an auto-plan has no requesting
+// user and no single target environment, so the deployment's own scope is
+// what tells the reader which SchemaBot instance failed. It must never
+// render a bare @ mention or an empty environment code span.
 func TestE2EAutoPlanFailureCommentAttributesAutomaticTrigger(t *testing.T) {
 	dbName := "webhook_autoplan_failure_attribution"
 	svc := setupE2EService(t, dbName)
+	svc.Config().AllowedEnvironments = []string{"staging"}
 
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
@@ -750,8 +752,8 @@ func TestE2EAutoPlanFailureCommentAttributesAutomaticTrigger(t *testing.T) {
 	select {
 	case body := <-result.comments:
 		assert.Contains(t, body, "## ❌ Plan Failed")
-		assert.Contains(t, body, "**Environment**: all configured environments",
-			"an auto-plan targets every configured environment, so the header must say so")
+		assert.Contains(t, body, "**Environment**: `staging`",
+			"an auto-plan is not scoped to one environment, so the header must name the deployment's environment scope")
 		assert.Contains(t, body, "Triggered automatically by a pull request update",
 			"a system-triggered plan must be attributed to the pull request update")
 		assert.NotContains(t, body, "**Environment**: ``")

--- a/pkg/webhook/auto_plan_integration_test.go
+++ b/pkg/webhook/auto_plan_integration_test.go
@@ -705,6 +705,62 @@ func TestE2EGitHubUnavailableDuringAutoPlanDoesNotPublishCheckRun(t *testing.T) 
 	assert.Nil(t, aggregate)
 }
 
+// TestE2EAutoPlanFailureCommentAttributesAutomaticTrigger verifies the
+// failure comment for an auto-plan that fails after dispatch: config
+// discovery succeeds, but the dispatched plan's own GitHub reads fail. The
+// comment must attribute the plan to the automatic pull request trigger and
+// state the multi-environment scope — an auto-plan has no requesting user
+// and no single target environment, so it must never render a bare @ mention
+// or an empty environment code span.
+func TestE2EAutoPlanFailureCommentAttributesAutomaticTrigger(t *testing.T) {
+	dbName := "webhook_autoplan_failure_attribution"
+	svc := setupE2EService(t, dbName)
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+
+	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
+	// Discovery reads the changed files once; the dispatched plan re-fetches
+	// them with a fresh client and hits the outage.
+	result.FailPRFilesAfterFirstFetch.Store(true)
+
+	h := newE2EHandler(t, svc, client)
+
+	req := buildPRWebhookRequest(t, prWebhookPayloadOpts{
+		action:  "opened",
+		headSHA: "abc123",
+		headRef: "feature-branch",
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "auto-plan started")
+
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "## ❌ Plan Failed")
+		assert.Contains(t, body, "**Environment**: all configured environments",
+			"an auto-plan targets every configured environment, so the header must say so")
+		assert.Contains(t, body, "Triggered automatically by a pull request update",
+			"a system-triggered plan must be attributed to the pull request update")
+		assert.NotContains(t, body, "**Environment**: ``")
+		assert.NotContains(t, body, "Requested by @")
+	case <-time.After(webhookIntegrationPollDeadline):
+		t.Fatal("timed out waiting for the auto-plan failure comment")
+	}
+}
+
 // TestE2EAutoPlanWithOnlySchemaBotConfigChangeClearsRollbackCheck verifies the
 // self-serve reconciliation path for a PR whose live database already matches
 // the current schema files. A no-op schemabot.yaml edit should make config

--- a/pkg/webhook/error_comment.go
+++ b/pkg/webhook/error_comment.go
@@ -32,12 +32,30 @@ func (h *Handler) postCommandError(
 	commandName, environment, requestedBy, errorDetail string,
 ) {
 	h.postComment(repo, pr, installationID, templates.RenderGenericError(templates.SchemaErrorData{
-		RequestedBy: requestedBy,
-		Timestamp:   templates.NowFunc().UTC().Format("2006-01-02 15:04:05"),
-		Environment: environment,
-		CommandName: commandName,
-		ErrorDetail: userFacingErrorDetail(errorDetail),
+		RequestedBy:  requestedBy,
+		Timestamp:    templates.NowFunc().UTC().Format("2006-01-02 15:04:05"),
+		Environment:  environment,
+		Environments: h.deploymentEnvironmentScope(environment),
+		CommandName:  commandName,
+		ErrorDetail:  userFacingErrorDetail(errorDetail),
 	}))
+}
+
+// deploymentEnvironmentScope returns the environments this deployment
+// handles, for rendering in error comments about commands that were not
+// scoped to a single environment. Returns nil when the command already
+// targeted one environment (the comment renders that instead) or when the
+// deployment is unscoped (the comment omits the environment segment — there
+// is no concrete list to show).
+func (h *Handler) deploymentEnvironmentScope(environment string) []string {
+	if environment != "" {
+		return nil
+	}
+	config, ok := h.serverConfig()
+	if !ok {
+		return nil
+	}
+	return config.AllowedEnvironments
 }
 
 func userFacingError(err error) string {

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -500,6 +500,7 @@ func (h *Handler) handleSchemaRequestError(repo string, pr int, installationID i
 		RequestedBy:  requestedBy,
 		Timestamp:    time.Now().UTC().Format("2006-01-02 15:04:05"),
 		Environment:  environment,
+		Environments: h.deploymentEnvironmentScope(environment),
 		DatabaseName: databaseName,
 		CommandName:  commandName,
 	}

--- a/pkg/webhook/templates/errors.go
+++ b/pkg/webhook/templates/errors.go
@@ -8,8 +8,13 @@ import (
 
 // SchemaErrorData contains data for rendering schema request error comments.
 type SchemaErrorData struct {
-	RequestedBy        string
-	Timestamp          string
+	// RequestedBy is the GitHub login that issued the command. Empty means the
+	// command was system-triggered (an auto-plan from a pull request update).
+	RequestedBy string
+	Timestamp   string
+	// Environment is the single environment the command targeted. Empty means
+	// the command was not scoped to one environment: multi-environment plans
+	// (including auto-plans) target every configured environment.
 	Environment        string
 	DatabaseName       string
 	SchemaPath         string
@@ -18,11 +23,41 @@ type SchemaErrorData struct {
 	AvailableDatabases string
 }
 
+// EnvironmentDisplay renders the environment header value: the environment as
+// a code span when the command targeted one, otherwise a statement that every
+// configured environment was in scope — never an empty code span.
+func (d SchemaErrorData) EnvironmentDisplay() string {
+	if d.Environment == "" {
+		return "all configured environments"
+	}
+	return "`" + d.Environment + "`"
+}
+
+// ExampleEnvironment is the -e value rendered inside pasteable usage
+// examples: the requested environment when one was given, otherwise a
+// placeholder for the reader to fill in.
+func (d SchemaErrorData) ExampleEnvironment() string {
+	if d.Environment == "" {
+		return "<environment>"
+	}
+	return d.Environment
+}
+
+// Attribution renders the footer attribution line: the requesting user for
+// user-issued commands, or the automatic trigger for system-issued ones —
+// never a bare @ mention.
+func (d SchemaErrorData) Attribution() string {
+	if d.RequestedBy == "" {
+		return "*Triggered automatically by a pull request update at " + d.Timestamp + " UTC*"
+	}
+	return "*Requested by @" + d.RequestedBy + " at " + d.Timestamp + " UTC*"
+}
+
 const databaseNotFoundTemplate = `## ⚠️ Database Not Found
 
-**Database**: ` + "`{{.DatabaseName}}`" + ` | **Environment**: ` + "`{{.Environment}}`" + `
+**Database**: ` + "`{{.DatabaseName}}`" + ` | **Environment**: {{.EnvironmentDisplay}}
 
-*Requested by @{{.RequestedBy}} at {{.Timestamp}} UTC*
+{{.Attribution}}
 
 No ` + "`schemabot.yaml`" + ` configuration with ` + "`database: {{.DatabaseName}}`" + ` was found in this repository.
 
@@ -30,9 +65,9 @@ Check that your ` + "`schemabot.yaml`" + ` file has the correct ` + "`database`"
 
 const invalidConfigTemplate = `## ⚠️ No Valid SchemaBot Configuration Found
 
-**Environment**: ` + "`{{.Environment}}`" + `
+**Environment**: {{.EnvironmentDisplay}}
 
-*Requested by @{{.RequestedBy}} at {{.Timestamp}} UTC*
+{{.Attribution}}
 
 The ` + "`schemabot.yaml`" + ` file must include ` + "`database`" + ` and ` + "`type`" + ` fields:
 
@@ -46,9 +81,9 @@ type: mysql
 
 const noConfigNoDatabaseTemplate = `## ℹ️ No SchemaBot Configuration Found
 
-**Environment**: ` + "`{{.Environment}}`" + `
+**Environment**: {{.EnvironmentDisplay}}
 
-*Requested by @{{.RequestedBy}} at {{.Timestamp}} UTC*
+{{.Attribution}}
 
 No ` + "`schemabot.yaml`" + ` configuration file was found in this repository.
 
@@ -64,14 +99,14 @@ type: mysql
 Use the ` + "`-d`" + ` flag to specify which database to {{.CommandName}}:
 
 ` + "```" + `
-schemabot {{.CommandName}} -e {{.Environment}} -d <database-name>
+schemabot {{.CommandName}} -e {{.ExampleEnvironment}} -d <database-name>
 ` + "```" + ``
 
 const noConfigWithDatabaseTemplate = `## ℹ️ No SchemaBot Configuration Found
 
-**Database**: ` + "`{{.DatabaseName}}`" + ` | **Environment**: ` + "`{{.Environment}}`" + `
+**Database**: ` + "`{{.DatabaseName}}`" + ` | **Environment**: {{.EnvironmentDisplay}}
 
-*Requested by @{{.RequestedBy}} at {{.Timestamp}} UTC*
+{{.Attribution}}
 
 No ` + "`schemabot.yaml`" + ` configuration file exists in this repository.
 
@@ -85,9 +120,9 @@ type: mysql
 
 const configOutsideAllowedDirsTemplate = `## ⚠️ SchemaBot Configuration Not Authorized
 
-**Database**: ` + "`{{.DatabaseName}}`" + ` | **Environment**: ` + "`{{.Environment}}`" + `
+**Database**: ` + "`{{.DatabaseName}}`" + ` | **Environment**: {{.EnvironmentDisplay}}
 
-*Requested by @{{.RequestedBy}} at {{.Timestamp}} UTC*
+{{.Attribution}}
 
 SchemaBot found a ` + "`schemabot.yaml`" + ` configuration, but this SchemaBot instance is not configured to manage its schema directory.
 
@@ -97,9 +132,9 @@ Ask a SchemaBot operator to add this directory to ` + "`databases.{{.DatabaseNam
 
 const multipleConfigsTemplate = `## ⚠️ Multiple Databases Detected
 
-**Environment**: ` + "`{{.Environment}}`" + `
+**Environment**: {{.EnvironmentDisplay}}
 
-*Requested by @{{.RequestedBy}} at {{.Timestamp}} UTC*
+{{.Attribution}}
 
 This repository has multiple ` + "`schemabot.yaml`" + ` configurations.
 
@@ -112,14 +147,14 @@ This repository has multiple ` + "`schemabot.yaml`" + ` configurations.
 Use the ` + "`-d`" + ` flag:
 
 ` + "```" + `
-schemabot {{.CommandName}} -e {{.Environment}} -d <database-name>
+schemabot {{.CommandName}} -e {{.ExampleEnvironment}} -d <database-name>
 ` + "```" + ``
 
 const genericErrorTemplate = `## ❌ {{.CommandName}} Failed
 
-**Environment**: ` + "`{{.Environment}}`" + `
+**Environment**: {{.EnvironmentDisplay}}
 
-*Requested by @{{.RequestedBy}} at {{.Timestamp}} UTC*
+{{.Attribution}}
 
 ### Error
 

--- a/pkg/webhook/templates/errors.go
+++ b/pkg/webhook/templates/errors.go
@@ -15,7 +15,14 @@ type SchemaErrorData struct {
 	// Environment is the single environment the command targeted. Empty means
 	// the command was not scoped to one environment: multi-environment plans
 	// (including auto-plans) target every configured environment.
-	Environment        string
+	Environment string
+	// Environments is the set of environments this SchemaBot deployment
+	// handles, rendered when Environment is empty. In a multi-deployment
+	// topology each deployment is scoped to its own environments, so this
+	// names the concrete environments the failed command covered. Empty means
+	// the deployment is unscoped and the header omits the environment segment
+	// rather than rendering filler.
+	Environments       []string
 	DatabaseName       string
 	SchemaPath         string
 	CommandName        string // "plan" or "apply"
@@ -23,24 +30,41 @@ type SchemaErrorData struct {
 	AvailableDatabases string
 }
 
-// EnvironmentDisplay renders the environment header value: the environment as
-// a code span when the command targeted one, otherwise a statement that every
-// configured environment was in scope — never an empty code span.
-func (d SchemaErrorData) EnvironmentDisplay() string {
-	if d.Environment == "" {
-		return "all configured environments"
+// EnvironmentHeader renders the environment header segment: the single
+// environment the command targeted, or the deployment's environment scope
+// when the command spanned environments (multi-environment plans, including
+// auto-plans). Returns "" when neither is known so templates drop the
+// segment — never an empty code span or a vague placeholder.
+func (d SchemaErrorData) EnvironmentHeader() string {
+	if d.Environment != "" {
+		return "**Environment**: " + markdownInlineCode(d.Environment)
 	}
-	return "`" + d.Environment + "`"
+	switch len(d.Environments) {
+	case 0:
+		return ""
+	case 1:
+		return "**Environment**: " + markdownInlineCode(d.Environments[0])
+	default:
+		quoted := make([]string, len(d.Environments))
+		for i, name := range d.Environments {
+			quoted[i] = markdownInlineCode(name)
+		}
+		return "**Environments**: " + strings.Join(quoted, ", ")
+	}
 }
 
 // ExampleEnvironment is the -e value rendered inside pasteable usage
-// examples: the requested environment when one was given, otherwise a
-// placeholder for the reader to fill in.
+// examples: the requested environment when one was given, the deployment's
+// sole environment when it is scoped to exactly one, otherwise a placeholder
+// for the reader to fill in.
 func (d SchemaErrorData) ExampleEnvironment() string {
-	if d.Environment == "" {
-		return "<environment>"
+	if d.Environment != "" {
+		return d.Environment
 	}
-	return d.Environment
+	if len(d.Environments) == 1 {
+		return d.Environments[0]
+	}
+	return "<environment>"
 }
 
 // Attribution renders the footer attribution line: the requesting user for
@@ -55,7 +79,7 @@ func (d SchemaErrorData) Attribution() string {
 
 const databaseNotFoundTemplate = `## ⚠️ Database Not Found
 
-**Database**: ` + "`{{.DatabaseName}}`" + ` | **Environment**: {{.EnvironmentDisplay}}
+**Database**: ` + "`{{.DatabaseName}}`" + `{{with .EnvironmentHeader}} | {{.}}{{end}}
 
 {{.Attribution}}
 
@@ -65,9 +89,9 @@ Check that your ` + "`schemabot.yaml`" + ` file has the correct ` + "`database`"
 
 const invalidConfigTemplate = `## ⚠️ No Valid SchemaBot Configuration Found
 
-**Environment**: {{.EnvironmentDisplay}}
+{{with .EnvironmentHeader}}{{.}}
 
-{{.Attribution}}
+{{end}}{{.Attribution}}
 
 The ` + "`schemabot.yaml`" + ` file must include ` + "`database`" + ` and ` + "`type`" + ` fields:
 
@@ -81,9 +105,9 @@ type: mysql
 
 const noConfigNoDatabaseTemplate = `## ℹ️ No SchemaBot Configuration Found
 
-**Environment**: {{.EnvironmentDisplay}}
+{{with .EnvironmentHeader}}{{.}}
 
-{{.Attribution}}
+{{end}}{{.Attribution}}
 
 No ` + "`schemabot.yaml`" + ` configuration file was found in this repository.
 
@@ -104,7 +128,7 @@ schemabot {{.CommandName}} -e {{.ExampleEnvironment}} -d <database-name>
 
 const noConfigWithDatabaseTemplate = `## ℹ️ No SchemaBot Configuration Found
 
-**Database**: ` + "`{{.DatabaseName}}`" + ` | **Environment**: {{.EnvironmentDisplay}}
+**Database**: ` + "`{{.DatabaseName}}`" + `{{with .EnvironmentHeader}} | {{.}}{{end}}
 
 {{.Attribution}}
 
@@ -120,7 +144,7 @@ type: mysql
 
 const configOutsideAllowedDirsTemplate = `## ⚠️ SchemaBot Configuration Not Authorized
 
-**Database**: ` + "`{{.DatabaseName}}`" + ` | **Environment**: {{.EnvironmentDisplay}}
+**Database**: ` + "`{{.DatabaseName}}`" + `{{with .EnvironmentHeader}} | {{.}}{{end}}
 
 {{.Attribution}}
 
@@ -132,9 +156,9 @@ Ask a SchemaBot operator to add this directory to ` + "`databases.{{.DatabaseNam
 
 const multipleConfigsTemplate = `## ⚠️ Multiple Databases Detected
 
-**Environment**: {{.EnvironmentDisplay}}
+{{with .EnvironmentHeader}}{{.}}
 
-{{.Attribution}}
+{{end}}{{.Attribution}}
 
 This repository has multiple ` + "`schemabot.yaml`" + ` configurations.
 
@@ -152,9 +176,9 @@ schemabot {{.CommandName}} -e {{.ExampleEnvironment}} -d <database-name>
 
 const genericErrorTemplate = `## ❌ {{.CommandName}} Failed
 
-**Environment**: {{.EnvironmentDisplay}}
+{{with .EnvironmentHeader}}{{.}}
 
-{{.Attribution}}
+{{end}}{{.Attribution}}
 
 ### Error
 

--- a/pkg/webhook/templates/errors_test.go
+++ b/pkg/webhook/templates/errors_test.go
@@ -6,6 +6,79 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestRenderGenericErrorAutoPlan covers the failure comment for a
+// system-triggered auto-plan: there is no requesting user and no single
+// target environment, so the comment must attribute the plan to the pull
+// request update and state the multi-environment scope — never render an
+// empty code span or a bare @ mention.
+func TestRenderGenericErrorAutoPlan(t *testing.T) {
+	body := RenderGenericError(SchemaErrorData{
+		Timestamp:   "2026-07-16 18:56:00",
+		CommandName: "plan",
+		ErrorDetail: "failed to fetch repository contents",
+	})
+
+	assert.Contains(t, body, "## ❌ Plan Failed")
+	assert.Contains(t, body, "**Environment**: all configured environments")
+	assert.Contains(t, body, "*Triggered automatically by a pull request update at 2026-07-16 18:56:00 UTC*")
+	assert.Contains(t, body, "> failed to fetch repository contents")
+	assert.NotContains(t, body, "``")
+	assert.NotContains(t, body, "@ ")
+}
+
+// TestRenderGenericErrorUserRequested pins the user-issued rendering: a
+// single environment shows as a code span and the footer names the requester.
+func TestRenderGenericErrorUserRequested(t *testing.T) {
+	body := RenderGenericError(SchemaErrorData{
+		RequestedBy: "octocat",
+		Timestamp:   "2026-07-16 18:56:00",
+		Environment: "staging",
+		CommandName: "plan",
+		ErrorDetail: "boom",
+	})
+
+	assert.Contains(t, body, "**Environment**: `staging`")
+	assert.Contains(t, body, "*Requested by @octocat at 2026-07-16 18:56:00 UTC*")
+	assert.NotContains(t, body, "Triggered automatically")
+}
+
+// TestRenderNoConfigUsageExample verifies the pasteable usage example: the
+// requested environment when one was given, otherwise a placeholder — never
+// an empty -e value.
+func TestRenderNoConfigUsageExample(t *testing.T) {
+	t.Run("multi-environment command uses a placeholder", func(t *testing.T) {
+		body := RenderNoConfig(SchemaErrorData{
+			Timestamp:   "2026-07-16 18:56:00",
+			CommandName: "plan",
+		})
+		assert.Contains(t, body, "schemabot plan -e <environment> -d <database-name>")
+		assert.Contains(t, body, "**Environment**: all configured environments")
+	})
+
+	t.Run("single-environment command uses the environment", func(t *testing.T) {
+		body := RenderNoConfig(SchemaErrorData{
+			RequestedBy: "octocat",
+			Timestamp:   "2026-07-16 18:56:00",
+			Environment: "staging",
+			CommandName: "plan",
+		})
+		assert.Contains(t, body, "schemabot plan -e staging -d <database-name>")
+	})
+}
+
+// TestRenderMultipleConfigsUsageExample verifies the multi-database picker
+// keeps a pasteable -e value when the command was not scoped to one
+// environment.
+func TestRenderMultipleConfigsUsageExample(t *testing.T) {
+	body := RenderMultipleConfigs(SchemaErrorData{
+		Timestamp:          "2026-07-16 18:56:00",
+		CommandName:        "plan",
+		AvailableDatabases: "- `testapp`\n- `payments`",
+	})
+	assert.Contains(t, body, "schemabot plan -e <environment> -d <database-name>")
+	assert.Contains(t, body, "*Triggered automatically by a pull request update at 2026-07-16 18:56:00 UTC*")
+}
+
 func TestRenderInvalidEnv(t *testing.T) {
 	t.Run("lists the configured environments", func(t *testing.T) {
 		body := RenderInvalidEnv("apply", []string{"production", "staging"})

--- a/pkg/webhook/templates/errors_test.go
+++ b/pkg/webhook/templates/errors_test.go
@@ -9,21 +9,73 @@ import (
 // TestRenderGenericErrorAutoPlan covers the failure comment for a
 // system-triggered auto-plan: there is no requesting user and no single
 // target environment, so the comment must attribute the plan to the pull
-// request update and state the multi-environment scope — never render an
-// empty code span or a bare @ mention.
+// request update and show the deployment's concrete environment scope — in a
+// multi-deployment topology each deployment handles its own environments, so
+// naming them is what tells the reader which deployment failed. It must
+// never render an empty code span or a bare @ mention.
 func TestRenderGenericErrorAutoPlan(t *testing.T) {
-	body := RenderGenericError(SchemaErrorData{
-		Timestamp:   "2026-07-16 18:56:00",
-		CommandName: "plan",
-		ErrorDetail: "failed to fetch repository contents",
+	t.Run("deployment scoped to one environment names it", func(t *testing.T) {
+		body := RenderGenericError(SchemaErrorData{
+			Timestamp:    "2026-07-16 18:56:00",
+			Environments: []string{"staging"},
+			CommandName:  "plan",
+			ErrorDetail:  "failed to fetch repository contents",
+		})
+
+		assert.Contains(t, body, "## ❌ Plan Failed")
+		assert.Contains(t, body, "**Environment**: `staging`")
+		assert.Contains(t, body, "*Triggered automatically by a pull request update at 2026-07-16 18:56:00 UTC*")
+		assert.Contains(t, body, "> failed to fetch repository contents")
+		assert.NotContains(t, body, "**Environment**: ``")
+		assert.NotContains(t, body, "Requested by")
 	})
 
-	assert.Contains(t, body, "## ❌ Plan Failed")
-	assert.Contains(t, body, "**Environment**: all configured environments")
-	assert.Contains(t, body, "*Triggered automatically by a pull request update at 2026-07-16 18:56:00 UTC*")
-	assert.Contains(t, body, "> failed to fetch repository contents")
-	assert.NotContains(t, body, "**Environment**: ``")
-	assert.NotContains(t, body, "Requested by")
+	t.Run("deployment scoped to several environments lists them", func(t *testing.T) {
+		body := RenderGenericError(SchemaErrorData{
+			Timestamp:    "2026-07-16 18:56:00",
+			Environments: []string{"staging", "production"},
+			CommandName:  "plan",
+			ErrorDetail:  "failed to fetch repository contents",
+		})
+
+		assert.Contains(t, body, "**Environments**: `staging`, `production`")
+	})
+
+	t.Run("unscoped deployment omits the environment header", func(t *testing.T) {
+		body := RenderGenericError(SchemaErrorData{
+			Timestamp:   "2026-07-16 18:56:00",
+			CommandName: "plan",
+			ErrorDetail: "failed to fetch repository contents",
+		})
+
+		assert.Contains(t, body, "## ❌ Plan Failed")
+		assert.NotContains(t, body, "**Environment")
+		assert.Contains(t, body, "*Triggered automatically by a pull request update at 2026-07-16 18:56:00 UTC*")
+	})
+}
+
+// TestRenderDatabaseNotFoundHeader pins the joined Database | Environment
+// header: the separator only appears when there is an environment segment to
+// join, so an unscoped deployment renders a clean database-only header.
+func TestRenderDatabaseNotFoundHeader(t *testing.T) {
+	t.Run("deployment scope joins the header", func(t *testing.T) {
+		body := RenderDatabaseNotFound(SchemaErrorData{
+			Timestamp:    "2026-07-16 18:56:00",
+			Environments: []string{"staging"},
+			DatabaseName: "testapp",
+		})
+		assert.Contains(t, body, "**Database**: `testapp` | **Environment**: `staging`")
+	})
+
+	t.Run("unscoped deployment drops the separator", func(t *testing.T) {
+		body := RenderDatabaseNotFound(SchemaErrorData{
+			Timestamp:    "2026-07-16 18:56:00",
+			DatabaseName: "testapp",
+		})
+		assert.Contains(t, body, "**Database**: `testapp`\n")
+		assert.NotContains(t, body, " | ")
+		assert.NotContains(t, body, "**Environment")
+	})
 }
 
 // TestRenderGenericErrorUserRequested pins the user-issued rendering: a
@@ -43,16 +95,37 @@ func TestRenderGenericErrorUserRequested(t *testing.T) {
 }
 
 // TestRenderNoConfigUsageExample verifies the pasteable usage example: the
-// requested environment when one was given, otherwise a placeholder — never
-// an empty -e value.
+// requested environment when one was given, the deployment's sole
+// environment when it is scoped to exactly one, otherwise a placeholder —
+// never an empty -e value.
 func TestRenderNoConfigUsageExample(t *testing.T) {
-	t.Run("multi-environment command uses a placeholder", func(t *testing.T) {
+	t.Run("unscoped multi-environment command uses a placeholder", func(t *testing.T) {
 		body := RenderNoConfig(SchemaErrorData{
 			Timestamp:   "2026-07-16 18:56:00",
 			CommandName: "plan",
 		})
 		assert.Contains(t, body, "schemabot plan -e <environment> -d <database-name>")
-		assert.Contains(t, body, "**Environment**: all configured environments")
+		assert.NotContains(t, body, "**Environment")
+	})
+
+	t.Run("single-scope deployment uses its environment", func(t *testing.T) {
+		body := RenderNoConfig(SchemaErrorData{
+			Timestamp:    "2026-07-16 18:56:00",
+			Environments: []string{"staging"},
+			CommandName:  "plan",
+		})
+		assert.Contains(t, body, "schemabot plan -e staging -d <database-name>")
+		assert.Contains(t, body, "**Environment**: `staging`")
+	})
+
+	t.Run("multi-scope deployment keeps the placeholder", func(t *testing.T) {
+		body := RenderNoConfig(SchemaErrorData{
+			Timestamp:    "2026-07-16 18:56:00",
+			Environments: []string{"staging", "production"},
+			CommandName:  "plan",
+		})
+		assert.Contains(t, body, "schemabot plan -e <environment> -d <database-name>")
+		assert.Contains(t, body, "**Environments**: `staging`, `production`")
 	})
 
 	t.Run("single-environment command uses the environment", func(t *testing.T) {

--- a/pkg/webhook/templates/errors_test.go
+++ b/pkg/webhook/templates/errors_test.go
@@ -22,8 +22,8 @@ func TestRenderGenericErrorAutoPlan(t *testing.T) {
 	assert.Contains(t, body, "**Environment**: all configured environments")
 	assert.Contains(t, body, "*Triggered automatically by a pull request update at 2026-07-16 18:56:00 UTC*")
 	assert.Contains(t, body, "> failed to fetch repository contents")
-	assert.NotContains(t, body, "``")
-	assert.NotContains(t, body, "@ ")
+	assert.NotContains(t, body, "**Environment**: ``")
+	assert.NotContains(t, body, "Requested by")
 }
 
 // TestRenderGenericErrorUserRequested pins the user-issued rendering: a
@@ -67,16 +67,17 @@ func TestRenderNoConfigUsageExample(t *testing.T) {
 }
 
 // TestRenderMultipleConfigsUsageExample verifies the multi-database picker
-// keeps a pasteable -e value when the command was not scoped to one
-// environment.
+// keeps a pasteable -e value and the requester attribution when a user issues
+// a command without scoping it to one environment.
 func TestRenderMultipleConfigsUsageExample(t *testing.T) {
 	body := RenderMultipleConfigs(SchemaErrorData{
+		RequestedBy:        "octocat",
 		Timestamp:          "2026-07-16 18:56:00",
 		CommandName:        "plan",
 		AvailableDatabases: "- `testapp`\n- `payments`",
 	})
 	assert.Contains(t, body, "schemabot plan -e <environment> -d <database-name>")
-	assert.Contains(t, body, "*Triggered automatically by a pull request update at 2026-07-16 18:56:00 UTC*")
+	assert.Contains(t, body, "*Requested by @octocat at 2026-07-16 18:56:00 UTC*")
 }
 
 func TestRenderInvalidEnv(t *testing.T) {

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -220,6 +220,17 @@ func PreviewCommentErrorGeneric() string {
 	})
 }
 
+// PreviewCommentErrorGenericAutoPlan renders the plan failure error comment
+// for a system-triggered auto-plan: no requesting user and no single target
+// environment.
+func PreviewCommentErrorGenericAutoPlan() string {
+	return RenderGenericError(SchemaErrorData{
+		Timestamp:   "2026-01-15 14:30:00",
+		CommandName: action.Plan,
+		ErrorDetail: "failed to fetch repository contents: API rate limit exceeded",
+	})
+}
+
 // PreviewCommentMissingEnv renders the "missing -e flag" error comment.
 func PreviewCommentMissingEnv() string {
 	return RenderMissingEnv(action.Plan)

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -222,12 +222,13 @@ func PreviewCommentErrorGeneric() string {
 
 // PreviewCommentErrorGenericAutoPlan renders the plan failure error comment
 // for a system-triggered auto-plan: no requesting user and no single target
-// environment.
+// environment, so the header shows the deployment's environment scope.
 func PreviewCommentErrorGenericAutoPlan() string {
 	return RenderGenericError(SchemaErrorData{
-		Timestamp:   "2026-01-15 14:30:00",
-		CommandName: action.Plan,
-		ErrorDetail: "failed to fetch repository contents: API rate limit exceeded",
+		Timestamp:    "2026-01-15 14:30:00",
+		Environments: []string{"staging"},
+		CommandName:  action.Plan,
+		ErrorDetail:  "failed to fetch repository contents: API rate limit exceeded",
 	})
 }
 

--- a/pkg/webhook/webhook_integration_test.go
+++ b/pkg/webhook/webhook_integration_test.go
@@ -305,6 +305,14 @@ type planFlowResult struct {
 	// before issuing the webhook request. Nil preserves the default
 	// "no checks → passing" behavior.
 	CheckStatusNodes atomic.Pointer[func() []checkStatusNode]
+
+	// FailPRFilesAfterFirstFetch makes /pulls/1/files serve only its first
+	// request and answer every later one with a 503. Config discovery fetches
+	// the changed files exactly once, so this simulates GitHub becoming
+	// unavailable between a successful discovery and the dispatched command's
+	// own re-fetch. False (the default) always serves the files.
+	FailPRFilesAfterFirstFetch atomic.Bool
+	prFilesRequests            atomic.Int64
 }
 
 func (p *planFlowResult) nextHeadSHA() string {
@@ -383,6 +391,10 @@ func setupFakeGitHubForPlanWithPRFiles(t *testing.T, mux *http.ServeMux, schemaS
 
 	// PR changed files — report schema files changed (in namespace subdir)
 	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, r *http.Request) {
+		if result.FailPRFilesAfterFirstFetch.Load() && result.prFilesRequests.Add(1) > 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
 		if prFiles != nil {
 			_ = json.NewEncoder(w).Encode(prFiles)
 			return


### PR DESCRIPTION
**Why this matters:** When an auto-plan fails (for example, GitHub becomes unavailable between config discovery and the dispatched plan's own fetch), the failure comment rendered with the user-command layout: an empty environment code span (`**Environment**: ``  `) and a bare `*Requested by @ at … UTC*`. Broken attribution on an error comment makes an already-confusing failure harder to trust and triage from the PR.

**What it does:**
- `SchemaErrorData` gains display helpers used by all seven schema-error templates: the environment header renders the targeted environment as a code span, or — when the command wasn't scoped to one environment — the deployment's own environment scope (`AllowedEnvironments`) as concrete names. In a multi-deployment topology each deployment handles its own environments, so naming them tells the reader which deployment posted the failure; a vague "all environments" placeholder would not. Unscoped deployments omit the environment header entirely instead of rendering filler.
- The attribution line names the requesting user, or credits the pull-request update for system-triggered plans — never a bare `@` mention.
- Pasteable `-e` usage examples use the requested environment, the deployment's sole environment when it is scoped to exactly one, or an `<environment>` placeholder — never an empty value.
- Commands scoped to a single environment render byte-identically to before; only the empty-environment cases change.
- Adds a template preview + TEMPLATES.md entry for the auto-plan generic error, and an integration test that drives a real PR-opened webhook with GitHub failing after discovery, asserting the posted comment carries the automatic-trigger attribution and the deployment's environment scope.

**Example** — auto-plan failure posted by a deployment scoped to `staging`:

> ## ❌ Plan Failed
>
> **Environment**: `staging`
>
> *Triggered automatically by a pull request update at 2026-01-15 14:30:00 UTC*
>
> ### Error
>
> > failed to fetch repository contents: API rate limit exceeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)