### PR TITLE
fix(tern): cancel orphaned pending tasks so they stop blocking new applies

### DIFF
--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -70,6 +70,12 @@ func (c *LocalClient) findBlockingTask(ctx context.Context, tasks []*storage.Tas
 			continue
 		}
 
+		// A pending task of a terminal apply can never start; cancel it so it
+		// stops blocking the database as phantom active work.
+		if c.tryResolveOrphanedPendingTask(ctx, t) {
+			continue
+		}
+
 		// Storage says non-terminal — verify with engine before blocking.
 		if c.tryResolveStaleTask(ctx, t, plan.Database) {
 			continue // Task was stale; engine confirmed it's done.
@@ -79,6 +85,46 @@ func (c *LocalClient) findBlockingTask(ctx context.Context, tasks []*storage.Tas
 		return t.TaskIdentifier
 	}
 	return ""
+}
+
+// tryResolveOrphanedPendingTask cancels a pending task whose parent apply has
+// already reached a terminal state. Such a task can never start: a terminal
+// apply is not claimable, so no drive will ever pick the task up, and pending
+// means no engine work or checkpoint exists to preserve. Left alone the task
+// would block every later apply targeting its database as phantom active work.
+// Any uncertainty — a non-pending state, a storage failure, or a missing apply
+// row — leaves the task untouched so it keeps blocking (fail closed).
+// Returns true if the task was cancelled and no longer blocks.
+func (c *LocalClient) tryResolveOrphanedPendingTask(ctx context.Context, t *storage.Task) bool {
+	if !state.IsState(t.State, state.Task.Pending) {
+		// Only a pending task is provably unstarted; every other state may own
+		// engine work or a checkpoint and stays with the engine-backed checks.
+		return false
+	}
+	apply, err := c.storage.Applies().Get(ctx, t.ApplyID)
+	if err != nil {
+		c.logger.Warn("conflict check: failed to load the pending task's apply; the task keeps blocking the database",
+			append(t.LogAttrs(), "error", err)...)
+		return false
+	}
+	if apply == nil {
+		c.logger.Warn("conflict check: pending task's apply row is missing; the task keeps blocking the database",
+			t.LogAttrs()...)
+		return false
+	}
+	if !state.IsTerminalApplyState(apply.State) {
+		c.logger.Debug("conflict check: pending task's apply is still active; the task blocks normally",
+			append(t.LogAttrs(), "apply_id", apply.ApplyIdentifier, "apply_state", apply.State)...)
+		return false
+	}
+	c.logger.Info("conflict check: cancelling orphaned pending task; its apply is terminal so the task can never start",
+		append(t.LogAttrs(), "apply_id", apply.ApplyIdentifier, "apply_state", apply.State)...)
+	now := time.Now()
+	t.ErrorMessage = "Task orphaned: its apply reached a terminal state before the task started"
+	t.CompletedAt = &now
+	c.transitionTaskState(ctx, t, apply.ID, state.Task.Cancelled,
+		"Cancelled orphaned pending task: its apply was already terminal, so the task could never start")
+	return true
 }
 
 // tryResolveStaleTask checks the engine to see if a non-terminal task is actually done.

--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -119,11 +119,27 @@ func (c *LocalClient) tryResolveOrphanedPendingTask(ctx context.Context, t *stor
 	}
 	c.logger.Info("conflict check: cancelling orphaned pending task; its apply is terminal so the task can never start",
 		append(t.LogAttrs(), "apply_id", apply.ApplyIdentifier, "apply_state", apply.State)...)
+	previousState := t.State
 	now := time.Now()
+	t.State = state.Task.Cancelled
 	t.ErrorMessage = "Task orphaned: its apply reached a terminal state before the task started"
 	t.CompletedAt = &now
