### PR TITLE
fix(github): resolve base branch tip for freshness gate and reject stale branches before the unsafe prompt

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -462,15 +462,21 @@ repos:
 ```
 
 This is path-scoped rather than a whole-branch freshness requirement. At apply
-time, SchemaBot compares the Git tree object for the managed schema directory
-at the PR merge base with the same directory at the current base commit. If the
-tree objects match, unrelated commits elsewhere in a busy repository do not
-block the apply. If they differ, SchemaBot rejects the apply and instructs the
-user to merge or rebase the current base branch before reviewing a new plan.
+time, SchemaBot resolves the base branch ref to its current tip commit and
+compares the Git tree object for the managed schema directory at the PR merge
+base with the same directory at that tip. If the tree objects match, unrelated
+commits elsewhere in a busy repository do not block the apply. If they differ,
+SchemaBot rejects the apply and instructs the user to merge or rebase the
+current base branch before reviewing a new plan.
 
-The gate fails closed when GitHub cannot provide the merge base or either tree.
-It defaults to disabled for compatibility; enable it per repository after
-confirming the repository's schema directories are dedicated to schema inputs.
+The freshness rejection outranks every plan-derived response, including the
+unsafe-change prompt: a stale branch whose plan would revert newer base schema
+is told to update the branch, never to re-run with `--allow-unsafe`.
+
+The gate fails closed when GitHub cannot resolve the base branch tip, the
+merge base, or either tree. It defaults to disabled for compatibility; enable
+it per repository after confirming the repository's schema directories are
+dedicated to schema inputs.
 
 ## Review Gate
 

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -744,12 +744,14 @@ func (ic *InstallationClient) AddReactionToComment(ctx context.Context, repo str
 	return nil
 }
 
-// PullRequestInfo holds relevant PR metadata.
+// PullRequestInfo holds relevant PR metadata. The base branch is carried by
+// ref only: GitHub's pull.base.sha is a snapshot from PR creation, not the
+// branch tip, so callers that need the current base commit must resolve
+// BaseRef themselves.
 type PullRequestInfo struct {
 	HeadRef string
 	HeadSHA string
 	BaseRef string
-	BaseSHA string
 	User    string
 	// State is the PR's lifecycle state as GitHub reports it: "open" or
 	// "closed" (a merged PR reads as closed).
@@ -916,7 +918,6 @@ func (ic *InstallationClient) fetchPullRequest(ctx context.Context, repo string,
 		HeadRef: ghPR.GetHead().GetRef(),
 		HeadSHA: ghPR.GetHead().GetSHA(),
 		BaseRef: ghPR.GetBase().GetRef(),
-		BaseSHA: ghPR.GetBase().GetSHA(),
 		User:    ghPR.GetUser().GetLogin(),
 		State:   ghPR.GetState(),
 	}, nil
@@ -1013,46 +1014,69 @@ func (ic *InstallationClient) FetchChangedFilesBetween(ctx context.Context, repo
 }
 
 // SchemaPathsChangedSinceMergeBase reports whether any schema path has a
-// different Git object on the PR's current base commit than it had when the PR
-// diverged. Paths may name directories or symlinks. Comparing object IDs keeps
-// the guard scoped to schema inputs: commits elsewhere in a busy repository do
-// not make the PR stale.
-func (ic *InstallationClient) SchemaPathsChangedSinceMergeBase(ctx context.Context, repo, baseSHA, headSHA string, schemaPaths []string) (bool, error) {
+// different Git object on the current tip of the PR's base branch than it had
+// at the PR's merge base. Paths may name directories or symlinks. Comparing
+// object IDs keeps the guard scoped to schema inputs: commits elsewhere in a
+// busy repository do not make the PR stale.
+//
+// The base branch is identified by ref, never by the PR object's base SHA:
+// GitHub snapshots pull.base.sha when the PR is created and does not advance
+// it as the base branch moves, so the snapshot typically equals the merge base
+// and can never observe commits that landed after the PR diverged. The ref is
+// resolved to a pinned tip SHA up front — returned for operator logs — so a
+// base branch advancing mid-check cannot make the merge-base lookup and the
+// tree reads observe different commits.
+func (ic *InstallationClient) SchemaPathsChangedSinceMergeBase(ctx context.Context, repo, baseRef, headSHA string, schemaPaths []string) (changed bool, baseTipSHA string, err error) {
 	owner, repoName := splitRepo(repo)
-	comparison, err := retryGitHubUnavailableRead(ctx, ic.logger, "find pull request merge base", []any{"repo", repo, "base_sha", baseSHA, "head_sha", headSHA}, func(ctx context.Context) (*gh.CommitsComparison, error) {
-		comparison, _, err := ic.client.Repositories.CompareCommits(ctx, owner, repoName, baseSHA, headSHA, nil)
+	tip, err := retryGitHubUnavailableRead(ctx, ic.logger, "resolve base branch tip", []any{"repo", repo, "base_ref", baseRef}, func(ctx context.Context) (*gh.Reference, error) {
+		ref, _, err := ic.client.Git.GetRef(ctx, owner, repoName, "heads/"+baseRef)
 		if err != nil {
-			return nil, fmt.Errorf("compare commits %s...%s: %w", baseSHA, headSHA, classifyGitHubAPIError(err))
+			return nil, fmt.Errorf("get ref heads/%s: %w", baseRef, classifyGitHubAPIError(err))
+		}
+		return ref, nil
+	})
+	if err != nil {
+		return false, "", err
+	}
+	baseTipSHA = tip.GetObject().GetSHA()
+	if baseTipSHA == "" {
+		return false, "", fmt.Errorf("ref heads/%s for %s resolved to no commit", baseRef, repo)
+	}
+
+	comparison, err := retryGitHubUnavailableRead(ctx, ic.logger, "find pull request merge base", []any{"repo", repo, "base_ref", baseRef, "base_tip_sha", baseTipSHA, "head_sha", headSHA}, func(ctx context.Context) (*gh.CommitsComparison, error) {
+		comparison, _, err := ic.client.Repositories.CompareCommits(ctx, owner, repoName, baseTipSHA, headSHA, nil)
+		if err != nil {
+			return nil, fmt.Errorf("compare commits %s...%s: %w", baseTipSHA, headSHA, classifyGitHubAPIError(err))
 		}
 		return comparison, nil
 	})
 	if err != nil {
-		return false, err
+		return false, baseTipSHA, err
 	}
 	mergeBaseSHA := comparison.GetMergeBaseCommit().GetSHA()
 	if mergeBaseSHA == "" {
-		return false, fmt.Errorf("compare commits %s...%s for %s returned no merge base", baseSHA, headSHA, repo)
+		return false, baseTipSHA, fmt.Errorf("compare commits %s...%s for %s returned no merge base", baseTipSHA, headSHA, repo)
 	}
 
 	levelCache := make(map[string][]TreeEntry)
 	for _, schemaPath := range schemaPaths {
 		mergeBaseObjectSHA, mergeBaseObjectType, mergeBaseFound, err := ic.resolveGitObjectSHA(ctx, repo, mergeBaseSHA, schemaPath, levelCache)
 		if err != nil {
-			return false, fmt.Errorf("resolve schema path %s at merge base %s: %w", schemaPath, mergeBaseSHA, err)
+			return false, baseTipSHA, fmt.Errorf("resolve schema path %s at merge base %s: %w", schemaPath, mergeBaseSHA, err)
 		}
-		baseObjectSHA, baseObjectType, baseFound, err := ic.resolveGitObjectSHA(ctx, repo, baseSHA, schemaPath, levelCache)
+		baseObjectSHA, baseObjectType, baseFound, err := ic.resolveGitObjectSHA(ctx, repo, baseTipSHA, schemaPath, levelCache)
 		if err != nil {
-			return false, fmt.Errorf("resolve schema path %s at base %s: %w", schemaPath, baseSHA, err)
+			return false, baseTipSHA, fmt.Errorf("resolve schema path %s at base tip %s: %w", schemaPath, baseTipSHA, err)
 		}
 
 		if mergeBaseFound != baseFound {
-			return true, nil
+			return true, baseTipSHA, nil
 		}
 		if mergeBaseFound && (mergeBaseObjectSHA != baseObjectSHA || mergeBaseObjectType != baseObjectType) {
-			return true, nil
+			return true, baseTipSHA, nil
 		}
 	}
-	return false, nil
+	return false, baseTipSHA, nil
 }
 
 // CheckRunOptions contains options for creating or updating a GitHub Check Run.

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -511,34 +511,48 @@ func TestGetPRCheckStatusesClassifiesTrustedSiblingAppAsSchemaBot(t *testing.T) 
 	assert.False(t, byName["ci/build"].IsSchemaBot, "unrelated app check must remain external CI")
 }
 
+// registerBaseTipRef serves the base-branch ref resolution the freshness
+// comparison performs before comparing commits. The tip SHA is deliberately
+// distinct from any PR-object base snapshot: the comparison must observe the
+// branch's current tip, which GitHub only exposes via the ref.
+func registerBaseTipRef(t *testing.T, mux *http.ServeMux, tipSHA string) {
+	t.Helper()
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/ref/heads/main", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.Reference{
+			Ref:    new("refs/heads/main"),
+			Object: &gh.GitObject{Type: new("commit"), SHA: &tipSHA},
+		}))
+	})
+}
+
 func TestSchemaPathsChangedSinceMergeBase(t *testing.T) {
 	tests := []struct {
 		name         string
 		mergeTreeSHA string
-		baseTreeSHA  string
+		tipTreeSHA   string
 		mergeHasPath bool
-		baseHasPath  bool
+		tipHasPath   bool
 		wantChanged  bool
 	}{
 		{
 			name:         "same schema tree ignores unrelated base commits",
 			mergeTreeSHA: "schema-tree",
-			baseTreeSHA:  "schema-tree",
+			tipTreeSHA:   "schema-tree",
 			mergeHasPath: true,
-			baseHasPath:  true,
+			tipHasPath:   true,
 		},
 		{
-			name:         "changed schema tree is stale",
+			name:         "schema tree changed on base tip is stale",
 			mergeTreeSHA: "schema-tree-old",
-			baseTreeSHA:  "schema-tree-new",
+			tipTreeSHA:   "schema-tree-new",
 			mergeHasPath: true,
-			baseHasPath:  true,
+			tipHasPath:   true,
 			wantChanged:  true,
 		},
 		{
 			name:        "schema path added on base is stale",
-			baseTreeSHA: "schema-tree-new",
-			baseHasPath: true,
+			tipTreeSHA:  "schema-tree-new",
+			tipHasPath:  true,
 			wantChanged: true,
 		},
 		{
@@ -555,7 +569,8 @@ func TestSchemaPathsChangedSinceMergeBase(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client, mux := setupRateLimitedTestGitHubServer(t)
-			mux.HandleFunc("GET /repos/octocat/hello-world/compare/base-sha...head-sha", func(w http.ResponseWriter, _ *http.Request) {
+			registerBaseTipRef(t, mux, "base-tip-sha")
+			mux.HandleFunc("GET /repos/octocat/hello-world/compare/base-tip-sha...head-sha", func(w http.ResponseWriter, _ *http.Request) {
 				require.NoError(t, json.NewEncoder(w).Encode(gh.CommitsComparison{
 					MergeBaseCommit: &gh.RepositoryCommit{SHA: new("merge-base-sha")},
 				}))
@@ -570,35 +585,64 @@ func TestSchemaPathsChangedSinceMergeBase(t *testing.T) {
 				})
 			}
 			registerRootTree("GET /repos/octocat/hello-world/git/trees/merge-base-sha", tt.mergeHasPath, tt.mergeTreeSHA)
-			registerRootTree("GET /repos/octocat/hello-world/git/trees/base-sha", tt.baseHasPath, tt.baseTreeSHA)
+			registerRootTree("GET /repos/octocat/hello-world/git/trees/base-tip-sha", tt.tipHasPath, tt.tipTreeSHA)
 
 			ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
-			changed, err := ic.SchemaPathsChangedSinceMergeBase(t.Context(), "octocat/hello-world", "base-sha", "head-sha", []string{"schema"})
+			changed, baseTipSHA, err := ic.SchemaPathsChangedSinceMergeBase(t.Context(), "octocat/hello-world", "main", "head-sha", []string{"schema"})
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantChanged, changed)
+			assert.Equal(t, "base-tip-sha", baseTipSHA)
 		})
 	}
 }
 
 func TestSchemaPathsChangedSinceMergeBaseFailsWithoutMergeBase(t *testing.T) {
 	client, mux := setupRateLimitedTestGitHubServer(t)
-	mux.HandleFunc("GET /repos/octocat/hello-world/compare/base-sha...head-sha", func(w http.ResponseWriter, _ *http.Request) {
+	registerBaseTipRef(t, mux, "base-tip-sha")
+	mux.HandleFunc("GET /repos/octocat/hello-world/compare/base-tip-sha...head-sha", func(w http.ResponseWriter, _ *http.Request) {
 		require.NoError(t, json.NewEncoder(w).Encode(gh.CommitsComparison{}))
 	})
 
 	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
-	_, err := ic.SchemaPathsChangedSinceMergeBase(t.Context(), "octocat/hello-world", "base-sha", "head-sha", []string{"schema"})
+	_, _, err := ic.SchemaPathsChangedSinceMergeBase(t.Context(), "octocat/hello-world", "main", "head-sha", []string{"schema"})
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "returned no merge base")
+}
+
+// The base branch is compared by resolving its ref to the current tip; if the
+// ref cannot be resolved the comparison must fail (the caller rejects the
+// apply) rather than report the schema paths as unchanged.
+func TestSchemaPathsChangedSinceMergeBaseFailsWhenBaseRefUnresolvable(t *testing.T) {
+	client, _ := setupRateLimitedTestGitHubServer(t)
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	_, _, err := ic.SchemaPathsChangedSinceMergeBase(t.Context(), "octocat/hello-world", "main", "head-sha", []string{"schema"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "get ref heads/main")
+}
+
+func TestSchemaPathsChangedSinceMergeBaseFailsWhenBaseRefHasNoCommit(t *testing.T) {
+	client, mux := setupRateLimitedTestGitHubServer(t)
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/ref/heads/main", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.Reference{Ref: new("refs/heads/main")}))
+	})
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	_, _, err := ic.SchemaPathsChangedSinceMergeBase(t.Context(), "octocat/hello-world", "main", "head-sha", []string{"schema"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolved to no commit")
 }
 
 func TestSchemaPathsChangedSinceMergeBaseDetectsSymlinkRetarget(t *testing.T) {
 	client, mux := setupRateLimitedTestGitHubServer(t)
 	var mergeRootRequests, baseRootRequests atomic.Int32
 	var mergeSchemaRequests, baseSchemaRequests atomic.Int32
-	mux.HandleFunc("GET /repos/octocat/hello-world/compare/base-sha...head-sha", func(w http.ResponseWriter, _ *http.Request) {
+	registerBaseTipRef(t, mux, "base-tip-sha")
+	mux.HandleFunc("GET /repos/octocat/hello-world/compare/base-tip-sha...head-sha", func(w http.ResponseWriter, _ *http.Request) {
 		require.NoError(t, json.NewEncoder(w).Encode(gh.CommitsComparison{
 			MergeBaseCommit: &gh.RepositoryCommit{SHA: new("merge-base-sha")},
 		}))
@@ -609,7 +653,7 @@ func TestSchemaPathsChangedSinceMergeBaseDetectsSymlinkRetarget(t *testing.T) {
 			{Path: new("schema"), Type: new("tree"), SHA: new("merge-schema-tree")},
 		}}))
 	})
-	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/base-sha", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/base-tip-sha", func(w http.ResponseWriter, _ *http.Request) {
 		baseRootRequests.Add(1)
 		require.NoError(t, json.NewEncoder(w).Encode(gh.Tree{Entries: []*gh.TreeEntry{
 			{Path: new("schema"), Type: new("tree"), SHA: new("base-schema-tree")},
@@ -631,10 +675,11 @@ func TestSchemaPathsChangedSinceMergeBaseDetectsSymlinkRetarget(t *testing.T) {
 	})
 
 	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
-	changed, err := ic.SchemaPathsChangedSinceMergeBase(t.Context(), "octocat/hello-world", "base-sha", "head-sha", []string{"schema/base", "schema/production"})
+	changed, baseTipSHA, err := ic.SchemaPathsChangedSinceMergeBase(t.Context(), "octocat/hello-world", "main", "head-sha", []string{"schema/base", "schema/production"})
 
 	require.NoError(t, err)
 	assert.True(t, changed)
+	assert.Equal(t, "base-tip-sha", baseTipSHA)
 	assert.Equal(t, int32(1), mergeRootRequests.Load())
 	assert.Equal(t, int32(1), baseRootRequests.Load())
 	assert.Equal(t, int32(1), mergeSchemaRequests.Load())
@@ -643,19 +688,20 @@ func TestSchemaPathsChangedSinceMergeBaseDetectsSymlinkRetarget(t *testing.T) {
 
 func TestSchemaPathsChangedSinceMergeBaseUsesRootTreeSHA(t *testing.T) {
 	client, mux := setupRateLimitedTestGitHubServer(t)
-	mux.HandleFunc("GET /repos/octocat/hello-world/compare/base-sha...head-sha", func(w http.ResponseWriter, _ *http.Request) {
+	registerBaseTipRef(t, mux, "base-tip-sha")
+	mux.HandleFunc("GET /repos/octocat/hello-world/compare/base-tip-sha...head-sha", func(w http.ResponseWriter, _ *http.Request) {
 		require.NoError(t, json.NewEncoder(w).Encode(gh.CommitsComparison{
 			MergeBaseCommit: &gh.RepositoryCommit{SHA: new("merge-base-sha")},
 		}))
 	})
-	for _, ref := range []string{"merge-base-sha", "base-sha"} {
+	for _, ref := range []string{"merge-base-sha", "base-tip-sha"} {
 		mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/"+ref, func(w http.ResponseWriter, _ *http.Request) {
 			require.NoError(t, json.NewEncoder(w).Encode(gh.Tree{SHA: new("same-root-tree")}))
 		})
 	}
 
 	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
-	changed, err := ic.SchemaPathsChangedSinceMergeBase(t.Context(), "octocat/hello-world", "base-sha", "head-sha", []string{"."})
+	changed, _, err := ic.SchemaPathsChangedSinceMergeBase(t.Context(), "octocat/hello-world", "main", "head-sha", []string{"."})
 
 	require.NoError(t, err)
 	assert.False(t, changed, "different commit SHAs with the same root tree are unchanged")

--- a/pkg/github/pr_info_cache_test.go
+++ b/pkg/github/pr_info_cache_test.go
@@ -34,7 +34,7 @@ func TestFetchPullRequest_CacheCollapsesDuplicateCallsWithinScope(t *testing.T) 
 
 	ctx := WithPRInfoCache(t.Context())
 
-	want := &PullRequestInfo{HeadRef: "feature", HeadSHA: "abc123", BaseRef: "main", BaseSHA: "def456", User: "octocat"}
+	want := &PullRequestInfo{HeadRef: "feature", HeadSHA: "abc123", BaseRef: "main", User: "octocat"}
 
 	got, err := ic1.FetchPullRequest(ctx, "octo/repo", 42)
 	require.NoError(t, err)

--- a/pkg/webhook/apply_execute.go
+++ b/pkg/webhook/apply_execute.go
@@ -50,6 +50,35 @@ func (h *Handler) executeApply(
 		return
 	}
 
+	// Revalidate the PR before interpreting the re-plan. The earlier handler
+	// checks provide fast rejection, but the re-plan can be retried and the
+	// base branch or PR HEAD can advance while it runs. A stale snapshot must
+	// be rejected before any plan-derived response — the "no changes" release,
+	// the drift downgrade, and especially the unsafe-change prompt would all
+	// misread DDL that is only an artifact of the stale branch.
+	actionName := action.ApplyConfirm
+	if storedPlan != nil {
+		actionName = action.Apply
+	}
+	freshPRInfo, err := client.FetchPullRequestNoCache(ctx, repo, pr)
+	if err != nil {
+		h.logger.Error("apply rejected: failed final PR freshness fetch",
+			"repo", repo, "pr", pr, "database", database, "database_type", dbType,
+			"environment", environment, "action", actionName, "error", err)
+		h.postCommandError(repo, pr, installationID, actionName, environment, requestedBy,
+			"SchemaBot could not verify the current PR state. The apply was rejected; retry the command.")
+		h.releaseApplyLockIfIntentUnchanged(ctx, repo, pr, database, dbType, environment, expectedPendingPlanID, "final PR freshness fetch failure")
+		return
+	}
+	if rejected := h.assertSchemaStillCurrent(ctx, repo, pr, installationID, schemaResult, freshPRInfo.HeadSHA, environment, requestedBy, actionName); rejected {
+		h.releaseApplyLockIfIntentUnchanged(ctx, repo, pr, database, dbType, environment, expectedPendingPlanID, "final stale-schema rejection")
+		return
+	}
+	if rejected := h.assertBaseSchemaStillCurrent(ctx, client, repo, pr, installationID, schemaResult, freshPRInfo, environment, requestedBy, actionName); rejected {
+		h.releaseApplyLockIfIntentUnchanged(ctx, repo, pr, database, dbType, environment, expectedPendingPlanID, "final base-schema freshness rejection")
+		return
+	}
+
 	// No changes — release the lock (keyed on the pending intent this handler
 	// observed, so a lock re-pinned by a newer plan is preserved) and notify.
 	if len(planResp.FlatTables()) == 0 {
@@ -85,32 +114,6 @@ func (h *Handler) executeApply(
 		commentData := buildPlanCommentData(schemaResult, planResp, environment, result.Tenant, requestedBy)
 		h.logger.Info("apply blocked by unsafe changes", "repo", repo, "pr", pr, "database", database, "environment", environment)
 		h.postComment(repo, pr, installationID, templates.RenderUnsafeChangesBlocked(commentData))
-		return
-	}
-
-	// Revalidate the PR immediately before the apply is queued. The earlier
-	// handler checks provide fast rejection, but the apply-time re-plan can be
-	// retried and the base branch or PR HEAD can advance while it runs.
-	actionName := action.ApplyConfirm
-	if storedPlan != nil {
-		actionName = action.Apply
-	}
-	freshPRInfo, err := client.FetchPullRequestNoCache(ctx, repo, pr)
-	if err != nil {
-		h.logger.Error("apply rejected: failed final PR freshness fetch",
-			"repo", repo, "pr", pr, "database", database, "database_type", dbType,
-			"environment", environment, "action", actionName, "error", err)
-		h.postCommandError(repo, pr, installationID, actionName, environment, requestedBy,
-			"SchemaBot could not verify the current PR state. The apply was rejected; retry the command.")
-		h.releaseApplyLockIfIntentUnchanged(ctx, repo, pr, database, dbType, environment, expectedPendingPlanID, "final PR freshness fetch failure")
-		return
-	}
-	if rejected := h.assertSchemaStillCurrent(ctx, repo, pr, installationID, schemaResult, freshPRInfo.HeadSHA, environment, requestedBy, actionName); rejected {
-		h.releaseApplyLockIfIntentUnchanged(ctx, repo, pr, database, dbType, environment, expectedPendingPlanID, "final stale-schema rejection")
-		return
-	}
-	if rejected := h.assertBaseSchemaStillCurrent(ctx, client, repo, pr, installationID, schemaResult, freshPRInfo, environment, requestedBy, actionName); rejected {
-		h.releaseApplyLockIfIntentUnchanged(ctx, repo, pr, database, dbType, environment, expectedPendingPlanID, "final base-schema freshness rejection")
 		return
 	}
 

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -150,6 +150,29 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		}
 	}
 
+	// Reject a stale snapshot before planning. A stale branch needs an update
+	// no matter what a plan would say, so freshness rejections outrank every
+	// plan-derived response — in particular the unsafe-change prompt, which
+	// would otherwise coach the user toward `--allow-unsafe` for DDL that only
+	// looks destructive because the branch is missing newer base-branch schema
+	// changes. No lock is held here, so rejections need no release.
+	//
+	// Use FetchPullRequestNoCache: the cached FetchPullRequest used by
+	// discovery would return the discovery-time HeadSHA, masking the race.
+	prInfo, prErr := client.FetchPullRequestNoCache(ctx, repo, pr)
+	if prErr != nil {
+		h.logger.Error("failed to fetch PR for stale-schema check",
+			"repo", repo, "pr", pr, "database", database, "database_type", dbType, "environment", environment, "error", prErr)
+		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Failed to verify PR HEAD before apply: "+prErr.Error())
+		return
+	}
+	if rejected := h.assertSchemaStillCurrent(ctx, repo, pr, installationID, schemaResult, prInfo.HeadSHA, environment, requestedBy, action.Apply); rejected {
+		return
+	}
+	if rejected := h.assertBaseSchemaStillCurrent(ctx, client, repo, pr, installationID, schemaResult, prInfo, environment, requestedBy, action.Apply); rejected {
+		return
+	}
+
 	// Generate plan
 	prNumber := int32(pr)
 	planReq := api.PlanRequest{
@@ -212,36 +235,10 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	commentData.SkipRevert = result.SkipRevert
 	commentData.AllowUnsafe = result.AllowUnsafe
 
-	// Check safety conditions before proceeding.
-	// Reject if the PR HEAD advanced after discovery loaded schema files.
-	// Running against the loaded files would execute DDL derived from an
-	// older commit than the branch is on right now. Release the lock
-	// acquired above so the user can re-run `schemabot apply -e <env>`
-	// cleanly without a manual unlock.
-	//
-	// Use FetchPullRequestNoCache: the cached FetchPullRequest used by
-	// discovery would return the discovery-time HeadSHA, masking the race.
-	prInfo, prErr := client.FetchPullRequestNoCache(ctx, repo, pr)
-	if prErr != nil {
-		h.logger.Error("failed to fetch PR for stale-schema check, releasing lock",
-			"repo", repo, "pr", pr, "database", database, "database_type", dbType, "environment", environment, "error", prErr)
-		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Failed to verify PR HEAD before apply: "+prErr.Error())
-		h.releaseApplyLockIfIntentUnchanged(ctx, repo, pr, database, dbType, environment, planResp.PlanID, "PR freshness fetch failure")
-		return
-	}
-	if rejected := h.assertSchemaStillCurrent(ctx, repo, pr, installationID, schemaResult, prInfo.HeadSHA, environment, requestedBy, action.Apply); rejected {
-		h.releaseApplyLockIfIntentUnchanged(ctx, repo, pr, database, dbType, environment, planResp.PlanID, "stale-schema rejection")
-		return
-	}
-	if rejected := h.assertBaseSchemaStillCurrent(ctx, client, repo, pr, installationID, schemaResult, prInfo, environment, requestedBy, action.Apply); rejected {
-		h.releaseApplyLockIfIntentUnchanged(ctx, repo, pr, database, dbType, environment, planResp.PlanID, "base-schema freshness rejection")
-		return
-	}
-
-	// Re-evaluate the checks gate against the fresh HEAD before executing.
-	// The early gate at the top of handleApplyCommand ran against the
-	// discovery-time HeadSHA. On the automatic apply path there is no second
-	// user action between plan and apply, so a required check that
+	// Re-evaluate the checks gate against the freshness-checked HEAD before
+	// executing. The early gate at the top of handleApplyCommand ran against
+	// the discovery-time HeadSHA. On the automatic apply path there is no
+	// second user action between plan and apply, so a required check that
 	// transitioned to failing on the same SHA (e.g. CI re-ran red, or a
 	// new required check was added) would otherwise sneak past. Release
 	// the lock on block so the user can re-run `schemabot apply -e <env>`

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -163,7 +163,8 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	if prErr != nil {
 		h.logger.Error("failed to fetch PR for stale-schema check",
 			"repo", repo, "pr", pr, "database", database, "database_type", dbType, "environment", environment, "error", prErr)
-		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Failed to verify PR HEAD before apply: "+prErr.Error())
+		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy,
+			"SchemaBot could not verify the current PR state. The apply was rejected; retry the command.")
 		return
 	}
 	if rejected := h.assertSchemaStillCurrent(ctx, repo, pr, installationID, schemaResult, prInfo.HeadSHA, environment, requestedBy, action.Apply); rejected {

--- a/pkg/webhook/apply_integration_test.go
+++ b/pkg/webhook/apply_integration_test.go
@@ -1521,11 +1521,12 @@ func TestE2EApplyStaleBaseSchemaOutranksUnsafePrompt(t *testing.T) {
 
 // The final revalidation inside apply execution also outranks the unsafe
 // prompt. Here the base branch advances only while the confirm's re-plan is
-// running: the handler-level gate sees an unchanged schema tree, then the
-// re-plan produces a destructive diff (the target already has the column the
-// stale snapshot omits) and the base tip's schema tree has moved by the time
-// the final gate reads it. The user must get the freshness rejection — with
-// the lock released — not an `--allow-unsafe` prompt for revert DDL.
+// running: the handler-level gate resolves the base ref to a tip whose schema
+// tree matches the merge base's, then the re-plan produces a destructive diff
+// (the target already has the column the stale snapshot omits) and the base
+// ref has moved to a newer tip by the time the final gate resolves it. The
+// user must get the freshness rejection — with the lock released — not an
+// `--allow-unsafe` prompt for revert DDL.
 func TestE2EApplyConfirmStaleBaseSchemaAtFinalGateOutranksUnsafePrompt(t *testing.T) {
 	dbName := "webhook_confirm_final_stale_base"
 	svc := setupE2EService(t, dbName)
@@ -1583,35 +1584,41 @@ func TestE2EApplyConfirmStaleBaseSchemaAtFinalGateOutranksUnsafePrompt(t *testin
 		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
 	}, schemabotConfig, dbName)
 
-	// The base branch schema tree is unchanged when the handler-level gate
-	// reads it and has moved by the time the final gate re-reads it after the
-	// re-plan. The merge-base tree is fixed; only the tip's tree flips.
+	// The base branch advances to a new tip commit while the re-plan runs:
+	// the handler-level gate resolves the ref to a tip whose schema tree
+	// still matches the merge base's, and the final gate — resolving the ref
+	// again — observes the newer tip whose schema tree differs. Each commit's
+	// tree is immutable; only the ref moves, so the gate detects the advance
+	// only if it re-resolves the ref rather than reusing an earlier tip.
+	var refReads atomic.Int32
 	mux.HandleFunc("GET /repos/octocat/hello-world/git/ref/heads/main", func(w http.ResponseWriter, _ *http.Request) {
+		tipSHA := "base-tip-1"
+		if refReads.Add(1) > 1 {
+			tipSHA = "base-tip-2"
+		}
 		require.NoError(t, json.NewEncoder(w).Encode(gh.Reference{
 			Ref:    new("refs/heads/main"),
-			Object: &gh.GitObject{Type: new("commit"), SHA: new("base-tip-sha")},
+			Object: &gh.GitObject{Type: new("commit"), SHA: &tipSHA},
 		}))
 	})
-	mux.HandleFunc("GET /repos/octocat/hello-world/compare/base-tip-sha...abc123", func(w http.ResponseWriter, _ *http.Request) {
-		require.NoError(t, json.NewEncoder(w).Encode(gh.CommitsComparison{
-			MergeBaseCommit: &gh.RepositoryCommit{SHA: new("def456")},
-		}))
-	})
-	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/def456", func(w http.ResponseWriter, _ *http.Request) {
-		require.NoError(t, json.NewEncoder(w).Encode(gh.Tree{Entries: []*gh.TreeEntry{
-			{Path: new("schema"), Type: new("tree"), SHA: new("schema-tree-old")},
-		}}))
-	})
-	var tipTreeReads atomic.Int32
-	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/base-tip-sha", func(w http.ResponseWriter, _ *http.Request) {
-		schemaTreeSHA := "schema-tree-old"
-		if tipTreeReads.Add(1) > 1 {
-			schemaTreeSHA = "schema-tree-new"
-		}
-		require.NoError(t, json.NewEncoder(w).Encode(gh.Tree{Entries: []*gh.TreeEntry{
-			{Path: new("schema"), Type: new("tree"), SHA: &schemaTreeSHA},
-		}}))
-	})
+	for _, tipSHA := range []string{"base-tip-1", "base-tip-2"} {
+		mux.HandleFunc("GET /repos/octocat/hello-world/compare/"+tipSHA+"...abc123", func(w http.ResponseWriter, _ *http.Request) {
+			require.NoError(t, json.NewEncoder(w).Encode(gh.CommitsComparison{
+				MergeBaseCommit: &gh.RepositoryCommit{SHA: new("def456")},
+			}))
+		})
+	}
+	for path, treeSHA := range map[string]string{
+		"def456":     "schema-tree-old",
+		"base-tip-1": "schema-tree-old",
+		"base-tip-2": "schema-tree-new",
+	} {
+		mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/"+path, func(w http.ResponseWriter, _ *http.Request) {
+			require.NoError(t, json.NewEncoder(w).Encode(gh.Tree{Entries: []*gh.TreeEntry{
+				{Path: new("schema"), Type: new("tree"), SHA: new(treeSHA)},
+			}}))
+		})
+	}
 
 	h := newE2EHandler(t, svc, client)
 	req := buildWebhookRequest(t, webhookPayloadOpts{

--- a/pkg/webhook/apply_integration_test.go
+++ b/pkg/webhook/apply_integration_test.go
@@ -1470,10 +1470,10 @@ func TestE2EApplyStaleBaseSchemaOutranksUnsafePrompt(t *testing.T) {
 	// The live target already carries the column the newer base commit added.
 	targetDB, err := sql.Open("mysql", e2eTargetDSN+"&multiStatements=true")
 	require.NoError(t, err)
+	defer utils.CloseAndLog(targetDB)
 	_, err = targetDB.ExecContext(t.Context(),
 		"CREATE TABLE `"+dbName+"`.`users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `email` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci")
 	require.NoError(t, err)
