### PR TITLE
fix(tern): refuse task-less completion when the apply owns task rows

### DIFF
--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -1184,6 +1184,26 @@ func (s *Service) resumeClaimedApplyWithOptions(ctx context.Context, driverID in
 			}
 			return false, err
 		}
+		if errors.Is(err, tern.ErrApplyTasksNotLoaded) {
+			// Fail-closed: the apply owns task rows the whole-apply drive did not
+			// load, so completing it would report success for schema changes that
+			// never ran. The drive mutated nothing; the apply stays claimable and
+			// this driver will re-attempt it on later polls, so the work stays
+			// visibly stuck (and this metric fires) until the rows load or an
+			// operator intervenes.
+			s.logger.Error("operator: apply owns task rows the drive did not load; refusing task-less completion and leaving the apply claimable",
+				"driver", driverID,
+				"apply_id", apply.ApplyIdentifier,
+				"database", apply.Database,
+				"deployment", deployment,
+				"environment", apply.Environment,
+				"error", err)
+			metrics.RecordOperatorResumeFailure(ctx, apply.Database, deployment, apply.Environment, "apply_tasks_not_loaded")
+			if retryableClaim {
+				metrics.AdjustActiveApplies(ctx, -1, apply.Database, deployment, apply.Environment)
+			}
+			return false, err
+		}
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil {
 			s.logger.Debug("operator: stopped while running claimed apply",
 				"driver", driverID,

--- a/pkg/storage/mysqlstore/tasks.go
+++ b/pkg/storage/mysqlstore/tasks.go
@@ -384,6 +384,22 @@ func (s *taskStore) GetByApplyID(ctx context.Context, applyID int64) ([]*storage
 	return scanTasks(rows)
 }
 
+// CountByApplyID returns the number of task rows the apply owns, with no shard
+// or operation filtering — the same "owns any task work" predicate the
+// operator's claim gate uses, so drives can tell a genuinely task-less apply
+// from one whose rows a filtered loader did not return.
+func (s *taskStore) CountByApplyID(ctx context.Context, applyID int64) (int64, error) {
+	var count int64
+	if err := s.db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM tasks
+		WHERE apply_id = ?
+	`, applyID).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count task rows for apply %d: %w", applyID, err)
+	}
+	return count, nil
+}
+
 // GetByApplyOperationID returns the drive tasks for a single apply_operation.
 // Unsharded operations load their per-table rows (shard = ""). Sharded work
 // operations load the row whose namespace/shard/table matches the operation key,

--- a/pkg/storage/mysqlstore/tasks_test.go
+++ b/pkg/storage/mysqlstore/tasks_test.go
@@ -129,7 +129,7 @@ func TestTaskStore_CountByApplyID(t *testing.T) {
 			State:            state.Task.Pending,
 			TableName:        table,
 			Shard:            shard,
-			DDL:              "ALTER TABLE " + table + " ADD COLUMN email VARCHAR(255)",
+			DDL:              "ALTER TABLE `" + table + "` ADD COLUMN `email` varchar(255)",
 			DDLAction:        "ALTER",
 			CreatedAt:        now,
 			UpdatedAt:        now,

--- a/pkg/storage/mysqlstore/tasks_test.go
+++ b/pkg/storage/mysqlstore/tasks_test.go
@@ -95,6 +95,61 @@ func TestTaskStore_OperationLeaseGuardsUpdate(t *testing.T) {
 	assert.Equal(t, state.Task.Completed, reloaded.State)
 }
 
+// CountByApplyID reports every task row an apply owns — unsharded drive rows
+// and shard-tagged rows alike, with no operation-key filtering — and never
+// another apply's rows. It is the predicate a drive uses to distinguish a
+// genuinely task-less apply (safe to complete as a no-op) from one whose rows
+// a filtered loader did not return (must fail closed).
+func TestTaskStore_CountByApplyID(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "testdb", "mysql", "staging")
+	applyWithTasks := createTestApply(t, store, lock, "apply_count_tasks", 1)
+	tasklessLock := createTestLock(t, store, "otherdb", "mysql", "staging")
+	applyTaskless := createTestApply(t, store, tasklessLock, "apply_count_taskless", 2)
+
+	opID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID: applyWithTasks.ID, Deployment: "region-a", Target: "payments",
+	})
+	require.NoError(t, err)
+
+	createTask := func(identifier, table, shard string) {
+		now := time.Now()
+		_, err := store.Tasks().Create(ctx, &storage.Task{
+			TaskIdentifier:   identifier,
+			ApplyID:          applyWithTasks.ID,
+			ApplyOperationID: &opID,
+			PlanID:           applyWithTasks.PlanID,
+			Database:         applyWithTasks.Database,
+			DatabaseType:     applyWithTasks.DatabaseType,
+			Engine:           storage.EngineSpirit,
+			Environment:      applyWithTasks.Environment,
+			State:            state.Task.Pending,
+			TableName:        table,
+			Shard:            shard,
+			DDL:              "ALTER TABLE " + table + " ADD COLUMN email VARCHAR(255)",
+			DDLAction:        "ALTER",
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		})
+		require.NoError(t, err)
+	}
+
+	createTask("task_count_users", "users", "")
+	createTask("task_count_users_-80", "users", "-80")
+	createTask("task_count_users_80-", "users", "80-")
+
+	count, err := store.Tasks().CountByApplyID(ctx, applyWithTasks.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), count, "every row counts, shard-tagged or not")
+
+	count, err = store.Tasks().CountByApplyID(ctx, applyTaskless.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count, "an apply with no rows counts zero, never a sibling apply's rows")
+}
+
 // TestTaskStore_GetByApplyOperationID verifies that tasks can be loaded for a
 // single apply_operation (one deployment) independently of its sibling
 // deployments under the same apply. This is the read primitive an operator

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -529,6 +529,13 @@ type TaskStore interface {
 	// Used for aggregating task states to derive Apply state.
 	GetByApplyID(ctx context.Context, applyID int64) ([]*Task, error)
 
+	// CountByApplyID returns the number of task rows an apply owns, with no
+	// shard or operation filtering. It answers "does this apply own any task
+	// work at all?" — the invariant behind the operator's claim gate — so a
+	// drive can distinguish a genuinely task-less apply from one whose rows a
+	// filtered loader did not return.
+	CountByApplyID(ctx context.Context, applyID int64) (int64, error)
+
 	// GetByApplyOperationID returns the drive tasks for a single apply_operation.
 	// Unsharded operations return their per-table tasks. Sharded work operations
 	// return the task whose namespace/shard/table matches the operation key so the

--- a/pkg/tern/client.go
+++ b/pkg/tern/client.go
@@ -25,6 +25,14 @@ var ErrNoTasksForApplyOperation = errors.New("no tasks found for apply operation
 // terminalizes the stale claim rather than retrying it forever.
 var ErrApplyOperationRowMissing = fmt.Errorf("apply_operation row missing: %w", ErrNoTasksForApplyOperation)
 
+// ErrApplyTasksNotLoaded is returned by a whole-apply drive that loaded zero
+// tasks for an apply that owns task rows. Such an apply is undriveable, not
+// done: completing it would report success for schema changes that never ran,
+// and the unreturned rows would keep blocking their database as active work.
+// The drive fails closed and the apply stays claimable, so the work stays
+// visibly stuck until the rows load or an operator intervenes.
+var ErrApplyTasksNotLoaded = errors.New("apply owns task rows the drive loader did not return")
+
 var (
 	// ErrPullSchemaUnsupportedType marks a pull request for a database type that
 	// the data plane does not yet support.

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -747,6 +747,10 @@ func (m *mockTaskStore) GetByApplyID(context.Context, int64) ([]*storage.Task, e
 	return m.tasks, nil
 }
 
+func (m *mockTaskStore) CountByApplyID(context.Context, int64) (int64, error) {
+	return int64(len(m.tasks)), nil
+}
+
 func (m *mockTaskStore) GetByApplyOperationID(_ context.Context, applyOperationID int64) ([]*storage.Task, error) {
 	m.lastOperationID = applyOperationID
 	if m.getByOperationIDErr != nil {

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -1350,8 +1350,25 @@ func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.A
 			c.notifyTerminalObserver(apply, tasks)
 			return nil
 		}
+		// Completing with zero loaded tasks is only legitimate when the apply
+		// truly owns no task rows. An apply that owns rows this drive did not
+		// load is undriveable, not done: completing it would report success for
+		// schema changes that never ran, and the unloaded rows would keep
+		// blocking their database as active work. Count the raw rows — the same
+		// "owns any task work" predicate the operator's claim gate uses — and
+		// fail closed on any mismatch, including count uncertainty.
+		totalTaskRows, err := c.storage.Tasks().CountByApplyID(ctx, apply.ID)
+		if err != nil {
+			return fmt.Errorf("count task rows for apply %s before task-less completion: %w", apply.ApplyIdentifier, err)
+		}
+		if totalTaskRows > 0 {
+			c.logger.Error("refusing to complete apply as a task-less no-op: it owns task rows this drive did not load; the apply stays claimable and will not finish until its tasks load",
+				append(apply.LogAttrs(), "task_row_count", totalTaskRows)...)
+			return fmt.Errorf("apply %s owns %d task rows: %w", apply.ApplyIdentifier, totalTaskRows, ErrApplyTasksNotLoaded)
+		}
 		c.logger.Info("no tasks found for apply during recovery; completing as a no-op",
 			"apply_id", apply.ApplyIdentifier)
+		previousState := apply.State
 		apply.State = state.Apply.Completed
 		apply.CompletedAt = &now
 		apply.UpdatedAt = now
@@ -1360,6 +1377,8 @@ func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.A
 			// recovery retries, and notify the observer only after a durable write.
 			return fmt.Errorf("complete task-less apply %s during recovery: %w", apply.ApplyIdentifier, err)
 		}
+		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
+			"Apply owns no task work; completed without engine work", previousState, state.Apply.Completed)
 		c.notifyTerminalObserver(apply, tasks)
 		return nil
 	}

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -1356,7 +1356,10 @@ func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.A
 		// schema changes that never ran, and the unloaded rows would keep
 		// blocking their database as active work. Count the raw rows — the same
 		// "owns any task work" predicate the operator's claim gate uses — and
-		// fail closed on any mismatch, including count uncertainty.
+		// refuse completion on any mismatch. A failed count also refuses
+		// completion, but surfaces as a storage error rather than
+		// ErrApplyTasksNotLoaded so triage can tell a storage failure apart
+		// from an ownership mismatch.
 		totalTaskRows, err := c.storage.Tasks().CountByApplyID(ctx, apply.ID)
 		if err != nil {
 			return fmt.Errorf("count task rows for apply %s before task-less completion: %w", apply.ApplyIdentifier, err)

--- a/pkg/tern/local_taskless_completion_integration_test.go
+++ b/pkg/tern/local_taskless_completion_integration_test.go
@@ -1,0 +1,174 @@
+//go:build integration
+
+package tern
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// An apply whose task rows exist but were not returned by the whole-apply
+// loader (e.g. reflected per-shard progress rows with no loadable drive task)
+// is undriveable, not done. The drive must refuse to complete it as a
+// task-less no-op: completing would report success on the PR for schema
+// changes that never ran, while the unloaded rows kept blocking the database
+// as active work. The refused apply stays claimable and non-terminal so the
+// stuck work remains visible.
+func TestLocalClient_ResumeRefusesTasklessCompletionWhenApplyOwnsTaskRows(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+	cleanupTestTables(t, dsn)
+
+	ctx := t.Context()
+	stor := createStorage(t, dsn)
+	defer utils.CloseAndLog(stor)
+	client, eng := newTasklessControlClient(t, dsn, stor)
+
+	now := time.Now()
+	plan := &storage.Plan{
+		PlanIdentifier: fmt.Sprintf("plan-hidden-tasks-%d", now.UnixNano()),
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Deployment:     "testdb",
+		Environment:    localClientTestEnvironment,
+		CreatedAt:      now,
+		Namespaces: map[string]*storage.NamespacePlanData{
+			"testdb": {
+				Tables: []storage.TableChange{
+					{Namespace: "testdb", Table: "users", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", Operation: "alter"},
+				},
+			},
+		},
+	}
+	planID, err := stor.Plans().Create(ctx, plan)
+	require.NoError(t, err)
+
+	apply := &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply-hidden-tasks-%d", now.UnixNano()),
+		PlanID:          planID,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Deployment:      "testdb",
+		Environment:     localClientTestEnvironment,
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Pending,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	// The task row is shard-tagged under an operation whose key does not match
+	// it, so no drive loader returns it — the reflected per-shard progress
+	// shape, owned by the apply but invisible to the whole-apply drive.
+	hiddenTask := &storage.Task{
+		TaskIdentifier: fmt.Sprintf("task-hidden-%d", now.UnixNano()),
+		PlanID:         planID,
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Engine:         storage.EngineSpirit,
+		Environment:    localClientTestEnvironment,
+		State:          state.Task.Pending,
+		Namespace:      "testdb",
+		TableName:      "users",
+		Shard:          "-80",
+		DDL:            "ALTER TABLE `users` ADD COLUMN `email` varchar(255)",
+		DDLAction:      "alter",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	applyID, err := stor.Applies().CreateWithTasksAndOperations(ctx, apply, []*storage.Task{hiddenTask}, []*storage.ApplyOperation{{
+		Deployment: apply.Deployment,
+		State:      state.ApplyOperation.Pending,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}})
+	require.NoError(t, err)
+	apply.ID = applyID
+
+	loaded, err := stor.Tasks().GetByApplyID(ctx, apply.ID)
+	require.NoError(t, err)
+	require.Empty(t, loaded, "the hidden task row must not load through the whole-apply loader for this scenario to hold")
+
+	claimed, err := stor.Applies().FindNextApply(ctx, "test-operator-"+t.Name())
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	require.Equal(t, apply.ApplyIdentifier, claimed.ApplyIdentifier)
+
+	driveCtx := storage.WithApplyLease(ctx, claimed.Lease())
+	err = client.ResumeApply(driveCtx, claimed)
+	require.ErrorIs(t, err, ErrApplyTasksNotLoaded)
+
+	assert.Empty(t, eng.recorded(), "a refused task-less completion must never reach the engine")
+
+	persisted, err := stor.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.False(t, state.IsTerminalApplyState(persisted.State),
+		"an apply owning unloaded task rows must not be settled (state %q)", persisted.State)
+	assert.Nil(t, persisted.CompletedAt, "an apply owning unloaded task rows must not be stamped completed")
+
+	tasks, err := stor.Tasks().CountByApplyID(ctx, apply.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), tasks, "the refused drive must not delete or settle the apply's task rows")
+}
+
+// A genuinely task-less apply — it owns no task rows at all — completes as a
+// no-op, and the completion is recorded in the apply's durable logs so remote
+// log readers and operators can see why the apply finished without any
+// engine work.
+func TestLocalClient_TasklessApplyCompletesWithDurableLog(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+	cleanupTestTables(t, dsn)
+
+	ctx := t.Context()
+	stor := createStorage(t, dsn)
+	defer utils.CloseAndLog(stor)
+	client, eng := newTasklessControlClient(t, dsn, stor)
+
+	apply := dispatchQueuedApply(t, stor, client, nil)
+
+	claimed, err := stor.Applies().FindNextApply(ctx, "test-operator-"+t.Name())
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	require.Equal(t, apply.ApplyIdentifier, claimed.ApplyIdentifier)
+
+	driveCtx := storage.WithApplyLease(ctx, claimed.Lease())
+	require.NoError(t, client.ResumeApply(driveCtx, claimed))
+
+	persisted, err := stor.Applies().Get(ctx, apply.ID)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.True(t, state.IsState(persisted.State, state.Apply.Completed),
+		"a genuinely task-less apply completes as a no-op (state %q)", persisted.State)
+	assert.NotNil(t, persisted.CompletedAt)
+
+	logs, err := stor.ApplyLogs().GetByApply(ctx, apply.ID)
+	require.NoError(t, err)
+	var found bool
+	for _, entry := range logs {
+		if entry.EventType == storage.LogEventStateTransition && entry.Message == "Apply owns no task work; completed without engine work" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "the no-op completion must be recorded in the apply's durable logs")
+
+	assert.Empty(t, eng.recorded(), "a task-less no-op completion must not touch the engine")
+}


### PR DESCRIPTION
## What broke

When a driver picks up an apply and the task loader returns zero rows, the drive assumed "nothing to do" and marked the apply completed. But *the loader returned nothing* and *the apply owns nothing* are not the same thing: if the apply actually owns task rows the loader missed, that completion reports success on the PR for DDL that never ran — and the missed rows keep blocking the database as active work.

## The fix

Before completing as a no-op, the drive counts **all** task rows the apply owns, with no filtering — the same "owns any work?" question the claim gate asks.

```
driver loads the apply's tasks ── gets zero
        │
        count every task row the apply owns
        │
        ├── count > 0, or the count failed ──► refuse to complete
        │                                      (ErrApplyTasksNotLoaded)
        │                                      nothing mutated; apply stays
        │                                      claimable; metric fires
        │
        └── count == 0 ──────────────────────► complete as a no-op
                                               + durable log line:
                                               "owns no task work"
```

A refused apply stays visibly stuck and is retried on later polls, with a dedicated metric reason (`apply_tasks_not_loaded`) so operators see it immediately. A genuinely task-less completion now leaves a durable apply-log entry, readable through `schemabot logs`, instead of only a server-side log line. #749 fixes the loader gap that made this guard necessary; this PR ensures any future gap fails loudly instead of silently succeeding.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)