### PR TITLE
feat(observability): read through deployment logs

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -587,6 +588,8 @@ type mockTernClient struct {
 	progressResp             *ternv1.ProgressResponse
 	progressErr              error
 	progressReq              *ternv1.ProgressRequest
+	logsReqs                 []*ternv1.LogsRequest
+	logsHook                 func(*ternv1.LogsRequest) (*ternv1.LogsResponse, error)
 	volumeResp               *ternv1.VolumeResponse
 	volumeErr                error
 	volumeReq                *ternv1.VolumeRequest // captured request
@@ -660,6 +663,87 @@ func (m *mockTernClient) Progress(ctx context.Context, req *ternv1.ProgressReque
 	}
 	return nil, m.progressErr
 }
+func (m *mockTernClient) Logs(_ context.Context, req *ternv1.LogsRequest) (*ternv1.LogsResponse, error) {
+	m.logsReqs = append(m.logsReqs, req)
+	if m.logsHook != nil {
+		return m.logsHook(req)
+	}
+	return &ternv1.LogsResponse{}, nil
+}
+
+func TestDeploymentLogEntryRejectsMalformedRecords(t *testing.T) {
+	_, err := deploymentLogEntry("remote-a", &ternv1.ApplyLog{CreatedAt: "not-a-time", MetadataJson: []byte(`{}`)})
+	require.ErrorContains(t, err, "created_at")
+
+	_, err = deploymentLogEntry("remote-a", &ternv1.ApplyLog{CreatedAt: "2026-07-17T01:02:03Z", MetadataJson: []byte(`{`)})
+	require.EqualError(t, err, "remote log metadata is not valid JSON")
+
+	taskID := int64(4)
+	entry, err := deploymentLogEntry("remote-a", &ternv1.ApplyLog{Id: 3, TaskId: &taskID, Level: "info", EventType: "state", Source: "driver", Message: "ready", OldState: "pending", NewState: "running", MetadataJson: []byte(`{"target":"-80"}`), CreatedAt: "2026-07-17T01:02:03.000000004Z"})
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), entry.ID)
+	assert.Equal(t, &taskID, entry.TaskID)
+	assert.JSONEq(t, `{"target":"-80"}`, string(entry.Metadata))
+	assert.Equal(t, time.Date(2026, 7, 17, 1, 2, 3, 4, time.UTC), entry.CreatedAt)
+}
+
+func TestDeploymentLogErrorIsSanitizedAndIncludesProvenance(t *testing.T) {
+	fetch := &deploymentLogFetch{target: "cluster-a", externalID: "remote-a", operations: []*apitypes.LogOperationProvenance{{OperationKey: "commerce/-80/orders", Target: "cluster-a", OperationKind: "work"}}}
+	got := deploymentLogError(fetch, status.Error(codes.Unavailable, "dial secret.example:443"))
+	assert.Equal(t, "RemoteLogReadFailed", got.Code)
+	assert.NotContains(t, got.Message, "secret.example")
+	assert.Equal(t, fetch.operations, got.Operations)
+
+	got = deploymentLogError(fetch, status.Error(codes.Unimplemented, "method Logs not implemented"))
+	assert.Equal(t, "UnsupportedCapability", got.Code)
+	assert.Equal(t, "upgrade_required", got.Reason)
+}
+
+func TestHandleDeploymentLogsFansOutDeduplicatesAndPreservesPartialResults(t *testing.T) {
+	apply := &storage.Apply{ID: 7, ApplyIdentifier: "apply-control", Database: "commerce", DatabaseType: storage.DatabaseTypeStrata, Environment: "staging"}
+	operations := []*storage.ApplyOperation{
+		{ApplyID: apply.ID, Deployment: "region-a", OperationKey: "commerce/-80/orders", OperationKind: storage.ApplyOperationKindWork, Target: "cluster-a", ExternalID: "remote-a", ExternalOperationID: "101"},
+		{ApplyID: apply.ID, Deployment: "region-a", OperationKey: "commerce/-80/customers", OperationKind: storage.ApplyOperationKindWork, Target: "cluster-a", ExternalID: "remote-a", ExternalOperationID: "102"},
+		{ApplyID: apply.ID, Deployment: "region-a", OperationKey: "commerce/80-/orders", OperationKind: storage.ApplyOperationKindWork, Target: "cluster-b", ExternalID: "remote-b", ExternalOperationID: "103"},
+	}
+	client := &mockTernClient{isRemote: true}
+	client.logsHook = func(req *ternv1.LogsRequest) (*ternv1.LogsResponse, error) {
+		if req.ApplyId == "remote-b" {
+			return nil, status.Error(codes.Unavailable, "dial private.example:443")
+		}
+		return &ternv1.LogsResponse{ApplyId: req.ApplyId, Logs: []*ternv1.ApplyLog{{Id: 11, Level: "error", EventType: "engine", Source: "driver", Message: "checksum failed", MetadataJson: []byte(`{"chunk":8}`), CreatedAt: "2026-07-17T01:02:03Z"}}}, nil
+	}
+	service := New(&mockStorageWithApplyStores{
+		applies:    &staticApplyStore{apply: apply},
+		operations: &staticApplyOperationStore{operations: operations},
+	}, testServerConfig(), map[string]tern.Client{"region-a/staging": client}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/logs?apply_id=apply-control&deployment=region-a&limit=25", nil)
+	w := httptest.NewRecorder()
+	service.handleLogsWithoutDatabase(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var response apitypes.DeploymentLogsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.Len(t, client.logsReqs, 2)
+	assert.Equal(t, "remote-a", client.logsReqs[0].ApplyId)
+	assert.Equal(t, "cluster-a", client.logsReqs[0].Target)
+	assert.Equal(t, int32(25), client.logsReqs[0].Limit)
+	assert.Equal(t, "remote-b", client.logsReqs[1].ApplyId)
+	require.Len(t, response.Sources, 1)
+	assert.Equal(t, "remote-a", response.Sources[0].ExternalID)
+	require.Len(t, response.Sources[0].Operations, 2)
+	assert.Equal(t, "commerce/-80/orders", response.Sources[0].Operations[0].OperationKey)
+	assert.NotContains(t, w.Body.String(), "101")
+	assert.NotContains(t, w.Body.String(), "102")
+	require.Len(t, response.Sources[0].Logs, 1)
+	assert.JSONEq(t, `{"chunk":8}`, string(response.Sources[0].Logs[0].Metadata))
+	require.Len(t, response.Errors, 1)
+	assert.Equal(t, "remote-b", response.Errors[0].ExternalID)
+	assert.Equal(t, "RemoteLogReadFailed", response.Errors[0].Code)
+	assert.NotContains(t, w.Body.String(), "private.example")
+}
+
 func (m *mockTernClient) Cutover(ctx context.Context, req *ternv1.CutoverRequest) (*ternv1.CutoverResponse, error) {
 	m.cutoverReq = req
 	if m.cutoverResp != nil {

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -697,6 +697,17 @@ func TestDeploymentLogErrorIsSanitizedAndIncludesProvenance(t *testing.T) {
 	got = deploymentLogError(fetch, status.Error(codes.Unimplemented, "method Logs not implemented"))
 	assert.Equal(t, "UnsupportedCapability", got.Code)
 	assert.Equal(t, "upgrade_required", got.Reason)
+
+	// The gRPC client wraps Unimplemented with upgrade guidance before it
+	// reaches this mapping; detection must see through the wrapping.
+	got = deploymentLogError(fetch, fmt.Errorf("selected data plane does not support log reads; upgrade that data plane: %w", status.Error(codes.Unimplemented, "method Logs not implemented")))
+	assert.Equal(t, "UnsupportedCapability", got.Code)
+	assert.Equal(t, "upgrade_required", got.Reason)
+
+	got = deploymentLogRecordError(fetch)
+	assert.Equal(t, "MalformedRemoteLog", got.Code)
+	assert.Equal(t, "malformed_remote_log", got.Reason)
+	assert.Equal(t, fetch.operations, got.Operations)
 }
 
 func TestHandleDeploymentLogsFansOutDeduplicatesAndPreservesPartialResults(t *testing.T) {
@@ -705,11 +716,16 @@ func TestHandleDeploymentLogsFansOutDeduplicatesAndPreservesPartialResults(t *te
 		{ApplyID: apply.ID, Deployment: "region-a", OperationKey: "commerce/-80/orders", OperationKind: storage.ApplyOperationKindWork, Target: "cluster-a", ExternalID: "remote-a", ExternalOperationID: "101"},
 		{ApplyID: apply.ID, Deployment: "region-a", OperationKey: "commerce/-80/customers", OperationKind: storage.ApplyOperationKindWork, Target: "cluster-a", ExternalID: "remote-a", ExternalOperationID: "102"},
 		{ApplyID: apply.ID, Deployment: "region-a", OperationKey: "commerce/80-/orders", OperationKind: storage.ApplyOperationKindWork, Target: "cluster-b", ExternalID: "remote-b", ExternalOperationID: "103"},
+		{ApplyID: apply.ID, Deployment: "region-a", OperationKey: "commerce/80-/customers", OperationKind: storage.ApplyOperationKindWork, Target: "cluster-c", ExternalID: "remote-c", ExternalOperationID: "104"},
+		{ApplyID: apply.ID, Deployment: "region-a", OperationKey: "commerce/finalize", OperationKind: storage.ApplyOperationKindGroupFinalizer, Target: "cluster-a"},
 	}
 	client := &mockTernClient{isRemote: true}
 	client.logsHook = func(req *ternv1.LogsRequest) (*ternv1.LogsResponse, error) {
-		if req.ApplyId == "remote-b" {
+		switch req.ApplyId {
+		case "remote-b":
 			return nil, status.Error(codes.Unavailable, "dial private.example:443")
+		case "remote-c":
+			return &ternv1.LogsResponse{ApplyId: req.ApplyId, Logs: []*ternv1.ApplyLog{{Id: 12, Level: "info", Message: "bad clock", CreatedAt: "not-a-time"}}}, nil
 		}
 		return &ternv1.LogsResponse{ApplyId: req.ApplyId, Logs: []*ternv1.ApplyLog{{Id: 11, Level: "error", EventType: "engine", Source: "driver", Message: "checksum failed", MetadataJson: []byte(`{"chunk":8}`), CreatedAt: "2026-07-17T01:02:03Z"}}}, nil
 	}
@@ -725,11 +741,12 @@ func TestHandleDeploymentLogsFansOutDeduplicatesAndPreservesPartialResults(t *te
 	require.Equal(t, http.StatusOK, w.Code)
 	var response apitypes.DeploymentLogsResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
-	require.Len(t, client.logsReqs, 2)
+	require.Len(t, client.logsReqs, 3)
 	assert.Equal(t, "remote-a", client.logsReqs[0].ApplyId)
 	assert.Equal(t, "cluster-a", client.logsReqs[0].Target)
 	assert.Equal(t, int32(25), client.logsReqs[0].Limit)
 	assert.Equal(t, "remote-b", client.logsReqs[1].ApplyId)
+	assert.Equal(t, "remote-c", client.logsReqs[2].ApplyId)
 	require.Len(t, response.Sources, 1)
 	assert.Equal(t, "remote-a", response.Sources[0].ExternalID)
 	require.Len(t, response.Sources[0].Operations, 2)
@@ -738,10 +755,13 @@ func TestHandleDeploymentLogsFansOutDeduplicatesAndPreservesPartialResults(t *te
 	assert.NotContains(t, w.Body.String(), "102")
 	require.Len(t, response.Sources[0].Logs, 1)
 	assert.JSONEq(t, `{"chunk":8}`, string(response.Sources[0].Logs[0].Metadata))
-	require.Len(t, response.Errors, 1)
+	require.Len(t, response.Errors, 2)
 	assert.Equal(t, "remote-b", response.Errors[0].ExternalID)
 	assert.Equal(t, "RemoteLogReadFailed", response.Errors[0].Code)
+	assert.Equal(t, "remote-c", response.Errors[1].ExternalID)
+	assert.Equal(t, "MalformedRemoteLog", response.Errors[1].Code)
 	assert.NotContains(t, w.Body.String(), "private.example")
+	assert.NotContains(t, w.Body.String(), "not-a-time")
 }
 
 func (m *mockTernClient) Cutover(ctx context.Context, req *ternv1.CutoverRequest) (*ternv1.CutoverResponse, error) {

--- a/pkg/api/log_handlers.go
+++ b/pkg/api/log_handlers.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"sort"
 	"strconv"
@@ -152,6 +153,7 @@ type deploymentLogFetch struct {
 func (s *Service) handleDeploymentLogs(w http.ResponseWriter, r *http.Request, apply *storage.Apply, deployment string, limit int) {
 	ops, err := s.storage.ApplyOperations().ListByApply(r.Context(), apply.ID)
 	if err != nil {
+		s.logger.Error("failed to list apply operations for data-plane logs", append(apply.LogAttrs(), "operation", "read_deployment_logs", "operation_deployment", deployment, "error", err)...)
 		s.writeError(w, http.StatusInternalServerError, "failed to list apply operations")
 		return
 	}
@@ -163,6 +165,9 @@ func (s *Service) handleDeploymentLogs(w http.ResponseWriter, r *http.Request, a
 		}
 		matched = true
 		if op.ExternalID == "" {
+			// An operation without a remote apply id ran on the control plane;
+			// its logs live in control-plane storage, not behind this fan-out.
+			s.logger.Debug("skipping operation without a remote apply id for data-plane logs", append(apply.LogAttrs(), "operation", "read_deployment_logs", "operation_deployment", deployment, "operation_key", op.OperationKey, "target", op.Target)...)
 			continue
 		}
 		key := op.Target + "\x00" + op.ExternalID
@@ -197,9 +202,10 @@ func (s *Service) handleDeploymentLogs(w http.ResponseWriter, r *http.Request, a
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
+	requestLimit := int32(min(int64(limit), math.MaxInt32))
 	for _, key := range keys {
 		fetch := fetches[key]
-		resp, fetchErr := client.Logs(r.Context(), &ternv1.LogsRequest{ApplyId: fetch.externalID, Target: fetch.target, Database: apply.Database, Type: apply.DatabaseType, Environment: apply.Environment, Limit: int32(limit)})
+		resp, fetchErr := client.Logs(r.Context(), &ternv1.LogsRequest{ApplyId: fetch.externalID, Target: fetch.target, Database: apply.Database, Type: apply.DatabaseType, Environment: apply.Environment, Limit: requestLimit})
 		if fetchErr != nil {
 			s.recordDeploymentLogFailure(apply, deployment, fetch, fetchErr)
 			result.Errors = append(result.Errors, deploymentLogError(fetch, fetchErr))
@@ -210,7 +216,7 @@ func (s *Service) handleDeploymentLogs(w http.ResponseWriter, r *http.Request, a
 			entry, convertErr := deploymentLogEntry(fetch.externalID, log)
 			if convertErr != nil {
 				s.recordDeploymentLogFailure(apply, deployment, fetch, convertErr)
-				result.Errors = append(result.Errors, deploymentLogError(fetch, convertErr))
+				result.Errors = append(result.Errors, deploymentLogRecordError(fetch))
 				source = nil
 				break
 			}
@@ -246,6 +252,13 @@ func deploymentLogError(fetch *deploymentLogFetch, err error) *apitypes.Deployme
 		result.Message = "The selected data plane does not support log reads; upgrade it and retry."
 	}
 	return result
+}
+
+// deploymentLogRecordError reports a source whose log records could not be
+// decoded. Unlike a transport failure, retrying cannot help — the data plane
+// returned records the control plane does not understand.
+func deploymentLogRecordError(fetch *deploymentLogFetch) *apitypes.DeploymentLogError {
+	return &apitypes.DeploymentLogError{ExternalID: fetch.externalID, Target: fetch.target, Operations: fetch.operations, Code: "MalformedRemoteLog", Reason: "malformed_remote_log", Message: "The data plane returned log records SchemaBot could not decode; check server logs."}
 }
 
 func (s *Service) recordDeploymentLogFailure(apply *storage.Apply, deployment string, fetch *deploymentLogFetch, err error) {

--- a/pkg/api/log_handlers.go
+++ b/pkg/api/log_handlers.go
@@ -1,10 +1,18 @@
 package api
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
+	"time"
 
+	"github.com/block/schemabot/pkg/apitypes"
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/storage"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // handleLogs returns apply logs for a database or apply.
@@ -15,13 +23,14 @@ func (s *Service) handleLogs(w http.ResponseWriter, r *http.Request) {
 	environment := r.URL.Query().Get("environment")
 	applyID := r.URL.Query().Get("apply_id")
 	limitStr := r.URL.Query().Get("limit")
+	deployment := r.URL.Query().Get("deployment")
 
 	if database == "" {
 		s.writeError(w, http.StatusBadRequest, "database is required")
 		return
 	}
 
-	s.handleLogsCommon(w, r, database, environment, applyID, limitStr)
+	s.handleLogsCommon(w, r, database, environment, applyID, deployment, limitStr)
 }
 
 // handleLogsWithoutDatabase returns apply logs for a specific apply ID.
@@ -29,23 +38,28 @@ func (s *Service) handleLogs(w http.ResponseWriter, r *http.Request) {
 func (s *Service) handleLogsWithoutDatabase(w http.ResponseWriter, r *http.Request) {
 	applyID := r.URL.Query().Get("apply_id")
 	limitStr := r.URL.Query().Get("limit")
+	deployment := r.URL.Query().Get("deployment")
 
 	if applyID == "" {
 		s.writeError(w, http.StatusBadRequest, "apply_id is required")
 		return
 	}
 
-	s.handleLogsCommon(w, r, "", "", applyID, limitStr)
+	s.handleLogsCommon(w, r, "", "", applyID, deployment, limitStr)
 }
 
 // handleLogsCommon is the shared implementation for log handlers.
-func (s *Service) handleLogsCommon(w http.ResponseWriter, r *http.Request, database, environment, applyID, limitStr string) {
+func (s *Service) handleLogsCommon(w http.ResponseWriter, r *http.Request, database, environment, applyID, deployment, limitStr string) {
 
 	limit := 50
 	if limitStr != "" {
 		if l, err := strconv.Atoi(limitStr); err == nil && l > 0 {
 			limit = l
 		}
+	}
+	if deployment != "" && applyID == "" {
+		s.writeError(w, http.StatusBadRequest, "deployment requires an explicit apply_id")
+		return
 	}
 
 	var apply *storage.Apply
@@ -85,6 +99,10 @@ func (s *Service) handleLogsCommon(w http.ResponseWriter, r *http.Request, datab
 		}
 		apply = applies[0]
 	}
+	if deployment != "" {
+		s.handleDeploymentLogs(w, r, apply, deployment, limit)
+		return
+	}
 
 	logs, err := s.storage.ApplyLogs().List(r.Context(), storage.ApplyLogFilter{
 		ApplyID: apply.ID,
@@ -123,4 +141,113 @@ func (s *Service) handleLogsCommon(w http.ResponseWriter, r *http.Request, datab
 		"logs":     logEntries,
 		"apply_id": apply.ApplyIdentifier,
 	})
+}
+
+type deploymentLogFetch struct {
+	target     string
+	externalID string
+	operations []*apitypes.LogOperationProvenance
+}
+
+func (s *Service) handleDeploymentLogs(w http.ResponseWriter, r *http.Request, apply *storage.Apply, deployment string, limit int) {
+	ops, err := s.storage.ApplyOperations().ListByApply(r.Context(), apply.ID)
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, "failed to list apply operations")
+		return
+	}
+	fetches := make(map[string]*deploymentLogFetch)
+	matched := false
+	for _, op := range ops {
+		if op.Deployment != deployment {
+			continue
+		}
+		matched = true
+		if op.ExternalID == "" {
+			continue
+		}
+		key := op.Target + "\x00" + op.ExternalID
+		fetch := fetches[key]
+		if fetch == nil {
+			fetch = &deploymentLogFetch{target: op.Target, externalID: op.ExternalID}
+			fetches[key] = fetch
+		}
+		fetch.operations = append(fetch.operations, &apitypes.LogOperationProvenance{OperationKey: op.OperationKey, Target: op.Target, OperationKind: op.OperationKind})
+	}
+	if !matched {
+		s.writeError(w, http.StatusBadRequest, fmt.Sprintf("deployment %q has no operations for apply %q", deployment, apply.ApplyIdentifier))
+		return
+	}
+	if len(fetches) == 0 {
+		s.writeError(w, http.StatusBadRequest, fmt.Sprintf("deployment %q has no remote operation logs; omit --deployment to read control-plane logs", deployment))
+		return
+	}
+	client, err := s.TernClient(deployment, apply.Environment)
+	if err != nil {
+		s.writeError(w, http.StatusBadRequest, fmt.Sprintf("cannot resolve deployment %q: %v", deployment, err))
+		return
+	}
+	if !client.IsRemote() {
+		s.writeError(w, http.StatusBadRequest, fmt.Sprintf("deployment %q is local-only; omit --deployment to read control-plane logs", deployment))
+		return
+	}
+	result := &apitypes.DeploymentLogsResponse{ApplyID: apply.ApplyIdentifier, Deployment: deployment, Sources: []*apitypes.DeploymentLogSource{}, Errors: []*apitypes.DeploymentLogError{}}
+	keys := make([]string, 0, len(fetches))
+	for key := range fetches {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		fetch := fetches[key]
+		resp, fetchErr := client.Logs(r.Context(), &ternv1.LogsRequest{ApplyId: fetch.externalID, Target: fetch.target, Database: apply.Database, Type: apply.DatabaseType, Environment: apply.Environment, Limit: int32(limit)})
+		if fetchErr != nil {
+			s.recordDeploymentLogFailure(apply, deployment, fetch, fetchErr)
+			result.Errors = append(result.Errors, deploymentLogError(fetch, fetchErr))
+			continue
+		}
+		source := &apitypes.DeploymentLogSource{ExternalID: fetch.externalID, Operations: fetch.operations, Logs: []*apitypes.LogEntry{}}
+		for _, log := range resp.Logs {
+			entry, convertErr := deploymentLogEntry(fetch.externalID, log)
+			if convertErr != nil {
+				s.recordDeploymentLogFailure(apply, deployment, fetch, convertErr)
+				result.Errors = append(result.Errors, deploymentLogError(fetch, convertErr))
+				source = nil
+				break
+			}
+			source.Logs = append(source.Logs, entry)
+		}
+		if source != nil {
+			result.Sources = append(result.Sources, source)
+		}
+	}
+	s.writeJSON(w, http.StatusOK, result)
+}
+
+func deploymentLogEntry(applyID string, log *ternv1.ApplyLog) (*apitypes.LogEntry, error) {
+	createdAt, err := time.Parse(time.RFC3339Nano, log.CreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("parse remote log created_at: %w", err)
+	}
+	var metadata json.RawMessage
+	if len(log.MetadataJson) > 0 {
+		if !json.Valid(log.MetadataJson) {
+			return nil, fmt.Errorf("remote log metadata is not valid JSON")
+		}
+		metadata = append(metadata, log.MetadataJson...)
+	}
+	return &apitypes.LogEntry{ID: log.Id, ApplyID: applyID, TaskID: log.TaskId, Level: log.Level, EventType: log.EventType, Source: log.Source, Message: log.Message, OldState: log.OldState, NewState: log.NewState, Metadata: metadata, CreatedAt: createdAt}, nil
+}
+
+func deploymentLogError(fetch *deploymentLogFetch, err error) *apitypes.DeploymentLogError {
+	result := &apitypes.DeploymentLogError{ExternalID: fetch.externalID, Target: fetch.target, Operations: fetch.operations, Code: "RemoteLogReadFailed", Reason: "remote_log_read_failed", Message: "Data-plane logs could not be read; check server logs and retry."}
+	if status.Code(err) == codes.Unimplemented {
+		result.Code = "UnsupportedCapability"
+		result.Reason = "upgrade_required"
+		result.Message = "The selected data plane does not support log reads; upgrade it and retry."
+	}
+	return result
+}
+
+func (s *Service) recordDeploymentLogFailure(apply *storage.Apply, deployment string, fetch *deploymentLogFetch, err error) {
+	attrs := append(apply.LogAttrs(), "operation", "read_deployment_logs", "operation_deployment", deployment, "target", fetch.target, "external_id", fetch.externalID, "error", err)
+	s.logger.Error("failed to read data-plane logs", attrs...)
 }

--- a/pkg/api/log_handlers.go
+++ b/pkg/api/log_handlers.go
@@ -183,7 +183,8 @@ func (s *Service) handleDeploymentLogs(w http.ResponseWriter, r *http.Request, a
 	}
 	client, err := s.TernClient(deployment, apply.Environment)
 	if err != nil {
-		s.writeError(w, http.StatusBadRequest, fmt.Sprintf("cannot resolve deployment %q: %v", deployment, err))
+		s.logger.Error("failed to resolve deployment for data-plane logs", append(apply.LogAttrs(), "operation", "read_deployment_logs", "operation_deployment", deployment, "error", err)...)
+		s.writeError(w, http.StatusBadRequest, fmt.Sprintf("cannot resolve deployment %q; check server logs", deployment))
 		return
 	}
 	if !client.IsRemote() {

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -3,7 +3,58 @@
 // This package has zero dependencies — import it freely from any package.
 package apitypes
 
-import "strings"
+import (
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+type LogEntry struct {
+	ID        int64           `json:"id"`
+	ApplyID   string          `json:"apply_id"`
+	TaskID    *int64          `json:"task_id,omitempty"`
+	Level     string          `json:"level"`
+	EventType string          `json:"event_type"`
+	Source    string          `json:"source,omitempty"`
+	Message   string          `json:"message"`
+	OldState  string          `json:"old_state,omitempty"`
+	NewState  string          `json:"new_state,omitempty"`
+	Metadata  json.RawMessage `json:"metadata,omitempty"`
+	CreatedAt time.Time       `json:"created_at"`
+}
+
+type LogsResponse struct {
+	ApplyID string      `json:"apply_id,omitempty"`
+	Logs    []*LogEntry `json:"logs"`
+}
+
+type DeploymentLogsResponse struct {
+	ApplyID    string                 `json:"apply_id"`
+	Deployment string                 `json:"deployment"`
+	Sources    []*DeploymentLogSource `json:"sources"`
+	Errors     []*DeploymentLogError  `json:"errors"`
+}
+
+type DeploymentLogSource struct {
+	ExternalID string                    `json:"external_id"`
+	Operations []*LogOperationProvenance `json:"operations"`
+	Logs       []*LogEntry               `json:"logs"`
+}
+
+type LogOperationProvenance struct {
+	OperationKey  string `json:"operation_key,omitempty"`
+	Target        string `json:"target,omitempty"`
+	OperationKind string `json:"operation_kind,omitempty"`
+}
+
+type DeploymentLogError struct {
+	ExternalID string                    `json:"external_id,omitempty"`
+	Target     string                    `json:"target,omitempty"`
+	Operations []*LogOperationProvenance `json:"operations"`
+	Code       string                    `json:"code"`
+	Reason     string                    `json:"reason"`
+	Message    string                    `json:"message"`
+}
 
 // =============================================================================
 // Error Codes

--- a/pkg/cmd/client/client.go
+++ b/pkg/cmd/client/client.go
@@ -596,18 +596,7 @@ func GetStatus(endpoint string, opts ...StatusOptions) (*apitypes.StatusResponse
 	return &result, nil
 }
 
-// LogEntry represents a single log entry from the apply logs.
-type LogEntry struct {
-	ID        int64     `json:"id"`
-	ApplyID   string    `json:"apply_id"`
-	TaskID    *int64    `json:"task_id,omitempty"`
-	Level     string    `json:"level"`
-	EventType string    `json:"event_type"`
-	Message   string    `json:"message"`
-	OldState  string    `json:"old_state,omitempty"`
-	NewState  string    `json:"new_state,omitempty"`
-	CreatedAt time.Time `json:"created_at"`
-}
+type LogEntry = apitypes.LogEntry
 
 // GetLogs retrieves apply logs for a database.
 // If applyID is provided, it fetches logs for that specific apply.
@@ -617,19 +606,23 @@ func GetLogs(endpoint, database, environment, applyID string, limit int) ([]*Log
 		return nil, fmt.Errorf("database or apply_id is required")
 	}
 
-	var path string
-	if database == "" && applyID != "" {
-		path = fmt.Sprintf("/api/logs?apply_id=%s", applyID)
-	} else {
-		path = fmt.Sprintf("/api/logs/%s?", database)
-		if applyID != "" {
-			path += fmt.Sprintf("apply_id=%s", applyID)
-		} else if environment != "" {
-			path += fmt.Sprintf("environment=%s", environment)
-		}
+	values := url.Values{}
+	if applyID != "" {
+		values.Set("apply_id", applyID)
+	} else if environment != "" {
+		values.Set("environment", environment)
 	}
 	if limit > 0 {
-		path += fmt.Sprintf("&limit=%d", limit)
+		values.Set("limit", strconv.Itoa(limit))
+	}
+	var path string
+	if database == "" && applyID != "" {
+		path = "/api/logs"
+	} else {
+		path = "/api/logs/" + url.PathEscape(database)
+	}
+	if encoded := values.Encode(); encoded != "" {
+		path += "?" + encoded
 	}
 
 	var result struct {
@@ -639,6 +632,20 @@ func GetLogs(endpoint, database, environment, applyID string, limit int) ([]*Log
 		return nil, err
 	}
 	return result.Logs, nil
+}
+
+func GetDeploymentLogs(endpoint, applyID, deployment string, limit int) (*apitypes.DeploymentLogsResponse, error) {
+	values := url.Values{}
+	values.Set("apply_id", applyID)
+	values.Set("deployment", deployment)
+	if limit > 0 {
+		values.Set("limit", strconv.Itoa(limit))
+	}
+	var result apitypes.DeploymentLogsResponse
+	if err := doGetInto(endpoint, "/api/logs?"+values.Encode(), &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // Setting represents a key-value setting.

--- a/pkg/cmd/client/client_test.go
+++ b/pkg/cmd/client/client_test.go
@@ -50,6 +50,28 @@ func TestCallPullSchemaAPI(t *testing.T) {
 	assert.Equal(t, "CREATE TABLE `users` (`id` bigint NOT NULL);\n", result.Namespaces["orders"].Tables["users"])
 }
 
+func TestLogRequestQueryValuesAreEncoded(t *testing.T) {
+	var requests []*http.Request
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Clone(t.Context()))
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"logs":[],"sources":[],"errors":[]}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := GetLogs(server.URL, "", "", "apply/a & b", 17)
+	require.NoError(t, err)
+	_, err = GetDeploymentLogs(server.URL, "apply/a & b", "data plane/one", 23)
+	require.NoError(t, err)
+	require.Len(t, requests, 2)
+	assert.Equal(t, "apply/a & b", requests[0].URL.Query().Get("apply_id"))
+	assert.Equal(t, "17", requests[0].URL.Query().Get("limit"))
+	assert.Equal(t, "apply/a & b", requests[1].URL.Query().Get("apply_id"))
+	assert.Equal(t, "data plane/one", requests[1].URL.Query().Get("deployment"))
+	assert.Equal(t, "23", requests[1].URL.Query().Get("limit"))
+}
+
 func TestCallPullSchemaAPIError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)

--- a/pkg/cmd/commands/logs.go
+++ b/pkg/cmd/commands/logs.go
@@ -97,8 +97,10 @@ func deploymentLogSourceLabel(target string, operations []*apitypes.LogOperation
 		target = operations[0].Target
 	}
 	parts := []string{target}
+	seenKinds := make(map[string]bool)
 	for _, op := range operations {
-		if op.OperationKind != "" {
+		if op.OperationKind != "" && !seenKinds[op.OperationKind] {
+			seenKinds[op.OperationKind] = true
 			parts = append(parts, op.OperationKind)
 		}
 	}

--- a/pkg/cmd/commands/logs.go
+++ b/pkg/cmd/commands/logs.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/cmd/client"
 	"github.com/block/schemabot/pkg/cmd/internal/templates"
 	webhooktemplates "github.com/block/schemabot/pkg/webhook/templates"
@@ -18,6 +19,8 @@ type LogsCmd struct {
 	ApplyID     string `short:"a" help:"Apply ID (e.g., apply_abc123)" name:"apply-id"`
 	Limit       int    `short:"n" help:"Number of log entries to show" default:"50"`
 	Follow      bool   `short:"f" help:"Follow logs in real-time"`
+	Deployment  string `help:"Read logs from the selected data-plane deployment"`
+	JSON        bool   `help:"Output as JSON"`
 }
 
 // Run executes the logs command.
@@ -36,6 +39,12 @@ func (cmd *LogsCmd) Run(g *Globals) error {
 			return fmt.Errorf("--environment is required (or provide an apply_id)")
 		}
 	}
+	if cmd.Deployment != "" && cmd.ApplyID == "" {
+		return fmt.Errorf("--deployment requires an explicit apply_id")
+	}
+	if cmd.Deployment != "" && cmd.Follow {
+		return fmt.Errorf("--deployment is incompatible with --follow")
+	}
 
 	ep, err := resolveEndpoint(g.Endpoint, g.Profile)
 	if err != nil {
@@ -45,20 +54,73 @@ func (cmd *LogsCmd) Run(g *Globals) error {
 	if cmd.Follow {
 		return followLogs(ep, cmd.Database, cmd.Environment, cmd.ApplyID)
 	}
+	if cmd.Deployment != "" {
+		return showDeploymentLogs(ep, cmd.ApplyID, cmd.Deployment, cmd.Limit, cmd.JSON)
+	}
 
-	return showLogs(ep, cmd.Database, cmd.Environment, cmd.ApplyID, cmd.Limit)
+	return showLogs(ep, cmd.Database, cmd.Environment, cmd.ApplyID, cmd.Limit, cmd.JSON)
+}
+
+func showDeploymentLogs(endpoint, applyID, deployment string, limit int, outputJSON bool) error {
+	var result *apitypes.DeploymentLogsResponse
+	err := withLoading("Loading data-plane logs...", !outputJSON, func() error {
+		var loadErr error
+		result, loadErr = client.GetDeploymentLogs(endpoint, applyID, deployment, limit)
+		return loadErr
+	})
+	if err != nil {
+		return err
+	}
+	if outputJSON {
+		return writeJSON(result)
+	}
+	if len(result.Sources) == 0 {
+		fmt.Println("No data-plane logs found.")
+	}
+	for i, source := range result.Sources {
+		if len(result.Sources) > 1 {
+			fmt.Printf("%s%s%s\n", templates.ANSIDim, deploymentLogSourceLabel("", source.Operations, source.ExternalID), templates.ANSIReset)
+		}
+		printLogs(source.Logs)
+		if i+1 < len(result.Sources) {
+			fmt.Println()
+		}
+	}
+	for _, sourceErr := range result.Errors {
+		fmt.Printf("Warning: %s: %s\n", deploymentLogSourceLabel(sourceErr.Target, sourceErr.Operations, sourceErr.ExternalID), sourceErr.Message)
+	}
+	return nil
+}
+
+func deploymentLogSourceLabel(target string, operations []*apitypes.LogOperationProvenance, externalID string) string {
+	if target == "" && len(operations) > 0 {
+		target = operations[0].Target
+	}
+	parts := []string{target}
+	for _, op := range operations {
+		if op.OperationKind != "" {
+			parts = append(parts, op.OperationKind)
+		}
+	}
+	if len(parts) == 1 && parts[0] == "" {
+		return externalID
+	}
+	return strings.Join(parts, " / ") + " (" + externalID + ")"
 }
 
 // showLogs displays logs once and exits.
-func showLogs(endpoint, database, environment, applyID string, limit int) error {
+func showLogs(endpoint, database, environment, applyID string, limit int, outputJSON bool) error {
 	var logs []*client.LogEntry
-	err := withLoading("Loading logs...", true, func() error {
+	err := withLoading("Loading logs...", !outputJSON, func() error {
 		var loadErr error
 		logs, loadErr = client.GetLogs(endpoint, database, environment, applyID, limit)
 		return loadErr
 	})
 	if err != nil {
 		return err
+	}
+	if outputJSON {
+		return writeJSON(&apitypes.LogsResponse{ApplyID: applyID, Logs: logs})
 	}
 
 	if len(logs) == 0 {

--- a/pkg/cmd/commands/logs_test.go
+++ b/pkg/cmd/commands/logs_test.go
@@ -1,0 +1,15 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogsCommandDeploymentValidation(t *testing.T) {
+	err := (&LogsCmd{Deployment: "data-plane", Database: "orders", Environment: "production"}).Run(&Globals{})
+	require.EqualError(t, err, "--deployment requires an explicit apply_id")
+
+	err = (&LogsCmd{Deployment: "data-plane", ApplyID: "apply-a", Follow: true}).Run(&Globals{})
+	require.EqualError(t, err, "--deployment is incompatible with --follow")
+}

--- a/pkg/proto/tern.proto
+++ b/pkg/proto/tern.proto
@@ -114,6 +114,14 @@ service Tern {
     };
   }
 
+  // Logs returns a bounded recent window of durable apply logs. It is read-only.
+  rpc Logs(LogsRequest) returns (LogsResponse) {
+    option (google.api.http) = {
+      post: "/v1/logs"
+      body: "*"
+    };
+  }
+
   // Cutover triggers the table swap phase for a schema change that was started
   // with defer_cutover=true. Only valid when state is waiting_for_cutover.
   //
@@ -545,6 +553,33 @@ message ProgressRequest {
   string apply_id = 1;
   // Environment: "staging" or "production".
   string environment = 2;
+}
+
+message LogsRequest {
+  string apply_id = 1;
+  string target = 2;
+  string database = 3;
+  string type = 4;
+  string environment = 5;
+  int32 limit = 6;
+}
+
+message ApplyLog {
+  int64 id = 1;
+  optional int64 task_id = 2;
+  string level = 3;
+  string event_type = 4;
+  string source = 5;
+  string message = 6;
+  string old_state = 7;
+  string new_state = 8;
+  bytes metadata_json = 9;
+  string created_at = 10;
+}
+
+message LogsResponse {
+  string apply_id = 1;
+  repeated ApplyLog logs = 2;
 }
 
 // ShardProgress contains progress information for a single Vitess shard.

--- a/pkg/proto/ternv1/tern.pb.go
+++ b/pkg/proto/ternv1/tern.pb.go
@@ -1879,6 +1879,258 @@ func (x *ProgressRequest) GetEnvironment() string {
 	return ""
 }
 
+type LogsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ApplyId       string                 `protobuf:"bytes,1,opt,name=apply_id,json=applyId,proto3" json:"apply_id,omitempty"`
+	Target        string                 `protobuf:"bytes,2,opt,name=target,proto3" json:"target,omitempty"`
+	Database      string                 `protobuf:"bytes,3,opt,name=database,proto3" json:"database,omitempty"`
+	Type          string                 `protobuf:"bytes,4,opt,name=type,proto3" json:"type,omitempty"`
+	Environment   string                 `protobuf:"bytes,5,opt,name=environment,proto3" json:"environment,omitempty"`
+	Limit         int32                  `protobuf:"varint,6,opt,name=limit,proto3" json:"limit,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LogsRequest) Reset() {
+	*x = LogsRequest{}
+	mi := &file_tern_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LogsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LogsRequest) ProtoMessage() {}
+
+func (x *LogsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_tern_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LogsRequest.ProtoReflect.Descriptor instead.
+func (*LogsRequest) Descriptor() ([]byte, []int) {
+	return file_tern_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *LogsRequest) GetApplyId() string {
+	if x != nil {
+		return x.ApplyId
+	}
+	return ""
+}
+
+func (x *LogsRequest) GetTarget() string {
+	if x != nil {
+		return x.Target
+	}
+	return ""
+}
+
+func (x *LogsRequest) GetDatabase() string {
+	if x != nil {
+		return x.Database
+	}
+	return ""
+}
+
+func (x *LogsRequest) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *LogsRequest) GetEnvironment() string {
+	if x != nil {
+		return x.Environment
+	}
+	return ""
+}
+
+func (x *LogsRequest) GetLimit() int32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+type ApplyLog struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	TaskId        *int64                 `protobuf:"varint,2,opt,name=task_id,json=taskId,proto3,oneof" json:"task_id,omitempty"`
+	Level         string                 `protobuf:"bytes,3,opt,name=level,proto3" json:"level,omitempty"`
+	EventType     string                 `protobuf:"bytes,4,opt,name=event_type,json=eventType,proto3" json:"event_type,omitempty"`
+	Source        string                 `protobuf:"bytes,5,opt,name=source,proto3" json:"source,omitempty"`
+	Message       string                 `protobuf:"bytes,6,opt,name=message,proto3" json:"message,omitempty"`
+	OldState      string                 `protobuf:"bytes,7,opt,name=old_state,json=oldState,proto3" json:"old_state,omitempty"`
+	NewState      string                 `protobuf:"bytes,8,opt,name=new_state,json=newState,proto3" json:"new_state,omitempty"`
+	MetadataJson  []byte                 `protobuf:"bytes,9,opt,name=metadata_json,json=metadataJson,proto3" json:"metadata_json,omitempty"`
+	CreatedAt     string                 `protobuf:"bytes,10,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ApplyLog) Reset() {
+	*x = ApplyLog{}
+	mi := &file_tern_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ApplyLog) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ApplyLog) ProtoMessage() {}
+
+func (x *ApplyLog) ProtoReflect() protoreflect.Message {
+	mi := &file_tern_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ApplyLog.ProtoReflect.Descriptor instead.
+func (*ApplyLog) Descriptor() ([]byte, []int) {
+	return file_tern_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *ApplyLog) GetId() int64 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+func (x *ApplyLog) GetTaskId() int64 {
+	if x != nil && x.TaskId != nil {
+		return *x.TaskId
+	}
+	return 0
+}
+
+func (x *ApplyLog) GetLevel() string {
+	if x != nil {
+		return x.Level
+	}
+	return ""
+}
+
+func (x *ApplyLog) GetEventType() string {
+	if x != nil {
+		return x.EventType
+	}
+	return ""
+}
+
+func (x *ApplyLog) GetSource() string {
+	if x != nil {
+		return x.Source
+	}
+	return ""
+}
+
+func (x *ApplyLog) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *ApplyLog) GetOldState() string {
+	if x != nil {
+		return x.OldState
+	}
+	return ""
+}
+
+func (x *ApplyLog) GetNewState() string {
+	if x != nil {
+		return x.NewState
+	}
+	return ""
+}
+
+func (x *ApplyLog) GetMetadataJson() []byte {
+	if x != nil {
+		return x.MetadataJson
+	}
+	return nil
+}
+
+func (x *ApplyLog) GetCreatedAt() string {
+	if x != nil {
+		return x.CreatedAt
+	}
+	return ""
+}
+
+type LogsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ApplyId       string                 `protobuf:"bytes,1,opt,name=apply_id,json=applyId,proto3" json:"apply_id,omitempty"`
+	Logs          []*ApplyLog            `protobuf:"bytes,2,rep,name=logs,proto3" json:"logs,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LogsResponse) Reset() {
+	*x = LogsResponse{}
+	mi := &file_tern_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LogsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LogsResponse) ProtoMessage() {}
+
+func (x *LogsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_tern_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LogsResponse.ProtoReflect.Descriptor instead.
+func (*LogsResponse) Descriptor() ([]byte, []int) {
+	return file_tern_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *LogsResponse) GetApplyId() string {
+	if x != nil {
+		return x.ApplyId
+	}
+	return ""
+}
+
+func (x *LogsResponse) GetLogs() []*ApplyLog {
+	if x != nil {
+		return x.Logs
+	}
+	return nil
+}
+
 // ShardProgress contains progress information for a single Vitess shard.
 type ShardProgress struct {
 	state              protoimpl.MessageState `protogen:"open.v1"`
@@ -1896,7 +2148,7 @@ type ShardProgress struct {
 
 func (x *ShardProgress) Reset() {
 	*x = ShardProgress{}
-	mi := &file_tern_proto_msgTypes[19]
+	mi := &file_tern_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1908,7 +2160,7 @@ func (x *ShardProgress) String() string {
 func (*ShardProgress) ProtoMessage() {}
 
 func (x *ShardProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[19]
+	mi := &file_tern_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1921,7 +2173,7 @@ func (x *ShardProgress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShardProgress.ProtoReflect.Descriptor instead.
 func (*ShardProgress) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{19}
+	return file_tern_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *ShardProgress) GetShard() string {
@@ -2006,7 +2258,7 @@ type TableProgress struct {
 
 func (x *TableProgress) Reset() {
 	*x = TableProgress{}
-	mi := &file_tern_proto_msgTypes[20]
+	mi := &file_tern_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2018,7 +2270,7 @@ func (x *TableProgress) String() string {
 func (*TableProgress) ProtoMessage() {}
 
 func (x *TableProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[20]
+	mi := &file_tern_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2031,7 +2283,7 @@ func (x *TableProgress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TableProgress.ProtoReflect.Descriptor instead.
 func (*TableProgress) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{20}
+	return file_tern_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *TableProgress) GetTaskId() string {
@@ -2158,7 +2410,7 @@ type ProgressResponse struct {
 
 func (x *ProgressResponse) Reset() {
 	*x = ProgressResponse{}
-	mi := &file_tern_proto_msgTypes[21]
+	mi := &file_tern_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2170,7 +2422,7 @@ func (x *ProgressResponse) String() string {
 func (*ProgressResponse) ProtoMessage() {}
 
 func (x *ProgressResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[21]
+	mi := &file_tern_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2183,7 +2435,7 @@ func (x *ProgressResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProgressResponse.ProtoReflect.Descriptor instead.
 func (*ProgressResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{21}
+	return file_tern_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *ProgressResponse) GetApplyId() string {
@@ -2269,7 +2521,7 @@ type CutoverRequest struct {
 
 func (x *CutoverRequest) Reset() {
 	*x = CutoverRequest{}
-	mi := &file_tern_proto_msgTypes[22]
+	mi := &file_tern_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2281,7 +2533,7 @@ func (x *CutoverRequest) String() string {
 func (*CutoverRequest) ProtoMessage() {}
 
 func (x *CutoverRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[22]
+	mi := &file_tern_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2294,7 +2546,7 @@ func (x *CutoverRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CutoverRequest.ProtoReflect.Descriptor instead.
 func (*CutoverRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{22}
+	return file_tern_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *CutoverRequest) GetApplyId() string {
@@ -2322,7 +2574,7 @@ type CutoverResponse struct {
 
 func (x *CutoverResponse) Reset() {
 	*x = CutoverResponse{}
-	mi := &file_tern_proto_msgTypes[23]
+	mi := &file_tern_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2334,7 +2586,7 @@ func (x *CutoverResponse) String() string {
 func (*CutoverResponse) ProtoMessage() {}
 
 func (x *CutoverResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[23]
+	mi := &file_tern_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2347,7 +2599,7 @@ func (x *CutoverResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CutoverResponse.ProtoReflect.Descriptor instead.
 func (*CutoverResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{23}
+	return file_tern_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *CutoverResponse) GetAccepted() bool {
@@ -2377,7 +2629,7 @@ type RevertRequest struct {
 
 func (x *RevertRequest) Reset() {
 	*x = RevertRequest{}
-	mi := &file_tern_proto_msgTypes[24]
+	mi := &file_tern_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2389,7 +2641,7 @@ func (x *RevertRequest) String() string {
 func (*RevertRequest) ProtoMessage() {}
 
 func (x *RevertRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[24]
+	mi := &file_tern_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2402,7 +2654,7 @@ func (x *RevertRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevertRequest.ProtoReflect.Descriptor instead.
 func (*RevertRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{24}
+	return file_tern_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *RevertRequest) GetApplyId() string {
@@ -2430,7 +2682,7 @@ type RevertResponse struct {
 
 func (x *RevertResponse) Reset() {
 	*x = RevertResponse{}
-	mi := &file_tern_proto_msgTypes[25]
+	mi := &file_tern_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2442,7 +2694,7 @@ func (x *RevertResponse) String() string {
 func (*RevertResponse) ProtoMessage() {}
 
 func (x *RevertResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[25]
+	mi := &file_tern_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2455,7 +2707,7 @@ func (x *RevertResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevertResponse.ProtoReflect.Descriptor instead.
 func (*RevertResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{25}
+	return file_tern_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *RevertResponse) GetAccepted() bool {
@@ -2485,7 +2737,7 @@ type SkipRevertRequest struct {
 
 func (x *SkipRevertRequest) Reset() {
 	*x = SkipRevertRequest{}
-	mi := &file_tern_proto_msgTypes[26]
+	mi := &file_tern_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2497,7 +2749,7 @@ func (x *SkipRevertRequest) String() string {
 func (*SkipRevertRequest) ProtoMessage() {}
 
 func (x *SkipRevertRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[26]
+	mi := &file_tern_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2510,7 +2762,7 @@ func (x *SkipRevertRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SkipRevertRequest.ProtoReflect.Descriptor instead.
 func (*SkipRevertRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{26}
+	return file_tern_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *SkipRevertRequest) GetApplyId() string {
@@ -2538,7 +2790,7 @@ type SkipRevertResponse struct {
 
 func (x *SkipRevertResponse) Reset() {
 	*x = SkipRevertResponse{}
-	mi := &file_tern_proto_msgTypes[27]
+	mi := &file_tern_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2550,7 +2802,7 @@ func (x *SkipRevertResponse) String() string {
 func (*SkipRevertResponse) ProtoMessage() {}
 
 func (x *SkipRevertResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[27]
+	mi := &file_tern_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2563,7 +2815,7 @@ func (x *SkipRevertResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SkipRevertResponse.ProtoReflect.Descriptor instead.
 func (*SkipRevertResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{27}
+	return file_tern_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *SkipRevertResponse) GetAccepted() bool {
@@ -2589,7 +2841,7 @@ type HealthRequest struct {
 
 func (x *HealthRequest) Reset() {
 	*x = HealthRequest{}
-	mi := &file_tern_proto_msgTypes[28]
+	mi := &file_tern_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2601,7 +2853,7 @@ func (x *HealthRequest) String() string {
 func (*HealthRequest) ProtoMessage() {}
 
 func (x *HealthRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[28]
+	mi := &file_tern_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2614,7 +2866,7 @@ func (x *HealthRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthRequest.ProtoReflect.Descriptor instead.
 func (*HealthRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{28}
+	return file_tern_proto_rawDescGZIP(), []int{31}
 }
 
 // HealthResponse is the health check response.
@@ -2627,7 +2879,7 @@ type HealthResponse struct {
 
 func (x *HealthResponse) Reset() {
 	*x = HealthResponse{}
-	mi := &file_tern_proto_msgTypes[29]
+	mi := &file_tern_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2639,7 +2891,7 @@ func (x *HealthResponse) String() string {
 func (*HealthResponse) ProtoMessage() {}
 
 func (x *HealthResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[29]
+	mi := &file_tern_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2652,7 +2904,7 @@ func (x *HealthResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthResponse.ProtoReflect.Descriptor instead.
 func (*HealthResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{29}
+	return file_tern_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *HealthResponse) GetStatus() string {
@@ -2675,7 +2927,7 @@ type StopRequest struct {
 
 func (x *StopRequest) Reset() {
 	*x = StopRequest{}
-	mi := &file_tern_proto_msgTypes[30]
+	mi := &file_tern_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2687,7 +2939,7 @@ func (x *StopRequest) String() string {
 func (*StopRequest) ProtoMessage() {}
 
 func (x *StopRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[30]
+	mi := &file_tern_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2700,7 +2952,7 @@ func (x *StopRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopRequest.ProtoReflect.Descriptor instead.
 func (*StopRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{30}
+	return file_tern_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *StopRequest) GetApplyId() string {
@@ -2734,7 +2986,7 @@ type StopResponse struct {
 
 func (x *StopResponse) Reset() {
 	*x = StopResponse{}
-	mi := &file_tern_proto_msgTypes[31]
+	mi := &file_tern_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2746,7 +2998,7 @@ func (x *StopResponse) String() string {
 func (*StopResponse) ProtoMessage() {}
 
 func (x *StopResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[31]
+	mi := &file_tern_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2759,7 +3011,7 @@ func (x *StopResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopResponse.ProtoReflect.Descriptor instead.
 func (*StopResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{31}
+	return file_tern_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *StopResponse) GetAccepted() bool {
@@ -2810,7 +3062,7 @@ type CancelRequest struct {
 
 func (x *CancelRequest) Reset() {
 	*x = CancelRequest{}
-	mi := &file_tern_proto_msgTypes[32]
+	mi := &file_tern_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2822,7 +3074,7 @@ func (x *CancelRequest) String() string {
 func (*CancelRequest) ProtoMessage() {}
 
 func (x *CancelRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[32]
+	mi := &file_tern_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2835,7 +3087,7 @@ func (x *CancelRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelRequest.ProtoReflect.Descriptor instead.
 func (*CancelRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{32}
+	return file_tern_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *CancelRequest) GetApplyId() string {
@@ -2867,7 +3119,7 @@ type CancelResponse struct {
 
 func (x *CancelResponse) Reset() {
 	*x = CancelResponse{}
-	mi := &file_tern_proto_msgTypes[33]
+	mi := &file_tern_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2879,7 +3131,7 @@ func (x *CancelResponse) String() string {
 func (*CancelResponse) ProtoMessage() {}
 
 func (x *CancelResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[33]
+	mi := &file_tern_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2892,7 +3144,7 @@ func (x *CancelResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelResponse.ProtoReflect.Descriptor instead.
 func (*CancelResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{33}
+	return file_tern_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *CancelResponse) GetAccepted() bool {
@@ -2936,7 +3188,7 @@ type StartRequest struct {
 
 func (x *StartRequest) Reset() {
 	*x = StartRequest{}
-	mi := &file_tern_proto_msgTypes[34]
+	mi := &file_tern_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2948,7 +3200,7 @@ func (x *StartRequest) String() string {
 func (*StartRequest) ProtoMessage() {}
 
 func (x *StartRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[34]
+	mi := &file_tern_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2961,7 +3213,7 @@ func (x *StartRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartRequest.ProtoReflect.Descriptor instead.
 func (*StartRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{34}
+	return file_tern_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *StartRequest) GetApplyId() string {
@@ -2993,7 +3245,7 @@ type StartResponse struct {
 
 func (x *StartResponse) Reset() {
 	*x = StartResponse{}
-	mi := &file_tern_proto_msgTypes[35]
+	mi := &file_tern_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3005,7 +3257,7 @@ func (x *StartResponse) String() string {
 func (*StartResponse) ProtoMessage() {}
 
 func (x *StartResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[35]
+	mi := &file_tern_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3018,7 +3270,7 @@ func (x *StartResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartResponse.ProtoReflect.Descriptor instead.
 func (*StartResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{35}
+	return file_tern_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *StartResponse) GetAccepted() bool {
@@ -3064,7 +3316,7 @@ type VolumeRequest struct {
 
 func (x *VolumeRequest) Reset() {
 	*x = VolumeRequest{}
-	mi := &file_tern_proto_msgTypes[36]
+	mi := &file_tern_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3076,7 +3328,7 @@ func (x *VolumeRequest) String() string {
 func (*VolumeRequest) ProtoMessage() {}
 
 func (x *VolumeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[36]
+	mi := &file_tern_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3089,7 +3341,7 @@ func (x *VolumeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VolumeRequest.ProtoReflect.Descriptor instead.
 func (*VolumeRequest) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{36}
+	return file_tern_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *VolumeRequest) GetApplyId() string {
@@ -3128,7 +3380,7 @@ type VolumeResponse struct {
 
 func (x *VolumeResponse) Reset() {
 	*x = VolumeResponse{}
-	mi := &file_tern_proto_msgTypes[37]
+	mi := &file_tern_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3140,7 +3392,7 @@ func (x *VolumeResponse) String() string {
 func (*VolumeResponse) ProtoMessage() {}
 
 func (x *VolumeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tern_proto_msgTypes[37]
+	mi := &file_tern_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3153,7 +3405,7 @@ func (x *VolumeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VolumeResponse.ProtoReflect.Descriptor instead.
 func (*VolumeResponse) Descriptor() ([]byte, []int) {
-	return file_tern_proto_rawDescGZIP(), []int{37}
+	return file_tern_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *VolumeResponse) GetAccepted() bool {
@@ -3352,7 +3604,33 @@ const file_tern_proto_rawDesc = "" +
 	"\x12apply_operation_id\x18\x04 \x01(\tR\x10applyOperationId\"N\n" +
 	"\x0fProgressRequest\x12\x19\n" +
 	"\bapply_id\x18\x01 \x01(\tR\aapplyId\x12 \n" +
-	"\venvironment\x18\x02 \x01(\tR\venvironment\"\xa7\x02\n" +
+	"\venvironment\x18\x02 \x01(\tR\venvironment\"\xa8\x01\n" +
+	"\vLogsRequest\x12\x19\n" +
+	"\bapply_id\x18\x01 \x01(\tR\aapplyId\x12\x16\n" +
+	"\x06target\x18\x02 \x01(\tR\x06target\x12\x1a\n" +
+	"\bdatabase\x18\x03 \x01(\tR\bdatabase\x12\x12\n" +
+	"\x04type\x18\x04 \x01(\tR\x04type\x12 \n" +
+	"\venvironment\x18\x05 \x01(\tR\venvironment\x12\x14\n" +
+	"\x05limit\x18\x06 \x01(\x05R\x05limit\"\xa9\x02\n" +
+	"\bApplyLog\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x1c\n" +
+	"\atask_id\x18\x02 \x01(\x03H\x00R\x06taskId\x88\x01\x01\x12\x14\n" +
+	"\x05level\x18\x03 \x01(\tR\x05level\x12\x1d\n" +
+	"\n" +
+	"event_type\x18\x04 \x01(\tR\teventType\x12\x16\n" +
+	"\x06source\x18\x05 \x01(\tR\x06source\x12\x18\n" +
+	"\amessage\x18\x06 \x01(\tR\amessage\x12\x1b\n" +
+	"\told_state\x18\a \x01(\tR\boldState\x12\x1b\n" +
+	"\tnew_state\x18\b \x01(\tR\bnewState\x12#\n" +
+	"\rmetadata_json\x18\t \x01(\fR\fmetadataJson\x12\x1d\n" +
+	"\n" +
+	"created_at\x18\n" +
+	" \x01(\tR\tcreatedAtB\n" +
+	"\n" +
+	"\b_task_id\"P\n" +
+	"\fLogsResponse\x12\x19\n" +
+	"\bapply_id\x18\x01 \x01(\tR\aapplyId\x12%\n" +
+	"\x04logs\x18\x02 \x03(\v2\x11.tern.v1.ApplyLogR\x04logs\"\xa7\x02\n" +
 	"\rShardProgress\x12\x14\n" +
 	"\x05shard\x18\x01 \x01(\tR\x05shard\x12\x16\n" +
 	"\x06status\x18\x02 \x01(\tR\x06status\x12\x1f\n" +
@@ -3494,14 +3772,15 @@ const file_tern_proto_rawDesc = "" +
 	"\x13CHANGE_TYPE_VSCHEMA\x10\x04*T\n" +
 	"\x11PullCatalogDetail\x12\x1d\n" +
 	"\x19PULL_CATALOG_DETAIL_BASIC\x10\x00\x12 \n" +
-	"\x1cPULL_CATALOG_DETAIL_DETAILED\x10\x012\xc8\b\n" +
+	"\x1cPULL_CATALOG_DETAIL_DETAILED\x10\x012\x92\t\n" +
 	"\x04Tern\x12a\n" +
 	"\n" +
 	"PullSchema\x12\x1a.tern.v1.PullSchemaRequest\x1a\x1b.tern.v1.PullSchemaResponse\"\x1a\x82\xd3\xe4\x93\x02\x14:\x01*\"\x0f/v1/pull-schema\x12H\n" +
 	"\x04Plan\x12\x14.tern.v1.PlanRequest\x1a\x15.tern.v1.PlanResponse\"\x13\x82\xd3\xe4\x93\x02\r:\x01*\"\b/v1/plan\x12U\n" +
 	"\bPlanDiff\x12\x14.tern.v1.PlanRequest\x1a\x19.tern.v1.PlanDiffResponse\"\x18\x82\xd3\xe4\x93\x02\x12:\x01*\"\r/v1/plan-diff\x12L\n" +
 	"\x05Apply\x12\x15.tern.v1.ApplyRequest\x1a\x16.tern.v1.ApplyResponse\"\x14\x82\xd3\xe4\x93\x02\x0e:\x01*\"\t/v1/apply\x12X\n" +
-	"\bProgress\x12\x18.tern.v1.ProgressRequest\x1a\x19.tern.v1.ProgressResponse\"\x17\x82\xd3\xe4\x93\x02\x11:\x01*\"\f/v1/progress\x12T\n" +
+	"\bProgress\x12\x18.tern.v1.ProgressRequest\x1a\x19.tern.v1.ProgressResponse\"\x17\x82\xd3\xe4\x93\x02\x11:\x01*\"\f/v1/progress\x12H\n" +
+	"\x04Logs\x12\x14.tern.v1.LogsRequest\x1a\x15.tern.v1.LogsResponse\"\x13\x82\xd3\xe4\x93\x02\r:\x01*\"\b/v1/logs\x12T\n" +
 	"\aCutover\x12\x17.tern.v1.CutoverRequest\x1a\x18.tern.v1.CutoverResponse\"\x16\x82\xd3\xe4\x93\x02\x10:\x01*\"\v/v1/cutover\x12P\n" +
 	"\x06Revert\x12\x16.tern.v1.RevertRequest\x1a\x17.tern.v1.RevertResponse\"\x15\x82\xd3\xe4\x93\x02\x0f:\x01*\"\n" +
 	"/v1/revert\x12a\n" +
@@ -3529,7 +3808,7 @@ func file_tern_proto_rawDescGZIP() []byte {
 }
 
 var file_tern_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_tern_proto_msgTypes = make([]protoimpl.MessageInfo, 49)
+var file_tern_proto_msgTypes = make([]protoimpl.MessageInfo, 52)
 var file_tern_proto_goTypes = []any{
 	(Engine)(0),                // 0: tern.v1.Engine
 	(State)(0),                 // 1: tern.v1.State
@@ -3554,53 +3833,56 @@ var file_tern_proto_goTypes = []any{
 	(*ApplyRequest)(nil),       // 20: tern.v1.ApplyRequest
 	(*ApplyResponse)(nil),      // 21: tern.v1.ApplyResponse
 	(*ProgressRequest)(nil),    // 22: tern.v1.ProgressRequest
-	(*ShardProgress)(nil),      // 23: tern.v1.ShardProgress
-	(*TableProgress)(nil),      // 24: tern.v1.TableProgress
-	(*ProgressResponse)(nil),   // 25: tern.v1.ProgressResponse
-	(*CutoverRequest)(nil),     // 26: tern.v1.CutoverRequest
-	(*CutoverResponse)(nil),    // 27: tern.v1.CutoverResponse
-	(*RevertRequest)(nil),      // 28: tern.v1.RevertRequest
-	(*RevertResponse)(nil),     // 29: tern.v1.RevertResponse
-	(*SkipRevertRequest)(nil),  // 30: tern.v1.SkipRevertRequest
-	(*SkipRevertResponse)(nil), // 31: tern.v1.SkipRevertResponse
-	(*HealthRequest)(nil),      // 32: tern.v1.HealthRequest
-	(*HealthResponse)(nil),     // 33: tern.v1.HealthResponse
-	(*StopRequest)(nil),        // 34: tern.v1.StopRequest
-	(*StopResponse)(nil),       // 35: tern.v1.StopResponse
-	(*CancelRequest)(nil),      // 36: tern.v1.CancelRequest
-	(*CancelResponse)(nil),     // 37: tern.v1.CancelResponse
-	(*StartRequest)(nil),       // 38: tern.v1.StartRequest
-	(*StartResponse)(nil),      // 39: tern.v1.StartResponse
-	(*VolumeRequest)(nil),      // 40: tern.v1.VolumeRequest
-	(*VolumeResponse)(nil),     // 41: tern.v1.VolumeResponse
-	nil,                        // 42: tern.v1.SchemaFiles.FilesEntry
-	nil,                        // 43: tern.v1.PulledNamespace.TablesEntry
-	nil,                        // 44: tern.v1.PulledNamespace.ArtifactsEntry
-	nil,                        // 45: tern.v1.PulledNamespace.TableCatalogEntry
-	nil,                        // 46: tern.v1.PullSchemaResponse.NamespacesEntry
-	nil,                        // 47: tern.v1.PlanRequest.SchemaFilesEntry
-	nil,                        // 48: tern.v1.SchemaChange.MetadataEntry
-	nil,                        // 49: tern.v1.SchemaChange.OriginalFilesEntry
-	nil,                        // 50: tern.v1.ApplyRequest.OptionsEntry
-	nil,                        // 51: tern.v1.ApplyRequest.SchemaFilesEntry
-	nil,                        // 52: tern.v1.ProgressResponse.MetadataEntry
+	(*LogsRequest)(nil),        // 23: tern.v1.LogsRequest
+	(*ApplyLog)(nil),           // 24: tern.v1.ApplyLog
+	(*LogsResponse)(nil),       // 25: tern.v1.LogsResponse
+	(*ShardProgress)(nil),      // 26: tern.v1.ShardProgress
+	(*TableProgress)(nil),      // 27: tern.v1.TableProgress
+	(*ProgressResponse)(nil),   // 28: tern.v1.ProgressResponse
+	(*CutoverRequest)(nil),     // 29: tern.v1.CutoverRequest
+	(*CutoverResponse)(nil),    // 30: tern.v1.CutoverResponse
+	(*RevertRequest)(nil),      // 31: tern.v1.RevertRequest
+	(*RevertResponse)(nil),     // 32: tern.v1.RevertResponse
+	(*SkipRevertRequest)(nil),  // 33: tern.v1.SkipRevertRequest
+	(*SkipRevertResponse)(nil), // 34: tern.v1.SkipRevertResponse
+	(*HealthRequest)(nil),      // 35: tern.v1.HealthRequest
+	(*HealthResponse)(nil),     // 36: tern.v1.HealthResponse
+	(*StopRequest)(nil),        // 37: tern.v1.StopRequest
+	(*StopResponse)(nil),       // 38: tern.v1.StopResponse
+	(*CancelRequest)(nil),      // 39: tern.v1.CancelRequest
+	(*CancelResponse)(nil),     // 40: tern.v1.CancelResponse
+	(*StartRequest)(nil),       // 41: tern.v1.StartRequest
+	(*StartResponse)(nil),      // 42: tern.v1.StartResponse
+	(*VolumeRequest)(nil),      // 43: tern.v1.VolumeRequest
+	(*VolumeResponse)(nil),     // 44: tern.v1.VolumeResponse
+	nil,                        // 45: tern.v1.SchemaFiles.FilesEntry
+	nil,                        // 46: tern.v1.PulledNamespace.TablesEntry
+	nil,                        // 47: tern.v1.PulledNamespace.ArtifactsEntry
+	nil,                        // 48: tern.v1.PulledNamespace.TableCatalogEntry
+	nil,                        // 49: tern.v1.PullSchemaResponse.NamespacesEntry
+	nil,                        // 50: tern.v1.PlanRequest.SchemaFilesEntry
+	nil,                        // 51: tern.v1.SchemaChange.MetadataEntry
+	nil,                        // 52: tern.v1.SchemaChange.OriginalFilesEntry
+	nil,                        // 53: tern.v1.ApplyRequest.OptionsEntry
+	nil,                        // 54: tern.v1.ApplyRequest.SchemaFilesEntry
+	nil,                        // 55: tern.v1.ProgressResponse.MetadataEntry
 }
 var file_tern_proto_depIdxs = []int32{
-	42, // 0: tern.v1.SchemaFiles.files:type_name -> tern.v1.SchemaFiles.FilesEntry
+	45, // 0: tern.v1.SchemaFiles.files:type_name -> tern.v1.SchemaFiles.FilesEntry
 	3,  // 1: tern.v1.PullSchemaRequest.catalog_detail:type_name -> tern.v1.PullCatalogDetail
-	43, // 2: tern.v1.PulledNamespace.tables:type_name -> tern.v1.PulledNamespace.TablesEntry
-	44, // 3: tern.v1.PulledNamespace.artifacts:type_name -> tern.v1.PulledNamespace.ArtifactsEntry
+	46, // 2: tern.v1.PulledNamespace.tables:type_name -> tern.v1.PulledNamespace.TablesEntry
+	47, // 3: tern.v1.PulledNamespace.artifacts:type_name -> tern.v1.PulledNamespace.ArtifactsEntry
 	7,  // 4: tern.v1.PulledNamespace.namespace_catalog:type_name -> tern.v1.NamespaceCatalog
-	45, // 5: tern.v1.PulledNamespace.table_catalog:type_name -> tern.v1.PulledNamespace.TableCatalogEntry
+	48, // 5: tern.v1.PulledNamespace.table_catalog:type_name -> tern.v1.PulledNamespace.TableCatalogEntry
 	9,  // 6: tern.v1.TableCatalog.columns:type_name -> tern.v1.ColumnCatalog
 	10, // 7: tern.v1.TableCatalog.indexes:type_name -> tern.v1.IndexCatalog
 	11, // 8: tern.v1.TableCatalog.foreign_keys:type_name -> tern.v1.ForeignKeyCatalog
-	46, // 9: tern.v1.PullSchemaResponse.namespaces:type_name -> tern.v1.PullSchemaResponse.NamespacesEntry
-	47, // 10: tern.v1.PlanRequest.schema_files:type_name -> tern.v1.PlanRequest.SchemaFilesEntry
+	49, // 9: tern.v1.PullSchemaResponse.namespaces:type_name -> tern.v1.PullSchemaResponse.NamespacesEntry
+	50, // 10: tern.v1.PlanRequest.schema_files:type_name -> tern.v1.PlanRequest.SchemaFilesEntry
 	2,  // 11: tern.v1.TableChange.change_type:type_name -> tern.v1.ChangeType
 	14, // 12: tern.v1.SchemaChange.table_changes:type_name -> tern.v1.TableChange
-	48, // 13: tern.v1.SchemaChange.metadata:type_name -> tern.v1.SchemaChange.MetadataEntry
-	49, // 14: tern.v1.SchemaChange.original_files:type_name -> tern.v1.SchemaChange.OriginalFilesEntry
+	51, // 13: tern.v1.SchemaChange.metadata:type_name -> tern.v1.SchemaChange.MetadataEntry
+	52, // 14: tern.v1.SchemaChange.original_files:type_name -> tern.v1.SchemaChange.OriginalFilesEntry
 	14, // 15: tern.v1.ShardPlan.changes:type_name -> tern.v1.TableChange
 	0,  // 16: tern.v1.PlanResponse.engine:type_name -> tern.v1.Engine
 	15, // 17: tern.v1.PlanResponse.changes:type_name -> tern.v1.SchemaChange
@@ -3610,50 +3892,53 @@ var file_tern_proto_depIdxs = []int32{
 	15, // 21: tern.v1.PlanDiffResponse.changes:type_name -> tern.v1.SchemaChange
 	16, // 22: tern.v1.PlanDiffResponse.lint_violations:type_name -> tern.v1.LintViolation
 	17, // 23: tern.v1.PlanDiffResponse.shards:type_name -> tern.v1.ShardPlan
-	50, // 24: tern.v1.ApplyRequest.options:type_name -> tern.v1.ApplyRequest.OptionsEntry
-	51, // 25: tern.v1.ApplyRequest.schema_files:type_name -> tern.v1.ApplyRequest.SchemaFilesEntry
+	53, // 24: tern.v1.ApplyRequest.options:type_name -> tern.v1.ApplyRequest.OptionsEntry
+	54, // 25: tern.v1.ApplyRequest.schema_files:type_name -> tern.v1.ApplyRequest.SchemaFilesEntry
 	14, // 26: tern.v1.ApplyRequest.ddl_changes:type_name -> tern.v1.TableChange
-	23, // 27: tern.v1.TableProgress.shards:type_name -> tern.v1.ShardProgress
-	2,  // 28: tern.v1.TableProgress.change_type:type_name -> tern.v1.ChangeType
-	1,  // 29: tern.v1.ProgressResponse.state:type_name -> tern.v1.State
-	0,  // 30: tern.v1.ProgressResponse.engine:type_name -> tern.v1.Engine
-	24, // 31: tern.v1.ProgressResponse.tables:type_name -> tern.v1.TableProgress
-	52, // 32: tern.v1.ProgressResponse.metadata:type_name -> tern.v1.ProgressResponse.MetadataEntry
-	8,  // 33: tern.v1.PulledNamespace.TableCatalogEntry.value:type_name -> tern.v1.TableCatalog
-	6,  // 34: tern.v1.PullSchemaResponse.NamespacesEntry.value:type_name -> tern.v1.PulledNamespace
-	4,  // 35: tern.v1.PlanRequest.SchemaFilesEntry.value:type_name -> tern.v1.SchemaFiles
-	4,  // 36: tern.v1.ApplyRequest.SchemaFilesEntry.value:type_name -> tern.v1.SchemaFiles
-	5,  // 37: tern.v1.Tern.PullSchema:input_type -> tern.v1.PullSchemaRequest
-	13, // 38: tern.v1.Tern.Plan:input_type -> tern.v1.PlanRequest
-	13, // 39: tern.v1.Tern.PlanDiff:input_type -> tern.v1.PlanRequest
-	20, // 40: tern.v1.Tern.Apply:input_type -> tern.v1.ApplyRequest
-	22, // 41: tern.v1.Tern.Progress:input_type -> tern.v1.ProgressRequest
-	26, // 42: tern.v1.Tern.Cutover:input_type -> tern.v1.CutoverRequest
-	28, // 43: tern.v1.Tern.Revert:input_type -> tern.v1.RevertRequest
-	30, // 44: tern.v1.Tern.SkipRevert:input_type -> tern.v1.SkipRevertRequest
-	32, // 45: tern.v1.Tern.Health:input_type -> tern.v1.HealthRequest
-	34, // 46: tern.v1.Tern.Stop:input_type -> tern.v1.StopRequest
-	36, // 47: tern.v1.Tern.Cancel:input_type -> tern.v1.CancelRequest
-	38, // 48: tern.v1.Tern.Start:input_type -> tern.v1.StartRequest
-	40, // 49: tern.v1.Tern.Volume:input_type -> tern.v1.VolumeRequest
-	12, // 50: tern.v1.Tern.PullSchema:output_type -> tern.v1.PullSchemaResponse
-	18, // 51: tern.v1.Tern.Plan:output_type -> tern.v1.PlanResponse
-	19, // 52: tern.v1.Tern.PlanDiff:output_type -> tern.v1.PlanDiffResponse
-	21, // 53: tern.v1.Tern.Apply:output_type -> tern.v1.ApplyResponse
-	25, // 54: tern.v1.Tern.Progress:output_type -> tern.v1.ProgressResponse
-	27, // 55: tern.v1.Tern.Cutover:output_type -> tern.v1.CutoverResponse
-	29, // 56: tern.v1.Tern.Revert:output_type -> tern.v1.RevertResponse
-	31, // 57: tern.v1.Tern.SkipRevert:output_type -> tern.v1.SkipRevertResponse
-	33, // 58: tern.v1.Tern.Health:output_type -> tern.v1.HealthResponse
-	35, // 59: tern.v1.Tern.Stop:output_type -> tern.v1.StopResponse
-	37, // 60: tern.v1.Tern.Cancel:output_type -> tern.v1.CancelResponse
-	39, // 61: tern.v1.Tern.Start:output_type -> tern.v1.StartResponse
-	41, // 62: tern.v1.Tern.Volume:output_type -> tern.v1.VolumeResponse
-	50, // [50:63] is the sub-list for method output_type
-	37, // [37:50] is the sub-list for method input_type
-	37, // [37:37] is the sub-list for extension type_name
-	37, // [37:37] is the sub-list for extension extendee
-	0,  // [0:37] is the sub-list for field type_name
+	24, // 27: tern.v1.LogsResponse.logs:type_name -> tern.v1.ApplyLog
+	26, // 28: tern.v1.TableProgress.shards:type_name -> tern.v1.ShardProgress
+	2,  // 29: tern.v1.TableProgress.change_type:type_name -> tern.v1.ChangeType
+	1,  // 30: tern.v1.ProgressResponse.state:type_name -> tern.v1.State
+	0,  // 31: tern.v1.ProgressResponse.engine:type_name -> tern.v1.Engine
+	27, // 32: tern.v1.ProgressResponse.tables:type_name -> tern.v1.TableProgress
+	55, // 33: tern.v1.ProgressResponse.metadata:type_name -> tern.v1.ProgressResponse.MetadataEntry
+	8,  // 34: tern.v1.PulledNamespace.TableCatalogEntry.value:type_name -> tern.v1.TableCatalog
+	6,  // 35: tern.v1.PullSchemaResponse.NamespacesEntry.value:type_name -> tern.v1.PulledNamespace
+	4,  // 36: tern.v1.PlanRequest.SchemaFilesEntry.value:type_name -> tern.v1.SchemaFiles
+	4,  // 37: tern.v1.ApplyRequest.SchemaFilesEntry.value:type_name -> tern.v1.SchemaFiles
+	5,  // 38: tern.v1.Tern.PullSchema:input_type -> tern.v1.PullSchemaRequest
+	13, // 39: tern.v1.Tern.Plan:input_type -> tern.v1.PlanRequest
+	13, // 40: tern.v1.Tern.PlanDiff:input_type -> tern.v1.PlanRequest
+	20, // 41: tern.v1.Tern.Apply:input_type -> tern.v1.ApplyRequest
+	22, // 42: tern.v1.Tern.Progress:input_type -> tern.v1.ProgressRequest
+	23, // 43: tern.v1.Tern.Logs:input_type -> tern.v1.LogsRequest
+	29, // 44: tern.v1.Tern.Cutover:input_type -> tern.v1.CutoverRequest
+	31, // 45: tern.v1.Tern.Revert:input_type -> tern.v1.RevertRequest
+	33, // 46: tern.v1.Tern.SkipRevert:input_type -> tern.v1.SkipRevertRequest
+	35, // 47: tern.v1.Tern.Health:input_type -> tern.v1.HealthRequest
+	37, // 48: tern.v1.Tern.Stop:input_type -> tern.v1.StopRequest
+	39, // 49: tern.v1.Tern.Cancel:input_type -> tern.v1.CancelRequest
+	41, // 50: tern.v1.Tern.Start:input_type -> tern.v1.StartRequest
+	43, // 51: tern.v1.Tern.Volume:input_type -> tern.v1.VolumeRequest
+	12, // 52: tern.v1.Tern.PullSchema:output_type -> tern.v1.PullSchemaResponse
+	18, // 53: tern.v1.Tern.Plan:output_type -> tern.v1.PlanResponse
+	19, // 54: tern.v1.Tern.PlanDiff:output_type -> tern.v1.PlanDiffResponse
+	21, // 55: tern.v1.Tern.Apply:output_type -> tern.v1.ApplyResponse
+	28, // 56: tern.v1.Tern.Progress:output_type -> tern.v1.ProgressResponse
+	25, // 57: tern.v1.Tern.Logs:output_type -> tern.v1.LogsResponse
+	30, // 58: tern.v1.Tern.Cutover:output_type -> tern.v1.CutoverResponse
+	32, // 59: tern.v1.Tern.Revert:output_type -> tern.v1.RevertResponse
+	34, // 60: tern.v1.Tern.SkipRevert:output_type -> tern.v1.SkipRevertResponse
+	36, // 61: tern.v1.Tern.Health:output_type -> tern.v1.HealthResponse
+	38, // 62: tern.v1.Tern.Stop:output_type -> tern.v1.StopResponse
+	40, // 63: tern.v1.Tern.Cancel:output_type -> tern.v1.CancelResponse
+	42, // 64: tern.v1.Tern.Start:output_type -> tern.v1.StartResponse
+	44, // 65: tern.v1.Tern.Volume:output_type -> tern.v1.VolumeResponse
+	52, // [52:66] is the sub-list for method output_type
+	38, // [38:52] is the sub-list for method input_type
+	38, // [38:38] is the sub-list for extension type_name
+	38, // [38:38] is the sub-list for extension extendee
+	0,  // [0:38] is the sub-list for field type_name
 }
 
 func init() { file_tern_proto_init() }
@@ -3661,13 +3946,14 @@ func file_tern_proto_init() {
 	if File_tern_proto != nil {
 		return
 	}
+	file_tern_proto_msgTypes[20].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_tern_proto_rawDesc), len(file_tern_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   49,
+			NumMessages:   52,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/proto/ternv1/tern.pb.gw.go
+++ b/pkg/proto/ternv1/tern.pb.gw.go
@@ -170,6 +170,33 @@ func local_request_Tern_Progress_0(ctx context.Context, marshaler runtime.Marsha
 	return msg, metadata, err
 }
 
+func request_Tern_Logs_0(ctx context.Context, marshaler runtime.Marshaler, client TernClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq LogsRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.Logs(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_Tern_Logs_0(ctx context.Context, marshaler runtime.Marshaler, server TernServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq LogsRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.Logs(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_Tern_Cutover_0(ctx context.Context, marshaler runtime.Marshaler, client TernClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq CutoverRequest
@@ -486,6 +513,26 @@ func RegisterTernHandlerServer(ctx context.Context, mux *runtime.ServeMux, serve
 		}
 		forward_Tern_Progress_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_Tern_Logs_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/tern.v1.Tern/Logs", runtime.WithHTTPPathPattern("/v1/logs"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Tern_Logs_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_Tern_Logs_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_Tern_Cutover_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -771,6 +818,23 @@ func RegisterTernHandlerClient(ctx context.Context, mux *runtime.ServeMux, clien
 		}
 		forward_Tern_Progress_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_Tern_Logs_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/tern.v1.Tern/Logs", runtime.WithHTTPPathPattern("/v1/logs"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Tern_Logs_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_Tern_Logs_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_Tern_Cutover_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -916,6 +980,7 @@ var (
 	pattern_Tern_PlanDiff_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "plan-diff"}, ""))
 	pattern_Tern_Apply_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "apply"}, ""))
 	pattern_Tern_Progress_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "progress"}, ""))
+	pattern_Tern_Logs_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "logs"}, ""))
 	pattern_Tern_Cutover_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "cutover"}, ""))
 	pattern_Tern_Revert_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "revert"}, ""))
 	pattern_Tern_SkipRevert_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "skip-revert"}, ""))
@@ -932,6 +997,7 @@ var (
 	forward_Tern_PlanDiff_0   = runtime.ForwardResponseMessage
 	forward_Tern_Apply_0      = runtime.ForwardResponseMessage
 	forward_Tern_Progress_0   = runtime.ForwardResponseMessage
+	forward_Tern_Logs_0       = runtime.ForwardResponseMessage
 	forward_Tern_Cutover_0    = runtime.ForwardResponseMessage
 	forward_Tern_Revert_0     = runtime.ForwardResponseMessage
 	forward_Tern_SkipRevert_0 = runtime.ForwardResponseMessage

--- a/pkg/proto/ternv1/tern_grpc.pb.go
+++ b/pkg/proto/ternv1/tern_grpc.pb.go
@@ -24,6 +24,7 @@ const (
 	Tern_PlanDiff_FullMethodName   = "/tern.v1.Tern/PlanDiff"
 	Tern_Apply_FullMethodName      = "/tern.v1.Tern/Apply"
 	Tern_Progress_FullMethodName   = "/tern.v1.Tern/Progress"
+	Tern_Logs_FullMethodName       = "/tern.v1.Tern/Logs"
 	Tern_Cutover_FullMethodName    = "/tern.v1.Tern/Cutover"
 	Tern_Revert_FullMethodName     = "/tern.v1.Tern/Revert"
 	Tern_SkipRevert_FullMethodName = "/tern.v1.Tern/SkipRevert"
@@ -118,6 +119,8 @@ type TernClient interface {
 	//
 	// Unknown apply IDs return NOT_FOUND.
 	Progress(ctx context.Context, in *ProgressRequest, opts ...grpc.CallOption) (*ProgressResponse, error)
+	// Logs returns a bounded recent window of durable apply logs. It is read-only.
+	Logs(ctx context.Context, in *LogsRequest, opts ...grpc.CallOption) (*LogsResponse, error)
 	// Cutover triggers the table swap phase for a schema change that was started
 	// with defer_cutover=true. Only valid when state is waiting_for_cutover.
 	//
@@ -238,6 +241,16 @@ func (c *ternClient) Progress(ctx context.Context, in *ProgressRequest, opts ...
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ProgressResponse)
 	err := c.cc.Invoke(ctx, Tern_Progress_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *ternClient) Logs(ctx context.Context, in *LogsRequest, opts ...grpc.CallOption) (*LogsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(LogsResponse)
+	err := c.cc.Invoke(ctx, Tern_Logs_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -408,6 +421,8 @@ type TernServer interface {
 	//
 	// Unknown apply IDs return NOT_FOUND.
 	Progress(context.Context, *ProgressRequest) (*ProgressResponse, error)
+	// Logs returns a bounded recent window of durable apply logs. It is read-only.
+	Logs(context.Context, *LogsRequest) (*LogsResponse, error)
 	// Cutover triggers the table swap phase for a schema change that was started
 	// with defer_cutover=true. Only valid when state is waiting_for_cutover.
 	//
@@ -497,6 +512,9 @@ func (UnimplementedTernServer) Apply(context.Context, *ApplyRequest) (*ApplyResp
 }
 func (UnimplementedTernServer) Progress(context.Context, *ProgressRequest) (*ProgressResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Progress not implemented")
+}
+func (UnimplementedTernServer) Logs(context.Context, *LogsRequest) (*LogsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method Logs not implemented")
 }
 func (UnimplementedTernServer) Cutover(context.Context, *CutoverRequest) (*CutoverResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Cutover not implemented")
@@ -628,6 +646,24 @@ func _Tern_Progress_Handler(srv interface{}, ctx context.Context, dec func(inter
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(TernServer).Progress(ctx, req.(*ProgressRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Tern_Logs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(LogsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TernServer).Logs(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Tern_Logs_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TernServer).Logs(ctx, req.(*LogsRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -802,6 +838,10 @@ var Tern_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Progress",
 			Handler:    _Tern_Progress_Handler,
+		},
+		{
+			MethodName: "Logs",
+			Handler:    _Tern_Logs_Handler,
 		},
 		{
 			MethodName: "Cutover",

--- a/pkg/tern/client.go
+++ b/pkg/tern/client.go
@@ -55,6 +55,9 @@ type Client interface {
 	// Progress returns detailed progress for an active schema change.
 	Progress(ctx context.Context, req *ternv1.ProgressRequest) (*ternv1.ProgressResponse, error)
 
+	// Logs returns a bounded recent window of durable apply logs.
+	Logs(ctx context.Context, req *ternv1.LogsRequest) (*ternv1.LogsResponse, error)
+
 	// Cutover triggers the cutover phase when defer_cutover was used.
 	Cutover(ctx context.Context, req *ternv1.CutoverRequest) (*ternv1.CutoverResponse, error)
 

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -473,6 +473,14 @@ func (c *GRPCClient) Progress(ctx context.Context, req *ternv1.ProgressRequest) 
 	return c.client.Progress(ctx, req)
 }
 
+func (c *GRPCClient) Logs(ctx context.Context, req *ternv1.LogsRequest) (*ternv1.LogsResponse, error) {
+	resp, err := c.client.Logs(ctx, req)
+	if status.Code(err) == codes.Unimplemented {
+		return nil, fmt.Errorf("selected data plane does not support log reads; upgrade that data plane: %w", err)
+	}
+	return resp, err
+}
+
 func (c *GRPCClient) Cutover(ctx context.Context, req *ternv1.CutoverRequest) (*ternv1.CutoverResponse, error) {
 	return c.client.Cutover(ctx, req)
 }

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -64,6 +64,9 @@ func (s *mockTernServer) Progress(ctx context.Context, req *ternv1.ProgressReque
 		Engine: ternv1.Engine_ENGINE_SPIRIT,
 	}, nil
 }
+func (s *mockTernServer) Logs(context.Context, *ternv1.LogsRequest) (*ternv1.LogsResponse, error) {
+	return &ternv1.LogsResponse{}, nil
+}
 
 func (s *mockTernServer) Cutover(ctx context.Context, req *ternv1.CutoverRequest) (*ternv1.CutoverResponse, error) {
 	if req.ApplyId == "" {
@@ -628,6 +631,9 @@ func (s *capturingTernServer) Progress(_ context.Context, req *ternv1.ProgressRe
 	}
 	return &ternv1.ProgressResponse{State: ps, Tables: tables, Volume: volume, ErrorMessage: errorMessage}, nil
 }
+func (s *capturingTernServer) Logs(context.Context, *ternv1.LogsRequest) (*ternv1.LogsResponse, error) {
+	return &ternv1.LogsResponse{}, nil
+}
 
 func (s *capturingTernServer) getStartApplyID() string {
 	s.mu.Lock()
@@ -758,7 +764,8 @@ func (m *mockTaskStore) Update(context.Context, *storage.Task) error { return m.
 
 type mockApplyLogStore struct {
 	storage.ApplyLogStore
-	logs []*storage.ApplyLog
+	logs        []*storage.ApplyLog
+	recentLimit int
 }
 
 func (m *mockApplyLogStore) Append(_ context.Context, log *storage.ApplyLog) error {
@@ -768,6 +775,11 @@ func (m *mockApplyLogStore) Append(_ context.Context, log *storage.ApplyLog) err
 }
 
 func (m *mockApplyLogStore) GetByApply(context.Context, int64) ([]*storage.ApplyLog, error) {
+	return m.logs, nil
+}
+
+func (m *mockApplyLogStore) GetRecentByApply(_ context.Context, _ int64, limit int) ([]*storage.ApplyLog, error) {
+	m.recentLimit = limit
 	return m.logs, nil
 }
 

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -2336,6 +2336,44 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 	return resp, nil
 }
 
+const maxLogsLimit = 1000
+
+func (c *LocalClient) Logs(ctx context.Context, req *ternv1.LogsRequest) (*ternv1.LogsResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("logs request is required")
+	}
+	if req.ApplyId == "" {
+		return nil, fmt.Errorf("apply_id is required")
+	}
+	limit := int(req.Limit)
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > maxLogsLimit {
+		limit = maxLogsLimit
+	}
+	apply, err := c.storage.Applies().GetByApplyIdentifier(ctx, req.ApplyId)
+	if err != nil {
+		return nil, fmt.Errorf("get apply %s for logs: %w", req.ApplyId, err)
+	}
+	if apply == nil {
+		return nil, fmt.Errorf("get apply %s for logs: %w", req.ApplyId, storage.ErrApplyNotFound)
+	}
+	logs, err := c.storage.ApplyLogs().GetRecentByApply(ctx, apply.ID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("get recent logs for apply %s: %w", req.ApplyId, err)
+	}
+	resp := &ternv1.LogsResponse{ApplyId: req.ApplyId, Logs: make([]*ternv1.ApplyLog, 0, len(logs))}
+	for _, log := range logs {
+		entry := &ternv1.ApplyLog{Id: log.ID, Level: log.Level, EventType: log.EventType, Source: log.Source, Message: log.Message, OldState: log.OldState, NewState: log.NewState, MetadataJson: log.Metadata, CreatedAt: log.CreatedAt.UTC().Format(time.RFC3339Nano)}
+		if log.TaskID != nil {
+			entry.TaskId = log.TaskID
+		}
+		resp.Logs = append(resp.Logs, entry)
+	}
+	return resp, nil
+}
+
 // loadStoredShardsByTable loads the persisted per-shard rows for an apply's
 // operations, grouped by (namespace, table), so the progress response renders
 // the per-shard breakdown from storage. It is Vitess-only (other engines have no

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -2,6 +2,7 @@ package tern
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"reflect"
@@ -31,6 +32,39 @@ func TestPulledSchemaFileContentValidatesDDL(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "parse pulled schema for database orders table broken_users")
+}
+
+func TestLocalClientLogsValidationAndConversion(t *testing.T) {
+	logs := &mockApplyLogStore{}
+	client := &LocalClient{storage: &mockStorage{applies: &mockApplyStore{}, logs: logs}}
+
+	_, err := client.Logs(t.Context(), nil)
+	require.EqualError(t, err, "logs request is required")
+	_, err = client.Logs(t.Context(), &ternv1.LogsRequest{})
+	require.EqualError(t, err, "apply_id is required")
+	_, err = client.Logs(t.Context(), &ternv1.LogsRequest{ApplyId: "missing"})
+	require.ErrorIs(t, err, storage.ErrApplyNotFound)
+
+	taskID := int64(42)
+	createdAt := time.Date(2026, 7, 17, 1, 2, 3, 4, time.FixedZone("offset", 3600))
+	logs.logs = []*storage.ApplyLog{{ID: 7, TaskID: &taskID, Level: "info", EventType: "state", Source: "driver", Message: "ready", OldState: "pending", NewState: "running", Metadata: json.RawMessage(`{"shard":"-80"}`), CreatedAt: createdAt}}
+	client.storage = &mockStorage{applies: &mockApplyStore{apply: &storage.Apply{ID: 9}}, logs: logs}
+
+	resp, err := client.Logs(t.Context(), &ternv1.LogsRequest{ApplyId: "apply-a"})
+	require.NoError(t, err)
+	assert.Equal(t, 50, logs.recentLimit)
+	require.Len(t, resp.Logs, 1)
+	assert.Equal(t, int64(7), resp.Logs[0].Id)
+	assert.Equal(t, &taskID, resp.Logs[0].TaskId)
+	assert.Equal(t, []byte(`{"shard":"-80"}`), resp.Logs[0].MetadataJson)
+	assert.Equal(t, createdAt.UTC().Format(time.RFC3339Nano), resp.Logs[0].CreatedAt)
+	assert.Equal(t, "driver", resp.Logs[0].Source)
+	assert.Equal(t, "pending", resp.Logs[0].OldState)
+	assert.Equal(t, "running", resp.Logs[0].NewState)
+
+	_, err = client.Logs(t.Context(), &ternv1.LogsRequest{ApplyId: "apply-a", Limit: maxLogsLimit + 1})
+	require.NoError(t, err)
+	assert.Equal(t, maxLogsLimit, logs.recentLimit)
 }
 
 type pullSchemaPSClient struct {

--- a/pkg/tern/routing_client.go
+++ b/pkg/tern/routing_client.go
@@ -229,6 +229,28 @@ func (c *RoutingClient) Progress(ctx context.Context, req *ternv1.ProgressReques
 	}, Client.Progress)
 }
 
+func (c *RoutingClient) Logs(ctx context.Context, req *ternv1.LogsRequest) (*ternv1.LogsResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("logs request is required")
+	}
+	target, err := c.resolveSingleExecutionTarget(ctx, req.Database, req.Environment)
+	if err != nil {
+		return nil, err
+	}
+	client, err := c.clientForDeployment(ctx, target.Deployment, req.Environment)
+	if err != nil {
+		return nil, fmt.Errorf("get client for logs deployment %q environment %q: %w", target.Deployment, req.Environment, err)
+	}
+	routed := proto.Clone(req).(*ternv1.LogsRequest)
+	if routed.Target == "" {
+		routed.Target = target.Target
+	}
+	if routed.Type == "" {
+		routed.Type = target.DatabaseType
+	}
+	return client.Logs(ctx, routed)
+}
+
 // Cutover triggers the cutover phase when defer_cutover was used.
 func (c *RoutingClient) Cutover(ctx context.Context, req *ternv1.CutoverRequest) (*ternv1.CutoverResponse, error) {
 	return routeApply(ctx, c, req, "cutover", func(r *ternv1.CutoverRequest, applyID, environment string) {

--- a/pkg/tern/routing_client_test.go
+++ b/pkg/tern/routing_client_test.go
@@ -57,6 +57,7 @@ type routingRecordingClient struct {
 	applyReq                 *ternv1.ApplyRequest
 	applyErr                 error
 	progressReq              *ternv1.ProgressRequest
+	logsReq                  *ternv1.LogsRequest
 	resumeApply              *storage.Apply
 	resumeOperationID        int64
 	resumeCutoverOperationID int64
@@ -92,6 +93,10 @@ func (c *routingRecordingClient) Apply(_ context.Context, req *ternv1.ApplyReque
 func (c *routingRecordingClient) Progress(_ context.Context, req *ternv1.ProgressRequest) (*ternv1.ProgressResponse, error) {
 	c.progressReq = req
 	return &ternv1.ProgressResponse{ApplyId: req.ApplyId}, nil
+}
+func (c *routingRecordingClient) Logs(_ context.Context, req *ternv1.LogsRequest) (*ternv1.LogsResponse, error) {
+	c.logsReq = req
+	return &ternv1.LogsResponse{ApplyId: req.ApplyId}, nil
 }
 
 func (c *routingRecordingClient) ResumeApply(_ context.Context, apply *storage.Apply) error {
@@ -814,6 +819,27 @@ func TestRoutingClientResumeApplyOperationRejectsOperationApplyMismatch(t *testi
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "belongs to apply 100, not apply 42")
 	assert.Nil(t, clients["west/staging"].resumeApply)
+}
+
+func TestRoutingClientLogsPreservesExplicitOperationTarget(t *testing.T) {
+	selected := &routingRecordingClient{}
+	client := newTestRoutingClient(t, RoutingClientConfig{
+		Resolver: routingResolverFunc(func(context.Context, routing.Request) ([]routing.ExecutionTarget, error) {
+			return []routing.ExecutionTarget{{Deployment: "west", Target: "primary-target", DatabaseType: storage.DatabaseTypeMySQL}}, nil
+		}),
+		PlanLookup:  routingPlanLookup{},
+		ApplyLookup: routingApplyLookup{},
+		ClientForDeployment: testDeploymentClientFunc(map[string]*routingRecordingClient{
+			"west/staging": selected,
+		}),
+	})
+
+	_, err := client.Logs(t.Context(), &ternv1.LogsRequest{ApplyId: "remote-apply", Database: "orders", Environment: "staging", Target: "operation-target", Type: storage.DatabaseTypeStrata})
+	require.NoError(t, err)
+	require.NotNil(t, selected.logsReq)
+	assert.Equal(t, "remote-apply", selected.logsReq.ApplyId)
+	assert.Equal(t, "operation-target", selected.logsReq.Target)
+	assert.Equal(t, storage.DatabaseTypeStrata, selected.logsReq.Type)
 }
 
 func newTestRoutingClient(t *testing.T, config RoutingClientConfig) *RoutingClient {

--- a/pkg/tern/server.go
+++ b/pkg/tern/server.go
@@ -109,6 +109,20 @@ func (s *Server) Progress(ctx context.Context, req *ternv1.ProgressRequest) (*te
 	return resp, nil
 }
 
+func (s *Server) Logs(ctx context.Context, req *ternv1.LogsRequest) (*ternv1.LogsResponse, error) {
+	if err := requireApplyID(req.GetApplyId()); err != nil {
+		return nil, err
+	}
+	resp, err := s.client.Logs(ctx, req)
+	if err != nil {
+		if errors.Is(err, storage.ErrApplyNotFound) {
+			return nil, status.Error(codes.NotFound, err.Error())
+		}
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	return resp, nil
+}
+
 func (s *Server) Cutover(ctx context.Context, req *ternv1.CutoverRequest) (*ternv1.CutoverResponse, error) {
 	if err := requireApplyID(req.ApplyId); err != nil {
 		return nil, err

--- a/pkg/tern/server_test.go
+++ b/pkg/tern/server_test.go
@@ -24,6 +24,9 @@ type progressErrorClient struct {
 func (c progressErrorClient) Progress(context.Context, *ternv1.ProgressRequest) (*ternv1.ProgressResponse, error) {
 	return nil, c.err
 }
+func (c progressErrorClient) Logs(context.Context, *ternv1.LogsRequest) (*ternv1.LogsResponse, error) {
+	return nil, storage.ErrApplyNotFound
+}
 
 type applyErrorClient struct {
 	Client

--- a/pkg/tern/server_test.go
+++ b/pkg/tern/server_test.go
@@ -24,8 +24,14 @@ type progressErrorClient struct {
 func (c progressErrorClient) Progress(context.Context, *ternv1.ProgressRequest) (*ternv1.ProgressResponse, error) {
 	return nil, c.err
 }
-func (c progressErrorClient) Logs(context.Context, *ternv1.LogsRequest) (*ternv1.LogsResponse, error) {
-	return nil, storage.ErrApplyNotFound
+
+type logsErrorClient struct {
+	Client
+	err error
+}
+
+func (c logsErrorClient) Logs(context.Context, *ternv1.LogsRequest) (*ternv1.LogsResponse, error) {
+	return nil, c.err
 }
 
 type applyErrorClient struct {
@@ -75,6 +81,26 @@ func TestServerProgressMapsMissingApplyDataToNotFound(t *testing.T) {
 			})
 			require.Error(t, err)
 			assert.Equal(t, codes.NotFound, status.Code(err))
+		})
+	}
+}
+
+func TestServerLogsMapsErrorsToStatusCode(t *testing.T) {
+	testCases := []struct {
+		name string
+		err  error
+		want codes.Code
+	}{
+		{name: "missing apply", err: fmt.Errorf("get apply missing: %w", storage.ErrApplyNotFound), want: codes.NotFound},
+		{name: "storage failure", err: errors.New("storage unavailable"), want: codes.Internal},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := NewServer(logsErrorClient{err: tc.err})
+			_, err := server.Logs(t.Context(), &ternv1.LogsRequest{ApplyId: "apply-123"})
+			require.Error(t, err)
+			assert.Equal(t, tc.want, status.Code(err))
 		})
 	}
 }

--- a/pkg/tern/target_router.go
+++ b/pkg/tern/target_router.go
@@ -271,6 +271,17 @@ func (r *TargetRouter) Progress(ctx context.Context, req *ternv1.ProgressRequest
 	return routeStoredApply(ctx, r, req, "progress", Client.Progress)
 }
 
+func (r *TargetRouter) Logs(ctx context.Context, req *ternv1.LogsRequest) (*ternv1.LogsResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("logs request is required")
+	}
+	client, _, err := r.clientForTarget(ctx, req.Target, req.Type, req.Environment, req.Database)
+	if err != nil {
+		return nil, fmt.Errorf("route logs for target %q: %w", req.Target, err)
+	}
+	return client.Logs(ctx, req)
+}
+
 // Cutover triggers cutover for a stored apply by routing through its target.
 func (r *TargetRouter) Cutover(ctx context.Context, req *ternv1.CutoverRequest) (*ternv1.CutoverResponse, error) {
 	return routeStoredApply(ctx, r, req, "cutover", Client.Cutover)

--- a/pkg/tern/target_router_test.go
+++ b/pkg/tern/target_router_test.go
@@ -112,6 +112,9 @@ func (c *targetRouterRecordingClient) Progress(_ context.Context, req *ternv1.Pr
 	c.progressReq = req
 	return &ternv1.ProgressResponse{ApplyId: req.ApplyId}, nil
 }
+func (c *targetRouterRecordingClient) Logs(_ context.Context, req *ternv1.LogsRequest) (*ternv1.LogsResponse, error) {
+	return &ternv1.LogsResponse{ApplyId: req.ApplyId}, nil
+}
 
 func (c *targetRouterRecordingClient) Cutover(context.Context, *ternv1.CutoverRequest) (*ternv1.CutoverResponse, error) {
 	return &ternv1.CutoverResponse{Accepted: true}, nil

--- a/pkg/tern/target_router_test.go
+++ b/pkg/tern/target_router_test.go
@@ -80,6 +80,7 @@ type targetRouterRecordingClient struct {
 	planDiffReq        *ternv1.PlanRequest
 	applyReq           *ternv1.ApplyRequest
 	progressReq        *ternv1.ProgressRequest
+	logsReq            *ternv1.LogsRequest
 	resumeApply        *storage.Apply
 	targetDSN          string
 	targetMetadata     map[string]string
@@ -113,6 +114,7 @@ func (c *targetRouterRecordingClient) Progress(_ context.Context, req *ternv1.Pr
 	return &ternv1.ProgressResponse{ApplyId: req.ApplyId}, nil
 }
 func (c *targetRouterRecordingClient) Logs(_ context.Context, req *ternv1.LogsRequest) (*ternv1.LogsResponse, error) {
+	c.logsReq = req
 	return &ternv1.LogsResponse{ApplyId: req.ApplyId}, nil
 }
 
@@ -238,6 +240,24 @@ func TestTargetRouterRoutesPlanDiffThroughStaticTarget(t *testing.T) {
 	assert.Equal(t, storage.DatabaseTypeMySQL, client.planDiffReq.Type)
 	assert.Equal(t, "dsid-orders-prod", client.planDiffReq.Target)
 	assert.Equal(t, "root@tcp(localhost:3306)/", client.targetDSN)
+}
+
+func TestTargetRouterRoutesLogsThroughExplicitTarget(t *testing.T) {
+	resolver := newStaticResolver(t)
+	created := make(map[string]*targetRouterRecordingClient)
+	router := newTargetRouterForTest(t, resolver, nil, nil, created)
+
+	_, err := router.Logs(t.Context(), nil)
+	require.EqualError(t, err, "logs request is required")
+
+	req := &ternv1.LogsRequest{ApplyId: "apply-remote", Database: "orders-logical", Type: storage.DatabaseTypeMySQL, Environment: "production", Target: "dsid-orders-prod", Limit: 25}
+	resp, err := router.Logs(t.Context(), req)
+
+	require.NoError(t, err)
+	assert.Equal(t, "apply-remote", resp.ApplyId)
+	client := created["orders-logical"]
+	require.NotNil(t, client)
+	assert.Same(t, req, client.logsReq)
 }
 
 func TestTargetRouterApplyUsesTargetScopedPendingObserver(t *testing.T) {

--- a/pkg/webhook/control_integration_test.go
+++ b/pkg/webhook/control_integration_test.go
@@ -1157,6 +1157,9 @@ func (c *stopCommandTernClient) Apply(context.Context, *ternv1.ApplyRequest) (*t
 func (c *stopCommandTernClient) Progress(context.Context, *ternv1.ProgressRequest) (*ternv1.ProgressResponse, error) {
 	return nil, nil
 }
+func (c *stopCommandTernClient) Logs(context.Context, *ternv1.LogsRequest) (*ternv1.LogsResponse, error) {
+	return &ternv1.LogsResponse{}, nil
+}
 
 func (c *stopCommandTernClient) Cutover(context.Context, *ternv1.CutoverRequest) (*ternv1.CutoverResponse, error) {
 	return nil, nil


### PR DESCRIPTION
## Why
Operators and agents need direct access to the durable logs owned by a remote data plane when diagnosing a schema change.

## What
- Add `schemabot logs <apply-id> --deployment <name>` with agent-friendly JSON output
- Read a bounded log window through Tern while preserving timestamps and metadata
- Fan out across operation targets and return successful sources alongside sanitized per-source errors
- Preserve shard/operation provenance without exposing internal numeric operation IDs

## Risk Assessment
Medium — this adds a read-only RPC and CLI/API path without changing existing log behavior. Selected data planes must be upgraded before remote log reads are available.

Generated with Amp