-	_ = targetDB.Close()
 
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
@@ -1543,7 +1543,7 @@ func TestE2EApplyConfirmStaleBaseSchemaAtFinalGateOutranksUnsafePrompt(t *testin
 		PendingPlanID: pendingPlanID,
 	}))
 	t.Cleanup(func() {
-		_ = svc.Storage().Locks().ForceRelease(context.WithoutCancel(t.Context()), dbName, "mysql")
+		_ = svc.Storage().Locks().ForceRelease(t.Context(), dbName, "mysql")
 	})
 
 	// The confirmation plan the user reviewed, rendered at the current HEAD so
@@ -1567,10 +1567,10 @@ func TestE2EApplyConfirmStaleBaseSchemaAtFinalGateOutranksUnsafePrompt(t *testin
 	// so the re-plan from the stale snapshot emits a destructive DROP COLUMN.
 	targetDB, err := sql.Open("mysql", e2eTargetDSN+"&multiStatements=true")
 	require.NoError(t, err)
+	defer utils.CloseAndLog(targetDB)
 	_, err = targetDB.ExecContext(t.Context(),
 		"CREATE TABLE `"+dbName+"`.`users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `email` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci")
 	require.NoError(t, err)
-	_ = targetDB.Close()
 
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)

--- a/pkg/webhook/apply_integration_test.go
+++ b/pkg/webhook/apply_integration_test.go
@@ -1396,8 +1396,11 @@ func TestE2EApplyAutoConfirmRejectsWhenHEADAdvanced(t *testing.T) {
 }
 
 // A PR whose managed schema directory changed on the base branch after it
