### PR TITLE
fix(github): make the terminal summary exactly-once via an atomic marker claim

### DIFF
--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -1711,16 +1711,18 @@ func (s *Service) updateApplyStateFromOperations(ctx context.Context, driverID i
 	}, nil
 }
 
-// publishTerminalSummaryIfWon publishes the apply-level terminal summary exactly
-// once, when this drive won the aggregate non-terminal→terminal projection CAS
-// for a multi-operation apply. Single-operation applies (OperationCount <= 1)
-// publish their summary through the per-driver observer and are skipped here, so
-// this is a no-op on the legacy path. Because the parent apply is already
+// publishTerminalSummaryIfWon publishes the apply-level terminal summary when
+// this drive won the aggregate non-terminal→terminal projection CAS, whatever
+// the apply's operation count. A live single-operation drive usually has its
+// per-driver observer publish first, but when no live observer is left — for
+// example stop reconciliation terminalizing an apply whose driver is gone —
+// this is the only publisher; the atomic summary-marker claim inside the
+// publish path keeps the two exactly-once. Because the parent apply is already
 // durably terminal once result.BecameTerminal is true, publishing is best
 // effort: every failure is logged with triage identifiers and counted, never
 // reverted, and left for summary reconciliation to repair.
 func (s *Service) publishTerminalSummaryIfWon(ctx context.Context, driverID int, apply *storage.Apply, result applyProjectionResult) {
-	if !result.BecameTerminal || result.OperationCount <= 1 {
+	if !result.BecameTerminal {
 		return
 	}
 	if s.OnApplyTerminalSummary == nil {
@@ -1781,7 +1783,7 @@ func (s *Service) publishTerminalSummaryIfWon(ctx context.Context, driverID int,
 		metrics.RecordOperatorTerminalSummaryFailure(ctx, "callback_error")
 		return
 	}
-	s.logger.Info("operator: published aggregate terminal summary for multi-operation apply",
+	s.logger.Info("operator: published aggregate terminal summary",
 		"driver", driverID, "apply_id", terminalApply.ApplyIdentifier,
 		"database", terminalApply.Database, "environment", terminalApply.Environment,
 		"derived_state", result.DerivedState, "operation_count", result.OperationCount)

--- a/pkg/api/operator_terminal_summary_test.go
+++ b/pkg/api/operator_terminal_summary_test.go
@@ -72,18 +72,16 @@ type recordedTerminalSummary struct {
 	tasks []*storage.Task
 }
 
-// TestPublishTerminalSummaryIfWon_Gating verifies the publisher only fires for a
-// multi-operation apply that just won the non-terminal→terminal projection CAS,
-// and is an inert no-op for single-operation applies and non-terminal results so
-// the legacy per-driver observer path is never disturbed.
+// TestPublishTerminalSummaryIfWon_Gating verifies the publisher only fires when
+// this drive won the non-terminal→terminal projection CAS: a result that did not
+// terminalize the parent is an inert no-op, whatever the operation count.
 func TestPublishTerminalSummaryIfWon_Gating(t *testing.T) {
 	cases := []struct {
 		name   string
 		result applyProjectionResult
 	}{
-		{"not terminal", applyProjectionResult{BecameTerminal: false, OperationCount: 2}},
-		{"single operation", applyProjectionResult{BecameTerminal: true, OperationCount: 1}},
-		{"zero operations", applyProjectionResult{BecameTerminal: true, OperationCount: 0}},
+		{"not terminal multi operation", applyProjectionResult{BecameTerminal: false, OperationCount: 2}},
+		{"not terminal single operation", applyProjectionResult{BecameTerminal: false, OperationCount: 1}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -104,6 +102,33 @@ func TestPublishTerminalSummaryIfWon_Gating(t *testing.T) {
 			assert.False(t, taskStore.called, "must not reload tasks for a gated case")
 		})
 	}
+}
+
+// TestPublishTerminalSummaryIfWon_SingleOperationStopped verifies the CAS winner
+// publishes for a single-operation apply that settled stopped — the stop
+// reconciliation path, where no live per-driver observer remains to post the
+// stopped summary. The publisher receives the reloaded stopped apply.
+func TestPublishTerminalSummaryIfWon_SingleOperationStopped(t *testing.T) {
+	stoppedApply := &storage.Apply{ID: 7, ApplyIdentifier: "apply-x", Database: "db", Environment: "staging", State: state.Apply.Stopped}
+	tasks := []*storage.Task{{ID: 1, ApplyID: 7, TableName: "users", State: state.Task.Stopped}}
+	applyStore := &terminalSummaryApplyStore{apply: stoppedApply}
+	taskStore := &terminalSummaryTaskStore{tasks: tasks}
+	svc := newTerminalSummaryTestService(applyStore, taskStore)
+
+	var recorded []recordedTerminalSummary
+	svc.OnApplyTerminalSummary = func(_ context.Context, a *storage.Apply, ts []*storage.Task) error {
+		recorded = append(recorded, recordedTerminalSummary{apply: a, tasks: ts})
+		return nil
+	}
+
+	preCAS := &storage.Apply{ID: 7, ApplyIdentifier: "apply-x", State: state.Apply.Pending}
+	svc.publishTerminalSummaryIfWon(t.Context(), 1, preCAS,
+		applyProjectionResult{BecameTerminal: true, OperationCount: 1, DerivedState: state.Apply.Stopped})
+
+	require.Len(t, recorded, 1, "publisher must fire exactly once for a stopped single-operation apply")
+	assert.Same(t, stoppedApply, recorded[0].apply, "publisher receives the reloaded stopped apply")
+	assert.Equal(t, state.Apply.Stopped, recorded[0].apply.State)
+	assert.Len(t, recorded[0].tasks, 1)
 }
 
 // TestPublishTerminalSummaryIfWon_NilCallback verifies a missing publisher is a

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -106,13 +106,15 @@ func (c TernConfig) Endpoint(deployment, environment string) (string, error) {
 type RecoveryCallback func(apply *storage.Apply)
 
 // ApplyTerminalSummaryCallback is called after the operator wins the aggregate
-// non-terminal→terminal projection compare-and-swap for a multi-operation apply.
-// A multi-operation drive owns only its operation and suppresses the per-driver
-// terminal observer, so the apply-level terminal summary is published exactly
-// once, here, by the CAS winner. The apply and tasks are reloaded from storage
-// (the apply at its terminal state, the tasks across every operation) before
-// invocation. Single-operation applies keep publishing via the per-driver
-// observer and never reach this callback.
+// non-terminal→terminal projection compare-and-swap for an apply, whatever its
+// operation count. A multi-operation drive owns only its operation and
+// suppresses the per-driver terminal observer, so its apply-level terminal
+// summary is published only here, by the CAS winner. A single-operation apply
+// usually publishes through its live per-driver observer, but paths with no
+// live observer — stop reconciliation terminalizing an orphaned apply — also
+// publish here; the summary-marker claim inside the publisher keeps the two
+// exactly-once. The apply and tasks are reloaded from storage (the apply at
+// its terminal state, the tasks across every operation) before invocation.
 type ApplyTerminalSummaryCallback func(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) error
 
 type pendingObserverKey struct {
@@ -168,10 +170,11 @@ type Service struct {
 	// an observer for PR comments.
 	OnApplyRecovered RecoveryCallback
 
-	// OnApplyTerminalSummary is called after a multi-operation apply is
-	// terminalized by the aggregate projection CAS. Set by the webhook handler to
-	// publish the apply-level terminal PR summary and refresh GitHub check state
-	// exactly once, since multi-operation drives suppress the per-driver observer.
+	// OnApplyTerminalSummary is called after an apply is terminalized by the
+	// aggregate projection CAS. Set by the webhook handler to publish the
+	// apply-level terminal PR summary and refresh GitHub check state; the
+	// summary-marker claim inside the publish path keeps it exactly-once
+	// against any still-live per-driver observer.
 	OnApplyTerminalSummary ApplyTerminalSummaryCallback
 
 	pendingObserverMu sync.Mutex

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -746,18 +746,18 @@ var knownOperatorTerminalSummaryFailureReasons = map[string]bool{
 	"callback_error":               true,
 }
 
-// RecordOperatorTerminalSummaryFailure increments the counter for a
-// multi-operation apply whose aggregate terminal summary failed to publish after
-// the projection CAS already terminalized the parent. A spike means terminal PR
-// summaries / check refreshes are being dropped; the parent state itself is
-// already durable, so the expected operator action is to check the GitHub
-// side-effect path (App client, check state) and rely on summary reconciliation.
+// RecordOperatorTerminalSummaryFailure increments the counter for an apply
+// whose aggregate terminal summary failed to publish after the projection CAS
+// already terminalized the parent. A spike means terminal PR summaries / check
+// refreshes are being dropped; the parent state itself is already durable, so
+// the expected operator action is to check the GitHub side-effect path (App
+// client, check state) and rely on summary reconciliation.
 func RecordOperatorTerminalSummaryFailure(ctx context.Context, reason string) {
 	if !knownOperatorTerminalSummaryFailureReasons[reason] {
 		reason = "unknown"
 	}
 	addOperatorCounter(ctx, "terminal_summary_publish_failures_total",
-		"Total number of multi-operation aggregate terminal summary publishes that failed", "{apply}",
+		"Total number of aggregate terminal summary publishes that failed", "{apply}",
 		EnvironmentAttribute(""),
 		attribute.String("reason", reason),
 	)
@@ -1227,6 +1227,20 @@ func RecordWebhookInboxStatsCollectionFailure(ctx context.Context) {
 		"Total number of failed durable webhook inbox metric snapshots", "{failure}",
 		EnvironmentAttribute(""),
 	)
+}
+
+// RecordSummaryCommentRepaired counts terminal summary comments posted by
+// startup reconciliation because no publisher had posted one — the driver's
+// observer lost its lease or crashed, or a claimed publish died before
+// posting. A nonzero rate means terminal summaries are being missed at apply
+// time; investigate the terminal-publish paths (observer lease churn, stop
+// reconciliation, aggregate CAS publisher) for the apply state on the label.
+func RecordSummaryCommentRepaired(ctx context.Context, repo string, applyState string) {
+	addCounter(ctx, "schemabot.webhook.summary_comments_repaired_total",
+		"Total number of missing terminal summary comments posted by startup reconciliation", "{comment}",
+		EnvironmentAttribute(""),
+		attribute.String("repository", repo),
+		attribute.String("apply_state", applyState))
 }
 
 // RecordWebhookReconcileMissingEvent counts open PR heads the webhook

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -1942,23 +1942,38 @@ func (s *applyStore) GetByDatabase(ctx context.Context, database, dbType, enviro
 	return scanApplies(rows)
 }
 
-// FindMissingSummaryComment returns GitHub-backed applies that should have a
-// terminal summary comment but only have a progress comment. Used to post missing
-// summaries after restart.
+// FindMissingSummaryComment returns GitHub-backed applies that reached a
+// terminal state recently but whose progress comment was never followed by a
+// summary comment. Used to post missing summaries after restart.
+//
+// Two forms of "missing" qualify: no summary marker at all (the publisher never
+// ran), and a summary claim sentinel (github_comment_id = 0) stale for longer
+// than storage.SummaryClaimStaleAfter (the publisher claimed, then crashed
+// before posting). A fresh sentinel is an in-flight publish and is left alone.
+//
+// Recency is judged per state family: most terminal states stamp completed_at,
+// but a stopped apply is resumable and keeps completed_at NULL, so it qualifies
+// by updated_at instead.
 func (s *applyStore) FindMissingSummaryComment(ctx context.Context) ([]*storage.Apply, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT `+applyColumnsForApplyAlias+`
 		FROM applies a
 		JOIN apply_comments acp ON acp.apply_id = a.id AND acp.comment_state = 'progress'
 		LEFT JOIN apply_comments acs ON acs.apply_id = a.id AND acs.comment_state = 'summary'
-		WHERE a.state IN (?, ?, ?, ?)
-		  AND a.repository != ''
+		WHERE a.repository != ''
 		  AND a.pull_request > 0
 		  AND a.installation_id > 0
-		  AND a.completed_at > NOW() - INTERVAL 1 HOUR
-		  AND acs.id IS NULL
-		ORDER BY a.completed_at DESC
-	`, state.Apply.Completed, state.Apply.Failed, state.Apply.Reverted, state.Apply.Cancelled)
+		  AND (
+			(a.state IN (?, ?, ?, ?) AND a.completed_at > NOW() - INTERVAL 1 HOUR)
+			OR (a.state = ? AND a.updated_at > NOW() - INTERVAL 1 HOUR)
+		  )
+		  AND (
+			acs.id IS NULL
+			OR (acs.github_comment_id = 0 AND acs.updated_at < NOW() - INTERVAL ? SECOND)
+		  )
+		ORDER BY a.updated_at DESC
+	`, state.Apply.Completed, state.Apply.Failed, state.Apply.Reverted, state.Apply.Cancelled,
+		state.Apply.Stopped, int64(storage.SummaryClaimStaleAfter.Seconds()))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -2915,6 +2915,102 @@ func TestApplyStore_FindMissingSummaryComment_ExcludesAppliesWithoutGitHubDestin
 	assert.Equal(t, githubApply.ApplyIdentifier, applies[0].ApplyIdentifier)
 }
 
+// seedApplyMissingSummary creates a GitHub-backed apply in the given state with
+// a tracked progress comment and no summary marker — the shape
+// FindMissingSummaryComment exists to repair. Terminal states other than
+// stopped stamp completed_at; a stopped apply keeps it NULL (resumable) and
+// must qualify by recency of updated_at instead.
+func seedApplyMissingSummary(t *testing.T, store *Storage, name, applyState string, planID int64) *storage.Apply {
+	t.Helper()
+	ctx := t.Context()
+	lock := createTestLockWithPR(t, store, name+"_db", storage.DatabaseTypeMySQL, "staging", "org/repo", 123)
+	apply := &storage.Apply{
+		ApplyIdentifier: name,
+		LockID:          lock.ID,
+		PlanID:          planID,
+		Database:        lock.DatabaseName,
+		DatabaseType:    lock.DatabaseType,
+		Repository:      lock.Repository,
+		PullRequest:     lock.PullRequest,
+		Environment:     "staging",
+		Caller:          "org/repo#123",
+		InstallationID:  12345,
+		Engine:          storage.EngineSpirit,
+		State:           applyState,
+	}
+	applyID, err := store.Applies().Create(ctx, apply)
+	require.NoError(t, err)
+	apply.ID = applyID
+	if applyState != state.Apply.Stopped {
+		now := time.Now()
+		apply.CompletedAt = &now
+		require.NoError(t, store.Applies().Update(ctx, apply))
+	}
+	require.NoError(t, store.ApplyComments().Upsert(ctx, &storage.ApplyComment{
+		ApplyID:         apply.ID,
+		CommentState:    state.Comment.Progress,
+		GitHubCommentID: 1001,
+	}))
+	return apply
+}
+
+// TestApplyStore_FindMissingSummaryComment_IncludesRecentlyStoppedApplies
+// verifies stopped applies participate in summary reconciliation: a stop is
+// terminal for summary purposes even though it is resumable and never stamps
+// completed_at, so recency is judged by updated_at. A stopped apply whose last
+// update is older than the reconciliation lookback is left alone.
+func TestApplyStore_FindMissingSummaryComment_IncludesRecentlyStoppedApplies(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	recent := seedApplyMissingSummary(t, store, "apply_stopped_recent", state.Apply.Stopped, 700)
+	stale := seedApplyMissingSummary(t, store, "apply_stopped_stale", state.Apply.Stopped, 701)
+	_, err := testDB.ExecContext(ctx, `UPDATE applies SET updated_at = NOW() - INTERVAL 2 HOUR WHERE id = ?`, stale.ID)
+	require.NoError(t, err)
+
+	applies, err := store.Applies().FindMissingSummaryComment(ctx)
+	require.NoError(t, err)
+	require.Len(t, applies, 1)
+	assert.Equal(t, recent.ApplyIdentifier, applies[0].ApplyIdentifier)
+	assert.Equal(t, state.Apply.Stopped, applies[0].State)
+}
+
+// TestApplyStore_FindMissingSummaryComment_SummaryClaimSentinels verifies the
+// claim-aware missing test: a fresh claim sentinel means a publisher is posting
+// right now, so the apply is not reported; a sentinel stale past
+// storage.SummaryClaimStaleAfter means that publisher crashed before posting,
+// so the apply is reported for repair; and a marker recording a real posted
+// comment never reports.
+func TestApplyStore_FindMissingSummaryComment_SummaryClaimSentinels(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	freshClaim := seedApplyMissingSummary(t, store, "apply_claim_fresh", state.Apply.Completed, 710)
+	won, err := store.ApplyComments().ClaimSummaryComment(ctx, freshClaim.ID)
+	require.NoError(t, err)
+	require.True(t, won)
+
+	staleClaim := seedApplyMissingSummary(t, store, "apply_claim_stale", state.Apply.Completed, 711)
+	won, err = store.ApplyComments().ClaimSummaryComment(ctx, staleClaim.ID)
+	require.NoError(t, err)
+	require.True(t, won)
+	backdateSummaryClaim(t, staleClaim.ID)
+
+	posted := seedApplyMissingSummary(t, store, "apply_summary_posted", state.Apply.Completed, 712)
+	require.NoError(t, store.ApplyComments().Upsert(ctx, &storage.ApplyComment{
+		ApplyID:         posted.ID,
+		CommentState:    state.Comment.Summary,
+		GitHubCommentID: 2002,
+	}))
+
+	applies, err := store.Applies().FindMissingSummaryComment(ctx)
+	require.NoError(t, err)
+	require.Len(t, applies, 1)
+	assert.Equal(t, staleClaim.ApplyIdentifier, applies[0].ApplyIdentifier)
+}
+
 func TestApplyStore_GetByPR(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/mysqlstore/apply_comments.go
+++ b/pkg/storage/mysqlstore/apply_comments.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/spirit/pkg/utils"
 )
@@ -214,6 +215,69 @@ func (s *applyCommentStore) ClearPendingFreeze(ctx context.Context, applyID int6
 		if err := ensureApplyLeaseStillOwned(ctx, s.db, lease); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// ClaimSummaryComment atomically claims the terminal summary publish for an
+// apply by inserting the summary marker as a claim sentinel
+// (github_comment_id = 0). The unique key on (apply_id, comment_state) makes
+// this a race-safe first-writer-wins: the insert that lands the row wins the
+// claim; a duplicate-key loss means another writer already claimed or posted
+// the summary. Deliberately lease-agnostic — the claim itself is the
+// exactly-once authority, so a publisher whose apply lease was re-claimed can
+// still win or lose cleanly.
+func (s *applyCommentStore) ClaimSummaryComment(ctx context.Context, applyID int64) (bool, error) {
+	result, err := s.db.ExecContext(ctx, `
+		INSERT IGNORE INTO apply_comments (apply_id, comment_state, github_comment_id)
+		VALUES (?, ?, 0)
+	`, applyID, state.Comment.Summary)
+	if err != nil {
+		return false, fmt.Errorf("claim summary comment for apply %d: %w", applyID, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("read summary claim rows affected for apply %d: %w", applyID, err)
+	}
+	return rows == 1, nil
+}
+
+// ReclaimStaleSummaryClaim takes over a summary claim sentinel abandoned by a
+// crashed publisher: still github_comment_id = 0 and not updated for at least
+// storage.SummaryClaimStaleAfter. Bumping updated_at transfers ownership, and
+// because concurrent reclaimers race on the same conditional update, exactly
+// one sees an affected row and wins.
+func (s *applyCommentStore) ReclaimStaleSummaryClaim(ctx context.Context, applyID int64) (bool, error) {
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE apply_comments
+		SET updated_at = NOW()
+		WHERE apply_id = ? AND comment_state = ?
+		  AND github_comment_id = 0
+		  AND updated_at < NOW() - INTERVAL ? SECOND
+	`, applyID, state.Comment.Summary, int64(storage.SummaryClaimStaleAfter.Seconds()))
+	if err != nil {
+		return false, fmt.Errorf("reclaim stale summary claim for apply %d: %w", applyID, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("read summary claim reclaim rows affected for apply %d: %w", applyID, err)
+	}
+	return rows == 1, nil
+}
+
+// ReleaseSummaryClaim deletes the summary claim sentinel for an apply so a
+// later publisher can retry without waiting out the stale-claim window. Only
+// the sentinel form (github_comment_id = 0) is deleted — a marker that already
+// records a posted comment is never released. A missing sentinel is not an
+// error: the claim may have been converted to a real comment or reclaimed by
+// another writer in the meantime.
+func (s *applyCommentStore) ReleaseSummaryClaim(ctx context.Context, applyID int64) error {
+	_, err := s.db.ExecContext(ctx, `
+		DELETE FROM apply_comments
+		WHERE apply_id = ? AND comment_state = ? AND github_comment_id = 0
+	`, applyID, state.Comment.Summary)
+	if err != nil {
+		return fmt.Errorf("release summary claim for apply %d: %w", applyID, err)
 	}
 	return nil
 }

--- a/pkg/storage/mysqlstore/apply_comments_test.go
+++ b/pkg/storage/mysqlstore/apply_comments_test.go
@@ -430,3 +430,137 @@ func TestApplyCommentStore_DeleteByApply_DBError(t *testing.T) {
 	err = store.ApplyComments().DeleteByApply(t.Context(), 1)
 	require.Error(t, err)
 }
+
+// TestApplyCommentStore_ClaimSummaryComment verifies the atomic summary-marker
+// claim is first-writer-wins: the first claim inserts the sentinel
+// (github_comment_id = 0) and wins, every later claim for the same apply loses,
+// and a summary marker that already records a real comment also blocks the
+// claim. Claims for different applies are independent.
+func TestApplyCommentStore_ClaimSummaryComment(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_comment_claim", 1)
+	otherLock := createTestLock(t, store, "testdb_other", "mysql", "staging")
+	other := createTestApply(t, store, otherLock, "apply_comment_claim_other", 2)
+
+	won, err := store.ApplyComments().ClaimSummaryComment(ctx, apply.ID)
+	require.NoError(t, err)
+	assert.True(t, won, "first claim must win")
+
+	claimed, err := store.ApplyComments().Get(ctx, apply.ID, state.Comment.Summary)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, int64(0), claimed.GitHubCommentID, "won claim is the sentinel form of the marker")
+
+	won, err = store.ApplyComments().ClaimSummaryComment(ctx, apply.ID)
+	require.NoError(t, err)
+	assert.False(t, won, "second claim for the same apply must lose")
+
+	won, err = store.ApplyComments().ClaimSummaryComment(ctx, other.ID)
+	require.NoError(t, err)
+	assert.True(t, won, "claims for different applies are independent")
+
+	// A recorded real comment blocks the claim the same way a sentinel does.
+	require.NoError(t, store.ApplyComments().ReleaseSummaryClaim(ctx, apply.ID))
+	require.NoError(t, store.ApplyComments().Upsert(ctx, &storage.ApplyComment{
+		ApplyID: apply.ID, CommentState: state.Comment.Summary, GitHubCommentID: 9001,
+	}))
+	won, err = store.ApplyComments().ClaimSummaryComment(ctx, apply.ID)
+	require.NoError(t, err)
+	assert.False(t, won, "a posted summary must block the claim")
+}
+
+// TestApplyCommentStore_ReclaimStaleSummaryClaim verifies crashed-publisher
+// takeover: a claim sentinel older than the stale window transfers to the
+// reclaimer (bumping updated_at so a second reclaimer loses), while a fresh
+// sentinel, a missing marker, and a recorded real comment are all not
+// reclaimable.
+func TestApplyCommentStore_ReclaimStaleSummaryClaim(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_comment_reclaim", 1)
+
+	reclaimed, err := store.ApplyComments().ReclaimStaleSummaryClaim(ctx, apply.ID)
+	require.NoError(t, err)
+	assert.False(t, reclaimed, "missing marker is not reclaimable")
+
+	won, err := store.ApplyComments().ClaimSummaryComment(ctx, apply.ID)
+	require.NoError(t, err)
+	require.True(t, won)
+
+	reclaimed, err = store.ApplyComments().ReclaimStaleSummaryClaim(ctx, apply.ID)
+	require.NoError(t, err)
+	assert.False(t, reclaimed, "fresh sentinel is an in-flight publish, not reclaimable")
+
+	// Backdate the sentinel past the stale window to simulate a publisher that
+	// crashed between claiming and posting.
+	backdateSummaryClaim(t, apply.ID)
+
+	reclaimed, err = store.ApplyComments().ReclaimStaleSummaryClaim(ctx, apply.ID)
+	require.NoError(t, err)
+	assert.True(t, reclaimed, "stale sentinel transfers to the reclaimer")
+
+	reclaimed, err = store.ApplyComments().ReclaimStaleSummaryClaim(ctx, apply.ID)
+	require.NoError(t, err)
+	assert.False(t, reclaimed, "a just-reclaimed sentinel is fresh again; a second reclaimer loses")
+
+	// A recorded real comment is never reclaimable, however old.
+	require.NoError(t, store.ApplyComments().Upsert(ctx, &storage.ApplyComment{
+		ApplyID: apply.ID, CommentState: state.Comment.Summary, GitHubCommentID: 9001,
+	}))
+	backdateSummaryClaim(t, apply.ID)
+	reclaimed, err = store.ApplyComments().ReclaimStaleSummaryClaim(ctx, apply.ID)
+	require.NoError(t, err)
+	assert.False(t, reclaimed, "a posted summary must never be reclaimed")
+}
+
+// TestApplyCommentStore_ReleaseSummaryClaim verifies release deletes only the
+// sentinel form of the summary marker: a released claim can be re-won, a
+// missing marker releases without error, and a marker recording a real posted
+// comment survives release untouched.
+func TestApplyCommentStore_ReleaseSummaryClaim(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	apply := createTestApply(t, store, lock, "apply_comment_release", 1)
+
+	require.NoError(t, store.ApplyComments().ReleaseSummaryClaim(ctx, apply.ID), "releasing a missing claim is not an error")
+
+	won, err := store.ApplyComments().ClaimSummaryComment(ctx, apply.ID)
+	require.NoError(t, err)
+	require.True(t, won)
+	require.NoError(t, store.ApplyComments().ReleaseSummaryClaim(ctx, apply.ID))
+
+	won, err = store.ApplyComments().ClaimSummaryComment(ctx, apply.ID)
+	require.NoError(t, err)
+	assert.True(t, won, "a released claim must be re-winnable")
+
+	// Convert the claim to a posted summary; release must not delete it.
+	require.NoError(t, store.ApplyComments().Upsert(ctx, &storage.ApplyComment{
+		ApplyID: apply.ID, CommentState: state.Comment.Summary, GitHubCommentID: 9001,
+	}))
+	require.NoError(t, store.ApplyComments().ReleaseSummaryClaim(ctx, apply.ID))
+	posted, err := store.ApplyComments().Get(ctx, apply.ID, state.Comment.Summary)
+	require.NoError(t, err)
+	require.NotNil(t, posted, "a recorded posted summary must survive release")
+	assert.Equal(t, int64(9001), posted.GitHubCommentID)
+}
+
+// backdateSummaryClaim pushes an apply's summary marker updated_at past the
+// stale-claim window, simulating a publisher that crashed after claiming.
+func backdateSummaryClaim(t *testing.T, applyID int64) {
+	t.Helper()
+	_, err := testDB.ExecContext(t.Context(), `
+		UPDATE apply_comments SET updated_at = NOW() - INTERVAL ? SECOND
+		WHERE apply_id = ? AND comment_state = ?
+	`, int64(storage.SummaryClaimStaleAfter.Seconds())+1, applyID, state.Comment.Summary)
+	require.NoError(t, err)
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -448,9 +448,13 @@ type ApplyStore interface {
 	// active again.
 	ReapplyFailed(ctx context.Context, applyID int64) (*Apply, error)
 
-	// FindMissingSummaryComment returns GitHub-backed applies that should have
-	// a terminal summary comment but only have a progress comment. Used by
-	// startup reconciliation to post missing summary comments after restarts.
+	// FindMissingSummaryComment returns GitHub-backed applies that recently
+	// reached a terminal state (including stopped, judged by updated_at since a
+	// resumable stop keeps completed_at NULL) but whose progress comment was
+	// never followed by a summary comment — either no summary marker exists, or
+	// only a claim sentinel stale for longer than SummaryClaimStaleAfter
+	// remains from a publisher that crashed before posting. Used by startup
+	// reconciliation to post missing summary comments after restarts.
 	FindMissingSummaryComment(ctx context.Context) ([]*Apply, error)
 
 	// GetByPR returns all applies for a PR.
@@ -588,7 +592,40 @@ type ApplyCommentStore interface {
 	// has landed on GitHub. A missing row or an already-clear marker is not an
 	// error.
 	ClearPendingFreeze(ctx context.Context, applyID int64, commentState string) error
+
+	// ClaimSummaryComment atomically claims the right to publish the terminal
+	// summary comment for an apply by inserting the summary marker as a claim
+	// sentinel (github_comment_id = 0). Exactly one caller wins per apply: the
+	// winner posts the summary and records the real comment ID via Upsert; every
+	// loser skips. The claim — not the apply lease — is the exactly-once
+	// authority for the summary, so a writer whose lease was re-claimed (stop
+	// reconciliation, resume) can still be beaten to the post without a
+	// duplicate. Returns true when this caller won the claim.
+	ClaimSummaryComment(ctx context.Context, applyID int64) (bool, error)
+
+	// ReclaimStaleSummaryClaim takes over a summary claim sentinel whose holder
+	// crashed between claiming and posting: a sentinel (github_comment_id = 0)
+	// not updated for at least SummaryClaimStaleAfter. Ownership transfers by
+	// bumping updated_at, so concurrent reclaimers race on the same conditional
+	// update and exactly one wins. Returns true when this caller now owns the
+	// claim; false when the sentinel is missing, fresh, or already a real
+	// comment.
+	ReclaimStaleSummaryClaim(ctx context.Context, applyID int64) (bool, error)
+
+	// ReleaseSummaryClaim releases a summary claim this caller won but could not
+	// convert into a posted comment, so a later publisher (or startup
+	// reconciliation) can retry immediately instead of waiting out the stale-
+	// claim window. Deletes only the sentinel form of the marker — a recorded
+	// real comment is never released.
+	ReleaseSummaryClaim(ctx context.Context, applyID int64) error
 }
+
+// SummaryClaimStaleAfter is how long a summary claim sentinel
+// (apply_comments row with github_comment_id = 0) may go without an update
+// before it is considered abandoned by a crashed publisher and becomes
+// reclaimable. Claims are normally held only for the duration of one GitHub
+// post, so anything older than this window is a crash, not a slow post.
+const SummaryClaimStaleAfter = 2 * time.Minute
 
 // PlanCommentStore tracks plan comments posted on PRs so a newer plan comment
 // for the same database can minimize the ones it supersedes. Rows exist only

--- a/pkg/webhook/apply_comment_integration_test.go
+++ b/pkg/webhook/apply_comment_integration_test.go
@@ -1151,6 +1151,236 @@ func TestE2EReconcileMissingSummaryCommentsPostsSummary(t *testing.T) {
 	assert.Equal(t, created.ID, summaryComment.GitHubCommentID)
 }
 
+// seedReconcileScenario clears the shared storage rows for a repo, then seeds a
+// GitHub-backed apply in the given state with one task and a tracked progress
+// comment but no summary marker — a restart that lost the terminal summary.
+// Stopped applies keep completed_at NULL (a stop is resumable), matching how
+// stop reconciliation leaves them.
+func seedReconcileScenario(t *testing.T, st storage.Storage, schemabotDB *sql.DB, repo, database, applyState, taskState string) *storage.Apply {
+	t.Helper()
+	ctx := t.Context()
+
+	for _, stmt := range []string{
+		"DELETE FROM apply_comments",
+		"DELETE FROM tasks WHERE repository = ?",
+		"DELETE FROM applies WHERE repository = ?",
+		"DELETE FROM locks WHERE repository = ?",
+	} {
+		args := []any{repo}
+		if stmt == "DELETE FROM apply_comments" {
+			args = nil
+		}
+		_, err := schemabotDB.ExecContext(ctx, stmt, args...)
+		require.NoError(t, err)
+	}
+
+	lock := &storage.Lock{
+		DatabaseName: database,
+		DatabaseType: storage.DatabaseTypeMySQL,
+		Repository:   repo,
+		PullRequest:  44,
+		Owner:        repo + "#44",
+	}
+	require.NoError(t, st.Locks().Acquire(ctx, lock))
+	lock, err := st.Locks().Get(ctx, database, storage.DatabaseTypeMySQL)
+	require.NoError(t, err)
+
+	now := time.Now()
+	startedAt := now.Add(-time.Minute)
+	apply := &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply_reconcile_%s_%d", applyState, now.UnixNano()),
+		LockID:          lock.ID,
+		PlanID:          1,
+		Database:        database,
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Repository:      repo,
+		PullRequest:     44,
+		Environment:     "staging",
+		Caller:          repo + "#44",
+		InstallationID:  12345,
+		Engine:          storage.EngineSpirit,
+		State:           applyState,
+	}
+	applyID, err := st.Applies().Create(ctx, apply)
+	require.NoError(t, err)
+	apply.ID = applyID
+	apply.StartedAt = &startedAt
+	if applyState != state.Apply.Stopped {
+		apply.CompletedAt = &now
+	}
+	require.NoError(t, st.Applies().Update(ctx, apply))
+
+	task := &storage.Task{
+		TaskIdentifier: fmt.Sprintf("task_reconcile_%s_%d", applyState, now.UnixNano()),
+		ApplyID:        applyID,
+		PlanID:         1,
+		Database:       database,
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Engine:         storage.EngineSpirit,
+		Repository:     repo,
+		PullRequest:    44,
+		Environment:    "staging",
+		State:          taskState,
+		TableName:      "reconcile_users",
+		DDL:            "ALTER TABLE reconcile_users ADD COLUMN email VARCHAR(255)",
+		DDLAction:      "alter",
+		RowsCopied:     5,
+		RowsTotal:      10,
+		CreatedAt:      startedAt,
+		UpdatedAt:      now,
+		StartedAt:      &startedAt,
+	}
+	_, err = st.Tasks().Create(ctx, task)
+	require.NoError(t, err)
+
+	require.NoError(t, st.ApplyComments().Upsert(ctx, &storage.ApplyComment{
+		ApplyID:         applyID,
+		CommentState:    state.Comment.Progress,
+		GitHubCommentID: 9001,
+	}))
+	return apply
+}
+
+// TestE2EReconcileMissingSummaryCommentsRepairsStoppedApply verifies startup
+// reconciliation repairs a stopped apply that lost its terminal summary — the
+// operator stopped the apply (stop reconciliation, driver crash) and no
+// publisher posted the "⏹️ Stopped" summary before the restart. The PR must
+// still get exactly one stopped summary, and the recorded marker must prevent
+// a repeat on the next startup.
+func TestE2EReconcileMissingSummaryCommentsRepairsStoppedApply(t *testing.T) {
+	ctx := t.Context()
+
+	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
+	require.NoError(t, err)
+	t.Cleanup(func() { utils.CloseAndLog(schemabotDB) })
+	st := mysqlstore.New(schemabotDB)
+
+	apply := seedReconcileScenario(t, st, schemabotDB, "org/reconcile-stopped", "e2e_reconcile_stopped_db", state.Apply.Stopped, state.Task.Stopped)
+
+	installClient, capture := setupFakeGitHubForComments(t)
+	factory := &fakeClientFactory{client: installClient}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	svc := api.New(st, &api.ServerConfig{}, map[string]tern.Client{}, logger)
+	t.Cleanup(func() { utils.CloseAndLog(svc) })
+
+	h := NewHandler(svc, factory, nil, logger)
+	h.ReconcileMissingSummaryComments(ctx)
+
+	var created commentCreate
+	select {
+	case created = <-capture.creates:
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "timed out waiting for stopped summary comment")
+	}
+	assert.Contains(t, created.Body, "Schema Change Stopped")
+	assert.Contains(t, created.Body, "reconcile_users")
+	assert.Contains(t, created.Body, apply.ApplyIdentifier)
+
+	summaryComment, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Summary)
+	require.NoError(t, err)
+	require.NotNil(t, summaryComment)
+	assert.Equal(t, created.ID, summaryComment.GitHubCommentID)
+}
+
+// TestE2EReconcileMissingSummaryCommentsRespectsFreshClaim verifies the
+// reconciler defers to an in-flight publisher: an apply whose summary marker is
+// a fresh claim sentinel is being posted right now by another writer, so the
+// reconciler must not post a duplicate and must leave the claim untouched.
+func TestE2EReconcileMissingSummaryCommentsRespectsFreshClaim(t *testing.T) {
+	ctx := t.Context()
+
+	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
+	require.NoError(t, err)
+	t.Cleanup(func() { utils.CloseAndLog(schemabotDB) })
+	st := mysqlstore.New(schemabotDB)
+
+	apply := seedReconcileScenario(t, st, schemabotDB, "org/reconcile-claimed", "e2e_reconcile_claimed_db", state.Apply.Completed, state.Task.Completed)
+
+	won, err := st.ApplyComments().ClaimSummaryComment(ctx, apply.ID)
+	require.NoError(t, err)
+	require.True(t, won)
+
+	installClient, capture := setupFakeGitHubForComments(t)
+	factory := &fakeClientFactory{client: installClient}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	svc := api.New(st, &api.ServerConfig{}, map[string]tern.Client{}, logger)
+	t.Cleanup(func() { utils.CloseAndLog(svc) })
+
+	h := NewHandler(svc, factory, nil, logger)
+	h.ReconcileMissingSummaryComments(ctx)
+
+	select {
+	case created := <-capture.creates:
+		t.Fatalf("reconciler must not post while a fresh claim is held, posted: %q", created.Body)
+	default:
+	}
+
+	marker, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Summary)
+	require.NoError(t, err)
+	require.NotNil(t, marker)
+	assert.Equal(t, int64(0), marker.GitHubCommentID, "the in-flight claim sentinel must survive reconciliation")
+}
+
+// TestE2EAggregateTerminalObserverClaimsSummaryExactlyOnce verifies the
+// summary-marker claim makes concurrent terminal publishers exactly-once: when
+// two aggregate CAS-winner observers (for example stop reconciliation's
+// publisher racing a still-live driver observer) both reach the terminal
+// summary step for the same apply, exactly one summary comment lands on the PR
+// and the marker records its comment ID.
+func TestE2EAggregateTerminalObserverClaimsSummaryExactlyOnce(t *testing.T) {
+	ctx := t.Context()
+
+	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
+	require.NoError(t, err)
+	t.Cleanup(func() { utils.CloseAndLog(schemabotDB) })
+	st := mysqlstore.New(schemabotDB)
+
+	apply := seedReconcileScenario(t, st, schemabotDB, "org/claim-once", "e2e_claim_once_db", state.Apply.Stopped, state.Task.Stopped)
+	tasks, err := st.Tasks().GetByApplyID(ctx, apply.ID)
+	require.NoError(t, err)
+
+	installClient, capture := setupFakeGitHubForComments(t)
+	factory := &fakeClientFactory{client: installClient}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	newObserver := func() *CommentObserver {
+		return NewAggregateTerminalCommentObserver(CommentObserverConfig{
+			GHClient:       factory,
+			Storage:        st,
+			Repo:           apply.Repository,
+			PR:             apply.PullRequest,
+			InstallationID: apply.InstallationID,
+			ApplyID:        apply.ID,
+			Logger:         logger,
+		})
+	}
+
+	newObserver().OnTerminal(apply, tasks)
+	newObserver().OnTerminal(apply, tasks)
+
+	var created commentCreate
+	select {
+	case created = <-capture.creates:
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "timed out waiting for the claimed summary comment")
+	}
+	assert.Contains(t, created.Body, "Schema Change Stopped")
+	assert.Contains(t, created.Body, apply.ApplyIdentifier)
+
+	select {
+	case duplicate := <-capture.creates:
+		t.Fatalf("the second publisher must lose the claim and skip, posted duplicate: %q", duplicate.Body)
+	default:
+	}
+
+	marker, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Summary)
+	require.NoError(t, err)
+	require.NotNil(t, marker)
+	assert.Equal(t, created.ID, marker.GitHubCommentID)
+}
+
 // TestE2EApplyCommentUpsertOnResume tests that Start/resume replaces old comment IDs.
 func TestE2EApplyCommentUpsertOnResume(t *testing.T) {
 	ctx := t.Context()

--- a/pkg/webhook/apply_comment_integration_test.go
+++ b/pkg/webhook/apply_comment_integration_test.go
@@ -1252,7 +1252,9 @@ func TestE2EReconcileMissingSummaryCommentsRepairsStoppedApply(t *testing.T) {
 
 	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
 	require.NoError(t, err)
-	t.Cleanup(func() { utils.CloseAndLog(schemabotDB) })
+	// Redundant early-exit closer: svc owns the storage (and this handle) and
+	// closes it below, so discard the guaranteed already-closed error.
+	t.Cleanup(func() { _ = schemabotDB.Close() })
 	st := mysqlstore.New(schemabotDB)
 
 	apply := seedReconcileScenario(t, st, schemabotDB, "org/reconcile-stopped", "e2e_reconcile_stopped_db", state.Apply.Stopped, state.Task.Stopped)
@@ -1292,7 +1294,9 @@ func TestE2EReconcileMissingSummaryCommentsRespectsFreshClaim(t *testing.T) {
 
 	schemabotDB, err := sql.Open("mysql", e2eSchemabotDSN)
 	require.NoError(t, err)
-	t.Cleanup(func() { utils.CloseAndLog(schemabotDB) })
+	// Redundant early-exit closer: svc owns the storage (and this handle) and
+	// closes it below, so discard the guaranteed already-closed error.
+	t.Cleanup(func() { _ = schemabotDB.Close() })
 	st := mysqlstore.New(schemabotDB)
 
 	apply := seedReconcileScenario(t, st, schemabotDB, "org/reconcile-claimed", "e2e_reconcile_claimed_db", state.Apply.Completed, state.Task.Completed)

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -195,10 +195,12 @@ func NewCommentObserver(cfg CommentObserverConfig) *CommentObserver {
 }
 
 // NewAggregateTerminalCommentObserver builds a one-shot observer for the
-// operator to publish a multi-operation apply's single terminal summary after it
-// won the aggregate projection compare-and-swap. The CAS win — not a parent
-// apply lease — is the authority, so this observer bypasses the per-driver
-// apply-lease checks. Only OnTerminal is meant to be called on it.
+// operator to publish an apply's single terminal summary after it won the
+// aggregate projection compare-and-swap. The CAS win — not a parent apply
+// lease — is the authority for the comment edits, so this observer bypasses
+// the per-driver apply-lease checks; the separate summary post is additionally
+// serialized by the summary-marker claim against any still-live per-driver
+// observer. Only OnTerminal is meant to be called on it.
 func NewAggregateTerminalCommentObserver(cfg CommentObserverConfig) *CommentObserver {
 	o := NewCommentObserver(cfg)
 	o.aggregateTerminalCASWinner = true
@@ -365,7 +367,7 @@ func (o *CommentObserver) OnTerminal(apply *storage.Apply, tasks []*storage.Task
 		// to it rather than post a duplicate, partial summary.
 		if o.shouldPublishSeparateSummary(apply, ops, opsErr) {
 			summaryBody := o.summaryCommentFromOps(ctx, apply, ops, opsErr, tasks, shardsByTable)
-			o.postAndTrackComment(apply, state.Comment.Summary, summaryBody, nil)
+			o.publishClaimedSummary(apply, summaryBody)
 		}
 	}
 
@@ -1010,6 +1012,70 @@ func (o *CommentObserver) postAndTrackComment(apply *storage.Apply, commentState
 
 func (o *CommentObserver) renderPRComment(body string) string {
 	return appendSupportChannelFooter(body, o.supportChannel)
+}
+
+// publishClaimedSummary posts the separate apply-level terminal summary
+// comment under the atomic summary-marker claim. Multiple writers can reach a
+// terminal apply's summary step — the origin driver's observer, the aggregate
+// CAS-winner observer, and stop reconciliation's publisher — so the claim, not
+// the apply lease, is the exactly-once authority here: whichever writer wins
+// the claim posts the one summary, and every loser skips. The storage writes
+// are deliberately lease-free — a writer whose apply lease was re-claimed (for
+// example by stop reconciliation) must still be able to lose the claim cleanly,
+// and the winner must be able to record its post.
+func (o *CommentObserver) publishClaimedSummary(apply *storage.Apply, body string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	won, err := o.stor.ApplyComments().ClaimSummaryComment(ctx, o.applyID)
+	if err != nil {
+		o.logError(apply, "observer: failed to claim terminal summary; summary not posted, left for reconciliation",
+			"error", err)
+		return
+	}
+	if !won {
+		o.logInfo(apply, "observer: terminal summary already claimed or posted by another writer; skipping")
+		return
+	}
+
+	client, err := o.ghClient.ForInstallation(o.installationID)
+	if err != nil {
+		o.logError(apply, "observer: failed to create GitHub client for claimed terminal summary; releasing claim",
+			"error", err)
+		o.releaseSummaryClaim(ctx, apply)
+		return
+	}
+	commentID, _, err := client.CreateIssueComment(ctx, o.repo, o.pr, o.renderPRComment(body))
+	if err != nil {
+		o.logError(apply, "observer: failed to post claimed terminal summary; releasing claim",
+			"error", err)
+		o.releaseSummaryClaim(ctx, apply)
+		return
+	}
+
+	marker := &storage.ApplyComment{
+		ApplyID:         o.applyID,
+		CommentState:    state.Comment.Summary,
+		GitHubCommentID: commentID,
+	}
+	if err := o.stor.ApplyComments().Upsert(ctx, marker); err != nil {
+		// The comment is live on the PR but the marker still looks like a claim
+		// sentinel, so once it goes stale, reconciliation will reclaim it and may
+		// post one duplicate — the bounded-duplicate contract for a lost tracking
+		// write.
+		o.logError(apply, "observer: posted terminal summary but failed to record its comment ID",
+			"error", err, "comment_id", commentID)
+	}
+}
+
+// releaseSummaryClaim returns a won-but-unused summary claim so another
+// publisher or startup reconciliation can retry immediately instead of waiting
+// out the stale-claim window.
+func (o *CommentObserver) releaseSummaryClaim(ctx context.Context, apply *storage.Apply) {
+	if err := o.stor.ApplyComments().ReleaseSummaryClaim(ctx, o.applyID); err != nil {
+		o.logError(apply, "observer: failed to release terminal summary claim; reconciliation will reclaim it once stale",
+			"error", err)
+	}
 }
 
 // markSummaryPosted upserts a summary marker record in apply_comments.

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -442,7 +442,7 @@ func (h *Handler) ReconcileMissingSummaryComments(ctx context.Context) {
 
 	applies, err := h.service.Storage().Applies().FindMissingSummaryComment(ctx)
 	if err != nil {
-		h.logger.Error("summary comment reconciliation skipped this startup; PRs with a finished apply may show no final summary until the next restart",
+		h.logger.Error("summary comment reconciliation skipped this startup; terminal applies (including stopped) missing a summary comment stay unrepaired until the next restart",
 			"error", err)
 		return
 	}

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -275,9 +275,12 @@ func NewHandlerWithDispatch(service *api.Service, ghClients github.ClientSet, we
 				}))
 		}
 
-		// Register the aggregate terminal-summary callback. A multi-operation
-		// apply suppresses the per-driver observer, so its single terminal summary
-		// is published here by the operator that won the aggregate projection CAS.
+		// Register the aggregate terminal-summary callback, invoked by the
+		// operator that won the aggregate projection CAS. A multi-operation apply
+		// suppresses the per-driver observer, so this is its only summary
+		// publisher; a single-operation apply reaches it from paths with no live
+		// observer (stop reconciliation), where the summary-marker claim keeps
+		// the publish exactly-once against any observer still alive.
 		service.OnApplyTerminalSummary = func(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) error {
 			if apply.Repository == "" || apply.PullRequest == 0 || apply.InstallationID == 0 {
 				logger.Debug("aggregate terminal summary skipped: apply has no GitHub destination",
@@ -291,7 +294,7 @@ func NewHandlerWithDispatch(service *api.Service, ghClients github.ClientSet, we
 				return fmt.Errorf("resolve GitHub App client for aggregate terminal summary of apply %s repo %s pr %d: %w",
 					apply.ApplyIdentifier, apply.Repository, apply.PullRequest, err)
 			}
-			logger.Info("publishing aggregate terminal summary for multi-operation apply",
+			logger.Info("publishing aggregate terminal summary",
 				"apply_id", apply.ApplyIdentifier,
 				"repo", apply.Repository,
 				"pr", apply.PullRequest,
@@ -425,8 +428,12 @@ func (h *Handler) clientForRepo(repo string, installationID int64) (*github.Inst
 }
 
 // ReconcileMissingSummaryComments repairs the apply_comments outbox on startup.
-// It finds applies with a progress comment but no summary comment, then posts
-// the missing summary so the PR shows the final result after a restart.
+// It finds recently terminal applies (including stopped) with a progress
+// comment but no summary comment, then posts the missing summary so the PR
+// shows the final result after a restart. Each repair goes through the atomic
+// summary-marker claim, so a publisher racing this reconciler — or another
+// pod's reconciler — still yields exactly one summary; a claim sentinel left
+// by a publisher that crashed before posting is taken over once stale.
 func (h *Handler) ReconcileMissingSummaryComments(ctx context.Context) {
 	if h.service == nil {
 		h.logger.Debug("skipping missing summary reconciliation without service")
@@ -448,9 +455,14 @@ func (h *Handler) ReconcileMissingSummaryComments(ctx context.Context) {
 	h.logger.Info("found applies missing summary comments", "count", len(applies))
 
 	for _, apply := range applies {
+		if !h.claimSummaryForReconciliation(ctx, apply) {
+			continue
+		}
+
 		tasks, err := h.service.Storage().Tasks().GetByApplyID(ctx, apply.ID)
 		if err != nil {
-			h.logger.Error("failed to load tasks for missing summary reconciliation", append(apply.LogAttrs(), "error", err)...)
+			h.logger.Error("failed to load tasks for missing summary reconciliation; releasing summary claim", append(apply.LogAttrs(), "error", err)...)
+			h.releaseSummaryClaim(ctx, apply)
 			continue
 		}
 
@@ -473,7 +485,81 @@ func (h *Handler) ReconcileMissingSummaryComments(ctx context.Context) {
 		released := releasedForApply(ctx, h.service.Storage(), apply, ops, h.logger)
 		summaryBase := formatApplySummaryComment(apply, ops, released, tasks, resolveDisplayByOperation(ctx, h.service.Storage(), apply, ops), nil, h.deploymentTenant())
 		summaryBody := summaryBase + failureLogsSection(ctx, h.service.Storage(), h.logger, apply, summaryBase)
-		h.postAndTrackComment(ctx, apply.Repository, apply.PullRequest, apply.InstallationID, apply, state.Comment.Summary, summaryBody)
+		h.postClaimedSummaryComment(ctx, apply, summaryBody)
+	}
+}
+
+// claimSummaryForReconciliation acquires the atomic summary-marker claim for a
+// reconciliation repair. A fresh claim wins when no marker exists; when the
+// marker is a claim sentinel left behind by a crashed publisher, the stale
+// takeover path transfers it instead. Losing both means another writer posted
+// or is actively posting the summary, so the repair is skipped.
+func (h *Handler) claimSummaryForReconciliation(ctx context.Context, apply *storage.Apply) bool {
+	won, err := h.service.Storage().ApplyComments().ClaimSummaryComment(ctx, apply.ID)
+	if err != nil {
+		h.logger.Error("failed to claim summary comment for reconciliation; apply skipped until next startup",
+			append(apply.LogAttrs(), "error", err)...)
+		return false
+	}
+	if won {
+		return true
+	}
+	reclaimed, err := h.service.Storage().ApplyComments().ReclaimStaleSummaryClaim(ctx, apply.ID)
+	if err != nil {
+		h.logger.Error("failed to reclaim stale summary claim for reconciliation; apply skipped until next startup",
+			append(apply.LogAttrs(), "error", err)...)
+		return false
+	}
+	if !reclaimed {
+		h.logger.Info("summary comment already claimed or posted by another writer; skipping reconciliation for apply",
+			apply.LogAttrs()...)
+		return false
+	}
+	return true
+}
+
+// postClaimedSummaryComment posts a reconciled summary comment under a claim
+// this reconciler holds and records the posted comment ID. A failed post
+// releases the claim so the next startup can retry immediately; a post that
+// lands but fails to record leaves the sentinel to be reclaimed once stale
+// (bounding the duplicate to one).
+func (h *Handler) postClaimedSummaryComment(ctx context.Context, apply *storage.Apply, body string) {
+	client, err := h.clientForRepo(apply.Repository, apply.InstallationID)
+	if err != nil {
+		h.logger.Error("failed to create GitHub client for reconciled summary comment; releasing summary claim",
+			append(apply.LogAttrs(), "error", err)...)
+		h.releaseSummaryClaim(ctx, apply)
+		return
+	}
+
+	commentID, _, err := client.CreateIssueComment(ctx, apply.Repository, apply.PullRequest, h.renderPRComment(body))
+	if err != nil {
+		h.logger.Error("failed to post reconciled summary comment; releasing summary claim",
+			append(apply.LogAttrs(), "error", err)...)
+		h.releaseSummaryClaim(ctx, apply)
+		return
+	}
+
+	metrics.RecordSummaryCommentRepaired(ctx, apply.Repository, apply.State)
+
+	marker := &storage.ApplyComment{
+		ApplyID:         apply.ID,
+		CommentState:    state.Comment.Summary,
+		GitHubCommentID: commentID,
+	}
+	if err := h.service.Storage().ApplyComments().Upsert(ctx, marker); err != nil {
+		h.logger.Error("posted reconciled summary comment but failed to record its comment ID",
+			append(apply.LogAttrs(), "error", err, "comment_id", commentID)...)
+	}
+}
+
+// releaseSummaryClaim returns a won-but-unused summary claim so a later
+// publisher or the next startup's reconciliation can retry immediately instead
+// of waiting out the stale-claim window.
+func (h *Handler) releaseSummaryClaim(ctx context.Context, apply *storage.Apply) {
+	if err := h.service.Storage().ApplyComments().ReleaseSummaryClaim(ctx, apply.ID); err != nil {
+		h.logger.Error("failed to release summary claim; reconciliation will reclaim it once stale",
+			append(apply.LogAttrs(), "error", err)...)
 	}
 }
 


### PR DESCRIPTION
## Why this matters

A stopped apply can leave its PR with no terminal summary comment. Stop reconciliation re-claims the apply lease, which permanently locks the origin driver's lease-gated observer out of its one terminal tick — and nothing else steps in: the aggregate terminal publisher skipped single-operation applies, and startup reconciliation couldn't see stopped applies at all (a resumable stop never stamps `completed_at`). The operator stops an apply and the PR just goes silent.

The root cause is ownership, not timing. When an apply reaches its final state, the parent row is flipped by a compare-and-swap (CAS) — an atomic conditional update (`UPDATE applies SET state = <terminal> WHERE ... state is still non-terminal`) that exactly one racing writer can win. Multi-operation applies already use that CAS win as the authority for who publishes the summary. Single-operation applies were instead left on apply-lease authority — and a lease is exactly the thing a re-claim takes away.

## What it does

Makes the summary-marker row in `apply_comments` the exactly-once authority for the terminal summary, instead of the apply lease. Every publisher — per-driver observer, aggregate CAS-winner, startup reconciliation — first claims the marker by atomically inserting it as a sentinel (`github_comment_id = 0`) under the existing `(apply_id, comment_state)` unique key. The winner posts and records the real comment ID; losers skip; a failed post releases the claim; a sentinel left by a publisher that crashed before posting is taken over once stale.

```
terminal writers                     apply_comments (summary marker)
────────────────                     ───────────────────────────────
driver observer ───────claim──┐      none      → INSERT sentinel: won
CAS-winner publisher ───claim─┼──►   sentinel  → lose (fresh) /
startup reconciler ─────claim─┘                  reclaim (stale)
                                     posted id → lose
```

With the claim in place:

- `publishTerminalSummaryIfWon` drops its single-operation guard, so stop reconciliation publishes the stopped summary for the applies whose observer it just disenfranchised.
- `FindMissingSummaryComment` learns stopped applies (recency by `updated_at`) and stale claim sentinels, so a crash between claim and post is repaired on the next startup.
- Repairs are counted by a new `summary_comments_repaired_total` metric.

Apply leases still guard everything else (progress edits, check refreshes); only the separate summary post moves to claim authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)