-	c.transitionTaskState(ctx, t, apply.ID, state.Task.Cancelled,
-		"Cancelled orphaned pending task: its apply was already terminal, so the task could never start")
+	t.UpdatedAt = now
+	// The task only stops blocking once the cancellation is durably written:
+	// reporting it resolved on a failed write would admit the new apply while
+	// storage still records the orphan as active work.
+	if err := c.storage.Tasks().Update(ctx, t); err != nil {
+		t.State = previousState
+		t.ErrorMessage = ""
+		t.CompletedAt = nil
+		c.logger.Error("conflict check: failed to persist orphaned task cancellation; the task keeps blocking the database",
+			append(t.LogAttrs(), "apply_id", apply.ApplyIdentifier, "error", err)...)
+		return false
+	}
+	taskID := t.ID
+	c.logApplyEvent(ctx, apply.ID, &taskID, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
+		"Cancelled orphaned pending task: its apply was already terminal, so the task could never start",
+		previousState, state.Task.Cancelled)
 	return true
 }
 

--- a/pkg/tern/local_apply_conflict_test.go
+++ b/pkg/tern/local_apply_conflict_test.go
@@ -1,6 +1,7 @@
 package tern
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"testing"
@@ -206,6 +207,127 @@ func TestConflictCheckIsPerShard(t *testing.T) {
 	// The same shard still conflicts.
 	assert.Equal(t, "task-shard-neg40", client.findBlockingTask(t.Context(), tasks, plan, "-40"),
 		"an active task on shard -40 must block another apply on shard -40")
+}
+
+// A pending task whose apply already reached a terminal state is orphaned: the
+// apply will never be claimed again, so the task can never start, and pending
+// means no engine work or checkpoint exists. The conflict check cancels it so
+// it stops blocking the database, and the new apply is admitted.
+func TestConflictCheckCancelsOrphanedPendingTask(t *testing.T) {
+	for _, applyState := range []string{
+		state.Apply.Completed,
+		state.Apply.Failed,
+		state.Apply.Cancelled,
+	} {
+		t.Run(applyState, func(t *testing.T) {
+			orphan := &storage.Task{
+				ID:             6,
+				ApplyID:        61,
+				TaskIdentifier: "task-orphan",
+				Database:       "testdb",
+				DatabaseType:   storage.DatabaseTypeMySQL,
+				TableName:      "users",
+				Shard:          "-80",
+				State:          state.Task.Pending,
+			}
+			client := newNoActiveChangeClient("testdb", []*storage.Task{orphan})
+			client.storage.(*exactProgressStorage).applies = &mockApplyStore{apply: &storage.Apply{
+				ID: 61, ApplyIdentifier: "apply-terminal", Database: "testdb",
+				DatabaseType: storage.DatabaseTypeMySQL, State: applyState,
+			}}
+
+			plan := &storage.Plan{Database: "testdb", DatabaseType: storage.DatabaseTypeMySQL}
+			err := client.checkActiveTaskConflict(t.Context(), plan, "")
+			require.NoError(t, err, "an orphaned pending task must not refuse a new apply")
+			assert.Equal(t, state.Task.Cancelled, orphan.State, "the orphaned task must be cancelled")
+			assert.Contains(t, orphan.ErrorMessage, "orphaned")
+			assert.NotNil(t, orphan.CompletedAt)
+		})
+	}
+}
+
+// A pending task whose apply is still active is normal queued work — the drive
+// that owns it will start it. The conflict check must leave it pending and
+// refuse the new apply.
+func TestConflictCheckPreservesPendingTaskOfActiveApply(t *testing.T) {
+	pending := &storage.Task{
+		ID:             7,
+		ApplyID:        71,
+		TaskIdentifier: "task-pending-active",
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		TableName:      "users",
+		State:          state.Task.Pending,
+	}
+	client := newNoActiveChangeClient("testdb", []*storage.Task{pending})
+	client.storage.(*exactProgressStorage).applies = &mockApplyStore{apply: &storage.Apply{
+		ID: 71, ApplyIdentifier: "apply-active", Database: "testdb",
+		DatabaseType: storage.DatabaseTypeMySQL, State: state.Apply.Running,
+	}}
+
+	plan := &storage.Plan{Database: "testdb", DatabaseType: storage.DatabaseTypeMySQL}
+	err := client.checkActiveTaskConflict(t.Context(), plan, "")
+	require.Error(t, err, "a pending task of an active apply must refuse a new apply")
+	assert.Contains(t, err.Error(), "schema change already in progress")
+	assert.Equal(t, state.Task.Pending, pending.State, "the pending task must be left untouched")
+	assert.Empty(t, pending.ErrorMessage)
+	assert.Nil(t, pending.CompletedAt)
+}
+
+// When the pending task's apply cannot be loaded — a storage failure or a
+// missing row — the ownership question is unresolved, so the task keeps
+// blocking rather than being cancelled on uncertainty.
+func TestConflictCheckKeepsPendingTaskOnApplyLookupUncertainty(t *testing.T) {
+	t.Run("apply row missing", func(t *testing.T) {
+		pending := &storage.Task{
+			ID:             8,
+			ApplyID:        81,
+			TaskIdentifier: "task-pending-no-apply",
+			Database:       "testdb",
+			DatabaseType:   storage.DatabaseTypeMySQL,
+			TableName:      "users",
+			State:          state.Task.Pending,
+		}
+		client := newNoActiveChangeClient("testdb", []*storage.Task{pending})
+		client.storage.(*exactProgressStorage).applies = &mockApplyStore{apply: nil}
+
+		plan := &storage.Plan{Database: "testdb", DatabaseType: storage.DatabaseTypeMySQL}
+		err := client.checkActiveTaskConflict(t.Context(), plan, "")
+		require.Error(t, err, "a pending task with a missing apply row must keep blocking")
+		assert.Equal(t, state.Task.Pending, pending.State)
+		assert.Nil(t, pending.CompletedAt)
+	})
+
+	t.Run("apply load error", func(t *testing.T) {
+		pending := &storage.Task{
+			ID:             9,
+			ApplyID:        91,
+			TaskIdentifier: "task-pending-load-error",
+			Database:       "testdb",
+			DatabaseType:   storage.DatabaseTypeMySQL,
+			TableName:      "users",
+			State:          state.Task.Pending,
+		}
+		client := newNoActiveChangeClient("testdb", []*storage.Task{pending})
+		client.storage.(*exactProgressStorage).applies = &erroringApplyStore{err: errors.New("storage down")}
+
+		plan := &storage.Plan{Database: "testdb", DatabaseType: storage.DatabaseTypeMySQL}
+		err := client.checkActiveTaskConflict(t.Context(), plan, "")
+		require.Error(t, err, "a pending task must keep blocking when its apply cannot be loaded")
+		assert.Equal(t, state.Task.Pending, pending.State)
+		assert.Nil(t, pending.CompletedAt)
+	})
+}
+
+// erroringApplyStore fails every load, standing in for storage that is
+// unavailable while the conflict check runs.
+type erroringApplyStore struct {
+	storage.ApplyStore
+	err error
+}
+
+func (s *erroringApplyStore) Get(context.Context, int64) (*storage.Apply, error) {
+	return nil, s.err
 }
 
 // Once an abandoned in-flight task has been failed, it no longer blocks the