-// diverged is rejected before execution and its lock is released. Unrelated
-// base-branch commits are excluded by the directory tree comparison.
+// diverged is rejected before any plan is generated or lock acquired.
+// Unrelated base-branch commits are excluded by the directory tree comparison.
+// The fake models real GitHub semantics: the PR object's base SHA is a
+// creation-time snapshot equal to the merge base, so the gate only sees the
+// newer base commits by resolving the base ref to its current tip.
 func TestE2EApplyAutoConfirmRejectsStaleBaseSchema(t *testing.T) {
 	dbName := "webhook_auto_confirm_stale_base"
 	svc := setupE2EService(t, dbName)
@@ -1448,6 +1451,195 @@ func TestE2EApplyAutoConfirmRejectsStaleBaseSchema(t *testing.T) {
 	require.NoError(t, err)
 	for _, apply := range applies {
 		assert.NotEqual(t, dbName, apply.Database, "base-stale schema must not start an apply")
+	}
+}
+
+// A stale branch outranks the unsafe-change prompt. The base branch gained a
+// schema column after this PR diverged, and the live target already has it —
+// so a plan from the stale snapshot would emit a destructive DROP COLUMN that
+// only exists because the branch is missing the newer base schema. The apply
+// must answer with the base-schema freshness rejection, never coach the user
+// toward `--allow-unsafe`, and must not lock or start an apply.
+func TestE2EApplyStaleBaseSchemaOutranksUnsafePrompt(t *testing.T) {
+	dbName := "webhook_stale_base_unsafe"
+	svc := setupE2EService(t, dbName)
+	svc.Config().Repos = map[string]api.RepoConfig{
+		"octocat/hello-world": {RequireUpToDateWithBase: true},
+	}
+
+	// The live target already carries the column the newer base commit added.
+	targetDB, err := sql.Open("mysql", e2eTargetDSN+"&multiStatements=true")
+	require.NoError(t, err)
+	_, err = targetDB.ExecContext(t.Context(),
+		"CREATE TABLE `"+dbName+"`.`users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `email` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci")
+	require.NoError(t, err)
+	_ = targetDB.Close()
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	// The stale PR snapshot omits the email column the base branch added.
+	result := setupFakeGitHubForPlan(t, mux, map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}, schemabotConfig, dbName)
+	registerStaleBaseSchemaComparison(t, mux)
+
+	h := newE2EHandler(t, svc, client)
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot apply -e staging",
+		isPR:    true,
+	}, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "Apply rejected — base schema is newer")
+		assert.Contains(t, body, "Merge or rebase")
+		assert.NotContains(t, body, "allow-unsafe", "stale branch must not be coached toward --allow-unsafe")
+		assert.NotContains(t, body, "Unsafe Change", "unsafe prompt must not outrank the freshness rejection")
+		assert.NotContains(t, body, "DROP COLUMN", "no stale-plan DDL may be rendered")
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for base-schema rejection")
+	}
+
+	lock, err := svc.Storage().Locks().Get(t.Context(), dbName, "mysql")
+	require.NoError(t, err)
+	assert.Nil(t, lock, "freshness rejection must not leave a lock behind")
+
+	applies, err := svc.Storage().Applies().GetByPR(t.Context(), "octocat/hello-world", 1)
+	require.NoError(t, err)
+	for _, apply := range applies {
+		assert.NotEqual(t, dbName, apply.Database, "base-stale schema must not start an apply")
+	}
+}
+
+// The final revalidation inside apply execution also outranks the unsafe
+// prompt. Here the base branch advances only while the confirm's re-plan is
+// running: the handler-level gate sees an unchanged schema tree, then the
+// re-plan produces a destructive diff (the target already has the column the
+// stale snapshot omits) and the base tip's schema tree has moved by the time
+// the final gate reads it. The user must get the freshness rejection — with
+// the lock released — not an `--allow-unsafe` prompt for revert DDL.
+func TestE2EApplyConfirmStaleBaseSchemaAtFinalGateOutranksUnsafePrompt(t *testing.T) {
+	dbName := "webhook_confirm_final_stale_base"
+	svc := setupE2EService(t, dbName)
+	svc.Config().Repos = map[string]api.RepoConfig{
+		"octocat/hello-world": {RequireUpToDateWithBase: true},
+	}
+
+	const pendingPlanID = "plan-pending-confirmation"
+	require.NoError(t, svc.Storage().Locks().Acquire(t.Context(), &storage.Lock{
+		DatabaseName:  dbName,
+		DatabaseType:  "mysql",
+		Repository:    "octocat/hello-world",
+		PullRequest:   1,
+		Owner:         "octocat/hello-world#1",
+		PendingPlanID: pendingPlanID,
+	}))
+	t.Cleanup(func() {
+		_ = svc.Storage().Locks().ForceRelease(context.WithoutCancel(t.Context()), dbName, "mysql")
+	})
+
+	// The confirmation plan the user reviewed, rendered at the current HEAD so
+	// the cross-delivery plan check passes and execution reaches the re-plan.
+	planID, err := svc.Storage().Plans().Create(t.Context(), &storage.Plan{
+		PlanIdentifier: pendingPlanID,
+		Database:       dbName,
+		DatabaseType:   "mysql",
+		Deployment:     dbName,
+		Target:         dbName,
+		Repository:     "octocat/hello-world",
+		PullRequest:    1,
+		Environment:    "staging",
+		HeadSHA:        "abc123",
+		CreatedAt:      time.Now(),
+	})
+	require.NoError(t, err)
+	require.NotZero(t, planID)
+
+	// The live target already carries the column the newer base commit added,
+	// so the re-plan from the stale snapshot emits a destructive DROP COLUMN.
+	targetDB, err := sql.Open("mysql", e2eTargetDSN+"&multiStatements=true")
+	require.NoError(t, err)
+	_, err = targetDB.ExecContext(t.Context(),
+		"CREATE TABLE `"+dbName+"`.`users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `email` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci")
+	require.NoError(t, err)
+	_ = targetDB.Close()
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	result := setupFakeGitHubForPlan(t, mux, map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}, schemabotConfig, dbName)
+
+	// The base branch schema tree is unchanged when the handler-level gate
+	// reads it and has moved by the time the final gate re-reads it after the
+	// re-plan. The merge-base tree is fixed; only the tip's tree flips.
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/ref/heads/main", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.Reference{
+			Ref:    new("refs/heads/main"),
+			Object: &gh.GitObject{Type: new("commit"), SHA: new("base-tip-sha")},
+		}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/compare/base-tip-sha...abc123", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.CommitsComparison{
+			MergeBaseCommit: &gh.RepositoryCommit{SHA: new("def456")},
+		}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/def456", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.Tree{Entries: []*gh.TreeEntry{
+			{Path: new("schema"), Type: new("tree"), SHA: new("schema-tree-old")},
+		}}))
+	})
+	var tipTreeReads atomic.Int32
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/base-tip-sha", func(w http.ResponseWriter, _ *http.Request) {
+		schemaTreeSHA := "schema-tree-old"
+		if tipTreeReads.Add(1) > 1 {
+			schemaTreeSHA = "schema-tree-new"
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(gh.Tree{Entries: []*gh.TreeEntry{
+			{Path: new("schema"), Type: new("tree"), SHA: &schemaTreeSHA},
+		}}))
+	})
+
+	h := newE2EHandler(t, svc, client)
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot apply-confirm -e staging",
+		isPR:    true,
+	}, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "Apply rejected — base schema is newer")
+		assert.NotContains(t, body, "allow-unsafe", "stale branch must not be coached toward --allow-unsafe")
+		assert.NotContains(t, body, "Unsafe Change", "unsafe prompt must not outrank the freshness rejection")
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for final-gate base-schema rejection")
+	}
+
+	require.Eventually(t, func() bool {
+		lock, err := svc.Storage().Locks().Get(t.Context(), dbName, "mysql")
+		return err == nil && lock == nil
+	}, 5*time.Second, 50*time.Millisecond, "lock must be released after final-gate base-schema rejection")
+
+	applies, err := svc.Storage().Applies().GetByPR(t.Context(), "octocat/hello-world", 1)
+	require.NoError(t, err)
+	for _, apply := range applies {
+		assert.NotEqual(t, dbName, apply.Database, "base-stale confirmation must not start an apply")
 	}
 }
 
