### PR TITLE
fix(tern): presume the drive lease lost after heartbeats fail for the staleness window

### DIFF
--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -1209,6 +1209,21 @@ func (s *Service) resumeClaimedApplyWithOptions(ctx context.Context, driverID in
 			s.failClaimedApplyAfterDrivePanic(ctx, driverID, apply, applyOperationID, deployment, drivePanic)
 			return false, err
 		}
+		if errors.Is(err, tern.ErrApplyLeasePresumedLost) {
+			s.logger.Warn("operator: apply lease presumed lost after heartbeat failures spanning the staleness window; driver will stop writing this apply and a peer will reclaim it",
+				"driver", driverID,
+				"lease_owner", lease.Owner,
+				"apply_id", apply.ApplyIdentifier,
+				"database", apply.Database,
+				"deployment", deployment,
+				"environment", apply.Environment,
+				"error", err)
+			metrics.RecordOperatorResumeFailure(ctx, apply.Database, deployment, apply.Environment, "lease_presumed_lost")
+			if retryableClaim {
+				metrics.AdjustActiveApplies(ctx, -1, apply.Database, deployment, apply.Environment)
+			}
+			return false, err
+		}
 		if errors.Is(err, storage.ErrApplyLeaseLost) {
 			s.logger.Warn("operator: apply lease was lost; driver will stop writing this apply",
 				"driver", driverID,

--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -20,17 +20,12 @@ const (
 	// OperatorPollInterval is the default interval for polling applies that need attention.
 	OperatorPollInterval = 10 * time.Second
 
-	// HeartbeatTimeout is how long since last heartbeat before
-	// an apply is considered to have a crashed driver and needs recovery.
-	// FindNextApply uses this (via SQL: updated_at < NOW() - INTERVAL 1 MINUTE).
-	HeartbeatTimeout = 1 * time.Minute
-
 	// ApplyOperationHeartbeatInterval bounds how often the operation-row
 	// heartbeat fires while ResumeApply runs. It is kept safely below
-	// HeartbeatTimeout so that a large (or misconfigured) operator poll
-	// interval cannot let apply_operations.updated_at go stale and allow a peer
-	// driver to re-claim the operation mid-resume. The effective cadence is
-	// min(operatorPollInterval, ApplyOperationHeartbeatInterval).
+	// storage.ApplyLeaseStaleAfter so that a large (or misconfigured) operator
+	// poll interval cannot let apply_operations.updated_at go stale and allow a
+	// peer driver to re-claim the operation mid-resume. The effective cadence
+	// is min(operatorPollInterval, ApplyOperationHeartbeatInterval).
 	ApplyOperationHeartbeatInterval = 10 * time.Second
 
 	// DefaultDrivers is the number of concurrent operator drivers
@@ -1484,8 +1479,11 @@ func (s *Service) logApplyDrivePanicFailure(ctx context.Context, driverID int, a
 // ResumeApply runs, at min(operatorPollInterval, ApplyOperationHeartbeatInterval)
 // so the row cannot go stale and be re-claimed by a peer even when the poll
 // interval is large. The heartbeat writes under the operation lease, so a lost
-// operation lease cancels the run and the displaced driver stops; other
-// heartbeat errors are logged and retried on the next tick.
+// operation lease cancels the run and the displaced driver stops. Other
+// heartbeat errors are logged and retried on the next tick — until they have
+// persisted for the full storage.ApplyLeaseStaleAfter window, at which point
+// the lease is presumed lost (a peer can already have reclaimed the stale row)
+// and the run is cancelled the same way.
 // Returns a stop func that is safe to call more than once.
 func (s *Service) startApplyOperationHeartbeat(ctx context.Context, driverID int, op *storage.ApplyOperation, apply *storage.Apply, cancelRun context.CancelFunc) func() {
 	hbCtx, stop := context.WithCancel(ctx)
@@ -1493,37 +1491,59 @@ func (s *Service) startApplyOperationHeartbeat(ctx context.Context, driverID int
 	s.recoveryWg.Go(func() {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
+		lastSuccess := s.clock.Now()
 		for {
 			select {
 			case <-hbCtx.Done():
 				return
 			case <-ticker.C:
-				if err := s.storage.ApplyOperations().Heartbeat(hbCtx, op.ID); err != nil {
-					if errors.Is(err, storage.ErrApplyLeaseLost) {
-						s.logger.Warn("operator: apply_operation heartbeat lost operation lease; driver will stop",
-							"driver", driverID,
-							"apply_operation_id", op.ID,
-							"apply_id", apply.ApplyIdentifier,
-							"database", apply.Database,
-							"deployment", op.Deployment,
-							"environment", apply.Environment,
-							"error", err)
-						cancelRun()
-						return
-					}
-					s.logger.Warn("operator: apply_operation heartbeat failed; will retry",
-						"driver", driverID,
-						"apply_operation_id", op.ID,
-						"apply_id", apply.ApplyIdentifier,
-						"database", apply.Database,
-						"deployment", op.Deployment,
-						"environment", apply.Environment,
-						"error", err)
+				err := s.storage.ApplyOperations().Heartbeat(hbCtx, op.ID)
+				if err == nil {
+					lastSuccess = s.clock.Now()
+					continue
+				}
+				if hbCtx.Err() != nil {
+					// The run is shutting down; the failed write is
+					// cancellation fallout, not lease trouble.
+					return
+				}
+				if s.operationHeartbeatFailureStopsDrive(hbCtx, driverID, op, apply, err, lastSuccess) {
+					cancelRun()
+					return
 				}
 			}
 		}
 	})
 	return stop
+}
+
+// operationHeartbeatFailureStopsDrive classifies a failed operation heartbeat
+// write and reports whether the driver must stop driving: either storage
+// reported the operation lease definitively lost, or heartbeat failures have
+// persisted since lastSuccess for the full lease staleness window, so a peer
+// driver can already have reclaimed the stale row. A transient failure inside
+// the window keeps the run going and is retried on the next tick.
+func (s *Service) operationHeartbeatFailureStopsDrive(ctx context.Context, driverID int, op *storage.ApplyOperation, apply *storage.Apply, hbErr error, lastSuccess time.Time) bool {
+	logAttrs := append(op.LogAttrs(),
+		"driver", driverID,
+		"apply_id", apply.ApplyIdentifier,
+		"database", apply.Database,
+		"environment", apply.Environment,
+	)
+	if errors.Is(hbErr, storage.ErrApplyLeaseLost) {
+		s.logger.Warn("operator: apply_operation heartbeat lost operation lease; driver will stop",
+			append(logAttrs, "error", hbErr)...)
+		return true
+	}
+	if s.clock.Now().Sub(lastSuccess) >= storage.ApplyLeaseStaleAfter {
+		s.logger.Warn("operator: apply_operation heartbeat has failed for the full lease staleness window; a peer driver can reclaim the operation, so this driver will stop",
+			append(logAttrs, "last_successful_heartbeat", lastSuccess, "error", hbErr)...)
+		metrics.RecordOperatorResumeFailure(ctx, apply.Database, op.Deployment, apply.Environment, "lease_presumed_lost")
+		return true
+	}
+	s.logger.Warn("operator: apply_operation heartbeat failed; will retry",
+		append(logAttrs, "error", hbErr)...)
+	return false
 }
 
 // markOperationFromApplyState transitions the claimed operation row to mirror

--- a/pkg/api/operator_heartbeat_test.go
+++ b/pkg/api/operator_heartbeat_test.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// TestOperationHeartbeatFailureStopsDrive verifies how an operation drive
+// reacts to a failed operation-row heartbeat write: a definitively lost
+// operation lease stops the driver immediately, a transient storage error
+// inside the lease staleness window keeps the run going so the heartbeat is
+// retried on the next tick, and failures that have persisted for the full
+// window stop the driver because a peer can already have reclaimed the stale
+// operation row.
+func TestOperationHeartbeatFailureStopsDrive(t *testing.T) {
+	svc := newTestService()
+	op := &storage.ApplyOperation{
+		ID:            7,
+		ApplyID:       41,
+		Deployment:    "default",
+		OperationKind: storage.ApplyOperationKindWork,
+		State:         state.Apply.Running,
+	}
+	apply := &storage.Apply{
+		ID:              41,
+		ApplyIdentifier: "apply-operation-heartbeat",
+		Database:        "widgets",
+		Deployment:      "default",
+		Environment:     "staging",
+		State:           state.Apply.Running,
+	}
+
+	t.Run("lost operation lease stops the driver immediately", func(t *testing.T) {
+		hbErr := fmt.Errorf("heartbeat apply_operation %d: %w", op.ID, storage.ErrApplyLeaseLost)
+		assert.True(t, svc.operationHeartbeatFailureStopsDrive(t.Context(), 1, op, apply, hbErr, time.Now()))
+	})
+
+	t.Run("transient failure inside the window keeps driving", func(t *testing.T) {
+		hbErr := errors.New("connection refused")
+		assert.False(t, svc.operationHeartbeatFailureStopsDrive(t.Context(), 1, op, apply, hbErr, time.Now()))
+	})
+
+	t.Run("failures spanning the staleness window stop the driver", func(t *testing.T) {
+		hbErr := errors.New("connection refused")
+		lastSuccess := time.Now().Add(-storage.ApplyLeaseStaleAfter)
+		assert.True(t, svc.operationHeartbeatFailureStopsDrive(t.Context(), 1, op, apply, hbErr, lastSuccess))
+	})
+}

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -1136,8 +1136,8 @@ func (s *applyStore) GetRecent(ctx context.Context, filter storage.RecentApplies
 //
 // Matches queued pending applies with persisted tasks, pending, stopped, or
 // waiting-for-deploy applies with a pending start control request, stale active
-// applies where heartbeat expired > 1 minute, and recently failed_retryable
-// applies that still have retry budget.
+// applies whose heartbeat expired beyond the lease staleness window, and
+// recently failed_retryable applies that still have retry budget.
 // Apply creation/update enforces one active apply per database/type/environment,
 // so claims only need to lease one row and avoid driver races on that row.
 func (s *applyStore) FindNextApply(ctx context.Context, owner string) (*storage.Apply, error) {
@@ -1183,7 +1183,7 @@ func (s *applyStore) FindNextApply(ctx context.Context, owner string) (*storage.
 					EXISTS (SELECT 1 FROM tasks t WHERE t.apply_id = a.id)
 					OR EXISTS (SELECT 1 FROM apply_operations ao WHERE ao.apply_id = a.id)
 				))
-				OR (a.state IN (%s) AND a.updated_at < NOW() - INTERVAL 1 MINUTE)
+				OR (a.state IN (%s) AND a.updated_at < NOW() - INTERVAL %s)
 				OR (a.state = ? AND a.attempt < ? AND a.updated_at >= NOW() - INTERVAL ? DAY)
 				OR (
 					a.state = ?
@@ -1210,7 +1210,7 @@ func (s *applyStore) FindNextApply(ctx context.Context, owner string) (*storage.
 						AND (
 							a.lease_acquired_at IS NULL
 							OR a.lease_acquired_at < cr.updated_at
-							OR a.updated_at < NOW() - INTERVAL 1 MINUTE
+							OR a.updated_at < NOW() - INTERVAL %s
 						)
 					)
 				)
@@ -1218,7 +1218,7 @@ func (s *applyStore) FindNextApply(ctx context.Context, owner string) (*storage.
 		ORDER BY a.created_at
 		LIMIT 1
 		FOR UPDATE SKIP LOCKED
-	`, applyColumns, activeStatePlaceholders), queryArgs...)
+	`, applyColumns, activeStatePlaceholders, applyLeaseStalenessSQL, applyLeaseStalenessSQL), queryArgs...)
 
 	apply, err := scanApplyInto(row)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -1289,7 +1289,7 @@ func (s *applyStore) ClaimApplyByID(ctx context.Context, applyID int64, owner st
 					EXISTS (SELECT 1 FROM tasks t WHERE t.apply_id = a.id)
 					OR EXISTS (SELECT 1 FROM apply_operations ao WHERE ao.apply_id = a.id)
 				))
-				OR (a.state IN (%s) AND a.updated_at < NOW() - INTERVAL 1 MINUTE)
+				OR (a.state IN (%s) AND a.updated_at < NOW() - INTERVAL %s)
 				OR (a.state = ? AND a.attempt < ? AND a.updated_at >= NOW() - INTERVAL ? DAY)
 				OR (
 					a.state = ?
@@ -1316,14 +1316,14 @@ func (s *applyStore) ClaimApplyByID(ctx context.Context, applyID int64, owner st
 						AND (
 							a.lease_acquired_at IS NULL
 							OR a.lease_acquired_at < cr.updated_at
-							OR a.updated_at < NOW() - INTERVAL 1 MINUTE
+							OR a.updated_at < NOW() - INTERVAL %s
 						)
 					)
 				)
 			)
 		LIMIT 1
 		FOR UPDATE SKIP LOCKED
-	`, applyColumns, activeStatePlaceholders), queryArgs...)
+	`, applyColumns, activeStatePlaceholders, applyLeaseStalenessSQL, applyLeaseStalenessSQL), queryArgs...)
 
 	apply, err := scanApplyInto(row)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/pkg/storage/mysqlstore/apply_operations.go
+++ b/pkg/storage/mysqlstore/apply_operations.go
@@ -575,11 +575,6 @@ func (s *applyOperationStore) GetEngineResumeState(ctx context.Context, operatio
 	}, nil
 }
 
-// applyOperationHeartbeatStaleness is the lease window after which a claimed
-// apply_operations row may be re-claimed by another driver. Mirrors the apply
-// heartbeat staleness in applies.go.
-const applyOperationHeartbeatStaleness = "1 MINUTE"
-
 // releasedFailureExemptionSQL stops a terminal-failed earlier sibling from
 // blocking a later deployment's claim once the rollout policy says to keep
 // going: on_failure='continue', or on_failure='pause' after a release control
@@ -900,7 +895,7 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 						AND (
 							apply_operations.lease_acquired_at IS NULL
 							OR apply_operations.lease_acquired_at < cr.updated_at
-							OR apply_operations.updated_at < NOW() - INTERVAL 1 MINUTE
+							OR apply_operations.updated_at < NOW() - INTERVAL %s
 						)
 				)
 			)
