### PR TITLE
fix(github): label an over-estimate row copy "Finalizing copy" instead of "Active"

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -2161,11 +2161,11 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 **Status**: In Progress
 
-📊 1/3 complete · 1 running (Active) · 1 queued
+📊 1/3 complete · 1 running (finalizing copy) · 1 queued
 
 **Schema `testapp`**
 
-**`users`**: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Active
+**`users`**: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Finalizing copy
 
 ```sql
 ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
@@ -7338,7 +7338,7 @@ The following changes will permanently delete data:
 ```
 ⣾ Running...
 
-     ~ users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Active ⠋
+     ~ users: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Finalizing copy ⠋
        ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
        • Rows copied: 145,250,000 so far
        • ℹ️ More rows than initially estimated, copying is still active and will continue

--- a/pkg/cmd/commands/apply.go
+++ b/pkg/cmd/commands/apply.go
@@ -866,7 +866,7 @@ func (e *logEmitter) emitProgressHeartbeat(tbl *apitypes.TableProgressResponse, 
 	kvs := tableKVs("Copying rows", tbl, ts)
 	if ui.EstimateExceeded(tbl.RowsCopied, tbl.RowsTotal) {
 		kvs = append(kvs,
-			"progress", "Active",
+			"progress", "Finalizing copy",
 			"rows_copied", fmt.Sprintf("%s so far", ui.FormatNumber(tbl.RowsCopied)),
 		)
 	} else {

--- a/pkg/cmd/commands/apply_log_test.go
+++ b/pkg/cmd/commands/apply_log_test.go
@@ -280,7 +280,7 @@ func TestLogEmitter_EmitProgressHeartbeat(t *testing.T) {
 		assert.Contains(t, plain, "progress=100%")
 	})
 
-	t.Run("estimate exceeded shows active progress", func(t *testing.T) {
+	t.Run("estimate exceeded shows finalizing copy progress", func(t *testing.T) {
 		e := &logEmitter{}
 		ts := &tableLogState{}
 		tbl := &apitypes.TableProgressResponse{
@@ -295,7 +295,7 @@ func TestLogEmitter_EmitProgressHeartbeat(t *testing.T) {
 		})
 		plain := stripANSI(output)
 
-		assert.Contains(t, plain, "progress=Active")
+		assert.Contains(t, plain, "progress=\"Finalizing copy\"")
 		assert.Contains(t, plain, "rows_copied=\"145,000 so far\"")
 		assert.NotContains(t, plain, "145%")
 		assert.NotContains(t, plain, "100%")

--- a/pkg/cmd/commands/watch_tui_test.go
+++ b/pkg/cmd/commands/watch_tui_test.go
@@ -262,7 +262,7 @@ func TestWatchModel_EstimateExceededUsesActivityLabel(t *testing.T) {
 
 	view := m.View()
 
-	assert.Contains(t, view, ui.ProgressBarActivity()+" Active ⠹")
+	assert.Contains(t, view, ui.ProgressBarActivity()+" Finalizing copy ⠹")
 	assert.Contains(t, view, "Rows copied: 145,000 so far")
 	assert.Contains(t, view, "More rows than initially estimated, copying is still active and will continue")
 	assert.NotContains(t, view, "145%")

--- a/pkg/cmd/commands/watch_tui_view.go
+++ b/pkg/cmd/commands/watch_tui_view.go
@@ -348,7 +348,7 @@ func (m WatchModel) renderTables(b *strings.Builder, tables []tableProgress) {
 
 	activityBar := ui.ProgressBarActivity()
 	activityLabelStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("14"))
-	activityLabel := activityLabelStyle.Render("Active " + activityLabelFrames[m.activityLabelFrame%len(activityLabelFrames)])
+	activityLabel := activityLabelStyle.Render("Finalizing copy " + activityLabelFrames[m.activityLabelFrame%len(activityLabelFrames)])
 	if hasNamespaces {
 		b.WriteString(templates.FormatNamespacedTablesWithActivity(tplTables, activityBar, activityLabel))
 	} else {

--- a/pkg/cmd/internal/templates/progress.go
+++ b/pkg/cmd/internal/templates/progress.go
@@ -231,7 +231,7 @@ func FormatNamespacedTables(tables []TableProgress) string {
 // FormatNamespacedTablesWithActivityBar returns tables grouped by keyspace using
 // the provided activity bar when row-copy progress has exceeded its estimate.
 func FormatNamespacedTablesWithActivityBar(tables []TableProgress, activityBar string) string {
-	return FormatNamespacedTablesWithActivity(tables, activityBar, "Active")
+	return FormatNamespacedTablesWithActivity(tables, activityBar, "Finalizing copy")
 }
 
 // FormatNamespacedTablesWithActivity returns tables grouped by keyspace using
@@ -411,7 +411,7 @@ func FormatTableProgress(t TableProgress) string {
 // FormatTableProgressWithActivityBar returns progress for a single table using
 // the provided activity bar when row-copy progress has exceeded its estimate.
 func FormatTableProgressWithActivityBar(t TableProgress, activityBar string) string {
-	return FormatTableProgressWithActivity(t, activityBar, "Active")
+	return FormatTableProgressWithActivity(t, activityBar, "Finalizing copy")
 }
 
 // FormatTableProgressWithActivity returns progress for a single table using the

--- a/pkg/cmd/internal/templates/progress_states_test.go
+++ b/pkg/cmd/internal/templates/progress_states_test.go
@@ -404,7 +404,7 @@ func TestFormatTableProgress_EstimateExceeded(t *testing.T) {
 		}
 
 		output := FormatTableProgress(tp)
-		assert.Contains(t, output, ui.ProgressBarActivity()+" Active")
+		assert.Contains(t, output, ui.ProgressBarActivity()+" Finalizing copy")
 		assert.Contains(t, output, "Rows copied: 145,000 so far")
 		assert.Contains(t, output, ui.EstimateExceededTooltip)
 		assert.NotContains(t, output, "145%")
@@ -421,7 +421,7 @@ func TestFormatTableProgress_EstimateExceeded(t *testing.T) {
 		}
 
 		output := FormatTableProgress(tp)
-		assert.Contains(t, output, ui.ProgressBarActivity()+" Active")
+		assert.Contains(t, output, ui.ProgressBarActivity()+" Finalizing copy")
 		assert.Contains(t, output, "Rows copied: 145,000 so far")
 		assert.NotContains(t, output, "100%")
 	})

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -451,7 +451,7 @@ func writeProgressSummary(sb *strings.Builder, tables []TableProgressData) {
 			label = fmt.Sprintf("%d running", running)
 		}
 		if runningEstimateExceeded {
-			label += " (Active)"
+			label += " (finalizing copy)"
 		} else if runningPct > 0 {
 			label += fmt.Sprintf(" (%d%%)", runningPct)
 		}
@@ -852,7 +852,7 @@ func isCopyingShardStatus(status string) bool {
 func renderRunningTable(sb *strings.Builder, table TableProgressData) {
 	if table.RowsTotal > 0 {
 		if ui.EstimateExceeded(table.RowsCopied, table.RowsTotal) {
-			fmt.Fprintf(sb, "**`%s`**: %s Active\n", table.TableName, ui.ProgressBarActivity())
+			fmt.Fprintf(sb, "**`%s`**: %s Finalizing copy\n", table.TableName, ui.ProgressBarActivity())
 			writeDDLLine(sb, table.DDL)
 			fmt.Fprintf(sb, "- Rows copied: %s so far\n", ui.FormatNumber(table.RowsCopied))
 			fmt.Fprintf(sb, "- ℹ️ _%s_\n", ui.EstimateExceededTooltip)

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -679,8 +679,8 @@ func TestRenderApplyStatusComment_EstimateExceeded(t *testing.T) {
 
 	result := RenderApplyStatusComment(data)
 
-	assert.Contains(t, result, "1 running (Active)")
-	assert.Contains(t, result, ui.ProgressBarActivity()+" Active")
+	assert.Contains(t, result, "1 running (finalizing copy)")
+	assert.Contains(t, result, ui.ProgressBarActivity()+" Finalizing copy")
 	assert.Contains(t, result, "- Rows copied: 145,000 so far\n- ℹ️ _"+ui.EstimateExceededTooltip+"_")
 	assert.NotContains(t, result, "[ℹ️](##")
 	assert.NotContains(t, result, "<br>")
@@ -1264,8 +1264,8 @@ func TestPreviewCommentApplyEstimateExceeded(t *testing.T) {
 	result := PreviewCommentApplyEstimateExceeded()
 
 	assert.Contains(t, result, "Schema Change Status")
-	assert.Contains(t, result, "1 running (Active)")
-	assert.Contains(t, result, "Active")
+	assert.Contains(t, result, "1 running (finalizing copy)")
+	assert.Contains(t, result, "Finalizing copy")
 	assert.Contains(t, result, "Rows copied: 145,000,000 so far")
 	assert.NotContains(t, result, "145%")
 	assert.NotContains(t, result, "100,000,000 / 100,000,000")


### PR DESCRIPTION
**Why this matters:** When a row copy passes MySQL's initial row estimate, the progress surfaces switch to a full activity bar with no percentage. The "Active" label shown there said nothing about what the apply was actually doing — a reader watching a long apply couldn't tell the copy was past its estimate and finishing up.

**What it does:** Renames the estimate-exceeded activity label from "Active" to "Finalizing copy" on every surface that renders it: the PR comment per-table row, the PR comment summary line (`1 running (finalizing copy)`), the CLI table view, the watch TUI (spinner label), and the CLI log heartbeat (`progress="Finalizing copy"`). The ℹ️ explainer line beneath it is unchanged. All other progress states render byte-identically.

**Example** — PR comment table row after the copy exceeds the estimate:

> **`users`**: 🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦🟦 Finalizing copy
> - Rows copied: 145,000 so far
> - ℹ️ _More rows than initially estimated, copying is still active and will continue_

🤖 Generated with [Claude Code](https://claude.com/claude-code)