@@ -1625,22 +1817,35 @@ func registerStaleBaseSchemaComparison(t *testing.T, mux *http.ServeMux) {
 	registerStaleBaseSchemaComparisonWithHook(t, mux, nil)
 }
 
+// registerStaleBaseSchemaComparisonWithHook wires the fake GitHub endpoints
+// the base-schema freshness gate reads when the base branch gained schema
+// commits after the PR diverged. It mirrors real GitHub semantics: the PR
+// object's base SHA ("def456") is a creation-time snapshot equal to the merge
+// base, so only resolving the base ref reveals the advanced tip, whose schema
+// tree differs from the merge base's. The optional hook runs when the
+// merge-base comparison is fetched, mid-way through the gate's reads.
 func registerStaleBaseSchemaComparisonWithHook(t *testing.T, mux *http.ServeMux, hook func()) {
 	t.Helper()
-	mux.HandleFunc("GET /repos/octocat/hello-world/compare/def456...abc123", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/ref/heads/main", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.Reference{
+			Ref:    new("refs/heads/main"),
+			Object: &gh.GitObject{Type: new("commit"), SHA: new("base-tip-sha")},
+		}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/compare/base-tip-sha...abc123", func(w http.ResponseWriter, _ *http.Request) {
 		if hook != nil {
 			hook()
 		}
 		require.NoError(t, json.NewEncoder(w).Encode(gh.CommitsComparison{
-			MergeBaseCommit: &gh.RepositoryCommit{SHA: new("merge-base-sha")},
+			MergeBaseCommit: &gh.RepositoryCommit{SHA: new("def456")},
 		}))
 	})
