### PR TITLE
feat(observability): count orphaned pending task cancellations

### DIFF
--- a/pkg/metrics/README.md
+++ b/pkg/metrics/README.md
@@ -33,6 +33,7 @@ available, such as `repository`, `github_app`, and `installation_id`.
 | `schemabot.github.rate_limit.used` | Gauge | environment, operation, resource, repository, github_app, installation_id | GitHub primary rate limit requests used for the observed API resource |
 | `schemabot.control_operations_total` | Counter | operation, database, environment, status | Control operations (cutover, stop, start, etc.) |
 | `schemabot.lock_operations_total` | Counter | operation, database, environment, status | Lock acquire/release operations |
+| `schemabot.orphaned_task_cancel_total` | Counter | database, environment, outcome | Conflict-check cancellations of pending tasks whose apply was already terminal |
 | `schemabot.operator.resumed_total` | Counter | database, environment, previous_state | Applies resumed by the operator |
 | `schemabot.operator.resume_failures_total` | Counter | database, environment, reason | Operator resume attempts that failed |
 | `schemabot.operator.claim_failures_total` | Counter | environment, reason | Operator claim attempts that failed |

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -686,6 +686,34 @@ func RecordRemoteApplyDedup(ctx context.Context, database, environment, outcome 
 	)
 }
 
+// knownOrphanedTaskCancelOutcomes limits metric cardinality to the expected
+// orphaned pending task cancellation outcomes.
+var knownOrphanedTaskCancelOutcomes = map[string]bool{
+	"cancelled":    true,
+	"write_failed": true,
+}
+
+// RecordOrphanedTaskCancel increments the counter for conflict-check
+// cancellations of orphaned pending tasks — tasks whose apply reached a
+// terminal state before they started and would otherwise block every later
+// apply on their database as phantom active work. Outcome should be one of:
+//   - "cancelled": the orphan was durably cancelled and stopped blocking. The
+//     sweep self-heals, but a spike means something upstream is settling
+//     applies while leaving their tasks pending, which is worth investigating.
+//   - "write_failed": the cancellation could not be written, so the task kept
+//     blocking fail-closed and the new apply was refused.
+func RecordOrphanedTaskCancel(ctx context.Context, database, environment, outcome string) {
+	if !knownOrphanedTaskCancelOutcomes[outcome] {
+		outcome = "unknown"
+	}
+	addCounter(ctx, "schemabot.orphaned_task_cancel_total",
+		"Total conflict-check cancellations of orphaned pending tasks", "{task}",
+		attribute.String("database", database),
+		EnvironmentAttribute(environment),
+		attribute.String("outcome", outcome),
+	)
+}
+
 // operatorMetricNames returns the canonical operator metric name alongside its
 // deprecated schemabot.scheduler.* alias. Both are emitted for one release so
 // dashboards and alerts can migrate before the legacy series is removed.

--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/block/schemabot/pkg/engine"
 	"github.com/block/schemabot/pkg/engine/spirit"
+	"github.com/block/schemabot/pkg/metrics"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 )
@@ -134,8 +135,10 @@ func (c *LocalClient) tryResolveOrphanedPendingTask(ctx context.Context, t *stor
 		t.CompletedAt = nil
 		c.logger.Error("conflict check: failed to persist orphaned task cancellation; the task keeps blocking the database",
 			append(t.LogAttrs(), "apply_id", apply.ApplyIdentifier, "error", err)...)
+		metrics.RecordOrphanedTaskCancel(ctx, t.Database, t.Environment, "write_failed")
 		return false
 	}
+	metrics.RecordOrphanedTaskCancel(ctx, t.Database, t.Environment, "cancelled")
 	taskID := t.ID
 	c.logApplyEvent(ctx, apply.ID, &taskID, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
 		"Cancelled orphaned pending task: its apply was already terminal, so the task could never start",


### PR DESCRIPTION
## Why this matters

The conflict check now cancels pending tasks whose apply already reached a terminal state so they stop blocking new applies. That sweep self-heals the database, but every cancellation means something upstream settled an apply while leaving its task pending — a signal operators should see spike and investigate, not discover through log searches.

## What it does

- Adds a `schemabot.orphaned_task_cancel_total` counter (database, environment, outcome) recorded by the conflict-check sweep, with outcomes `cancelled` (orphan durably cancelled) and `write_failed` (cancellation write failed, task kept blocking fail-closed).
- Documents the metric in the metrics README.

Follow-up observability for the orphaned-task sweep introduced in #750.

🤖 Generated with [Claude Code](https://claude.com/claude-code)