### PR TITLE
feat(github): guard applies against newer base schema

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -5500,7 +5500,7 @@ schemabot apply -e staging
 
 **Database**: `testapp`
 
-The schema directory `schema/testapp` on the base branch has changed since this PR diverged. Applying this branch could revert those newer schema changes.
+The base branch contains newer changes to the schema directory `schema/testapp` that are not included in this PR. Applying this branch could revert those changes.
 
 Merge or rebase the current base branch into this PR, review the updated plan, then run `apply` again.
 

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -5500,7 +5500,7 @@ schemabot apply -e staging
 
 **Database**: `testapp`
 
-The schema directory `schema/testapp` changed on the base branch after this PR diverged. Applying this branch could revert those newer schema changes.
+The schema directory `schema/testapp` on the base branch has changed since this PR diverged. Applying this branch could revert those newer schema changes.
 
 Merge or rebase the current base branch into this PR, review the updated plan, then run `apply` again.
 

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -5493,6 +5493,23 @@ schemabot apply -e staging
 </details>
 
 <details>
+<summary><a name="base-schema-changed-since-pr-diverged"></a><strong>Base Schema Changed Since PR Diverged</strong></summary>
+
+
+## ⚠️ Apply rejected — base schema is newer — Production
+
+**Database**: `testapp`
+
+The schema directory `schema/testapp` changed on the base branch after this PR diverged. Applying this branch could revert those newer schema changes.
+
+Merge or rebase the current base branch into this PR, review the updated plan, then run `apply` again.
+
+_Requested by @jackjackbits_
+
+
+</details>
+
+<details>
 <summary><a name="blocked-by-prior-env-pending"></a><strong>Blocked By Prior Env (Pending)</strong></summary>
 
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -450,6 +450,28 @@ If the GitHub API is unreachable when checking statuses, the apply is blocked (f
 
 Set `require_passing_checks: false` to disable this gate.
 
+## Base Branch Schema Freshness
+
+SchemaBot can reject `apply` and `apply-confirm` when a PR does not include
+schema changes that landed on its base branch after the PR diverged:
+
+```yaml
+repos:
+  myorg/monorepo:
+    require_up_to_date_with_base: true
+```
+
+This is path-scoped rather than a whole-branch freshness requirement. At apply
+time, SchemaBot compares the Git tree object for the managed schema directory
+at the PR merge base with the same directory at the current base commit. If the
+tree objects match, unrelated commits elsewhere in a busy repository do not
+block the apply. If they differ, SchemaBot rejects the apply and instructs the
+user to merge or rebase the current base branch before reviewing a new plan.
+
+The gate fails closed when GitHub cannot provide the merge base or either tree.
+It defaults to disabled for compatibility; enable it per repository after
+confirming the repository's schema directories are dedicated to schema inputs.
+
 ## Review Gate
 
 SchemaBot can block `apply` and `apply-confirm` until the PR has a satisfying review. This prevents unapproved schema changes from being applied to any environment.

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -724,6 +724,12 @@ type RepoConfig struct {
 	// own safety gates. Defaults to true when not configured.
 	EnableChecks *bool `yaml:"enable_checks,omitempty"`
 
+	// RequireUpToDateWithBase rejects applies when the configured schema
+	// directory changed on the base branch after the PR diverged. Unlike a
+	// whole-branch freshness gate, unrelated base-branch commits do not block
+	// applies. Defaults to false when not configured.
+	RequireUpToDateWithBase bool `yaml:"require_up_to_date_with_base,omitempty"`
+
 	// GitHubApp names the App in ServerConfig.Apps that owns webhooks and
 	// outbound GitHub API calls for this repository. Required when Apps is
 	// configured and must match a key in ServerConfig.Apps. Setting it
@@ -1674,6 +1680,17 @@ func (c *ServerConfig) AreChecksEnabled(repo string) bool {
 		return true
 	}
 	return *repoConfig.EnableChecks
+}
+
+// RequiresUpToDateWithBase reports whether repo applies must use a branch
+// whose managed schema directory includes every schema change on the current
+// base branch.
+func (c *ServerConfig) RequiresUpToDateWithBase(repo string) bool {
+	if c == nil {
+		return false
+	}
+	repoConfig, ok := c.Repos[repo]
+	return ok && repoConfig.RequireUpToDateWithBase
 }
 
 // ResolvedGitHubApp identifies which configured GitHub App owns a repository.

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -114,6 +114,7 @@ tern_deployments:
 repos:
   org/repo:
     enable_checks: false
+    require_up_to_date_with_base: true
 `
 	err := os.WriteFile(configPath, []byte(content), 0644)
 	require.NoError(t, err, "write config file")
@@ -124,6 +125,7 @@ repos:
 	assert.Equal(t, 2, len(cfg.TernDeployments))
 	assert.Contains(t, cfg.Repos, "org/repo")
 	assert.False(t, cfg.AreChecksEnabled("org/repo"))
+	assert.True(t, cfg.RequiresUpToDateWithBase("org/repo"))
 }
 
 func TestLoadServerConfigFromFile_DSNFrom(t *testing.T) {
@@ -2406,6 +2408,26 @@ func TestServerConfig_AreChecksEnabled(t *testing.T) {
 			},
 		}
 		assert.True(t, cfg.AreChecksEnabled("org/repo"))
+	})
+}
+
+func TestServerConfig_RequiresUpToDateWithBase(t *testing.T) {
+	t.Run("defaults to disabled", func(t *testing.T) {
+		cfg := ServerConfig{Repos: map[string]RepoConfig{"org/repo": {}}}
+		assert.False(t, cfg.RequiresUpToDateWithBase("org/repo"))
+	})
+
+	t.Run("enabled for configured repo only", func(t *testing.T) {
+		cfg := ServerConfig{Repos: map[string]RepoConfig{
+			"org/repo": {RequireUpToDateWithBase: true},
+		}}
+		assert.True(t, cfg.RequiresUpToDateWithBase("org/repo"))
+		assert.False(t, cfg.RequiresUpToDateWithBase("org/other-repo"))
+	})
+
+	t.Run("nil config defaults to disabled", func(t *testing.T) {
+		var cfg *ServerConfig
+		assert.False(t, cfg.RequiresUpToDateWithBase("org/repo"))
 	})
 }
 

--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -338,6 +338,10 @@ type ApplyRequest struct {
 	Options        map[string]string `json:"options,omitempty"`
 	Caller         string            `json:"caller,omitempty"`          // Identity of the caller (e.g., "cli:user@host")
 	InstallationID int64             `json:"installation_id,omitempty"` // GitHub App installation ID (for PR comment tracking)
+	// ExpectedLockOwner and ExpectedPendingPlanID are internal webhook guards;
+	// direct API callers cannot assert a lock intent through JSON.
+	ExpectedLockOwner     string `json:"-"`
+	ExpectedPendingPlanID string `json:"-"`
 }
 
 // handlePlan handles POST /api/plan requests.
@@ -961,22 +965,24 @@ func (s *Service) createStoredApply(
 	caller := resolveCaller(ctx, req.Caller)
 
 	apply := &storage.Apply{
-		ApplyIdentifier: applyIdentifier,
-		LockID:          lockID,
-		PlanID:          plan.ID,
-		Database:        plan.Database,
-		DatabaseType:    plan.DatabaseType,
-		Repository:      plan.Repository,
-		PullRequest:     plan.PullRequest,
-		Environment:     req.Environment,
-		Deployment:      targets[0].Deployment,
-		Caller:          caller,
-		InstallationID:  req.InstallationID,
-		Engine:          storage.EngineForType(plan.DatabaseType),
-		State:           state.Apply.Pending,
-		Options:         storage.MarshalApplyOptions(applyOpts),
-		CreatedAt:       now,
-		UpdatedAt:       now,
+		ApplyIdentifier:       applyIdentifier,
+		LockID:                lockID,
+		ExpectedLockOwner:     req.ExpectedLockOwner,
+		ExpectedPendingPlanID: req.ExpectedPendingPlanID,
+		PlanID:                plan.ID,
+		Database:              plan.Database,
+		DatabaseType:          plan.DatabaseType,
+		Repository:            plan.Repository,
+		PullRequest:           plan.PullRequest,
+		Environment:           req.Environment,
+		Deployment:            targets[0].Deployment,
+		Caller:                caller,
+		InstallationID:        req.InstallationID,
+		Engine:                storage.EngineForType(plan.DatabaseType),
+		State:                 state.Apply.Pending,
+		Options:               storage.MarshalApplyOptions(applyOpts),
+		CreatedAt:             now,
+		UpdatedAt:             now,
 	}
 
 	taskChanges := applyTaskChanges(plan)

--- a/pkg/cmd/commands/preview.go
+++ b/pkg/cmd/commands/preview.go
@@ -109,7 +109,8 @@ func (cmd *PreviewCmd) Run(g *Globals) error {
 		templates.PreviewCommentApplyWaiting, templates.PreviewCommentUnlock,
 		templates.PreviewCommentApplyBlocked, templates.PreviewCommentApplyBlockedCLI,
 		templates.PreviewCommentApplyActive,
-		templates.PreviewCommentApplyNoLock, templates.PreviewCommentApplyAllType,
+		templates.PreviewCommentApplyNoLock, templates.PreviewCommentBaseSchemaStale,
+		templates.PreviewCommentApplyAllType,
 		templates.PreviewCommentChecksGateNotPassing, templates.PreviewCommentChecksGateInProgress,
 		templates.PreviewCommentActorNotAuthorized, templates.PreviewCommentActorAuthUnavailable,
 		templates.PreviewCommentDatabaseNotConfigured,
@@ -295,6 +296,7 @@ Apply Command Comments (GitHub PR apply commands):
   comment_apply_blocked_cli     Apply blocked by CLI session
   comment_apply_active          Apply already in progress
   comment_apply_no_lock         No lock found (need apply first)
+  comment_base_schema_stale     Base schema changed after PR divergence
   comment_actor_not_authorized  Actor authorization denied
   comment_actor_auth_unavailable Actor authorization fail-closed error
   comment_database_not_configured Actor authorization database missing from this instance

--- a/pkg/cmd/internal/templates/preview.go
+++ b/pkg/cmd/internal/templates/preview.go
@@ -178,6 +178,7 @@ const (
 	PreviewCommentApplyBlockedCLI       PreviewType = "comment_apply_blocked_cli"            // Apply blocked by CLI session
 	PreviewCommentApplyActive           PreviewType = "comment_apply_active"                 // Apply already in progress
 	PreviewCommentApplyNoLock           PreviewType = "comment_apply_no_lock"                // No lock found
+	PreviewCommentBaseSchemaStale       PreviewType = "comment_base_schema_stale"            // Base schema changed after PR divergence
 	PreviewCommentBlockedByPriorEnv     PreviewType = "comment_blocked_prior_env"            // Blocked by staging (pending)
 	PreviewCommentBlockedByPriorFailed  PreviewType = "comment_blocked_prior_env_failed"     // Blocked by staging (failed)
 	PreviewCommentBlockedByPriorInProg  PreviewType = "comment_blocked_prior_env_inprogress" // Blocked by staging (in progress)

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -119,6 +119,7 @@ func previewApplyCommandAllOutput() {
 		{"APPLY BLOCKED BY CLI", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByCLI()) }},
 		{"APPLY ALREADY IN PROGRESS", func() { fmt.Print(webhooktemplates.PreviewCommentApplyInProgress()) }},
 		{"NO LOCK FOUND", func() { fmt.Print(webhooktemplates.PreviewCommentApplyConfirmNoLock()) }},
+		{"BASE SCHEMA CHANGED SINCE PR DIVERGED", func() { fmt.Print(webhooktemplates.PreviewCommentBaseSchemaFreshnessRejected()) }},
 		{"BLOCKED BY PRIOR ENV (PENDING)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByPriorEnv()) }},
 		{"BLOCKED BY PRIOR ENV (FAILED)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByPriorEnvFailed()) }},
 		{"BLOCKED BY PRIOR ENV (IN PROGRESS)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByPriorEnvInProgress()) }},

--- a/pkg/cmd/internal/templates/preview_dispatch.go
+++ b/pkg/cmd/internal/templates/preview_dispatch.go
@@ -239,6 +239,8 @@ func PreviewCLIOutput(previewType PreviewType) {
 		fmt.Print(webhooktemplates.PreviewCommentApplyInProgress())
 	case PreviewCommentApplyNoLock:
 		fmt.Print(webhooktemplates.PreviewCommentApplyConfirmNoLock())
+	case PreviewCommentBaseSchemaStale:
+		fmt.Print(webhooktemplates.PreviewCommentBaseSchemaFreshnessRejected())
 	case PreviewCommentBlockedByPriorEnv:
 		fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByPriorEnv())
 	case PreviewCommentBlockedByPriorFailed:

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -1012,6 +1012,48 @@ func (ic *InstallationClient) FetchChangedFilesBetween(ctx context.Context, repo
 	return files, nil
 }
 
+// SchemaPathsChangedSinceMergeBase reports whether any schema path has a
+// different Git object on the PR's current base commit than it had when the PR
+// diverged. Paths may name directories or symlinks. Comparing object IDs keeps
+// the guard scoped to schema inputs: commits elsewhere in a busy repository do
+// not make the PR stale.
+func (ic *InstallationClient) SchemaPathsChangedSinceMergeBase(ctx context.Context, repo, baseSHA, headSHA string, schemaPaths []string) (bool, error) {
+	owner, repoName := splitRepo(repo)
+	comparison, err := retryGitHubUnavailableRead(ctx, ic.logger, "find pull request merge base", []any{"repo", repo, "base_sha", baseSHA, "head_sha", headSHA}, func(ctx context.Context) (*gh.CommitsComparison, error) {
+		comparison, _, err := ic.client.Repositories.CompareCommits(ctx, owner, repoName, baseSHA, headSHA, nil)
+		if err != nil {
+			return nil, fmt.Errorf("compare commits %s...%s: %w", baseSHA, headSHA, classifyGitHubAPIError(err))
+		}
+		return comparison, nil
+	})
+	if err != nil {
+		return false, err
+	}
+	mergeBaseSHA := comparison.GetMergeBaseCommit().GetSHA()
+	if mergeBaseSHA == "" {
+		return false, fmt.Errorf("compare commits %s...%s for %s returned no merge base", baseSHA, headSHA, repo)
+	}
+
+	for _, schemaPath := range schemaPaths {
+		mergeBaseObjectSHA, mergeBaseObjectType, mergeBaseFound, err := ic.resolveGitObjectSHA(ctx, repo, mergeBaseSHA, schemaPath, nil)
+		if err != nil {
+			return false, fmt.Errorf("resolve schema path %s at merge base %s: %w", schemaPath, mergeBaseSHA, err)
+		}
+		baseObjectSHA, baseObjectType, baseFound, err := ic.resolveGitObjectSHA(ctx, repo, baseSHA, schemaPath, nil)
+		if err != nil {
+			return false, fmt.Errorf("resolve schema path %s at base %s: %w", schemaPath, baseSHA, err)
+		}
+
+		if mergeBaseFound != baseFound {
+			return true, nil
+		}
+		if mergeBaseFound && (mergeBaseObjectSHA != baseObjectSHA || mergeBaseObjectType != baseObjectType) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // CheckRunOptions contains options for creating or updating a GitHub Check Run.
 type CheckRunOptions struct {
 	Name       string
@@ -1526,7 +1568,7 @@ func (ic *InstallationClient) FetchGitTree(ctx context.Context, repo, treeSHA st
 // listings, so it can resolve paths inside repositories whose full tree is
 // truncated. If GitHub ever truncates even a single level, this fails rather
 // than let the caller act on an incomplete listing.
-func (ic *InstallationClient) fetchGitTreeShallow(ctx context.Context, repo, treeSHA string) ([]TreeEntry, error) {
+func (ic *InstallationClient) fetchGitTreeShallow(ctx context.Context, repo, treeSHA string) ([]TreeEntry, string, error) {
 	owner, repoName := splitRepo(repo)
 	ghTree, err := retryGitHubUnavailableRead(ctx, ic.logger, "fetch git tree level", []any{"repo", repo, "tree_sha", treeSHA}, func(ctx context.Context) (*gh.Tree, error) {
 		ghTree, _, err := ic.client.Git.GetTree(ctx, owner, repoName, treeSHA, false)
@@ -1536,10 +1578,10 @@ func (ic *InstallationClient) fetchGitTreeShallow(ctx context.Context, repo, tre
 		return ghTree, nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	if ghTree.GetTruncated() {
-		return nil, fmt.Errorf("fetch git tree level %s in repo %s: %w", treeSHA, repo, ErrGitTreeTruncated)
+		return nil, "", fmt.Errorf("fetch git tree level %s in repo %s: %w", treeSHA, repo, ErrGitTreeTruncated)
 	}
 
 	entries := make([]TreeEntry, len(ghTree.Entries))
@@ -1552,7 +1594,7 @@ func (ic *InstallationClient) fetchGitTreeShallow(ctx context.Context, repo, tre
 			Size: entry.GetSize(),
 		}
 	}
-	return entries, nil
+	return entries, ghTree.GetSHA(), nil
 }
 
 // FetchGitSubtree fetches the recursive tree of the directory dir at ref.
@@ -1571,29 +1613,9 @@ func (ic *InstallationClient) FetchGitSubtree(ctx context.Context, repo, ref, di
 // directories at the same ref pass one map so shared path-prefix levels (and
 // the root tree) cost a single API call per scan; nil disables memoization.
 func (ic *InstallationClient) fetchGitSubtreeCached(ctx context.Context, repo, ref, dir string, levelCache map[string][]TreeEntry) (entries []TreeEntry, found bool, err error) {
-	treeSHA := ref
-	for segment := range strings.SplitSeq(dir, "/") {
-		levelEntries, cached := levelCache[treeSHA]
-		if !cached {
-			levelEntries, err = ic.fetchGitTreeShallow(ctx, repo, treeSHA)
-			if err != nil {
-				return nil, false, fmt.Errorf("resolve %s under %s in repo %s ref %s: %w", segment, dir, repo, ref, err)
-			}
-			if levelCache != nil {
-				levelCache[treeSHA] = levelEntries
-			}
-		}
-		next := ""
-		for _, entry := range levelEntries {
-			if entry.Path == segment && entry.Type == "tree" {
-				next = entry.SHA
-				break
-			}
-		}
-		if next == "" {
-			return nil, false, nil
-		}
-		treeSHA = next
+	treeSHA, found, err := ic.resolveGitTreeSHA(ctx, repo, ref, dir, levelCache)
+	if err != nil || !found {
+		return nil, found, err
 	}
 
 	entries, truncated, err := ic.FetchGitTree(ctx, repo, treeSHA)
@@ -1604,6 +1626,71 @@ func (ic *InstallationClient) fetchGitSubtreeCached(ctx context.Context, repo, r
 		return nil, false, fmt.Errorf("fetch subtree %s in repo %s ref %s: %w", dir, repo, ref, ErrGitTreeTruncated)
 	}
 	return entries, true, nil
+}
+
+// resolveGitTreeSHA resolves dir to its tree object without listing that
+// directory recursively. The ref itself is the root tree when dir is repo
+// root. found is false when any path segment is absent or is not a tree.
+func (ic *InstallationClient) resolveGitTreeSHA(ctx context.Context, repo, ref, dir string, levelCache map[string][]TreeEntry) (treeSHA string, found bool, err error) {
+	objectSHA, objectType, found, err := ic.resolveGitObjectSHA(ctx, repo, ref, dir, levelCache)
+	if err != nil || !found {
+		return "", found, err
+	}
+	if objectType != "tree" {
+		return "", false, nil
+	}
+	return objectSHA, true, nil
+}
+
+func (ic *InstallationClient) resolveGitObjectSHA(ctx context.Context, repo, ref, objectPath string, levelCache map[string][]TreeEntry) (objectSHA, objectType string, found bool, err error) {
+	cleanPath := path.Clean(objectPath)
+	if cleanPath == "." {
+		_, rootTreeSHA, err := ic.fetchGitTreeShallow(ctx, repo, ref)
+		if err != nil {
+			return "", "", false, fmt.Errorf("resolve repo root in repo %s ref %s: %w", repo, ref, err)
+		}
+		if rootTreeSHA == "" {
+			return "", "", false, fmt.Errorf("resolve repo root in repo %s ref %s: GitHub returned no tree SHA", repo, ref)
+		}
+		return rootTreeSHA, "tree", true, nil
+	}
+	if path.IsAbs(cleanPath) || cleanPath == ".." || strings.HasPrefix(cleanPath, "../") {
+		return "", "", false, fmt.Errorf("schema path %q is not repo-relative", objectPath)
+	}
+
+	treeSHA := ref
+	segments := strings.Split(cleanPath, "/")
+	for i, segment := range segments {
+		levelEntries, cached := levelCache[treeSHA]
+		if !cached {
+			levelEntries, _, err = ic.fetchGitTreeShallow(ctx, repo, treeSHA)
+			if err != nil {
+				return "", "", false, fmt.Errorf("resolve %s under %s in repo %s ref %s: %w", segment, objectPath, repo, ref, err)
+			}
+			if levelCache != nil {
+				levelCache[treeSHA] = levelEntries
+			}
+		}
+		var matched *TreeEntry
+		for _, entry := range levelEntries {
+			if entry.Path == segment {
+				entryCopy := entry
+				matched = &entryCopy
+				break
+			}
+		}
+		if matched == nil {
+			return "", "", false, nil
+		}
+		if i == len(segments)-1 {
+			return matched.SHA, matched.Type, true, nil
+		}
+		if matched.Type != "tree" {
+			return "", "", false, nil
+		}
+		treeSHA = matched.SHA
+	}
+	return "", "", false, nil
 }
 
 // FetchBlobContent fetches file content using the Git Blob API.

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -1034,12 +1034,13 @@ func (ic *InstallationClient) SchemaPathsChangedSinceMergeBase(ctx context.Conte
 		return false, fmt.Errorf("compare commits %s...%s for %s returned no merge base", baseSHA, headSHA, repo)
 	}
 
+	levelCache := make(map[string][]TreeEntry)
 	for _, schemaPath := range schemaPaths {
-		mergeBaseObjectSHA, mergeBaseObjectType, mergeBaseFound, err := ic.resolveGitObjectSHA(ctx, repo, mergeBaseSHA, schemaPath, nil)
+		mergeBaseObjectSHA, mergeBaseObjectType, mergeBaseFound, err := ic.resolveGitObjectSHA(ctx, repo, mergeBaseSHA, schemaPath, levelCache)
 		if err != nil {
 			return false, fmt.Errorf("resolve schema path %s at merge base %s: %w", schemaPath, mergeBaseSHA, err)
 		}
-		baseObjectSHA, baseObjectType, baseFound, err := ic.resolveGitObjectSHA(ctx, repo, baseSHA, schemaPath, nil)
+		baseObjectSHA, baseObjectType, baseFound, err := ic.resolveGitObjectSHA(ctx, repo, baseSHA, schemaPath, levelCache)
 		if err != nil {
 			return false, fmt.Errorf("resolve schema path %s at base %s: %w", schemaPath, baseSHA, err)
 		}

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -596,28 +596,34 @@ func TestSchemaPathsChangedSinceMergeBaseFailsWithoutMergeBase(t *testing.T) {
 
 func TestSchemaPathsChangedSinceMergeBaseDetectsSymlinkRetarget(t *testing.T) {
 	client, mux := setupRateLimitedTestGitHubServer(t)
+	var mergeRootRequests, baseRootRequests atomic.Int32
+	var mergeSchemaRequests, baseSchemaRequests atomic.Int32
 	mux.HandleFunc("GET /repos/octocat/hello-world/compare/base-sha...head-sha", func(w http.ResponseWriter, _ *http.Request) {
 		require.NoError(t, json.NewEncoder(w).Encode(gh.CommitsComparison{
 			MergeBaseCommit: &gh.RepositoryCommit{SHA: new("merge-base-sha")},
 		}))
 	})
 	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/merge-base-sha", func(w http.ResponseWriter, _ *http.Request) {
+		mergeRootRequests.Add(1)
 		require.NoError(t, json.NewEncoder(w).Encode(gh.Tree{Entries: []*gh.TreeEntry{
 			{Path: new("schema"), Type: new("tree"), SHA: new("merge-schema-tree")},
 		}}))
 	})
 	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/base-sha", func(w http.ResponseWriter, _ *http.Request) {
+		baseRootRequests.Add(1)
 		require.NoError(t, json.NewEncoder(w).Encode(gh.Tree{Entries: []*gh.TreeEntry{
 			{Path: new("schema"), Type: new("tree"), SHA: new("base-schema-tree")},
 		}}))
 	})
 	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/merge-schema-tree", func(w http.ResponseWriter, _ *http.Request) {
+		mergeSchemaRequests.Add(1)
 		require.NoError(t, json.NewEncoder(w).Encode(gh.Tree{Entries: []*gh.TreeEntry{
 			{Path: new("base"), Type: new("tree"), SHA: new("resolved-schema-tree")},
 			{Path: new("production"), Type: new("blob"), Mode: new(gitSymlinkMode), SHA: new("old-link")},
 		}}))
 	})
 	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/base-schema-tree", func(w http.ResponseWriter, _ *http.Request) {
+		baseSchemaRequests.Add(1)
 		require.NoError(t, json.NewEncoder(w).Encode(gh.Tree{Entries: []*gh.TreeEntry{
 			{Path: new("base"), Type: new("tree"), SHA: new("resolved-schema-tree")},
 			{Path: new("production"), Type: new("blob"), Mode: new(gitSymlinkMode), SHA: new("new-link")},
@@ -629,6 +635,10 @@ func TestSchemaPathsChangedSinceMergeBaseDetectsSymlinkRetarget(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.True(t, changed)
+	assert.Equal(t, int32(1), mergeRootRequests.Load())
+	assert.Equal(t, int32(1), baseRootRequests.Load())
+	assert.Equal(t, int32(1), mergeSchemaRequests.Load())
+	assert.Equal(t, int32(1), baseSchemaRequests.Load())
 }
 
 func TestSchemaPathsChangedSinceMergeBaseUsesRootTreeSHA(t *testing.T) {

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -511,6 +511,146 @@ func TestGetPRCheckStatusesClassifiesTrustedSiblingAppAsSchemaBot(t *testing.T) 
 	assert.False(t, byName["ci/build"].IsSchemaBot, "unrelated app check must remain external CI")
 }
 
+func TestSchemaPathsChangedSinceMergeBase(t *testing.T) {
+	tests := []struct {
+		name         string
+		mergeTreeSHA string
+		baseTreeSHA  string
+		mergeHasPath bool
+		baseHasPath  bool
+		wantChanged  bool
+	}{
+		{
+			name:         "same schema tree ignores unrelated base commits",
+			mergeTreeSHA: "schema-tree",
+			baseTreeSHA:  "schema-tree",
+			mergeHasPath: true,
+			baseHasPath:  true,
+		},
+		{
+			name:         "changed schema tree is stale",
+			mergeTreeSHA: "schema-tree-old",
+			baseTreeSHA:  "schema-tree-new",
+			mergeHasPath: true,
+			baseHasPath:  true,
+			wantChanged:  true,
+		},
+		{
+			name:        "schema path added on base is stale",
+			baseTreeSHA: "schema-tree-new",
+			baseHasPath: true,
+			wantChanged: true,
+		},
+		{
+			name:         "schema path removed on base is stale",
+			mergeTreeSHA: "schema-tree-old",
+			mergeHasPath: true,
+			wantChanged:  true,
+		},
+		{
+			name: "path absent at both commits is unchanged",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, mux := setupRateLimitedTestGitHubServer(t)
+			mux.HandleFunc("GET /repos/octocat/hello-world/compare/base-sha...head-sha", func(w http.ResponseWriter, _ *http.Request) {
+				require.NoError(t, json.NewEncoder(w).Encode(gh.CommitsComparison{
+					MergeBaseCommit: &gh.RepositoryCommit{SHA: new("merge-base-sha")},
+				}))
+			})
+			registerRootTree := func(pattern string, hasPath bool, schemaTreeSHA string) {
+				mux.HandleFunc(pattern, func(w http.ResponseWriter, _ *http.Request) {
+					entries := []*gh.TreeEntry{}
+					if hasPath {
+						entries = append(entries, &gh.TreeEntry{Path: new("schema"), Type: new("tree"), SHA: &schemaTreeSHA})
+					}
+					require.NoError(t, json.NewEncoder(w).Encode(gh.Tree{Entries: entries}))
+				})
+			}
+			registerRootTree("GET /repos/octocat/hello-world/git/trees/merge-base-sha", tt.mergeHasPath, tt.mergeTreeSHA)
+			registerRootTree("GET /repos/octocat/hello-world/git/trees/base-sha", tt.baseHasPath, tt.baseTreeSHA)
+
+			ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+			changed, err := ic.SchemaPathsChangedSinceMergeBase(t.Context(), "octocat/hello-world", "base-sha", "head-sha", []string{"schema"})
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantChanged, changed)
+		})
+	}
+}
+
+func TestSchemaPathsChangedSinceMergeBaseFailsWithoutMergeBase(t *testing.T) {
+	client, mux := setupRateLimitedTestGitHubServer(t)
+	mux.HandleFunc("GET /repos/octocat/hello-world/compare/base-sha...head-sha", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.CommitsComparison{}))
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	_, err := ic.SchemaPathsChangedSinceMergeBase(t.Context(), "octocat/hello-world", "base-sha", "head-sha", []string{"schema"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "returned no merge base")
+}
+
+func TestSchemaPathsChangedSinceMergeBaseDetectsSymlinkRetarget(t *testing.T) {
+	client, mux := setupRateLimitedTestGitHubServer(t)
+	mux.HandleFunc("GET /repos/octocat/hello-world/compare/base-sha...head-sha", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.CommitsComparison{
+			MergeBaseCommit: &gh.RepositoryCommit{SHA: new("merge-base-sha")},
+		}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/merge-base-sha", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.Tree{Entries: []*gh.TreeEntry{
+			{Path: new("schema"), Type: new("tree"), SHA: new("merge-schema-tree")},
+		}}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/base-sha", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.Tree{Entries: []*gh.TreeEntry{
+			{Path: new("schema"), Type: new("tree"), SHA: new("base-schema-tree")},
+		}}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/merge-schema-tree", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.Tree{Entries: []*gh.TreeEntry{
+			{Path: new("base"), Type: new("tree"), SHA: new("resolved-schema-tree")},
+			{Path: new("production"), Type: new("blob"), Mode: new(gitSymlinkMode), SHA: new("old-link")},
+		}}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/base-schema-tree", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.Tree{Entries: []*gh.TreeEntry{
+			{Path: new("base"), Type: new("tree"), SHA: new("resolved-schema-tree")},
+			{Path: new("production"), Type: new("blob"), Mode: new(gitSymlinkMode), SHA: new("new-link")},
+		}}))
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	changed, err := ic.SchemaPathsChangedSinceMergeBase(t.Context(), "octocat/hello-world", "base-sha", "head-sha", []string{"schema/base", "schema/production"})
+
+	require.NoError(t, err)
+	assert.True(t, changed)
+}
+
+func TestSchemaPathsChangedSinceMergeBaseUsesRootTreeSHA(t *testing.T) {
+	client, mux := setupRateLimitedTestGitHubServer(t)
+	mux.HandleFunc("GET /repos/octocat/hello-world/compare/base-sha...head-sha", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.CommitsComparison{
+			MergeBaseCommit: &gh.RepositoryCommit{SHA: new("merge-base-sha")},
+		}))
+	})
+	for _, ref := range []string{"merge-base-sha", "base-sha"} {
+		mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/"+ref, func(w http.ResponseWriter, _ *http.Request) {
+			require.NoError(t, json.NewEncoder(w).Encode(gh.Tree{SHA: new("same-root-tree")}))
+		})
+	}
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	changed, err := ic.SchemaPathsChangedSinceMergeBase(t.Context(), "octocat/hello-world", "base-sha", "head-sha", []string{"."})
+
+	require.NoError(t, err)
+	assert.False(t, changed, "different commit SHAs with the same root tree are unchanged")
+}
+
 func setupRateLimitedTestGitHubServer(t *testing.T) (*gh.Client, *http.ServeMux) {
 	t.Helper()
 

--- a/pkg/github/config_test.go
+++ b/pkg/github/config_test.go
@@ -531,7 +531,7 @@ func TestResolveSchemaRootForEnvironmentRejectsPathTraversal(t *testing.T) {
 	ic := &InstallationClient{}
 	for _, environment := range []string{"../other", "prod/blue", ".", "..", `prod\blue`} {
 		t.Run(environment, func(t *testing.T) {
-			_, err := ic.resolveSchemaRootForEnvironment(t.Context(), "octocat/hello-world", "abc123", "services/orders/schema", environment)
+			_, _, err := ic.resolveSchemaRootForEnvironment(t.Context(), "octocat/hello-world", "abc123", "services/orders/schema", environment)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "must be a single path segment")
 		})

--- a/pkg/github/schema.go
+++ b/pkg/github/schema.go
@@ -21,7 +21,11 @@ type SchemaRequestResult struct {
 	Repository   string
 	PullRequest  int
 	SchemaPath   string
-	HeadSHA      string // Commit SHA used to fetch schema files
+	// SchemaLinkPath is the logical environment path when SchemaPath was
+	// resolved through a symlink. Base-freshness checks compare both the link
+	// object and its target so retargeting the environment cannot go unnoticed.
+	SchemaLinkPath string
+	HeadSHA        string // Commit SHA used to fetch schema files
 }
 
 // EnvironmentValidator verifies that a discovered database can be used with
@@ -57,7 +61,7 @@ func (ic *InstallationClient) CreateSchemaRequestFromPR(ctx context.Context, rep
 	if err != nil {
 		return nil, fmt.Errorf("fetch PR info: %w", err)
 	}
-	schemaRoot, err := ic.resolveSchemaRootForEnvironment(ctx, repo, prInfo.HeadSHA, configDir, environment)
+	schemaRoot, schemaLinkPath, err := ic.resolveSchemaRootForEnvironment(ctx, repo, prInfo.HeadSHA, configDir, environment)
 	if err != nil {
 		return nil, err
 	}
@@ -78,51 +82,52 @@ func (ic *InstallationClient) CreateSchemaRequestFromPR(ctx context.Context, rep
 	}
 
 	return &SchemaRequestResult{
-		Database:    config.Database,
-		Type:        string(config.GetType()),
-		SchemaFiles: schemaFiles,
-		Repository:  repo,
-		PullRequest: pr,
-		SchemaPath:  schemaRoot,
-		HeadSHA:     prInfo.HeadSHA,
+		Database:       config.Database,
+		Type:           string(config.GetType()),
+		SchemaFiles:    schemaFiles,
+		Repository:     repo,
+		PullRequest:    pr,
+		SchemaPath:     schemaRoot,
+		SchemaLinkPath: schemaLinkPath,
+		HeadSHA:        prInfo.HeadSHA,
 	}, nil
 }
 
-func (ic *InstallationClient) resolveSchemaRootForEnvironment(ctx context.Context, repo, ref, configDir, environment string) (string, error) {
+func (ic *InstallationClient) resolveSchemaRootForEnvironment(ctx context.Context, repo, ref, configDir, environment string) (schemaRoot, schemaLinkPath string, err error) {
 	if environment == "" {
-		return configDir, nil
+		return configDir, "", nil
 	}
 	if err := validateEnvironmentPathSegment(environment); err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	candidate := path.Join(configDir, environment)
 	content, directoryContent, err := ic.fetchRepositoryContents(ctx, repo, candidate, ref)
 	if err != nil {
 		if IsNotFoundError(err) {
-			return configDir, nil
+			return configDir, "", nil
 		}
-		return "", fmt.Errorf("resolve schema root for environment %s at %s: %w", environment, candidate, err)
+		return "", "", fmt.Errorf("resolve schema root for environment %s at %s: %w", environment, candidate, err)
 	}
 	if directoryContent != nil {
-		return candidate, nil
+		return candidate, "", nil
 	}
 	if content == nil || content.GetType() != "symlink" {
-		return "", fmt.Errorf("environment schema root %s in repo %s ref %s is not a directory or symlink", candidate, repo, ref)
+		return "", "", fmt.Errorf("environment schema root %s in repo %s ref %s is not a directory or symlink", candidate, repo, ref)
 	}
 
 	resolved, err := resolveSchemaRootSymlinkTarget(configDir, candidate, content.GetTarget())
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	resolvedContent, resolvedDirectoryContent, err := ic.fetchRepositoryContents(ctx, repo, resolved, ref)
 	if err != nil {
-		return "", fmt.Errorf("resolve environment schema root symlink %s target %s: %w", candidate, resolved, err)
+		return "", "", fmt.Errorf("resolve environment schema root symlink %s target %s: %w", candidate, resolved, err)
 	}
 	if resolvedContent != nil || resolvedDirectoryContent == nil {
-		return "", fmt.Errorf("environment schema root symlink %s points to non-directory path %s", candidate, resolved)
+		return "", "", fmt.Errorf("environment schema root symlink %s points to non-directory path %s", candidate, resolved)
 	}
-	return resolved, nil
+	return resolved, candidate, nil
 }
 
 func validateEnvironmentPathSegment(environment string) error {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -301,6 +301,21 @@ func RecordStalePlanRejected(ctx context.Context, environment string) {
 	)
 }
 
+// RecordBaseSchemaFreshnessRejected increments the counter for apply commands
+// rejected by the path-scoped base freshness gate. outcome distinguishes a
+// confirmed stale schema directory from GitHub uncertainty that failed closed.
+func RecordBaseSchemaFreshnessRejected(ctx context.Context, action, environment, outcome string) {
+	if !knownSchemaFreshnessActions[action] {
+		action = "unknown"
+	}
+	addCounter(ctx, "schemabot.command.rejected_base_schema_freshness.total",
+		"Apply rejected because the base branch schema path changed after divergence or could not be verified", "{rejection}",
+		attribute.String("action", action),
+		EnvironmentAttribute(environment),
+		attribute.String("outcome", outcome),
+	)
+}
+
 // RecordTransientPlanRetry increments the counter for webhook plan retries
 // after transient remote deployment unavailability. A spike with
 // outcome="exhausted" for one environment means the network path to that

--- a/pkg/storage/errors.go
+++ b/pkg/storage/errors.go
@@ -13,6 +13,10 @@ var (
 	// ErrLockNotOwned is returned when attempting to release a lock not owned by caller.
 	ErrLockNotOwned = errors.New("lock not owned by caller")
 
+	// ErrLockIntentChanged is returned when an apply's captured lock owner or
+	// pending plan no longer matches at durable apply creation time.
+	ErrLockIntentChanged = errors.New("lock intent changed")
+
 	// ErrCheckNotFound is returned when a check does not exist.
 	ErrCheckNotFound = errors.New("check not found")
 

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -479,6 +479,9 @@ func (s *applyStore) Create(ctx context.Context, apply *storage.Apply) (int64, e
 		}
 	}
 	defer writeTx.close(ctx, "create apply")
+	if err := verifyExpectedLockIntent(ctx, writeTx.tx, apply); err != nil {
+		return 0, err
+	}
 
 	if lockTarget {
 		if err := checkNoActiveApplyForTargets(ctx, writeTx.tx, apply.Database, apply.DatabaseType, apply.Environment, []string{apply.Deployment}, 0); err != nil {
@@ -575,6 +578,9 @@ func (s *applyStore) createWithRows(ctx context.Context, apply *storage.Apply, o
 		}
 	}
 	defer writeTx.close(ctx, opName)
+	if err := verifyExpectedLockIntent(ctx, writeTx.tx, apply); err != nil {
+		return 0, err
+	}
 
 	if lockTarget {
 		if err := checkNoActiveApplyForTargets(ctx, writeTx.tx, apply.Database, apply.DatabaseType, apply.Environment, newDeployments, 0); err != nil {
@@ -614,6 +620,32 @@ func (s *applyStore) createWithRows(ctx context.Context, apply *storage.Apply, o
 	}
 
 	return id, nil
+}
+
+// verifyExpectedLockIntent locks and validates the webhook apply intent in the
+// same transaction that inserts the apply. This closes the gap where a
+// same-owner rollback can replace pending_plan_id after freshness validation
+// but before the forward apply becomes durable.
+func verifyExpectedLockIntent(ctx context.Context, tx *sql.Tx, apply *storage.Apply) error {
+	if apply.ExpectedLockOwner == "" && apply.ExpectedPendingPlanID == "" {
+		return nil
+	}
+
+	var lockID int64
+	err := tx.QueryRowContext(ctx, `
+		SELECT id
+		FROM locks
+		WHERE database_name = ? AND database_type = ? AND owner = ? AND pending_plan_id = ?
+		FOR UPDATE
+	`, apply.Database, apply.DatabaseType, apply.ExpectedLockOwner, apply.ExpectedPendingPlanID).Scan(&lockID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return storage.ErrLockIntentChanged
+	}
+	if err != nil {
+		return fmt.Errorf("verify lock intent for %s/%s: %w", apply.Database, apply.DatabaseType, err)
+	}
+	apply.LockID = lockID
+	return nil
 }
 
 func insertApplyTasksAndOperations(ctx context.Context, tx *sql.Tx, apply *storage.Apply, applyID int64, tasks []*storage.Task, operations []*storage.ApplyOperation) error {

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -627,13 +627,17 @@ func (s *applyStore) createWithRows(ctx context.Context, apply *storage.Apply, o
 // same-owner rollback can replace pending_plan_id after freshness validation
 // but before the forward apply becomes durable.
 func verifyExpectedLockIntent(ctx context.Context, tx *sql.Tx, apply *storage.Apply) error {
-	if apply.ExpectedLockOwner == "" && apply.ExpectedPendingPlanID == "" {
+	if apply.ExpectedLockOwner == "" {
+		if apply.ExpectedPendingPlanID != "" {
+			return fmt.Errorf("verify lock intent for %s/%s: expected pending plan ID set without an expected lock owner", apply.Database, apply.DatabaseType)
+		}
 		return nil
 	}
-	if apply.ExpectedLockOwner == "" || apply.ExpectedPendingPlanID == "" {
-		return fmt.Errorf("verify lock intent for %s/%s: expected lock owner and pending plan ID must both be set", apply.Database, apply.DatabaseType)
-	}
 
+	// An empty ExpectedPendingPlanID is a real observed intent, not a missing
+	// one: it matches only a lock whose pending_plan_id is unset (the column is
+	// NOT NULL DEFAULT ''), so an unpinned lock that a rollback re-pins mid-flight
+	// still fails this check.
 	var lockID int64
 	err := tx.QueryRowContext(ctx, `
 		SELECT id

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -630,6 +630,9 @@ func verifyExpectedLockIntent(ctx context.Context, tx *sql.Tx, apply *storage.Ap
 	if apply.ExpectedLockOwner == "" && apply.ExpectedPendingPlanID == "" {
 		return nil
 	}
+	if apply.ExpectedLockOwner == "" || apply.ExpectedPendingPlanID == "" {
+		return fmt.Errorf("verify lock intent for %s/%s: expected lock owner and pending plan ID must both be set", apply.Database, apply.DatabaseType)
+	}
 
 	var lockID int64
 	err := tx.QueryRowContext(ctx, `

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -28,6 +28,45 @@ func TestApplyStore_Create(t *testing.T) {
 	require.NotZero(t, created.ID)
 }
 
+func TestApplyStore_CreateRejectsChangedLockIntent(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	require.NoError(t, store.Locks().Acquire(ctx, &storage.Lock{
+		DatabaseName:  "testdb",
+		DatabaseType:  storage.DatabaseTypeMySQL,
+		Repository:    "org/repo",
+		PullRequest:   123,
+		Owner:         "org/repo#123",
+		PendingPlanID: "rollback:replacement",
+	}))
+	lock, err := store.Locks().Get(ctx, "testdb", storage.DatabaseTypeMySQL)
+	require.NoError(t, err)
+	require.NotNil(t, lock)
+
+	_, err = store.Applies().Create(ctx, &storage.Apply{
+		ApplyIdentifier:       "apply_changed_lock_intent",
+		LockID:                lock.ID,
+		ExpectedLockOwner:     "org/repo#123",
+		ExpectedPendingPlanID: "apply-original",
+		PlanID:                1,
+		Database:              "testdb",
+		DatabaseType:          storage.DatabaseTypeMySQL,
+		Repository:            "org/repo",
+		PullRequest:           123,
+		Environment:           "staging",
+		Deployment:            "default",
+		Engine:                storage.EngineSpirit,
+		State:                 state.Apply.Pending,
+	})
+	require.ErrorIs(t, err, storage.ErrLockIntentChanged)
+
+	applies, err := store.Applies().GetByPR(ctx, "org/repo", 123)
+	require.NoError(t, err)
+	assert.Empty(t, applies)
+}
+
 func TestApplyStore_CreateDuplicate(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -67,32 +67,101 @@ func TestApplyStore_CreateRejectsChangedLockIntent(t *testing.T) {
 	assert.Empty(t, applies)
 }
 
-func TestApplyStore_CreateRejectsPartialExpectedLockIntent(t *testing.T) {
+func TestApplyStore_CreateRejectsPendingPlanIntentWithoutOwner(t *testing.T) {
 	clearTables(t)
+	store := New(testDB)
+
+	_, err := store.Applies().Create(t.Context(), &storage.Apply{
+		ApplyIdentifier:       "apply_plan_intent_without_owner",
+		ExpectedPendingPlanID: "plan-123",
+		Database:              "testdb",
+		DatabaseType:          storage.DatabaseTypeMySQL,
+		Environment:           "staging",
+		State:                 state.Apply.Completed,
+	})
+	require.ErrorContains(t, err, "expected pending plan ID set without an expected lock owner")
+}
+
+func TestApplyStore_CreateWithMatchingLockIntent(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
 	store := New(testDB)
 
 	tests := []struct {
 		name          string
-		expectedOwner string
-		expectedPlan  string
+		pendingPlanID string
 	}{
-		{name: "owner only", expectedOwner: "org/repo#123"},
-		{name: "pending plan only", expectedPlan: "plan-123"},
+		{name: "pinned lock", pendingPlanID: "plan-abc"},
+		{name: "unpinned lock", pendingPlanID: ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := store.Applies().Create(t.Context(), &storage.Apply{
-				ApplyIdentifier:       "apply_partial_intent_" + strings.ReplaceAll(tt.name, " ", "_"),
-				ExpectedLockOwner:     tt.expectedOwner,
-				ExpectedPendingPlanID: tt.expectedPlan,
+			clearTables(t)
+			require.NoError(t, store.Locks().Acquire(ctx, &storage.Lock{
+				DatabaseName:  "testdb",
+				DatabaseType:  storage.DatabaseTypeMySQL,
+				Repository:    "org/repo",
+				PullRequest:   123,
+				Owner:         "org/repo#123",
+				PendingPlanID: tt.pendingPlanID,
+			}))
+			lock, err := store.Locks().Get(ctx, "testdb", storage.DatabaseTypeMySQL)
+			require.NoError(t, err)
+			require.NotNil(t, lock)
+
+			id, err := store.Applies().Create(ctx, &storage.Apply{
+				ApplyIdentifier:       "apply_matching_intent_" + strings.ReplaceAll(tt.name, " ", "_"),
+				ExpectedLockOwner:     "org/repo#123",
+				ExpectedPendingPlanID: tt.pendingPlanID,
+				PlanID:                1,
 				Database:              "testdb",
 				DatabaseType:          storage.DatabaseTypeMySQL,
+				Repository:            "org/repo",
+				PullRequest:           123,
 				Environment:           "staging",
-				State:                 state.Apply.Completed,
+				Deployment:            "default",
+				Engine:                storage.EngineSpirit,
+				State:                 state.Apply.Pending,
 			})
-			require.ErrorContains(t, err, "expected lock owner and pending plan ID must both be set")
+			require.NoError(t, err)
+			require.NotZero(t, id)
+
+			created, err := store.Applies().Get(ctx, id)
+			require.NoError(t, err)
+			require.NotNil(t, created)
+			assert.Equal(t, lock.ID, created.LockID)
 		})
 	}
+}
+
+func TestApplyStore_CreateRejectsIntentAgainstUnpinnedLock(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	require.NoError(t, store.Locks().Acquire(ctx, &storage.Lock{
+		DatabaseName: "testdb",
+		DatabaseType: storage.DatabaseTypeMySQL,
+		Repository:   "org/repo",
+		PullRequest:  123,
+		Owner:        "org/repo#123",
+	}))
+
+	_, err := store.Applies().Create(ctx, &storage.Apply{
+		ApplyIdentifier:       "apply_pinned_intent_unpinned_lock",
+		ExpectedLockOwner:     "org/repo#123",
+		ExpectedPendingPlanID: "plan-abc",
+		PlanID:                1,
+		Database:              "testdb",
+		DatabaseType:          storage.DatabaseTypeMySQL,
+		Repository:            "org/repo",
+		PullRequest:           123,
+		Environment:           "staging",
+		Deployment:            "default",
+		Engine:                storage.EngineSpirit,
+		State:                 state.Apply.Pending,
+	})
+	require.ErrorIs(t, err, storage.ErrLockIntentChanged)
 }
 
 func TestApplyStore_CreateDuplicate(t *testing.T) {

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -67,6 +67,34 @@ func TestApplyStore_CreateRejectsChangedLockIntent(t *testing.T) {
 	assert.Empty(t, applies)
 }
 
+func TestApplyStore_CreateRejectsPartialExpectedLockIntent(t *testing.T) {
+	clearTables(t)
+	store := New(testDB)
+
+	tests := []struct {
+		name          string
+		expectedOwner string
+		expectedPlan  string
+	}{
+		{name: "owner only", expectedOwner: "org/repo#123"},
+		{name: "pending plan only", expectedPlan: "plan-123"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := store.Applies().Create(t.Context(), &storage.Apply{
+				ApplyIdentifier:       "apply_partial_intent_" + strings.ReplaceAll(tt.name, " ", "_"),
+				ExpectedLockOwner:     tt.expectedOwner,
+				ExpectedPendingPlanID: tt.expectedPlan,
+				Database:              "testdb",
+				DatabaseType:          storage.DatabaseTypeMySQL,
+				Environment:           "staging",
+				State:                 state.Apply.Completed,
+			})
+			require.ErrorContains(t, err, "expected lock owner and pending plan ID must both be set")
+		})
+	}
+}
+
 func TestApplyStore_CreateDuplicate(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/mysqlstore/locks.go
+++ b/pkg/storage/mysqlstore/locks.go
@@ -162,6 +162,26 @@ func (s *lockStore) Release(ctx context.Context, database, dbType, owner string)
 	return nil
 }
 
+// ReleaseIfPendingPlanID atomically releases only the lock intent the caller
+// observed. Same-owner commands can replace pending_plan_id (for example, an
+// apply lock can become a rollback lock), so owner-only release is insufficient
+// after a network call or other long-running operation.
+func (s *lockStore) ReleaseIfPendingPlanID(ctx context.Context, database, dbType, owner, pendingPlanID string) (bool, error) {
+	result, err := s.db.ExecContext(ctx, `
+		DELETE FROM locks
+		WHERE database_name = ? AND database_type = ? AND owner = ? AND pending_plan_id = ?
+	`, database, dbType, owner, pendingPlanID)
+	if err != nil {
+		return false, err
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rowsAffected > 0, nil
+}
+
 // ForceRelease releases a lock regardless of owner (admin override).
 func (s *lockStore) ForceRelease(ctx context.Context, database, dbType string) error {
 	result, err := s.db.ExecContext(ctx, `

--- a/pkg/storage/mysqlstore/locks_test.go
+++ b/pkg/storage/mysqlstore/locks_test.go
@@ -314,6 +314,33 @@ func TestLockStore_Release(t *testing.T) {
 	require.ErrorIs(t, store.Locks().Release(ctx, "testdb", "vitess", "testuser"), storage.ErrLockNotFound)
 }
 
+func TestLockStore_ReleaseIfPendingPlanID(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	require.NoError(t, store.Locks().Acquire(ctx, &storage.Lock{
+		DatabaseName:  "testdb",
+		DatabaseType:  "vitess",
+		Repository:    "org/repo",
+		PullRequest:   123,
+		Owner:         "org/repo#123",
+		PendingPlanID: "rollback:replacement",
+	}))
+
+	released, err := store.Locks().ReleaseIfPendingPlanID(ctx, "testdb", "vitess", "org/repo#123", "apply-original")
+	require.NoError(t, err)
+	assert.False(t, released)
+	lock, err := store.Locks().Get(ctx, "testdb", "vitess")
+	require.NoError(t, err)
+	require.NotNil(t, lock)
+	assert.Equal(t, "rollback:replacement", lock.PendingPlanID)
+
+	released, err = store.Locks().ReleaseIfPendingPlanID(ctx, "testdb", "vitess", "org/repo#123", "rollback:replacement")
+	require.NoError(t, err)
+	assert.True(t, released)
+}
+
 func TestLockStore_ReleaseIsolation(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -70,6 +70,11 @@ type LockStore interface {
 	// Returns ErrLockNotOwned if the lock is not owned by the caller.
 	Release(ctx context.Context, database, dbType, owner string) error
 
+	// ReleaseIfPendingPlanID releases a lock only while both its owner and
+	// pending plan still match. A mismatch is a no-op so a superseding apply or
+	// rollback intent owned by the same PR remains intact.
+	ReleaseIfPendingPlanID(ctx context.Context, database, dbType, owner, pendingPlanID string) (bool, error)
+
 	// ForceRelease releases a lock regardless of owner (admin override).
 	// Used by `schemabot unlock` command and --force flag.
 	ForceRelease(ctx context.Context, database, dbType string) error

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -506,6 +506,12 @@ type Apply struct {
 	// LockID points to locks.id.
 	LockID int64
 
+	// ExpectedLockOwner and ExpectedPendingPlanID are optional creation-time
+	// guards. When set, the apply store verifies the captured lock intent in
+	// the same transaction that makes the apply durable. They are not persisted.
+	ExpectedLockOwner     string
+	ExpectedPendingPlanID string
+
 	// PlanID points to plans.id.
 	PlanID int64
 

--- a/pkg/webhook/apply_execute.go
+++ b/pkg/webhook/apply_execute.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -181,14 +182,18 @@ func (h *Handler) executeApply(
 	if err != nil {
 		h.service.SetPendingObserver(database, "", environment, nil)
 		h.logger.Error("apply execution failed", "repo", repo, "pr", pr, "database", database, "database_type", dbType, "environment", environment, "error", err)
-		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Failed to execute apply: "+err.Error())
+		message := "Failed to execute apply. See SchemaBot server logs for details."
+		if errors.Is(err, storage.ErrLockIntentChanged) {
+			message = "The pending schema change changed while this command was running. The apply was rejected; review the latest plan and run the command again."
+		}
+		h.postCommandError(repo, pr, installationID, actionName, environment, requestedBy, message)
 		return
 	}
 
 	if !applyResp.Accepted {
 		h.service.SetPendingObserver(database, "", environment, nil)
 		h.logger.Info("apply rejected by engine", "repo", repo, "pr", pr, "database", database, "environment", environment, "error", applyResp.ErrorMessage)
-		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Apply was not accepted: "+applyResp.ErrorMessage)
+		h.postCommandError(repo, pr, installationID, actionName, environment, requestedBy, "The apply was not accepted. See SchemaBot server logs for details.")
 		return
 	}
 

--- a/pkg/webhook/apply_execute.go
+++ b/pkg/webhook/apply_execute.go
@@ -2,7 +2,6 @@ package webhook
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -24,7 +23,7 @@ func (h *Handler) executeApply(
 	ctx context.Context, client *ghclient.InstallationClient,
 	repo string, pr int, schemaResult *ghclient.SchemaRequestResult,
 	environment string, installationID int64, requestedBy string,
-	result CommandResult, storedPlan *storage.Plan,
+	result CommandResult, storedPlan *storage.Plan, expectedPendingPlanID string,
 ) {
 	database := schemaResult.Database
 	dbType := schemaResult.Type
@@ -55,8 +54,8 @@ func (h *Handler) executeApply(
 	// acquired it; ErrLockNotFound / ErrLockNotOwned are expected.
 	if len(planResp.FlatTables()) == 0 {
 		lockOwner := fmt.Sprintf("%s#%d", repo, pr)
-		relErr := h.service.Storage().Locks().Release(ctx, database, dbType, lockOwner)
-		if relErr != nil && !errors.Is(relErr, storage.ErrLockNotFound) && !errors.Is(relErr, storage.ErrLockNotOwned) {
+		_, relErr := h.service.Storage().Locks().ReleaseIfPendingPlanID(ctx, database, dbType, lockOwner, expectedPendingPlanID)
+		if relErr != nil {
 			h.logger.Error("failed to release lock after no-changes confirm",
 				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
 		}
@@ -91,6 +90,32 @@ func (h *Handler) executeApply(
 		commentData := buildPlanCommentData(schemaResult, planResp, environment, result.Tenant, requestedBy)
 		h.logger.Info("apply blocked by unsafe changes", "repo", repo, "pr", pr, "database", database, "environment", environment)
 		h.postComment(repo, pr, installationID, templates.RenderUnsafeChangesBlocked(commentData))
+		return
+	}
+
+	// Revalidate the PR immediately before the apply is queued. The earlier
+	// handler checks provide fast rejection, but the apply-time re-plan can be
+	// retried and the base branch or PR HEAD can advance while it runs.
+	actionName := action.ApplyConfirm
+	if storedPlan != nil {
+		actionName = action.Apply
+	}
+	freshPRInfo, err := client.FetchPullRequestNoCache(ctx, repo, pr)
+	if err != nil {
+		h.logger.Error("apply rejected: failed final PR freshness fetch",
+			"repo", repo, "pr", pr, "database", database, "database_type", dbType,
+			"environment", environment, "action", actionName, "error", err)
+		h.postCommandError(repo, pr, installationID, actionName, environment, requestedBy,
+			"SchemaBot could not verify the current PR state. The apply was rejected; retry the command.")
+		h.releaseApplyLockAfterFreshnessRejection(ctx, repo, pr, database, dbType, environment, expectedPendingPlanID)
+		return
+	}
+	if rejected := h.assertSchemaStillCurrent(ctx, repo, pr, installationID, schemaResult, freshPRInfo.HeadSHA, environment, requestedBy, actionName); rejected {
+		h.releaseApplyLockAfterFreshnessRejection(ctx, repo, pr, database, dbType, environment, expectedPendingPlanID)
+		return
+	}
+	if rejected := h.assertBaseSchemaStillCurrent(ctx, client, repo, pr, installationID, schemaResult, freshPRInfo, environment, requestedBy, actionName); rejected {
+		h.releaseApplyLockAfterFreshnessRejection(ctx, repo, pr, database, dbType, environment, expectedPendingPlanID)
 		return
 	}
 
@@ -143,11 +168,13 @@ func (h *Handler) executeApply(
 	h.service.SetPendingObserver(database, "", environment, observer)
 
 	applyReq := api.ApplyRequest{
-		PlanID:         planResp.PlanID,
-		Environment:    environment,
-		Options:        options,
-		Caller:         caller,
-		InstallationID: installationID,
+		PlanID:                planResp.PlanID,
+		Environment:           environment,
+		Options:               options,
+		Caller:                caller,
+		InstallationID:        installationID,
+		ExpectedLockOwner:     fmt.Sprintf("%s#%d", repo, pr),
+		ExpectedPendingPlanID: expectedPendingPlanID,
 	}
 
 	applyResp, applyID, err := h.service.ExecuteApply(ctx, applyReq)
@@ -215,6 +242,20 @@ func (h *Handler) executeApply(
 			"apply_id", applyID, "error", err)
 		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Apply was accepted, but SchemaBot could not update the required status check: "+err.Error())
 		return
+	}
+}
+
+func (h *Handler) releaseApplyLockAfterFreshnessRejection(ctx context.Context, repo string, pr int, database, dbType, environment, expectedPendingPlanID string) {
+	lockOwner := fmt.Sprintf("%s#%d", repo, pr)
+	released, relErr := h.service.Storage().Locks().ReleaseIfPendingPlanID(ctx, database, dbType, lockOwner, expectedPendingPlanID)
+	if relErr != nil {
+		h.logger.Error("failed to release lock after final freshness rejection",
+			"repo", repo, "pr", pr, "database", database, "database_type", dbType,
+			"environment", environment, "error", relErr)
+	} else if !released {
+		h.logger.Info("preserved lock after final freshness rejection because its pending intent changed",
+			"repo", repo, "pr", pr, "database", database, "database_type", dbType,
+			"environment", environment, "expected_pending_plan_id", expectedPendingPlanID)
 	}
 }
 

--- a/pkg/webhook/apply_execute.go
+++ b/pkg/webhook/apply_execute.go
@@ -50,16 +50,10 @@ func (h *Handler) executeApply(
 		return
 	}
 
-	// No changes — release lock and notify. Use owner-scoped Release so we
-	// can't clobber a lock that has changed ownership since this handler
-	// acquired it; ErrLockNotFound / ErrLockNotOwned are expected.
+	// No changes — release the lock (keyed on the pending intent this handler
+	// observed, so a lock re-pinned by a newer plan is preserved) and notify.
 	if len(planResp.FlatTables()) == 0 {
-		lockOwner := fmt.Sprintf("%s#%d", repo, pr)
-		_, relErr := h.service.Storage().Locks().ReleaseIfPendingPlanID(ctx, database, dbType, lockOwner, expectedPendingPlanID)
-		if relErr != nil {
-			h.logger.Error("failed to release lock after no-changes confirm",
-				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
-		}
+		h.releaseApplyLockIfIntentUnchanged(ctx, repo, pr, database, dbType, environment, expectedPendingPlanID, "no changes to apply")
 		// The target already matches the PR schema — apply found nothing to do.
 		// Record the passing (no-change) check result and refresh the aggregate so
 		// the schema check reflects that the target is up to date, the same as the
@@ -108,15 +102,15 @@ func (h *Handler) executeApply(
 			"environment", environment, "action", actionName, "error", err)
 		h.postCommandError(repo, pr, installationID, actionName, environment, requestedBy,
 			"SchemaBot could not verify the current PR state. The apply was rejected; retry the command.")
-		h.releaseApplyLockAfterFreshnessRejection(ctx, repo, pr, database, dbType, environment, expectedPendingPlanID)
+		h.releaseApplyLockIfIntentUnchanged(ctx, repo, pr, database, dbType, environment, expectedPendingPlanID, "final PR freshness fetch failure")
 		return
 	}
 	if rejected := h.assertSchemaStillCurrent(ctx, repo, pr, installationID, schemaResult, freshPRInfo.HeadSHA, environment, requestedBy, actionName); rejected {
-		h.releaseApplyLockAfterFreshnessRejection(ctx, repo, pr, database, dbType, environment, expectedPendingPlanID)
+		h.releaseApplyLockIfIntentUnchanged(ctx, repo, pr, database, dbType, environment, expectedPendingPlanID, "final stale-schema rejection")
 		return
 	}
 	if rejected := h.assertBaseSchemaStillCurrent(ctx, client, repo, pr, installationID, schemaResult, freshPRInfo, environment, requestedBy, actionName); rejected {
-		h.releaseApplyLockAfterFreshnessRejection(ctx, repo, pr, database, dbType, environment, expectedPendingPlanID)
+		h.releaseApplyLockIfIntentUnchanged(ctx, repo, pr, database, dbType, environment, expectedPendingPlanID, "final base-schema freshness rejection")
 		return
 	}
 
@@ -250,17 +244,26 @@ func (h *Handler) executeApply(
 	}
 }
 
-func (h *Handler) releaseApplyLockAfterFreshnessRejection(ctx context.Context, repo string, pr int, database, dbType, environment, expectedPendingPlanID string) {
+// releaseApplyLockIfIntentUnchanged releases this PR's apply lock after a
+// pre-execution gate rejected (or obviated) the apply, but only while the lock
+// still carries the exact pending intent the rejecting handler observed. A lock
+// whose pending plan has since changed — e.g. a rollback plan re-pinned it while
+// the gate ran — belongs to that newer intent and is preserved. The reason names
+// the gate that triggered the release so logs distinguish the call sites.
+func (h *Handler) releaseApplyLockIfIntentUnchanged(ctx context.Context, repo string, pr int, database, dbType, environment, expectedPendingPlanID, reason string) {
 	lockOwner := fmt.Sprintf("%s#%d", repo, pr)
 	released, relErr := h.service.Storage().Locks().ReleaseIfPendingPlanID(ctx, database, dbType, lockOwner, expectedPendingPlanID)
 	if relErr != nil {
-		h.logger.Error("failed to release lock after final freshness rejection",
+		h.logger.Error("failed to release apply lock after pre-execution rejection",
 			"repo", repo, "pr", pr, "database", database, "database_type", dbType,
-			"environment", environment, "error", relErr)
-	} else if !released {
-		h.logger.Info("preserved lock after final freshness rejection because its pending intent changed",
+			"environment", environment, "reason", reason, "error", relErr)
+		return
+	}
+	if !released {
+		h.logger.Info("preserved apply lock after pre-execution rejection because its pending intent changed",
 			"repo", repo, "pr", pr, "database", database, "database_type", dbType,
-			"environment", environment, "expected_pending_plan_id", expectedPendingPlanID)
+			"environment", environment, "reason", reason,
+			"expected_pending_plan_id", expectedPendingPlanID)
 	}
 }
 

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -226,27 +226,15 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		h.logger.Error("failed to fetch PR for stale-schema check, releasing lock",
 			"repo", repo, "pr", pr, "database", database, "database_type", dbType, "environment", environment, "error", prErr)
 		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Failed to verify PR HEAD before apply: "+prErr.Error())
-		_, relErr := h.service.Storage().Locks().ReleaseIfPendingPlanID(ctx, database, dbType, lockOwner, planResp.PlanID)
-		if relErr != nil {
-			h.logger.Error("failed to release lock after PR fetch failure",
-				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
-		}
+		h.releaseApplyLockIfIntentUnchanged(ctx, repo, pr, database, dbType, environment, planResp.PlanID, "PR freshness fetch failure")
 		return
 	}
 	if rejected := h.assertSchemaStillCurrent(ctx, repo, pr, installationID, schemaResult, prInfo.HeadSHA, environment, requestedBy, action.Apply); rejected {
-		_, relErr := h.service.Storage().Locks().ReleaseIfPendingPlanID(ctx, database, dbType, lockOwner, planResp.PlanID)
-		if relErr != nil {
-			h.logger.Error("failed to release lock after stale-schema rejection",
-				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
-		}
+		h.releaseApplyLockIfIntentUnchanged(ctx, repo, pr, database, dbType, environment, planResp.PlanID, "stale-schema rejection")
 		return
 	}
 	if rejected := h.assertBaseSchemaStillCurrent(ctx, client, repo, pr, installationID, schemaResult, prInfo, environment, requestedBy, action.Apply); rejected {
-		_, relErr := h.service.Storage().Locks().ReleaseIfPendingPlanID(ctx, database, dbType, lockOwner, planResp.PlanID)
-		if relErr != nil {
-			h.logger.Error("failed to release lock after base-schema freshness rejection",
-				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
-		}
+		h.releaseApplyLockIfIntentUnchanged(ctx, repo, pr, database, dbType, environment, planResp.PlanID, "base-schema freshness rejection")
 		return
 	}
 
@@ -257,21 +245,11 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	// transitioned to failing on the same SHA (e.g. CI re-ran red, or a
 	// new required check was added) would otherwise sneak past. Release
 	// the lock on block so the user can re-run `schemabot apply -e <env>`
-	// once the checks recover, without a manual unlock.
-	//
-	// Use owner-scoped Release rather than ForceRelease: although this
-	// handler invocation acquired the lock earlier, ownership can change
-	// between acquisition and this point (e.g. `schemabot unlock` clears
-	// the lock and another PR acquires it). Release deletes only when
-	// owner matches; ErrLockNotFound / ErrLockNotOwned are expected here
-	// (lock may be absent or now held by another PR) and are not logged
-	// as errors.
+	// once the checks recover, without a manual unlock. The release is keyed
+	// on the (owner, pending plan) intent acquired above, so a lock that has
+	// since changed hands or been re-pinned is preserved.
 	if blocked := h.enforcePassingChecks(ctx, client, repo, pr, installationID, prInfo.HeadSHA, environment); blocked {
-		_, relErr := h.service.Storage().Locks().ReleaseIfPendingPlanID(ctx, database, dbType, lockOwner, planResp.PlanID)
-		if relErr != nil {
-			h.logger.Error("failed to release lock after fresh-HEAD checks gate block",
-				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
-		}
+		h.releaseApplyLockIfIntentUnchanged(ctx, repo, pr, database, dbType, environment, planResp.PlanID, "fresh-HEAD checks gate block")
 		return
 	}
 
@@ -390,6 +368,40 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 		h.postComment(repo, pr, installationID, templates.RenderApplyConfirmNoLock(database, environment))
 		return
 	}
+	// A same-PR rollback lock uses the same owner string but is confirmed via
+	// rollback-confirm, never here. Reject it before the freshness checks so no
+	// rejection path below can release it.
+	if existingLock.Owner == lockOwner && strings.HasPrefix(existingLock.PendingPlanID, rollbackPendingPlanPrefix) {
+		h.logger.Info("apply-confirm rejected: lock belongs to rollback plan", "repo", repo, "pr", pr,
+			"database", database, "environment", environment, "pending_plan_id", existingLock.PendingPlanID)
+		h.postCommandError(repo, pr, installationID, action.ApplyConfirm, environment, requestedBy,
+			"This lock belongs to a rollback plan. Use `schemabot rollback-confirm` to execute it, or `schemabot unlock` to cancel it.")
+		return
+	}
+
+	// Freshness rejections outrank the lock-conflict comment: a stale branch
+	// needs a rebase no matter who holds the lock. Release only when this PR
+	// owns the lock, keyed on the pending intent observed above, so another
+	// PR's lock — or this PR's lock re-pinned by a newer plan mid-check — is
+	// never removed.
+	releaseObservedApplyIntent := func(reason string) {
+		if existingLock.Owner != lockOwner {
+			h.logger.Info("left apply lock in place after pre-execution rejection because another PR holds it",
+				"repo", repo, "pr", pr, "database", database, "database_type", dbType,
+				"environment", environment, "reason", reason, "lock_owner", existingLock.Owner)
+			return
+		}
+		h.releaseApplyLockIfIntentUnchanged(ctx, repo, pr, database, dbType, environment, existingLock.PendingPlanID, reason)
+	}
+	if rejected := h.assertSchemaStillCurrent(ctx, repo, pr, installationID, schemaResult, confirmPRInfo.HeadSHA, environment, requestedBy, action.ApplyConfirm); rejected {
+		releaseObservedApplyIntent("stale-schema rejection")
+		return
+	}
+	if rejected := h.assertBaseSchemaStillCurrent(ctx, client, repo, pr, installationID, schemaResult, confirmPRInfo, environment, requestedBy, action.ApplyConfirm); rejected {
+		releaseObservedApplyIntent("base-schema freshness rejection")
+		return
+	}
+
 	if existingLock.Owner != lockOwner {
 		h.logger.Info("apply-confirm blocked by lock conflict", "repo", repo, "pr", pr, "database", database, "lock_owner", existingLock.Owner)
 		h.postComment(repo, pr, installationID, templates.RenderApplyBlockedByOtherPR(templates.ApplyLockConflictData{
@@ -401,33 +413,6 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 			LockPR:      existingLock.PullRequest,
 			LockCreated: existingLock.CreatedAt,
 		}))
-		return
-	}
-	if strings.HasPrefix(existingLock.PendingPlanID, rollbackPendingPlanPrefix) {
-		h.logger.Info("apply-confirm rejected: lock belongs to rollback plan", "repo", repo, "pr", pr,
-			"database", database, "environment", environment, "pending_plan_id", existingLock.PendingPlanID)
-		h.postCommandError(repo, pr, installationID, action.ApplyConfirm, environment, requestedBy,
-			"This lock belongs to a rollback plan. Use `schemabot rollback-confirm` to execute it, or `schemabot unlock` to cancel it.")
-		return
-	}
-
-	// Only release on freshness rejection after proving this lock belongs to
-	// the pending apply confirmation. A same-PR rollback lock uses the same
-	// owner string and must remain intact.
-	if rejected := h.assertSchemaStillCurrent(ctx, repo, pr, installationID, schemaResult, confirmPRInfo.HeadSHA, environment, requestedBy, action.ApplyConfirm); rejected {
-		_, relErr := h.service.Storage().Locks().ReleaseIfPendingPlanID(ctx, database, dbType, lockOwner, existingLock.PendingPlanID)
-		if relErr != nil {
-			h.logger.Error("failed to release lock after stale-schema rejection",
-				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
-		}
-		return
-	}
-	if rejected := h.assertBaseSchemaStillCurrent(ctx, client, repo, pr, installationID, schemaResult, confirmPRInfo, environment, requestedBy, action.ApplyConfirm); rejected {
-		_, relErr := h.service.Storage().Locks().ReleaseIfPendingPlanID(ctx, database, dbType, lockOwner, existingLock.PendingPlanID)
-		if relErr != nil {
-			h.logger.Error("failed to release lock after base-schema freshness rejection",
-				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
-		}
 		return
 	}
 	h.acknowledgeCommandActPoint(repo, pr, installationID, result)
@@ -446,12 +431,9 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 	// land in the same plans table and can supersede the confirmation plan a
 	// reviewer is about to confirm.
 	//
-	// Use owner-scoped Release rather than ForceRelease even though the
-	// ownership check above just succeeded: ownership can change between that
-	// Get and this delete (intervening unlock/reacquire by another PR), and
-	// ForceRelease would clear the new owner's lock. Release deletes only when
-	// owner still matches; ErrLockNotFound / ErrLockNotOwned are expected if
-	// ownership has already changed and are not logged as errors.
+	// The rejection release is keyed on the (owner, pending plan) intent
+	// observed above, so a lock that has since changed hands or been re-pinned
+	// by a newer plan is preserved.
 	storedPlan, planLoadErr := h.confirmationPlanForLock(ctx, existingLock)
 	if planLoadErr != nil {
 		h.logger.Error("failed to load confirmation plan for cross-delivery freshness check",
@@ -461,11 +443,7 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 		return
 	}
 	if rejected := h.assertPlanStillCurrent(ctx, repo, pr, installationID, storedPlan, confirmPRInfo.HeadSHA, environment, requestedBy); rejected {
-		_, relErr := h.service.Storage().Locks().ReleaseIfPendingPlanID(ctx, database, dbType, lockOwner, existingLock.PendingPlanID)
-		if relErr != nil {
-			h.logger.Error("failed to release lock after stale-plan rejection",
-				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
-		}
+		h.releaseApplyLockIfIntentUnchanged(ctx, repo, pr, database, dbType, environment, existingLock.PendingPlanID, "stale-plan rejection")
 		return
 	}
 

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -226,17 +226,25 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		h.logger.Error("failed to fetch PR for stale-schema check, releasing lock",
 			"repo", repo, "pr", pr, "database", database, "database_type", dbType, "environment", environment, "error", prErr)
 		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Failed to verify PR HEAD before apply: "+prErr.Error())
-		relErr := h.service.Storage().Locks().Release(ctx, database, dbType, lockOwner)
-		if relErr != nil && !errors.Is(relErr, storage.ErrLockNotFound) && !errors.Is(relErr, storage.ErrLockNotOwned) {
+		_, relErr := h.service.Storage().Locks().ReleaseIfPendingPlanID(ctx, database, dbType, lockOwner, planResp.PlanID)
+		if relErr != nil {
 			h.logger.Error("failed to release lock after PR fetch failure",
 				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
 		}
 		return
 	}
 	if rejected := h.assertSchemaStillCurrent(ctx, repo, pr, installationID, schemaResult, prInfo.HeadSHA, environment, requestedBy, action.Apply); rejected {
-		relErr := h.service.Storage().Locks().Release(ctx, database, dbType, lockOwner)
-		if relErr != nil && !errors.Is(relErr, storage.ErrLockNotFound) && !errors.Is(relErr, storage.ErrLockNotOwned) {
+		_, relErr := h.service.Storage().Locks().ReleaseIfPendingPlanID(ctx, database, dbType, lockOwner, planResp.PlanID)
+		if relErr != nil {
 			h.logger.Error("failed to release lock after stale-schema rejection",
+				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
+		}
+		return
+	}
+	if rejected := h.assertBaseSchemaStillCurrent(ctx, client, repo, pr, installationID, schemaResult, prInfo, environment, requestedBy, action.Apply); rejected {
+		_, relErr := h.service.Storage().Locks().ReleaseIfPendingPlanID(ctx, database, dbType, lockOwner, planResp.PlanID)
+		if relErr != nil {
+			h.logger.Error("failed to release lock after base-schema freshness rejection",
 				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
 		}
 		return
@@ -259,8 +267,8 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	// (lock may be absent or now held by another PR) and are not logged
 	// as errors.
 	if blocked := h.enforcePassingChecks(ctx, client, repo, pr, installationID, prInfo.HeadSHA, environment); blocked {
-		relErr := h.service.Storage().Locks().Release(ctx, database, dbType, lockOwner)
-		if relErr != nil && !errors.Is(relErr, storage.ErrLockNotFound) && !errors.Is(relErr, storage.ErrLockNotOwned) {
+		_, relErr := h.service.Storage().Locks().ReleaseIfPendingPlanID(ctx, database, dbType, lockOwner, planResp.PlanID)
+		if relErr != nil {
 			h.logger.Error("failed to release lock after fresh-HEAD checks gate block",
 				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
 		}
@@ -296,7 +304,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	}
 
 	// Check 2 (DDL drift) happens inside executeApply after re-plan
-	h.executeApply(ctx, client, repo, pr, schemaResult, environment, installationID, requestedBy, result, storedPlan)
+	h.executeApply(ctx, client, repo, pr, schemaResult, environment, installationID, requestedBy, result, storedPlan, planResp.PlanID)
 }
 
 // handleApplyConfirmCommand handles the "schemabot apply-confirm -e <env>" PR comment command.
@@ -357,26 +365,6 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 		return
 	}
 
-	// Reject if the PR HEAD advanced after discovery loaded schema files.
-	// Running against the loaded files would render a plan against an older
-	// commit than the branch is on right now. Release the lock so the user
-	// can re-run `schemabot apply -e <env>` cleanly.
-	//
-	// Use owner-scoped Release rather than ForceRelease: this handler runs on
-	// every PR comment, so a stale-schema rejection on PR #2 must never clear
-	// a lock held by PR #1 for the same target. Release deletes only when
-	// owner matches; ErrLockNotFound / ErrLockNotOwned are expected here
-	// (lock may be absent or held by another PR) and are not logged as errors.
-	if rejected := h.assertSchemaStillCurrent(ctx, repo, pr, installationID, schemaResult, confirmPRInfo.HeadSHA, environment, requestedBy, action.ApplyConfirm); rejected {
-		lockOwner := fmt.Sprintf("%s#%d", repo, pr)
-		relErr := h.service.Storage().Locks().Release(ctx, schemaResult.Database, schemaResult.Type, lockOwner)
-		if relErr != nil && !errors.Is(relErr, storage.ErrLockNotFound) && !errors.Is(relErr, storage.ErrLockNotOwned) {
-			h.logger.Error("failed to release lock after stale-schema rejection",
-				"repo", repo, "pr", pr, "database", schemaResult.Database, "database_type", schemaResult.Type, "error", relErr)
-		}
-		return
-	}
-
 	if blocked := h.enforcePassingChecks(ctx, client, repo, pr, installationID, confirmPRInfo.HeadSHA, environment); blocked {
 		return
 	}
@@ -422,6 +410,26 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 			"This lock belongs to a rollback plan. Use `schemabot rollback-confirm` to execute it, or `schemabot unlock` to cancel it.")
 		return
 	}
+
+	// Only release on freshness rejection after proving this lock belongs to
+	// the pending apply confirmation. A same-PR rollback lock uses the same
+	// owner string and must remain intact.
+	if rejected := h.assertSchemaStillCurrent(ctx, repo, pr, installationID, schemaResult, confirmPRInfo.HeadSHA, environment, requestedBy, action.ApplyConfirm); rejected {
+		_, relErr := h.service.Storage().Locks().ReleaseIfPendingPlanID(ctx, database, dbType, lockOwner, existingLock.PendingPlanID)
+		if relErr != nil {
+			h.logger.Error("failed to release lock after stale-schema rejection",
+				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
+		}
+		return
+	}
+	if rejected := h.assertBaseSchemaStillCurrent(ctx, client, repo, pr, installationID, schemaResult, confirmPRInfo, environment, requestedBy, action.ApplyConfirm); rejected {
+		_, relErr := h.service.Storage().Locks().ReleaseIfPendingPlanID(ctx, database, dbType, lockOwner, existingLock.PendingPlanID)
+		if relErr != nil {
+			h.logger.Error("failed to release lock after base-schema freshness rejection",
+				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
+		}
+		return
+	}
 	h.acknowledgeCommandActPoint(repo, pr, installationID, result)
 
 	// Cross-delivery freshness check: reject if the confirmation plan (the one
@@ -453,15 +461,15 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 		return
 	}
 	if rejected := h.assertPlanStillCurrent(ctx, repo, pr, installationID, storedPlan, confirmPRInfo.HeadSHA, environment, requestedBy); rejected {
-		relErr := h.service.Storage().Locks().Release(ctx, database, dbType, lockOwner)
-		if relErr != nil && !errors.Is(relErr, storage.ErrLockNotFound) && !errors.Is(relErr, storage.ErrLockNotOwned) {
+		_, relErr := h.service.Storage().Locks().ReleaseIfPendingPlanID(ctx, database, dbType, lockOwner, existingLock.PendingPlanID)
+		if relErr != nil {
 			h.logger.Error("failed to release lock after stale-plan rejection",
 				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "error", relErr)
 		}
 		return
 	}
 
-	h.executeApply(ctx, client, repo, pr, schemaResult, environment, installationID, requestedBy, result, nil)
+	h.executeApply(ctx, client, repo, pr, schemaResult, environment, installationID, requestedBy, result, nil, existingLock.PendingPlanID)
 }
 
 // handleUnlockCommand handles the "schemabot unlock" PR comment command.

--- a/pkg/webhook/apply_integration_test.go
+++ b/pkg/webhook/apply_integration_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/block/spirit/pkg/utils"
 
+	"github.com/block/schemabot/pkg/api"
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/storage"
 )
@@ -1392,6 +1393,258 @@ func TestE2EApplyAutoConfirmRejectsWhenHEADAdvanced(t *testing.T) {
 	for _, a := range applies {
 		assert.NotEqual(t, dbName, a.Database, "no apply for %s should have been started", dbName)
 	}
+}
+
+// A PR whose managed schema directory changed on the base branch after it
+// diverged is rejected before execution and its lock is released. Unrelated
+// base-branch commits are excluded by the directory tree comparison.
+func TestE2EApplyAutoConfirmRejectsStaleBaseSchema(t *testing.T) {
+	dbName := "webhook_auto_confirm_stale_base"
+	svc := setupE2EService(t, dbName)
+	svc.Config().Repos = map[string]api.RepoConfig{
+		"octocat/hello-world": {RequireUpToDateWithBase: true},
+	}
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
+	registerStaleBaseSchemaComparison(t, mux)
+
+	h := newE2EHandler(t, svc, client)
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot apply -e staging",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "Apply rejected — base schema is newer")
+		assert.Contains(t, body, "`schema`")
+		assert.Contains(t, body, "Merge or rebase")
+		assert.NotContains(t, body, "Applying automatically")
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for base-schema rejection")
+	}
+
+	require.Eventually(t, func() bool {
+		lock, err := svc.Storage().Locks().Get(t.Context(), dbName, "mysql")
+		return err == nil && lock == nil
+	}, 5*time.Second, 50*time.Millisecond, "lock must be released after base-schema rejection")
+
+	applies, err := svc.Storage().Applies().GetByPR(t.Context(), "octocat/hello-world", 1)
+	require.NoError(t, err)
+	for _, apply := range applies {
+		assert.NotEqual(t, dbName, apply.Database, "base-stale schema must not start an apply")
+	}
+}
+
+// A manual confirmation repeats the base-schema freshness gate and releases
+// only the apply-confirm lock when the branch is stale.
+func TestE2EApplyConfirmRejectsStaleBaseSchema(t *testing.T) {
+	dbName := "webhook_confirm_stale_base"
+	svc := setupE2EService(t, dbName)
+	svc.Config().Repos = map[string]api.RepoConfig{
+		"octocat/hello-world": {RequireUpToDateWithBase: true},
+	}
+	require.NoError(t, svc.Storage().Locks().Acquire(t.Context(), &storage.Lock{
+		DatabaseName:  dbName,
+		DatabaseType:  "mysql",
+		Repository:    "octocat/hello-world",
+		PullRequest:   1,
+		Owner:         "octocat/hello-world#1",
+		PendingPlanID: "plan-pending-confirmation",
+	}))
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	result := setupFakeGitHubForPlan(t, mux, map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}, schemabotConfig, dbName)
+	registerStaleBaseSchemaComparison(t, mux)
+
+	h := newE2EHandler(t, svc, client)
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot apply-confirm -e staging",
+		isPR:    true,
+	}, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "Apply rejected — base schema is newer")
+		assert.Contains(t, body, "Merge or rebase")
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for apply-confirm base-schema rejection")
+	}
+
+	require.Eventually(t, func() bool {
+		lock, err := svc.Storage().Locks().Get(t.Context(), dbName, "mysql")
+		return err == nil && lock == nil
+	}, 5*time.Second, 50*time.Millisecond, "apply-confirm lock must be released after base-schema rejection")
+
+	applies, err := svc.Storage().Applies().GetByPR(t.Context(), "octocat/hello-world", 1)
+	require.NoError(t, err)
+	for _, apply := range applies {
+		assert.NotEqual(t, dbName, apply.Database, "base-stale confirmation must not start an apply")
+	}
+}
+
+// apply-confirm validates lock intent before running freshness checks. A
+// rollback lock owned by the same PR must never be released by the apply path.
+func TestE2EApplyConfirmPreservesRollbackLockWithBaseFreshnessEnabled(t *testing.T) {
+	dbName := "webhook_confirm_rollback_lock"
+	svc := setupE2EService(t, dbName)
+	svc.Config().Repos = map[string]api.RepoConfig{
+		"octocat/hello-world": {RequireUpToDateWithBase: true},
+	}
+	require.NoError(t, svc.Storage().Locks().Acquire(t.Context(), &storage.Lock{
+		DatabaseName:  dbName,
+		DatabaseType:  "mysql",
+		Repository:    "octocat/hello-world",
+		PullRequest:   1,
+		Owner:         "octocat/hello-world#1",
+		PendingPlanID: rollbackPendingPlanPrefix + "apply-original",
+	}))
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	result := setupFakeGitHubForPlan(t, mux, map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}, schemabotConfig, dbName)
+
+	h := newE2EHandler(t, svc, client)
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot apply-confirm -e staging",
+		isPR:    true,
+	}, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "This lock belongs to a rollback plan")
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for rollback-lock rejection")
+	}
+
+	lock, err := svc.Storage().Locks().Get(t.Context(), dbName, "mysql")
+	require.NoError(t, err)
+	require.NotNil(t, lock)
+	assert.Equal(t, rollbackPendingPlanPrefix+"apply-original", lock.PendingPlanID)
+}
+
+// A same-PR rollback can replace the pending apply intent while apply-confirm
+// is waiting on GitHub. Freshness rejection must conditionally release the
+// apply intent it observed, not delete the newer rollback lock by owner alone.
+func TestE2EApplyConfirmFreshnessRacePreservesReplacementRollbackLock(t *testing.T) {
+	dbName := "webhook_confirm_rollback_race"
+	svc := setupE2EService(t, dbName)
+	svc.Config().Repos = map[string]api.RepoConfig{
+		"octocat/hello-world": {RequireUpToDateWithBase: true},
+	}
+	require.NoError(t, svc.Storage().Locks().Acquire(t.Context(), &storage.Lock{
+		DatabaseName:  dbName,
+		DatabaseType:  "mysql",
+		Repository:    "octocat/hello-world",
+		PullRequest:   1,
+		Owner:         "octocat/hello-world#1",
+		PendingPlanID: "plan-pending-confirmation",
+	}))
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	result := setupFakeGitHubForPlan(t, mux, map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}, schemabotConfig, dbName)
+	registerStaleBaseSchemaComparisonWithHook(t, mux, func() {
+		require.NoError(t, svc.Storage().Locks().Acquire(t.Context(), &storage.Lock{
+			DatabaseName:  dbName,
+			DatabaseType:  "mysql",
+			Repository:    "octocat/hello-world",
+			PullRequest:   1,
+			Owner:         "octocat/hello-world#1",
+			PendingPlanID: rollbackPendingPlanPrefix + "replacement",
+		}))
+	})
+
+	h := newE2EHandler(t, svc, client)
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot apply-confirm -e staging",
+		isPR:    true,
+	}, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "Apply rejected — base schema is newer")
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for apply-confirm base-schema rejection")
+	}
+
+	lock, err := svc.Storage().Locks().Get(t.Context(), dbName, "mysql")
+	require.NoError(t, err)
+	require.NotNil(t, lock)
+	assert.Equal(t, rollbackPendingPlanPrefix+"replacement", lock.PendingPlanID)
+}
+
+func registerStaleBaseSchemaComparison(t *testing.T, mux *http.ServeMux) {
+	t.Helper()
+	registerStaleBaseSchemaComparisonWithHook(t, mux, nil)
+}
+
+func registerStaleBaseSchemaComparisonWithHook(t *testing.T, mux *http.ServeMux, hook func()) {
+	t.Helper()
+	mux.HandleFunc("GET /repos/octocat/hello-world/compare/def456...abc123", func(w http.ResponseWriter, _ *http.Request) {
+		if hook != nil {
+			hook()
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(gh.CommitsComparison{
+			MergeBaseCommit: &gh.RepositoryCommit{SHA: new("merge-base-sha")},
+		}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/merge-base-sha", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.Tree{Entries: []*gh.TreeEntry{
+			{Path: new("schema"), Type: new("tree"), SHA: new("schema-tree-old")},
+		}}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/def456", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.Tree{Entries: []*gh.TreeEntry{
+			{Path: new("schema"), Type: new("tree"), SHA: new("schema-tree-new")},
+		}}))
+	})
 }
 
 // TestE2EApplyConfirmRejectsWhenHEADAdvanced verifies that `apply-confirm`

--- a/pkg/webhook/schema_freshness.go
+++ b/pkg/webhook/schema_freshness.go
@@ -73,3 +73,80 @@ func (h *Handler) assertSchemaStillCurrent(
 func metricActionKey(action string) string {
 	return strings.ReplaceAll(action, "-", "_")
 }
+
+// assertBaseSchemaStillCurrent enforces the opt-in repository policy that a PR
+// must include every base-branch change under its managed schema directory.
+// It compares Git tree object IDs at the PR merge base and current base, so
+// unrelated commits elsewhere in a monorepo never block an apply. GitHub read
+// uncertainty rejects the apply rather than silently bypassing the guard.
+func (h *Handler) assertBaseSchemaStillCurrent(
+	ctx context.Context,
+	client *ghclient.InstallationClient,
+	repo string,
+	pr int,
+	installationID int64,
+	schema *ghclient.SchemaRequestResult,
+	prInfo *ghclient.PullRequestInfo,
+	environment string,
+	requestedBy string,
+	action string,
+) bool {
+	config, ok := h.serverConfig()
+	if !ok || !config.RequiresUpToDateWithBase(repo) {
+		return false
+	}
+
+	schemaPaths := []string{schema.SchemaPath}
+	if schema.SchemaLinkPath != "" {
+		schemaPaths = append(schemaPaths, schema.SchemaLinkPath)
+	}
+	changed, err := client.SchemaPathsChangedSinceMergeBase(ctx, repo, prInfo.BaseSHA, prInfo.HeadSHA, schemaPaths)
+	if err != nil {
+		h.logger.Error("apply rejected: could not verify base schema freshness",
+			"repo", repo,
+			"pr", pr,
+			"environment", environment,
+			"database", schema.Database,
+			"database_type", schema.Type,
+			"schema_path", schema.SchemaPath,
+			"base_sha", prInfo.BaseSHA,
+			"head_sha", prInfo.HeadSHA,
+			"action", action,
+			"requested_by", requestedBy,
+			"error", err,
+		)
+		metrics.RecordBaseSchemaFreshnessRejected(ctx, metricActionKey(action), environment, "verification_failed")
+		h.postComment(repo, pr, installationID, templates.RenderBaseSchemaFreshnessRejection(templates.BaseSchemaFreshnessRejectionData{
+			RequestedBy:       requestedBy,
+			Database:          schema.Database,
+			Environment:       environment,
+			SchemaPath:        schema.SchemaPath,
+			VerificationError: true,
+		}))
+		return true
+	}
+	if !changed {
+		return false
+	}
+
+	h.logger.Warn("apply rejected: schema path changed on base branch after PR divergence",
+		"repo", repo,
+		"pr", pr,
+		"environment", environment,
+		"database", schema.Database,
+		"database_type", schema.Type,
+		"schema_path", schema.SchemaPath,
+		"base_sha", prInfo.BaseSHA,
+		"head_sha", prInfo.HeadSHA,
+		"action", action,
+		"requested_by", requestedBy,
+	)
+	metrics.RecordBaseSchemaFreshnessRejected(ctx, metricActionKey(action), environment, "stale")
+	h.postComment(repo, pr, installationID, templates.RenderBaseSchemaFreshnessRejection(templates.BaseSchemaFreshnessRejectionData{
+		RequestedBy: requestedBy,
+		Database:    schema.Database,
+		Environment: environment,
+		SchemaPath:  schema.SchemaPath,
+	}))
+	return true
+}

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -375,7 +375,7 @@ func RenderBaseSchemaFreshnessRejection(data BaseSchemaFreshnessRejectionData) s
 		sb.WriteString("SchemaBot could not verify whether this PR includes the current base branch's schema changes. The apply was rejected to avoid reverting a change that may already be on the base branch.\n\n")
 		sb.WriteString("Retry the command. If verification continues to fail, contact a SchemaBot operator.\n")
 	} else {
-		fmt.Fprintf(&sb, "The schema directory `%s` changed on the base branch after this PR diverged. Applying this branch could revert those newer schema changes.\n\n", data.SchemaPath)
+		fmt.Fprintf(&sb, "The schema directory `%s` on the base branch has changed since this PR diverged. Applying this branch could revert those newer schema changes.\n\n", data.SchemaPath)
 		sb.WriteString("Merge or rebase the current base branch into this PR, review the updated plan, then run `apply` again.\n")
 	}
 

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -375,7 +375,7 @@ func RenderBaseSchemaFreshnessRejection(data BaseSchemaFreshnessRejectionData) s
 		sb.WriteString("SchemaBot could not verify whether this PR includes the current base branch's schema changes. The apply was rejected to avoid reverting a change that may already be on the base branch.\n\n")
 		sb.WriteString("Retry the command. If verification continues to fail, contact a SchemaBot operator.\n")
 	} else {
-		fmt.Fprintf(&sb, "The schema directory `%s` on the base branch has changed since this PR diverged. Applying this branch could revert those newer schema changes.\n\n", data.SchemaPath)
+		fmt.Fprintf(&sb, "The base branch contains newer changes to the schema directory `%s` that are not included in this PR. Applying this branch could revert those changes.\n\n", data.SchemaPath)
 		sb.WriteString("Merge or rebase the current base branch into this PR, review the updated plan, then run `apply` again.\n")
 	}
 

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -352,6 +352,40 @@ func RenderStalePlanRejection(data StalePlanRejectionData) string {
 	return sb.String()
 }
 
+// BaseSchemaFreshnessRejectionData contains data for an apply rejected because
+// the PR does not include the current base branch's schema directory state.
+type BaseSchemaFreshnessRejectionData struct {
+	RequestedBy       string
+	Database          string
+	Environment       string
+	SchemaPath        string
+	VerificationError bool
+}
+
+// RenderBaseSchemaFreshnessRejection renders the path-scoped base freshness
+// rejection. GitHub errors remain server-side; the PR receives fixed guidance
+// that cannot expose infrastructure details.
+func RenderBaseSchemaFreshnessRejection(data BaseSchemaFreshnessRejectionData) string {
+	var sb strings.Builder
+
+	writeEnvironmentTitle(&sb, "⚠️ Apply rejected — base schema is newer", data.Environment)
+	writeDBLine(&sb, data.Database)
+	sb.WriteString("\n")
+	if data.VerificationError {
+		sb.WriteString("SchemaBot could not verify whether this PR includes the current base branch's schema changes. The apply was rejected to avoid reverting a change that may already be on the base branch.\n\n")
+		sb.WriteString("Retry the command. If verification continues to fail, contact a SchemaBot operator.\n")
+	} else {
+		fmt.Fprintf(&sb, "The schema directory `%s` changed on the base branch after this PR diverged. Applying this branch could revert those newer schema changes.\n\n", data.SchemaPath)
+		sb.WriteString("Merge or rebase the current base branch into this PR, review the updated plan, then run `apply` again.\n")
+	}
+
+	if data.RequestedBy != "" {
+		fmt.Fprintf(&sb, "\n_Requested by @%s_\n", data.RequestedBy)
+	}
+
+	return sb.String()
+}
+
 // RenderApplyConfirmNoLock renders a comment when apply-confirm is run without a lock.
 func RenderApplyConfirmNoLock(database, environment string) string {
 	var sb strings.Builder

--- a/pkg/webhook/templates/apply_commands_test.go
+++ b/pkg/webhook/templates/apply_commands_test.go
@@ -29,3 +29,33 @@ func TestRenderPRCommandNotAuthorizedListsPrincipals(t *testing.T) {
 	require.Contains(t, fallback, "A configured SchemaBot admin/database operator must run this command.")
 	require.NotContains(t, fallback, "Who can run this command")
 }
+
+func TestRenderBaseSchemaFreshnessRejection(t *testing.T) {
+	t.Run("stale schema path", func(t *testing.T) {
+		out := RenderBaseSchemaFreshnessRejection(BaseSchemaFreshnessRejectionData{
+			RequestedBy: "alice",
+			Database:    "orders",
+			Environment: "production",
+			SchemaPath:  "schema/orders",
+		})
+
+		require.Contains(t, out, "Apply rejected — base schema is newer")
+		require.Contains(t, out, "`schema/orders`")
+		require.Contains(t, out, "could revert those newer schema changes")
+		require.Contains(t, out, "Merge or rebase")
+		require.Contains(t, out, "@alice")
+	})
+
+	t.Run("verification failure is sanitized", func(t *testing.T) {
+		out := RenderBaseSchemaFreshnessRejection(BaseSchemaFreshnessRejectionData{
+			Database:          "orders",
+			Environment:       "production",
+			SchemaPath:        "schema/orders",
+			VerificationError: true,
+		})
+
+		require.Contains(t, out, "could not verify")
+		require.Contains(t, out, "apply was rejected")
+		require.NotContains(t, out, "schema/orders")
+	})
+}

--- a/pkg/webhook/templates/apply_commands_test.go
+++ b/pkg/webhook/templates/apply_commands_test.go
@@ -41,7 +41,9 @@ func TestRenderBaseSchemaFreshnessRejection(t *testing.T) {
 
 		require.Contains(t, out, "Apply rejected — base schema is newer")
 		require.Contains(t, out, "`schema/orders`")
-		require.Contains(t, out, "could revert those newer schema changes")
+		require.Contains(t, out, "newer changes")
+		require.Contains(t, out, "not included in this PR")
+		require.Contains(t, out, "could revert those changes")
 		require.Contains(t, out, "Merge or rebase")
 		require.Contains(t, out, "@alice")
 	})

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -293,6 +293,17 @@ func PreviewCommentApplyConfirmNoLock() string {
 	return RenderApplyConfirmNoLock("testapp", "staging")
 }
 
+// PreviewCommentBaseSchemaFreshnessRejected renders a sample path-scoped base
+// freshness rejection for a PR that must merge or rebase before applying.
+func PreviewCommentBaseSchemaFreshnessRejected() string {
+	return RenderBaseSchemaFreshnessRejection(BaseSchemaFreshnessRejectionData{
+		RequestedBy: previewRequestedBy,
+		Database:    "testapp",
+		Environment: "production",
+		SchemaPath:  "schema/testapp",
+	})
+}
+
 // PreviewCommentReviewRequired renders a sample "review required" comment.
 func PreviewCommentReviewRequired() string {
 	return RenderReviewRequired(ReviewGateData{


### PR DESCRIPTION
## Why
Two schema pull requests can remain open at the same time. If one applies and merges while the other sits idle, the older PR still describes the schema as it existed before the merge; applying it hours later can unknowingly revert the schema change that already shipped.

Requiring the entire branch to be current would prevent that, but would also unnecessarily block monorepos when only unrelated files changed on the base branch.

## What
- Add an opt-in repository guard that compares only managed schema paths between the PR merge base and current base
- Fail closed on comparison uncertainty and revalidate immediately before durable apply creation
- Preserve superseding apply or rollback lock intent across concurrent commands
- Add rejection comments, metrics, configuration docs, and a rendered preview scenario

### Stale PR scenario

```text
PR 1 (stale)                         PR 2 / main / database

┌──────────────────────┐             ┌──────────────────────┐
│ Opens from schema v1 │             │ Opens from schema v1 │
│ Adds change A        │             │ Adds change B        │
└──────────┬───────────┘             └──────────┬───────────┘
           │ sits idle                          │
           │                                    ▼
           │                         ┌────────────────────────┐
           │                         │ Apply B and merge PR 2 │
           │                         │ Main and DB: v1 + B    │
           │                         └────────────────────────┘
           │
           │ hours later
           ▼
┌────────────────────────┐
│ Apply requested        │
│ PR 1 schema: v1 + A    │
└───────────┬────────────┘
            │
            ▼
┌────────────────────────┐
│ Compare managed path   │
│ Merge base:   v1       │
│ Current base: v1 + B   │
└───────────┬────────────┘
            │ changed
            ▼
┌────────────────────────┐
│ Reject apply           │
│ Require merge/rebase   │
│ Preserve applied B     │
└────────────────────────┘
```

The comparison is scoped to the managed schema path, so unrelated commits merged during those hours do not block PR 1. Rejection cleanup and durable apply creation also match the captured lock intent so a concurrent command cannot bypass the final check.

### Rejection preview

> ## ⚠️ Apply rejected — base schema is newer — Production
>
> **Database**: `testapp`
>
> The base branch contains newer changes to the schema directory `schema/testapp` that are not included in this PR. Applying this branch could revert those changes.
>
> Merge or rebase the current base branch into this PR, review the updated plan, then run `apply` again.
>
> _Requested by @jackjackbits_

## Risk Assessment
Medium — this touches apply safety and lock concurrency, but the base-schema guard is disabled by default and lock-intent checks fail closed.

Generated with Amp