-	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/merge-base-sha", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/def456", func(w http.ResponseWriter, _ *http.Request) {
 		require.NoError(t, json.NewEncoder(w).Encode(gh.Tree{Entries: []*gh.TreeEntry{
 			{Path: new("schema"), Type: new("tree"), SHA: new("schema-tree-old")},
 		}}))
 	})
-	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/def456", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/base-tip-sha", func(w http.ResponseWriter, _ *http.Request) {
 		require.NoError(t, json.NewEncoder(w).Encode(gh.Tree{Entries: []*gh.TreeEntry{
 			{Path: new("schema"), Type: new("tree"), SHA: new("schema-tree-new")},
 		}}))

--- a/pkg/webhook/schema_freshness.go
+++ b/pkg/webhook/schema_freshness.go
@@ -76,7 +76,9 @@ func metricActionKey(action string) string {
 
 // assertBaseSchemaStillCurrent enforces the opt-in repository policy that a PR
 // must include every base-branch change under its managed schema directory.
-// It compares Git tree object IDs at the PR merge base and current base, so
+// It compares Git tree object IDs at the PR merge base and the current tip of
+// the base branch (resolved from prInfo.BaseRef — the PR object's base SHA is
+// a creation-time snapshot that never observes later base commits), so
 // unrelated commits elsewhere in a monorepo never block an apply. GitHub read
 // uncertainty rejects the apply rather than silently bypassing the guard.
 func (h *Handler) assertBaseSchemaStillCurrent(
@@ -100,7 +102,7 @@ func (h *Handler) assertBaseSchemaStillCurrent(
 	if schema.SchemaLinkPath != "" {
 		schemaPaths = append(schemaPaths, schema.SchemaLinkPath)
 	}
-	changed, err := client.SchemaPathsChangedSinceMergeBase(ctx, repo, prInfo.BaseSHA, prInfo.HeadSHA, schemaPaths)
+	changed, baseTipSHA, err := client.SchemaPathsChangedSinceMergeBase(ctx, repo, prInfo.BaseRef, prInfo.HeadSHA, schemaPaths)
 	if err != nil {
 		h.logger.Error("apply rejected: could not verify base schema freshness",
 			"repo", repo,
@@ -109,7 +111,7 @@ func (h *Handler) assertBaseSchemaStillCurrent(
 			"database", schema.Database,
 			"database_type", schema.Type,
 			"schema_path", schema.SchemaPath,
-			"base_sha", prInfo.BaseSHA,
+			"base_ref", prInfo.BaseRef,
 			"head_sha", prInfo.HeadSHA,
 			"action", action,
 			"requested_by", requestedBy,
@@ -136,7 +138,8 @@ func (h *Handler) assertBaseSchemaStillCurrent(
 		"database", schema.Database,
 		"database_type", schema.Type,
 		"schema_path", schema.SchemaPath,
-		"base_sha", prInfo.BaseSHA,
+		"base_ref", prInfo.BaseRef,
+		"base_tip_sha", baseTipSHA,
 		"head_sha", prInfo.HeadSHA,
 		"action", action,
 		"requested_by", requestedBy,


### PR DESCRIPTION
## Why this matters

The base-schema freshness gate could never fire. GitHub's `pull.base.sha` is a creation-time snapshot of the base branch — it typically equals the PR's merge base and never advances as the base moves — so the gate compared the schema directory's tree at the merge base against the same commit and always concluded "unchanged". A stale branch could re-plan a revert of schema changes that had just landed on the base branch, get flagged only by the unsafe-change gate, and be coached toward `--allow-unsafe` — exactly the destructive path the gate exists to block. The tests passed because the fakes populated `BaseSHA` with the live branch tip, masking the API semantics.

## What it does

- Resolves the base branch **ref** to its current tip commit (pinned up front, returned for triage logs) and compares merge-base vs tip schema trees. Removes `PullRequestInfo.BaseSHA` so nothing can trust the snapshot again. Fails closed when the ref cannot be resolved.
- Makes freshness rejections outrank plan-derived responses, on both paths:

```
apply:    discovery → gates → [head + base freshness] → plan → unsafe → lock → execute
confirm:  gates → [head + base freshness] → plan-currency → re-plan → [final freshness] → unsafe → queue
```

  A stale branch is now told to update — never prompted to re-run with `--allow-unsafe` for DDL that only looks destructive because the branch is missing newer base schema. On the apply path the gates run before planning, so no lock is taken and no data-plane plan is wasted on a snapshot that will be rejected.
- Webhook fakes now model real GitHub semantics (snapshot == merge base; only the ref reveals the advanced tip), turning the existing gate tests into true regression tests. New coverage: freshness-before-unsafe ordering on the apply path, the same at the final in-execution gate via a base tip that advances mid-re-plan, and fail-closed client tests for unresolvable base refs.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)