### PR TITLE
fix(tern): drive shard-scoped dispatched applies instead of completing as a no-op

### DIFF
--- a/pkg/api/plan_handlers.go
+++ b/pkg/api/plan_handlers.go
@@ -1130,7 +1130,7 @@ func buildShardedApplyOperationGroups(
 					if err := validateShardOperationKeyParts(namespace, shard.Shard, ddlChange.Table); err != nil {
 						return nil, err
 					}
-					operationKey := shardOperationKey(namespace, shard.Shard, ddlChange.Table)
+					operationKey := storage.ShardOperationKey(namespace, shard.Shard, ddlChange.Table)
 					if len(operationKey) > applyOperationKeyMaxLen {
 						return nil, fmt.Errorf("operation key for namespace %q shard %q table %q exceeds %d characters", namespace, shard.Shard, ddlChange.Table, applyOperationKeyMaxLen)
 					}
@@ -1223,10 +1223,6 @@ func changingShardsByNamespace(shards []storage.ShardPlan) map[string][]storage.
 		})
 	}
 	return shardsByNamespace
-}
-
-func shardOperationKey(namespace, shard, table string) string {
-	return namespace + "/" + shard + "/" + table
 }
 
 func finalizerOperationKey(namespace string) string {

--- a/pkg/storage/mysqlstore/tasks.go
+++ b/pkg/storage/mysqlstore/tasks.go
@@ -367,8 +367,12 @@ func (s *taskStore) insertShardTaskGuardedByApply(ctx context.Context, task *sto
 
 // GetByApplyID returns the drive tasks for an apply. Unsharded rows (shard = "")
 // always load. A shard-tagged row loads only when it is the drive task of a
-// shard-scoped work operation — its operation's key matches the row's
-// namespace/shard/table — the same discrimination GetByApplyOperationID applies.
+// shard-scoped work operation — its operation belongs to the same apply and its
+// operation's key matches the row's namespace/shard/table — the same
+// discrimination GetByApplyOperationID applies. The join is constrained to the
+// row's own apply so a mis-associated operation reference from another apply
+// can never classify a row as drive work; tasks has no foreign-key constraint
+// enforcing the association.
 // Reflected per-shard progress rows (a read-model written by the operator under
 // an operation whose key does not match) are excluded so they never re-enter the
 // per-table drive/gating/progress pipeline on reload. Read those via
@@ -377,7 +381,9 @@ func (s *taskStore) GetByApplyID(ctx context.Context, applyID int64) ([]*storage
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT `+prefixedTaskColumns("t")+`
 		FROM tasks t
-		LEFT JOIN apply_operations ao ON ao.id = t.apply_operation_id
+		LEFT JOIN apply_operations ao
+			ON ao.id = t.apply_operation_id
+			AND ao.apply_id = t.apply_id
 		WHERE t.apply_id = ?
 			AND (
 				t.shard = ''

--- a/pkg/storage/mysqlstore/tasks.go
+++ b/pkg/storage/mysqlstore/tasks.go
@@ -365,17 +365,30 @@ func (s *taskStore) insertShardTaskGuardedByApply(ctx context.Context, task *sto
 	return nil
 }
 
-// GetByApplyID returns the per-table tasks for an apply. Per-shard detail rows
-// (shard != "") are excluded: they are a reflected read-model written by the
-// operator and must not re-enter the per-table drive/gating/progress pipeline on
-// reload. Read those via GetShardProgressByApplyOperationID.
+// GetByApplyID returns the drive tasks for an apply. Unsharded rows (shard = "")
+// always load. A shard-tagged row loads only when it is the drive task of a
+// shard-scoped work operation — its operation's key matches the row's
+// namespace/shard/table — the same discrimination GetByApplyOperationID applies.
+// Reflected per-shard progress rows (a read-model written by the operator under
+// an operation whose key does not match) are excluded so they never re-enter the
+// per-table drive/gating/progress pipeline on reload. Read those via
+// GetShardProgressByApplyOperationID.
 func (s *taskStore) GetByApplyID(ctx context.Context, applyID int64) ([]*storage.Task, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT `+taskColumns+`
-		FROM tasks
-		WHERE apply_id = ? AND shard = ''
-		ORDER BY created_at DESC
-	`, applyID)
+		SELECT `+prefixedTaskColumns("t")+`
+		FROM tasks t
+		LEFT JOIN apply_operations ao ON ao.id = t.apply_operation_id
+		WHERE t.apply_id = ?
+			AND (
+				t.shard = ''
+				OR (
+					ao.operation_kind = ?
+					-- Keep this in sync with storage.ShardOperationKey's namespace/shard/table format.
+					AND ao.operation_key = CONCAT(t.namespace, '/', t.shard, '/', t.table_name)
+				)
+			)
+		ORDER BY t.created_at DESC
+	`, applyID, storage.ApplyOperationKindWork)
 	if err != nil {
 		return nil, fmt.Errorf("query tasks for apply %d: %w", applyID, err)
 	}
@@ -399,7 +412,7 @@ func (s *taskStore) GetByApplyOperationID(ctx context.Context, applyOperationID 
 				t.shard = ''
 				OR (
 					ao.operation_kind = ?
-					-- Keep this in sync with shardOperationKey's namespace/shard/table format.
+					-- Keep this in sync with storage.ShardOperationKey's namespace/shard/table format.
 					AND ao.operation_key = CONCAT(t.namespace, '/', t.shard, '/', t.table_name)
 				)
 			)

--- a/pkg/storage/mysqlstore/tasks_test.go
+++ b/pkg/storage/mysqlstore/tasks_test.go
@@ -338,6 +338,20 @@ func TestTaskStore_GetByApplyIDIncludesShardScopedDriveTasks(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// A work operation of a different apply with the same key. tasks has no
+	// foreign-key constraint on apply_operation_id, so a row mis-associated
+	// with another apply's operation must still be excluded from drive work.
+	otherLock := createTestLock(t, store, "resolute_other", storage.DatabaseTypeStrata, "staging")
+	otherApply := createTestApply(t, store, otherLock, "apply_other_shard_drive", 1)
+	foreignOpID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID:       otherApply.ID,
+		Deployment:    "region-a",
+		OperationKey:  "commerce/-80/users",
+		OperationKind: storage.ApplyOperationKindWork,
+		Target:        "resolute_other",
+	})
+	require.NoError(t, err)
+
 	now := time.Now()
 	createTask := func(identifier string, opID int64, table, shard string) {
 		_, err := store.Tasks().Create(ctx, &storage.Task{
@@ -364,6 +378,7 @@ func TestTaskStore_GetByApplyIDIncludesShardScopedDriveTasks(t *testing.T) {
 	createTask("task_users_80-_reflected", shardedOpID, "users", "80-")
 	createTask("task_orders_drive", unshardedOpID, "orders", "")
 	createTask("task_orders_-80_reflected", unshardedOpID, "orders", "-80")
+	createTask("task_users_-80_foreign_op", foreignOpID, "users", "-80")
 
 	tasks, err := store.Tasks().GetByApplyID(ctx, apply.ID)
 	require.NoError(t, err)

--- a/pkg/storage/mysqlstore/tasks_test.go
+++ b/pkg/storage/mysqlstore/tasks_test.go
@@ -304,6 +304,76 @@ func TestTaskStore_GetByApplyOperationIDIncludesMatchingShardedWorkTask(t *testi
 	assert.Equal(t, "-80", tasks[0].Shard)
 }
 
+// GetByApplyID is the whole-apply drive loader — an operator claiming a queued
+// apply loads every task it must drive through it. A shard-tagged row loads
+// only when it is the drive task of a sharded work operation (the operation's
+// shard key names the row's namespace/shard/table); unsharded per-table rows
+// always load; reflected per-shard progress rows — shard rows whose operation's
+// key does not match — stay out of the drive pipeline.
+func TestTaskStore_GetByApplyIDIncludesShardScopedDriveTasks(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "resolute", storage.DatabaseTypeStrata, "staging")
+	apply := createTestApply(t, store, lock, "apply_shard_drive_tasks", 1)
+
+	// A sharded work operation: its shard-tagged row for the keyed shard is the
+	// drive task; a sibling shard's row under the same operation is not.
+	shardedOpID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID:       apply.ID,
+		Deployment:    "region-a",
+		OperationKey:  "commerce/-80/users",
+		OperationKind: storage.ApplyOperationKindWork,
+		Target:        "resolute",
+	})
+	require.NoError(t, err)
+
+	// An unsharded operation: its per-table row drives; a shard-tagged row under
+	// it is reflected per-shard progress, not drive work.
+	unshardedOpID, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+		ApplyID:    apply.ID,
+		Deployment: "region-b",
+		Target:     "resolute",
+	})
+	require.NoError(t, err)
+
+	now := time.Now()
+	createTask := func(identifier string, opID int64, table, shard string) {
+		_, err := store.Tasks().Create(ctx, &storage.Task{
+			TaskIdentifier:   identifier,
+			ApplyID:          apply.ID,
+			ApplyOperationID: &opID,
+			PlanID:           apply.PlanID,
+			Database:         apply.Database,
+			DatabaseType:     apply.DatabaseType,
+			Engine:           storage.EngineStrata,
+			Environment:      apply.Environment,
+			State:            state.Task.Pending,
+			Namespace:        "commerce",
+			TableName:        table,
+			Shard:            shard,
+			DDL:              "ALTER TABLE `" + table + "` ADD COLUMN `email` varchar(255)",
+			DDLAction:        "ALTER",
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		})
+		require.NoError(t, err)
+	}
+	createTask("task_users_-80_drive", shardedOpID, "users", "-80")
+	createTask("task_users_80-_reflected", shardedOpID, "users", "80-")
+	createTask("task_orders_drive", unshardedOpID, "orders", "")
+	createTask("task_orders_-80_reflected", unshardedOpID, "orders", "-80")
+
+	tasks, err := store.Tasks().GetByApplyID(ctx, apply.ID)
+	require.NoError(t, err)
+	identifiers := make([]string, 0, len(tasks))
+	for _, task := range tasks {
+		identifiers = append(identifiers, task.TaskIdentifier)
+	}
+	assert.ElementsMatch(t, []string{"task_users_-80_drive", "task_orders_drive"}, identifiers)
+}
+
 // An unsharded engine (MySQL/Spirit) uses the empty-string shard sentinel, which
 // preserves today's one-task-per-table behavior.
 func TestTaskStore_UnshardedTaskHasEmptyShard(t *testing.T) {

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -284,6 +284,16 @@ const (
 	ApplyOperationKindGroupFinalizer = "group_finalizer"
 )
 
+// ShardOperationKey builds the operation key for one shard's work on one table
+// ("<namespace>/<shard>/<table>"). It is the canonical key for shard-scoped
+// work operations: the control plane's sharded fan-out stamps it on each
+// per-shard apply_operation, a shard-scoped dispatch stamps it on the data
+// plane's operation row, and the task loaders match shard-tagged task rows
+// against it to distinguish drive tasks from reflected per-shard progress rows.
+func ShardOperationKey(namespace, shard, table string) string {
+	return namespace + "/" + shard + "/" + table
+}
+
 // EngineForType returns the engine name for a database type.
 func EngineForType(dbType string) string {
 	switch dbType {

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -1535,7 +1535,9 @@ func scopedDispatchDDLChanges(changes []*ternv1.TableChange) ([]storage.TableCha
 // one (namespace, shard, table)'s changes per operation, so every change in the
 // dispatch must agree on namespace and table; a mixed set is a malformed
 // dispatch and fails closed rather than stamping a key that matches only some
-// of the dispatch's tasks.
+// of the dispatch's tasks. Components must not contain the key's "/" delimiter:
+// readers split the key back into exactly three parts, so a delimiter inside a
+// component would produce a key they no longer recognize as shard-scoped work.
 func shardScopedDispatchOperationKey(changes []storage.TableChange, shard string) (string, error) {
 	if len(changes) == 0 {
 		return "", fmt.Errorf("shard-scoped dispatch has no ddl changes to key its operation from")
@@ -1545,6 +1547,16 @@ func shardScopedDispatchOperationKey(changes []storage.TableChange, shard string
 		if ch.Namespace != namespace || ch.Table != table {
 			return "", fmt.Errorf("shard-scoped dispatch mixes tables %s.%s and %s.%s; a dispatch must carry one table's changes for one shard",
 				namespace, table, ch.Namespace, ch.Table)
+		}
+	}
+	for _, component := range []struct{ name, value string }{
+		{"namespace", namespace},
+		{"shard", shard},
+		{"table", table},
+	} {
+		if strings.Contains(component.value, "/") {
+			return "", fmt.Errorf("shard-scoped dispatch %s %q contains the shard operation key delimiter; refusing to stamp a key readers would misparse",
+				component.name, component.value)
 		}
 	}
 	return storage.ShardOperationKey(namespace, shard, table), nil

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -1530,6 +1530,26 @@ func scopedDispatchDDLChanges(changes []*ternv1.TableChange) ([]storage.TableCha
 	return out, nil
 }
 
+// shardScopedDispatchOperationKey builds the operation key for a shard-scoped
+// dispatch's single operation. The control plane's per-shard fan-out dispatches
+// one (namespace, shard, table)'s changes per operation, so every change in the
+// dispatch must agree on namespace and table; a mixed set is a malformed
+// dispatch and fails closed rather than stamping a key that matches only some
+// of the dispatch's tasks.
+func shardScopedDispatchOperationKey(changes []storage.TableChange, shard string) (string, error) {
+	if len(changes) == 0 {
+		return "", fmt.Errorf("shard-scoped dispatch has no ddl changes to key its operation from")
+	}
+	namespace, table := changes[0].Namespace, changes[0].Table
+	for _, ch := range changes[1:] {
+		if ch.Namespace != namespace || ch.Table != table {
+			return "", fmt.Errorf("shard-scoped dispatch mixes tables %s.%s and %s.%s; a dispatch must carry one table's changes for one shard",
+				namespace, table, ch.Namespace, ch.Table)
+		}
+	}
+	return storage.ShardOperationKey(namespace, shard, table), nil
+}
+
 // planForApplyRequest resolves the plan for an apply. It prefers a plan row in
 // this deployment's own storage (the single-deployment path, and the primary
 // deployment of a multi-deployment apply). When no local plan exists, a
@@ -1936,6 +1956,20 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 		}
 	}
 
+	// A shard-scoped dispatch tags its tasks with the target shard, so its
+	// operation row must carry the matching shard operation key: the task
+	// loaders treat a shard-tagged row as a drive task only when its operation's
+	// key matches (the convention the control plane's sharded fan-out stamps).
+	// Without the key, the operator's claim would load no drive tasks for the
+	// apply and the dispatched work would never run.
+	operationKey := ""
+	if dispatchShard != "" {
+		operationKey, err = shardScopedDispatchOperationKey(ddlChanges, dispatchShard)
+		if err != nil {
+			return nil, fmt.Errorf("apply for plan %s: %w", req.PlanId, err)
+		}
+	}
+
 	// Dual-write one apply_operations row alongside the applies row in the
 	// same transaction so every apply created via the Tern client carries a
 	// claimable, resumable operation. CreateWithTasksAndOperations links each
@@ -1947,11 +1981,12 @@ func (c *LocalClient) Apply(ctx context.Context, req *ternv1.ApplyRequest) (*ter
 	// apply path), so the store applies its safe defaults (rolling cutover,
 	// halt on failure).
 	operations := []*storage.ApplyOperation{{
-		Deployment: apply.Deployment,
-		Target:     plan.Target,
-		State:      state.ApplyOperation.Pending,
-		CreatedAt:  now,
-		UpdatedAt:  now,
+		Deployment:   apply.Deployment,
+		OperationKey: operationKey,
+		Target:       plan.Target,
+		State:        state.ApplyOperation.Pending,
+		CreatedAt:    now,
+		UpdatedAt:    now,
 	}}
 
 	applyID, err := c.storage.Applies().CreateWithTasksAndOperations(ctx, apply, tasks, operations)

--- a/pkg/tern/local_dispatch_shard_integration_test.go
+++ b/pkg/tern/local_dispatch_shard_integration_test.go
@@ -1,0 +1,117 @@
+//go:build integration
+
+package tern
+
+import (
+	"database/sql"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/block/spirit/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// A shard-scoped dispatch — the control plane's per-shard fan-out sending one
+// (namespace, shard, table)'s changes to a data plane — tags its drive tasks
+// with the target shard and stamps the matching shard operation key on its
+// operation row. The operator's whole-apply claim must load those tasks and
+// drive them through the engine: the apply reaches completed only after the
+// dispatched DDL actually ran on the target, never by completing a task-less
+// no-op that leaves the work pending.
+func TestLocalClient_ShardScopedDispatchDrivesItsTasks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTestTables(t, dsn)
+	cleanupTasks(t, dsn)
+
+	ctx := t.Context()
+
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(db)
+	_, err = db.ExecContext(ctx, "CREATE TABLE users (id INT PRIMARY KEY)")
+	require.NoError(t, err)
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	stor := createStorage(t, dsn)
+	client, err := NewLocalClient(LocalConfig{
+		Database:  "testdb",
+		Type:      "mysql",
+		TargetDSN: dsn,
+	}, stor, logger)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(client)
+
+	schemaFiles := buildSchemaWithAllTables(t, dsn, map[string]string{
+		"users": "CREATE TABLE users (id INT PRIMARY KEY, email VARCHAR(255))",
+	})
+	planResp, err := client.Plan(ctx, &ternv1.PlanRequest{
+		Type:     "mysql",
+		Database: "testdb",
+		SchemaFiles: map[string]*ternv1.SchemaFiles{
+			"testdb": {Files: schemaFiles},
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, planResp.PlanId)
+
+	applyResp, err := client.Apply(ctx, &ternv1.ApplyRequest{
+		PlanId:       planResp.PlanId,
+		Environment:  localClientTestEnvironment,
+		TargetShards: []string{"-80"},
+		DdlChanges: []*ternv1.TableChange{{
+			Namespace:  "testdb",
+			TableName:  "users",
+			Ddl:        "ALTER TABLE `users` ADD COLUMN `email` varchar(255)",
+			ChangeType: ternv1.ChangeType_CHANGE_TYPE_ALTER,
+		}},
+	})
+	require.NoError(t, err)
+	require.True(t, applyResp.Accepted, "shard-scoped dispatch was not accepted: %s", applyResp.ErrorMessage)
+
+	apply, err := stor.Applies().GetByApplyIdentifier(ctx, applyResp.ApplyId)
+	require.NoError(t, err)
+	require.NotNil(t, apply)
+
+	// The dispatch's operation carries the shard operation key that marks its
+	// shard-tagged rows as drive tasks, and the whole-apply loader returns them.
+	ops, err := stor.ApplyOperations().ListByApply(ctx, apply.ID)
+	require.NoError(t, err)
+	require.Len(t, ops, 1)
+	assert.Equal(t, "testdb/-80/users", ops[0].OperationKey)
+	assert.Equal(t, storage.ApplyOperationKindWork, ops[0].OperationKind)
+
+	tasks, err := stor.Tasks().GetByApplyID(ctx, apply.ID)
+	require.NoError(t, err)
+	require.Len(t, tasks, 1, "the whole-apply loader must return the shard-scoped drive task")
+	assert.Equal(t, "-80", tasks[0].Shard)
+	assert.Equal(t, "users", tasks[0].TableName)
+	assert.Equal(t, state.Task.Pending, tasks[0].State)
+
+	// The operator claim drives the queued dispatch to completion.
+	startTestOperator(t, stor, client)
+	waitForApplyComplete(t, client, ctx, applyResp.ApplyId)
+
+	// The dispatched DDL actually ran on the target database.
+	var columnCount int
+	err = db.QueryRowContext(ctx, "SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = 'testdb' AND TABLE_NAME = 'users' AND COLUMN_NAME = 'email'").Scan(&columnCount)
+	require.NoError(t, err)
+	assert.Equal(t, 1, columnCount, "the dispatched ALTER must have added the email column")
+
+	// The drive settled the shard-scoped task itself, not just the apply row.
+	tasks, err = stor.Tasks().GetByApplyID(ctx, apply.ID)
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, state.Task.Completed, tasks[0].State)
+	assert.Equal(t, "-80", tasks[0].Shard)
+}

--- a/pkg/tern/local_dispatch_shard_test.go
+++ b/pkg/tern/local_dispatch_shard_test.go
@@ -30,4 +30,19 @@ func TestShardScopedDispatchOperationKey(t *testing.T) {
 
 	_, err = shardScopedDispatchOperationKey(nil, "-80")
 	require.Error(t, err)
+
+	// A component containing the key's "/" delimiter would produce a key that
+	// splits into more than three parts, so readers would no longer classify
+	// the operation as shard-scoped work. Stamping must refuse it.
+	_, err = shardScopedDispatchOperationKey([]storage.TableChange{
+		{Namespace: "commerce", Table: "users/archive", DDL: "ALTER TABLE `users/archive` ADD COLUMN `email` varchar(255)", Operation: "alter"},
+	}, "-80")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "delimiter")
+
+	_, err = shardScopedDispatchOperationKey([]storage.TableChange{
+		{Namespace: "commerce", Table: "users", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", Operation: "alter"},
+	}, "-80/0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "delimiter")
 }

--- a/pkg/tern/local_dispatch_shard_test.go
+++ b/pkg/tern/local_dispatch_shard_test.go
@@ -1,0 +1,33 @@
+package tern
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// A shard-scoped dispatch keys its single operation from the one
+// (namespace, table) its changes target; several changes to the same table
+// share that key. A dispatch mixing tables or namespaces cannot be represented
+// by one shard operation key and must fail closed.
+func TestShardScopedDispatchOperationKey(t *testing.T) {
+	key, err := shardScopedDispatchOperationKey([]storage.TableChange{
+		{Namespace: "commerce", Table: "users", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", Operation: "alter"},
+		{Namespace: "commerce", Table: "users", DDL: "ALTER TABLE `users` ADD COLUMN `phone` varchar(32)", Operation: "alter"},
+	}, "-80")
+	require.NoError(t, err)
+	assert.Equal(t, "commerce/-80/users", key)
+
+	_, err = shardScopedDispatchOperationKey([]storage.TableChange{
+		{Namespace: "commerce", Table: "users", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", Operation: "alter"},
+		{Namespace: "commerce", Table: "orders", DDL: "ALTER TABLE `orders` ADD COLUMN `note` text", Operation: "alter"},
+	}, "-80")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mixes tables")
+
+	_, err = shardScopedDispatchOperationKey(nil, "-80")
+	require.Error(t, err)
+}


### PR DESCRIPTION
## What broke

On a sharded database, a schema change is dispatched one shard at a time, and the dispatch tags its tasks with the target shard. But the loader a driver uses to pick up an apply's work skipped every shard-tagged row (that filter exists to keep per-shard *progress mirror* rows out of the drive pipeline). So the driver loaded **zero tasks**, concluded there was nothing to do, and marked the apply completed — **without ever running the DDL**. The never-started tasks then blocked every later apply on that shard.

## The fix

Make shard-tagged *drive* tasks distinguishable from progress mirrors:

1. The dispatch stamps its operation with the key `namespace/shard/table`.
2. The loader accepts a shard-tagged task when its own operation carries the matching key. Mirror rows have no matching key and stay excluded.

```
driver loads the apply's tasks
        │
        ├── task not shard-tagged ──────────────► load (normal drive task)
        │
        └── task shard-tagged
                │
                ├── its operation's key matches
                │   namespace/shard/table ──────► load (shard-scoped drive task)
                │
                └── no matching key ────────────► skip (per-shard progress mirror)
```

The "matching key" arm is new — previously every shard-tagged row was skipped, so a shard-scoped dispatch drove nothing and completed as a no-op. With it, these applies run their DDL, and stop/cancel/progress/cutover paths see their tasks too. #748 adds the complementary guard: if a loader ever misses tasks again, the apply refuses to complete instead of silently succeeding.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)