@@ -927,7 +922,7 @@ func (s *applyOperationStore) FindNextApplyOperation(ctx context.Context, owner 
 		ORDER BY created_at, id
 		LIMIT 1
 		FOR UPDATE SKIP LOCKED
-	`, applyOperationColumns, activeStatePlaceholders, applyOperationHeartbeatStaleness, activeStatePlaceholders, activeStatePlaceholders, applyOperationHeartbeatStaleness), queryArgs...)
+	`, applyOperationColumns, activeStatePlaceholders, applyLeaseStalenessSQL, activeStatePlaceholders, applyLeaseStalenessSQL, activeStatePlaceholders, applyLeaseStalenessSQL), queryArgs...)
 
 	ad, err := scanApplyOperationInto(row)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -1214,7 +1209,7 @@ func (s *applyOperationStore) FindNextApplyOperationCutover(ctx context.Context,
 		ORDER BY created_at, id
 		LIMIT 1
 		FOR UPDATE SKIP LOCKED
-	`, applyOperationColumns, applyOperationHeartbeatStaleness), queryArgs...)
+	`, applyOperationColumns, applyLeaseStalenessSQL), queryArgs...)
 
 	ad, err := scanApplyOperationInto(row)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/pkg/storage/mysqlstore/sql_helpers.go