--- a/pkg/tern/local_apply_conflict_test.go
+++ b/pkg/tern/local_apply_conflict_test.go
@@ -330,6 +330,52 @@ func (s *erroringApplyStore) Get(context.Context, int64) (*storage.Apply, error)
 	return nil, s.err
 }
 
+// An orphan only stops blocking once its cancellation is durably written. If
+// the write fails, the task must keep blocking — reporting it resolved would
+// admit the new apply while storage still records the orphan as active work —
+// and the task must be left pending so a later conflict check retries the
+// cancellation cleanly.
+func TestConflictCheckKeepsOrphanWhenCancellationWriteFails(t *testing.T) {
+	orphan := &storage.Task{
+		ID:             10,
+		ApplyID:        101,
+		TaskIdentifier: "task-orphan-write-fails",
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		TableName:      "users",
+		State:          state.Task.Pending,
+	}
+	client := newNoActiveChangeClient("testdb", []*storage.Task{orphan})
+	stor := client.storage.(*exactProgressStorage)
+	stor.tasks = &updateFailingTaskStore{
+		exactProgressTaskStore: stor.tasks.(*exactProgressTaskStore),
+		updateErr:              errors.New("storage down"),
+	}
+	stor.applies = &mockApplyStore{apply: &storage.Apply{
+		ID: 101, ApplyIdentifier: "apply-terminal", Database: "testdb",
+		DatabaseType: storage.DatabaseTypeMySQL, State: state.Apply.Completed,
+	}}
+
+	plan := &storage.Plan{Database: "testdb", DatabaseType: storage.DatabaseTypeMySQL}
+	err := client.checkActiveTaskConflict(t.Context(), plan, "")
+	require.Error(t, err, "the orphan must keep blocking when its cancellation cannot be written")
+	assert.Contains(t, err.Error(), "schema change already in progress")
+	assert.Equal(t, state.Task.Pending, orphan.State, "the task must be restored to pending for a clean retry")
+	assert.Empty(t, orphan.ErrorMessage)
+	assert.Nil(t, orphan.CompletedAt)
+}
+
+// updateFailingTaskStore serves tasks normally but fails every state write,
+// standing in for storage that becomes unavailable mid-conflict-check.
+type updateFailingTaskStore struct {
+	*exactProgressTaskStore
+	updateErr error
+}
+
+func (s *updateFailingTaskStore) Update(context.Context, *storage.Task) error {
+	return s.updateErr
+}
+
 // Once an abandoned in-flight task has been failed, it no longer blocks the
 // database, so a new apply is admitted.
 func TestConflictCheckAdmitsApplyAfterFailingAbandonedTask(t *testing.T) {

--- a/pkg/tern/local_orphaned_task_integration_test.go
+++ b/pkg/tern/local_orphaned_task_integration_test.go
@@ -1,0 +1,129 @@
+//go:build integration
+
+package tern
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/block/spirit/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// A pending task whose apply already reached a terminal state is orphaned: the
+// apply will never be claimed again, so the task can never start. Without
+// cleanup it blocks every later apply targeting its database as phantom active
+// work. A new dispatch must cancel the orphan (durably, with an apply-log
+// entry) and proceed, instead of being refused forever.
+func TestLocalClient_DispatchCancelsOrphanedPendingTaskAndProceeds(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+	cleanupTestTables(t, dsn)
+
+	ctx := t.Context()
+	stor := createStorage(t, dsn)
+	defer utils.CloseAndLog(stor)
+	client, eng := newTasklessControlClient(t, dsn, stor)
+
+	now := time.Now()
+	plan := &storage.Plan{
+		PlanIdentifier: fmt.Sprintf("plan-orphan-%d", now.UnixNano()),
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Deployment:     "testdb",
+		Environment:    localClientTestEnvironment,
+		CreatedAt:      now,
+		Namespaces: map[string]*storage.NamespacePlanData{
+			"testdb": {
+				Tables: []storage.TableChange{
+					{Namespace: "testdb", Table: "users", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)", Operation: "alter"},
+				},
+			},
+		},
+	}
+	planID, err := stor.Plans().Create(ctx, plan)
+	require.NoError(t, err)
+
+	terminalApply := &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply-orphan-owner-%d", now.UnixNano()),
+		PlanID:          planID,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Deployment:      "testdb",
+		Environment:     localClientTestEnvironment,
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Pending,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	orphan := &storage.Task{
+		TaskIdentifier: fmt.Sprintf("task-orphan-%d", now.UnixNano()),
+		PlanID:         planID,
+		Database:       "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		Engine:         storage.EngineSpirit,
+		Environment:    localClientTestEnvironment,
+		State:          state.Task.Pending,
+		Namespace:      "testdb",
+		TableName:      "users",
+		Shard:          "-80",
+		DDL:            "ALTER TABLE `users` ADD COLUMN `email` varchar(255)",
+		DDLAction:      "alter",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	applyID, err := stor.Applies().CreateWithTasksAndOperations(ctx, terminalApply, []*storage.Task{orphan}, []*storage.ApplyOperation{{
+		Deployment: terminalApply.Deployment,
+		State:      state.ApplyOperation.Pending,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}})
+	require.NoError(t, err)
+	terminalApply.ID = applyID
+
+	// The owning apply settles without its task ever starting, leaving the
+	// pending task orphaned as the only non-terminal work on the database.
+	completedAt := time.Now()
+	terminalApply.State = state.Apply.Completed
+	terminalApply.CompletedAt = &completedAt
+	terminalApply.UpdatedAt = completedAt
+	require.NoError(t, stor.Applies().Update(ctx, terminalApply))
+
+	// A new dispatch on the same database must cancel the orphan and queue its
+	// apply instead of being refused.
+	newApply := dispatchQueuedApply(t, stor, client, []storage.TableChange{
+		{Namespace: "testdb", Table: "users", DDL: "ALTER TABLE `users` ADD COLUMN `phone` varchar(32)", Operation: "alter"},
+	})
+	require.NotNil(t, newApply)
+	assert.NotEqual(t, terminalApply.ApplyIdentifier, newApply.ApplyIdentifier)
+
+	persisted, err := stor.Tasks().Get(ctx, orphan.TaskIdentifier)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, state.Task.Cancelled, persisted.State, "the orphaned pending task must be durably cancelled")
+	assert.Contains(t, persisted.ErrorMessage, "orphaned")
+	assert.NotNil(t, persisted.CompletedAt)
+
+	logs, err := stor.ApplyLogs().GetByApply(ctx, terminalApply.ID)
+	require.NoError(t, err)
+	var found bool
+	for _, entry := range logs {
+		if entry.EventType == storage.LogEventStateTransition && entry.Message == "Cancelled orphaned pending task: its apply was already terminal, so the task could never start" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "the cancellation must be recorded in the owning apply's durable logs")
+
+	assert.Empty(t, eng.recorded(), "cancelling an orphan must not touch the engine")
+}


### PR DESCRIPTION
## What broke

A pending task whose apply already reached a terminal state is orphaned: terminal applies are never claimed again, so no drive will ever start the task. The conflict check that guards new dispatches ("is a schema change already in progress?") saw the non-terminal task and refused — permanently. Every dispatch to that database failed with "schema change already in progress", and nothing in the system could ever clear it.

## The fix

The conflict check now recognizes this shape and self-heals. Only a **pending** task qualifies — pending provably means no engine work or checkpoint ever existed. Anything uncertain keeps blocking.

```
new dispatch ── conflict check finds a non-terminal task
        │
        ├── task is pending AND its apply is terminal ──► cancel the orphan
        │                                                 (durably, + apply-log
        │                                                 entry) and proceed
        │
        └── anything else ──────────────────────────────► keep blocking
            (apply still active, stopped/retryable         (fail closed)
            task with a checkpoint, storage error,
            missing apply row)
```

Stopped and failed-retryable tasks are untouched — they own engine checkpoints and an operator retry budget. Databases already blocked by past orphans unblock automatically on their next dispatch, with the cancellation recorded in the owning apply's durable logs.

Completes the set with #749 (sharded dispatches drive their DDL) and #748 (a drive that can't load its tasks refuses to complete): #749 fixes the cause, #748 makes any recurrence loud, and this PR clears the blockage left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)