+++ b/pkg/storage/mysqlstore/sql_helpers.go
@@ -5,8 +5,18 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"log/slog"
+	"time"
+
+	"github.com/block/schemabot/pkg/storage"
 )
+
+// applyLeaseStalenessSQL is the SQL INTERVAL after which a claimed applies or
+// apply_operations row's lease heartbeat (updated_at) is stale and the row may
+// be re-claimed by another driver. Derived from storage.ApplyLeaseStaleAfter so
+// the reclaim window and the driver-side presumed-lost bound cannot drift apart.
+var applyLeaseStalenessSQL = fmt.Sprintf("%d SECOND", int64(storage.ApplyLeaseStaleAfter/time.Second))
 
 // rollbackTx rolls back tx, logging a warning if the rollback fails for a
 // reason other than the transaction already being finished. operation is

--- a/pkg/storage/mysqlstore/sql_helpers.go
+++ b/pkg/storage/mysqlstore/sql_helpers.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"time"
 
 	"github.com/block/schemabot/pkg/storage"
 )
@@ -15,8 +14,11 @@ import (
 // applyLeaseStalenessSQL is the SQL INTERVAL after which a claimed applies or
 // apply_operations row's lease heartbeat (updated_at) is stale and the row may
 // be re-claimed by another driver. Derived from storage.ApplyLeaseStaleAfter so
-// the reclaim window and the driver-side presumed-lost bound cannot drift apart.
-var applyLeaseStalenessSQL = fmt.Sprintf("%d SECOND", int64(storage.ApplyLeaseStaleAfter/time.Second))
+// the reclaim window and the driver-side presumed-lost bound cannot drift
+// apart; microsecond units keep the two windows exactly equal for any
+// duration, so the reclaim window can never round below the presumed-lost
+// bound.
+var applyLeaseStalenessSQL = fmt.Sprintf("%d MICROSECOND", storage.ApplyLeaseStaleAfter.Microseconds())
 
 // rollbackTx rolls back tx, logging a warning if the rollback fails for a
 // reason other than the transaction already being finished. operation is

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -12,6 +12,18 @@ import (
 // fresh plan so stale execution context is not reactivated unexpectedly.
 const ReapplyFailureFreshnessDays = 1
 
+// ApplyLeaseStaleAfter is how long an apply or apply_operation lease heartbeat
+// (updated_at) may go unrefreshed before peer drivers treat the lease as
+// expired and reclaim the row for crash recovery. The claim queries in
+// mysqlstore derive their SQL staleness window from this constant.
+//
+// The window is also the driver-side presumed-lost bound: a driver whose
+// heartbeats have been failing for this long must assume a peer can already
+// have reclaimed the work, stop driving, and stop writing apply state. Storage
+// writes remain lease-guarded either way; presuming the lease lost bounds how
+// long two drivers can run the same engine work concurrently.
+const ApplyLeaseStaleAfter = time.Minute
+
 // Storage provides access to all stores.
 type Storage interface {
 	// Locks returns the lock store.

--- a/pkg/tern/client.go
+++ b/pkg/tern/client.go
@@ -18,6 +18,15 @@ import (
 // callers can match it with errors.Is regardless of the transport.
 var ErrNoTasksForApplyOperation = errors.New("no tasks found for apply operation")
 
+// ErrApplyLeasePresumedLost is returned by a drive whose lease heartbeat
+// writes have been failing for the full storage.ApplyLeaseStaleAfter window.
+// The lease was never definitively reported lost — storage was unreachable —
+// but the row's heartbeat is now stale enough for a peer driver to reclaim
+// it, so the current owner must stop driving. Callers match it with errors.Is
+// to record the displacement once and release the claim without treating it
+// as an engine failure.
+var ErrApplyLeasePresumedLost = errors.New("apply lease presumed lost after heartbeat failures spanning the staleness window")
+
 // ErrApplyOperationRowMissing is returned by ResumeApplyOperation when tasks
 // scope to the operation but the apply_operation row itself is absent. It is a
 // distinct, more accurate cause than the no-tasks case, but wraps

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -2627,11 +2627,12 @@ func (c *GRPCClient) heartbeatScopedDrive(ctx context.Context, apply *storage.Ap
 // It returns a non-nil error when the drive must end: either storage reported
 // the lease definitively lost, or heartbeat failures have persisted since
 // lastSuccess for the full lease staleness window, so a peer driver can
-// already have reclaimed the stale row. A transient failure inside the window
-// returns nil so the drive keeps polling and the heartbeat is retried on the
-// next tick. The remote Tern keeps executing either way; the next claimant
-// reattaches to it.
-func driveEndingHeartbeatFailure(ctx context.Context, apply *storage.Apply, hbErr error, lastSuccess time.Time) error {
+// already have reclaimed the stale row — that case wraps
+// ErrApplyLeasePresumedLost so the operator records the displacement exactly
+// once. A transient failure inside the window returns nil so the drive keeps
+// polling and the heartbeat is retried on the next tick. The remote Tern keeps
+// executing either way; the next claimant reattaches to it.
+func driveEndingHeartbeatFailure(apply *storage.Apply, hbErr error, lastSuccess time.Time) error {
 	if errors.Is(hbErr, storage.ErrApplyLeaseLost) {
 		slog.Warn("gRPC drive heartbeat lost the lease; current owner will stop driving and writing apply state",
 			append(apply.LogAttrs(), "error", hbErr)...)
@@ -2640,9 +2641,8 @@ func driveEndingHeartbeatFailure(ctx context.Context, apply *storage.Apply, hbEr
 	if time.Since(lastSuccess) >= storage.ApplyLeaseStaleAfter {
 		slog.Warn("gRPC drive heartbeat has failed for the full lease staleness window; a peer driver can reclaim the work, so this owner will stop driving and writing apply state",
 			append(apply.LogAttrs(), "last_successful_heartbeat", lastSuccess, "error", hbErr)...)
-		metrics.RecordOperatorResumeFailure(ctx, apply.Database, apply.Deployment, apply.Environment, "lease_presumed_lost")
-		return fmt.Errorf("heartbeat gRPC apply %s: lease presumed lost after heartbeat failures since %s: %w",
-			apply.ApplyIdentifier, lastSuccess.UTC().Format(time.RFC3339), hbErr)
+		return fmt.Errorf("heartbeat gRPC apply %s: %w (heartbeats failing since %s): %w",
+			apply.ApplyIdentifier, ErrApplyLeasePresumedLost, lastSuccess.UTC().Format(time.RFC3339), hbErr)
 	}
 	slog.Warn("gRPC drive heartbeat failed; will retry",
 		append(apply.LogAttrs(), "error", hbErr)...)
@@ -3290,7 +3290,7 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 				// fallout, not lease trouble.
 				return ctx.Err()
 			}
-			if stopErr := driveEndingHeartbeatFailure(ctx, apply, err, lastHeartbeatSuccess); stopErr != nil {
+			if stopErr := driveEndingHeartbeatFailure(apply, err, lastHeartbeatSuccess); stopErr != nil {
 				return stopErr
 			}
 		case <-ticker.C:

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -2623,6 +2623,32 @@ func (c *GRPCClient) heartbeatScopedDrive(ctx context.Context, apply *storage.Ap
 	return c.storage.Applies().Heartbeat(ctx, apply.ID)
 }
 
+// driveEndingHeartbeatFailure classifies a failed drive-lease heartbeat write.
+// It returns a non-nil error when the drive must end: either storage reported
+// the lease definitively lost, or heartbeat failures have persisted since
+// lastSuccess for the full lease staleness window, so a peer driver can
+// already have reclaimed the stale row. A transient failure inside the window
+// returns nil so the drive keeps polling and the heartbeat is retried on the
+// next tick. The remote Tern keeps executing either way; the next claimant
+// reattaches to it.
+func driveEndingHeartbeatFailure(ctx context.Context, apply *storage.Apply, hbErr error, lastSuccess time.Time) error {
+	if errors.Is(hbErr, storage.ErrApplyLeaseLost) {
+		slog.Warn("gRPC drive heartbeat lost the lease; current owner will stop driving and writing apply state",
+			append(apply.LogAttrs(), "error", hbErr)...)
+		return fmt.Errorf("heartbeat gRPC apply %s: %w", apply.ApplyIdentifier, hbErr)
+	}
+	if time.Since(lastSuccess) >= storage.ApplyLeaseStaleAfter {
+		slog.Warn("gRPC drive heartbeat has failed for the full lease staleness window; a peer driver can reclaim the work, so this owner will stop driving and writing apply state",
+			append(apply.LogAttrs(), "last_successful_heartbeat", lastSuccess, "error", hbErr)...)
+		metrics.RecordOperatorResumeFailure(ctx, apply.Database, apply.Deployment, apply.Environment, "lease_presumed_lost")
+		return fmt.Errorf("heartbeat gRPC apply %s: lease presumed lost after heartbeat failures since %s: %w",
+			apply.ApplyIdentifier, lastSuccess.UTC().Format(time.RFC3339), hbErr)
+	}
+	slog.Warn("gRPC drive heartbeat failed; will retry",
+		append(apply.LogAttrs(), "error", hbErr)...)
+	return nil
+}
+
 func (c *GRPCClient) markRemoteApplyFailed(ctx context.Context, remoteApply *storage.Apply, storedTasks []*storage.Task, message string, retryable bool, scope applyTaskScope) error {
 	return c.markRemoteApplyFailedWithOptions(ctx, remoteApply, storedTasks, message, retryable, false, scope)
 }
@@ -3245,6 +3271,7 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 	loggedStoppedAfterStart := false
 	var stoppedAfterStartDeadline time.Time
 	var lastDisplayBlob string
+	lastHeartbeatSuccess := time.Now()
 	for {
 		select {
 		case <-ctx.Done():
@@ -3253,8 +3280,18 @@ func (c *GRPCClient) pollForCompletion(ctx context.Context, apply *storage.Apply
 			// Heartbeat: bump updated_at to maintain the lease. A multi-operation
 			// drive heartbeats its own operation row; every other drive
 			// heartbeats the parent applies row.
-			if err := c.heartbeatScopedDrive(ctx, apply, scope); err != nil {
-				return fmt.Errorf("heartbeat gRPC apply %s: %w", apply.ApplyIdentifier, err)
+			err := c.heartbeatScopedDrive(ctx, apply, scope)
+			if err == nil {
+				lastHeartbeatSuccess = time.Now()
+				continue
+			}
+			if ctx.Err() != nil {
+				// The drive is shutting down; the failed write is cancellation
+				// fallout, not lease trouble.
+				return ctx.Err()
+			}
+			if stopErr := driveEndingHeartbeatFailure(ctx, apply, err, lastHeartbeatSuccess); stopErr != nil {
+				return stopErr
 			}
 		case <-ticker.C:
 			if handled, err := c.processPendingCancelOrStopControlRequest(ctx, apply, scope); err != nil {

--- a/pkg/tern/lease_heartbeat_test.go
+++ b/pkg/tern/lease_heartbeat_test.go
@@ -1,0 +1,158 @@
+package tern
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+func leaseHeartbeatTestApply() *storage.Apply {
+	return &storage.Apply{
+		ID:              41,
+		ApplyIdentifier: "apply-lease-heartbeat",
+		Database:        "widgets",
+		Deployment:      "default",
+		Environment:     "staging",
+		State:           state.Apply.Running,
+	}
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// failingHeartbeatApplyStore is an ApplyStore whose Heartbeat always returns
+// the configured error, counting calls so tests can observe retry behavior.
+type failingHeartbeatApplyStore struct {
+	storage.ApplyStore
+	mu    sync.Mutex
+	err   error
+	calls int
+}
+
+func (s *failingHeartbeatApplyStore) Heartbeat(context.Context, int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	return s.err
+}
+
+func (s *failingHeartbeatApplyStore) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+// TestApplyHeartbeatFailureStopsDrive verifies how a local drive reacts to a
+// failed apply heartbeat write: a definitively lost lease stops the drive
+// immediately, a transient storage error inside the lease staleness window
+// keeps the drive running so the heartbeat is retried on the next tick, and
+// failures that have persisted for the full window stop the drive because a
+// peer operator can already have reclaimed the stale row.
+func TestApplyHeartbeatFailureStopsDrive(t *testing.T) {
+	client := &LocalClient{logger: discardLogger()}
+	apply := leaseHeartbeatTestApply()
+
+	t.Run("lost lease stops the drive immediately", func(t *testing.T) {
+		hbErr := fmt.Errorf("heartbeat apply %d: %w", apply.ID, storage.ErrApplyLeaseLost)
+		assert.True(t, client.applyHeartbeatFailureStopsDrive(t.Context(), apply, hbErr, time.Now()))
+	})
+
+	t.Run("transient failure inside the window keeps driving", func(t *testing.T) {
+		hbErr := errors.New("connection refused")
+		assert.False(t, client.applyHeartbeatFailureStopsDrive(t.Context(), apply, hbErr, time.Now()))
+	})
+
+	t.Run("failures spanning the staleness window stop the drive", func(t *testing.T) {
+		hbErr := errors.New("connection refused")
+		lastSuccess := time.Now().Add(-storage.ApplyLeaseStaleAfter)
+		assert.True(t, client.applyHeartbeatFailureStopsDrive(t.Context(), apply, hbErr, lastSuccess))
+	})
+}
+
+// TestDriveEndingHeartbeatFailure verifies how a gRPC drive reacts to a failed
+// lease heartbeat write: a definitively lost lease ends the drive immediately,
+// a transient storage error inside the lease staleness window keeps the drive
+// polling so the heartbeat is retried on the next tick, and failures that have
+// persisted for the full window end the drive because a peer driver can
+// already have reclaimed the stale row.
+func TestDriveEndingHeartbeatFailure(t *testing.T) {
+	apply := leaseHeartbeatTestApply()
+
+	t.Run("lost lease ends the drive immediately", func(t *testing.T) {
+		hbErr := fmt.Errorf("heartbeat apply %d: %w", apply.ID, storage.ErrApplyLeaseLost)
+		stopErr := driveEndingHeartbeatFailure(t.Context(), apply, hbErr, time.Now())
+		require.Error(t, stopErr)
+		assert.ErrorIs(t, stopErr, storage.ErrApplyLeaseLost)
+	})
+
+	t.Run("transient failure inside the window keeps driving", func(t *testing.T) {
+		hbErr := errors.New("connection refused")
+		assert.NoError(t, driveEndingHeartbeatFailure(t.Context(), apply, hbErr, time.Now()))
+	})
+
+	t.Run("failures spanning the staleness window end the drive", func(t *testing.T) {
+		hbErr := errors.New("connection refused")
+		lastSuccess := time.Now().Add(-storage.ApplyLeaseStaleAfter)
+		stopErr := driveEndingHeartbeatFailure(t.Context(), apply, hbErr, lastSuccess)
+		require.Error(t, stopErr)
+		assert.ErrorIs(t, stopErr, hbErr)
+		assert.Contains(t, stopErr.Error(), "lease presumed lost")
+	})
+}
+
+// TestStartApplyHeartbeatStopsDriveOnLostLease verifies the heartbeat
+// goroutine's stop wiring: when storage reports the apply lease definitively
+// lost, the heartbeat cancels the drive context so the displaced driver stops
+// executing engine work and writing apply state.
+func TestStartApplyHeartbeatStopsDriveOnLostLease(t *testing.T) {
+	store := &failingHeartbeatApplyStore{err: storage.ErrApplyLeaseLost}
+	client := &LocalClient{
+		storage:           &exactProgressStorage{applies: store},
+		logger:            discardLogger(),
+		heartbeatInterval: 5 * time.Millisecond,
+	}
+
+	driveCtx, cancelDrive := context.WithCancel(t.Context())
+	defer cancelDrive()
+	stop := client.startApplyHeartbeat(t.Context(), leaseHeartbeatTestApply(), cancelDrive)
+	defer stop()
+
+	require.Eventually(t, func() bool {
+		return driveCtx.Err() != nil
+	}, time.Second, 10*time.Millisecond, "lost lease must cancel the drive context")
+}
+
+// TestStartApplyHeartbeatRetriesTransientFailures verifies that a heartbeat
+// write failing with a transient storage error does not stop the drive: the
+// heartbeat keeps ticking and retrying while the failures stay inside the
+// lease staleness window.
+func TestStartApplyHeartbeatRetriesTransientFailures(t *testing.T) {
+	store := &failingHeartbeatApplyStore{err: errors.New("connection refused")}
+	client := &LocalClient{
+		storage:           &exactProgressStorage{applies: store},
+		logger:            discardLogger(),
+		heartbeatInterval: 5 * time.Millisecond,
+	}
+
+	driveCtx, cancelDrive := context.WithCancel(t.Context())
+	defer cancelDrive()
+	stop := client.startApplyHeartbeat(t.Context(), leaseHeartbeatTestApply(), cancelDrive)
+	defer stop()
+
+	require.Eventually(t, func() bool {
+		return store.callCount() >= 3
+	}, time.Second, 10*time.Millisecond, "heartbeat must keep retrying transient failures")
+	assert.NoError(t, driveCtx.Err(), "transient heartbeat failures inside the staleness window must not stop the drive")
+}

--- a/pkg/tern/lease_heartbeat_test.go
+++ b/pkg/tern/lease_heartbeat_test.go
@@ -92,23 +92,24 @@ func TestDriveEndingHeartbeatFailure(t *testing.T) {
 
 	t.Run("lost lease ends the drive immediately", func(t *testing.T) {
 		hbErr := fmt.Errorf("heartbeat apply %d: %w", apply.ID, storage.ErrApplyLeaseLost)
-		stopErr := driveEndingHeartbeatFailure(t.Context(), apply, hbErr, time.Now())
+		stopErr := driveEndingHeartbeatFailure(apply, hbErr, time.Now())
 		require.Error(t, stopErr)
 		assert.ErrorIs(t, stopErr, storage.ErrApplyLeaseLost)
 	})
 
 	t.Run("transient failure inside the window keeps driving", func(t *testing.T) {
 		hbErr := errors.New("connection refused")
-		assert.NoError(t, driveEndingHeartbeatFailure(t.Context(), apply, hbErr, time.Now()))
+		assert.NoError(t, driveEndingHeartbeatFailure(apply, hbErr, time.Now()))
 	})
 
 	t.Run("failures spanning the staleness window end the drive", func(t *testing.T) {
 		hbErr := errors.New("connection refused")
 		lastSuccess := time.Now().Add(-storage.ApplyLeaseStaleAfter)
-		stopErr := driveEndingHeartbeatFailure(t.Context(), apply, hbErr, lastSuccess)
+		stopErr := driveEndingHeartbeatFailure(apply, hbErr, lastSuccess)
 		require.Error(t, stopErr)
 		assert.ErrorIs(t, stopErr, hbErr)
-		assert.Contains(t, stopErr.Error(), "lease presumed lost")
+		assert.ErrorIs(t, stopErr, ErrApplyLeasePresumedLost,
+			"the presumed-lost sentinel must survive wrapping so the operator can classify the displacement")
 	})
 }
 

--- a/pkg/tern/local_apply_sequential.go
+++ b/pkg/tern/local_apply_sequential.go
@@ -269,37 +269,74 @@ type atomicPollState struct {
 }
 
 // startApplyHeartbeat starts a background goroutine that heartbeats the apply
-// every 10 seconds, preventing the operator from treating it as crashed.
-// Returns a cancel function that stops the heartbeat. Must be deferred by the caller.
+// on the client's heartbeat interval, preventing the operator from treating it
+// as crashed. A definitively lost lease cancels the drive so the displaced
+// driver stops executing. Transient heartbeat errors are retried on the next
+// tick — until they have persisted for the full storage.ApplyLeaseStaleAfter
+// window, at which point the lease is presumed lost (a peer operator can
+// already have reclaimed the stale row) and the drive is cancelled the same
+// way. Returns a cancel function that stops the heartbeat. Must be deferred by
+// the caller.
 func (c *LocalClient) startApplyHeartbeat(ctx context.Context, apply *storage.Apply, cancelApply ...context.CancelFunc) context.CancelFunc {
 	hbCtx, cancel := context.WithCancel(ctx)
+	stopDrive := func() {
+		for _, cancel := range cancelApply {
+			if cancel != nil {
+				cancel()
+			}
+		}
+		cancel()
+	}
 	go func() {
 		ticker := time.NewTicker(c.heartbeatInterval)
 		defer ticker.Stop()
+		lastSuccess := time.Now()
 		for {
 			select {
 			case <-hbCtx.Done():
 				return
 			case <-ticker.C:
-				if err := c.storage.Applies().Heartbeat(hbCtx, apply.ID); err != nil {
-					if errors.Is(err, storage.ErrApplyLeaseLost) {
-						c.logger.Warn("heartbeat failed because apply lease was lost; local driver will stop executing and writing apply state",
-							append(apply.LogAttrs(), "error", err)...)
-						metrics.RecordOperatorResumeFailure(hbCtx, apply.Database, apply.Deployment, apply.Environment, "lease_lost")
-						for _, cancel := range cancelApply {
-							if cancel != nil {
-								cancel()
-							}
-						}
-						cancel()
-						return
-					}
-					c.logger.Warn("heartbeat failed", append(apply.LogAttrs(), "error", err)...)
+				err := c.storage.Applies().Heartbeat(hbCtx, apply.ID)
+				if err == nil {
+					lastSuccess = time.Now()
+					continue
+				}
+				if hbCtx.Err() != nil {
+					// The drive is shutting down; the failed write is
+					// cancellation fallout, not lease trouble.
+					return
+				}
+				if c.applyHeartbeatFailureStopsDrive(hbCtx, apply, err, lastSuccess) {
+					stopDrive()
+					return
 				}
 			}
 		}
 	}()
 	return cancel
+}
+
+// applyHeartbeatFailureStopsDrive classifies a failed apply heartbeat write
+// and reports whether the driver must stop driving: either storage reported
+// the lease definitively lost, or heartbeat failures have persisted since
+// lastSuccess for the full lease staleness window, so a peer operator can
+// already have reclaimed the stale row. A transient failure inside the window
+// keeps the drive running and is retried on the next tick.
+func (c *LocalClient) applyHeartbeatFailureStopsDrive(ctx context.Context, apply *storage.Apply, hbErr error, lastSuccess time.Time) bool {
+	if errors.Is(hbErr, storage.ErrApplyLeaseLost) {
+		c.logger.Warn("heartbeat failed because apply lease was lost; local driver will stop executing and writing apply state",
+			append(apply.LogAttrs(), "error", hbErr)...)
+		metrics.RecordOperatorResumeFailure(ctx, apply.Database, apply.Deployment, apply.Environment, "lease_lost")
+		return true
+	}
+	if time.Since(lastSuccess) >= storage.ApplyLeaseStaleAfter {
+		c.logger.Warn("heartbeat has failed for the full lease staleness window; a peer operator can reclaim the apply, so this local driver will stop executing and writing apply state",
+			append(apply.LogAttrs(), "last_successful_heartbeat", lastSuccess, "error", hbErr)...)
+		metrics.RecordOperatorResumeFailure(ctx, apply.Database, apply.Deployment, apply.Environment, "lease_presumed_lost")
+		return true
+	}
+	c.logger.Warn("heartbeat failed; will retry", append(apply.LogAttrs(), "error", hbErr)...)
+	return false
 }
 
 // pollForCompletionAtomic polls the engine for progress in atomic mode (all tasks share state).


### PR DESCRIPTION
## Why this matters

Picture a driver mid-way through a long apply when its connection to SchemaBot storage goes bad. Its lease heartbeats start failing — and after a minute of missed heartbeats, the apply row looks abandoned, so a peer operator legitimately reclaims it and starts driving. The problem: the original driver never noticed it lost anything. It shrugged off every failed heartbeat and kept driving, so the same Spirit copy or remote deploy could run on two drivers at once. Lease-guarded writes kept the stale driver from corrupting stored state, but the engine work itself ran twice.

The gRPC drive had the opposite problem: a *single* failed heartbeat write — one transient database blip — ended the whole drive.

## What it does

1. **A driver that can't heartbeat eventually concedes it lost the lease.** All three drive-lease heartbeat loops (local apply drive, operator operation-row heartbeat, gRPC drive) now stop driving once heartbeat failures have persisted for the full staleness window — the same window after which peers are allowed to reclaim the row. The dangerous overlap where two drivers run the same engine work is now bounded by that window instead of unbounded. Each self-termination records `schemabot.operator.resume_failures_total{reason="lease_presumed_lost"}` so operators can spot storage trouble that displaced a driver.

2. **The gRPC drive now tolerates transient heartbeat failures.** A failed heartbeat write is logged and retried on the next tick, like the other two loops already did. The drive ends only on a definitively lost lease or the exhausted window — and the remote data plane keeps executing either way; the next claimant reattaches to it.

3. **The staleness window is single-sourced.** The one-minute window previously lived in three places that could silently drift apart: hardcoded `INTERVAL 1 MINUTE` literals in the claim queries, a SQL string constant in mysqlstore, and an unused `HeartbeatTimeout` constant in `pkg/api`. It is now one constant, `storage.ApplyLeaseStaleAfter`, from which both the SQL reclaim interval and the drivers' presumed-lost bound derive. That equality is the safety property: a driver always gives up no later than the moment a peer may take over.

Behavior at a glance:

```
before: heartbeats fail → driver keeps driving forever → peer reclaims → same work runs twice
after:  heartbeats fail → retry within the staleness window → presume lease lost → stop driving
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
