### PR TITLE
fix(observability): read single-operation deployment logs

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -764,6 +764,33 @@ func TestHandleDeploymentLogsFansOutDeduplicatesAndPreservesPartialResults(t *te
 	assert.NotContains(t, w.Body.String(), "not-a-time")
 }
 
+func TestHandleDeploymentLogsUsesParentExternalIDForSingleOperation(t *testing.T) {
+	apply := &storage.Apply{ID: 8, ApplyIdentifier: "apply-control", ExternalID: "remote-parent", Database: "orders", DatabaseType: storage.DatabaseTypeMySQL, Environment: "staging", Deployment: "region-a"}
+	operation := &storage.ApplyOperation{ApplyID: apply.ID, Deployment: "region-a", OperationKey: "schema", OperationKind: storage.ApplyOperationKindWork, Target: "cluster-a"}
+	client := &mockTernClient{isRemote: true}
+	client.logsHook = func(req *ternv1.LogsRequest) (*ternv1.LogsResponse, error) {
+		return &ternv1.LogsResponse{ApplyId: req.ApplyId, Logs: []*ternv1.ApplyLog{{Id: 13, Level: "info", Message: "apply complete", CreatedAt: "2026-07-18T18:33:10Z"}}}, nil
+	}
+	service := New(&mockStorageWithApplyStores{
+		applies:    &staticApplyStore{apply: apply},
+		operations: &staticApplyOperationStore{operations: []*storage.ApplyOperation{operation}},
+	}, testServerConfig(), map[string]tern.Client{"region-a/staging": client}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/logs?apply_id=apply-control&deployment=region-a", nil)
+	w := httptest.NewRecorder()
+	service.handleLogsWithoutDatabase(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Len(t, client.logsReqs, 1)
+	assert.Equal(t, "remote-parent", client.logsReqs[0].ApplyId)
+	var response apitypes.DeploymentLogsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.Len(t, response.Sources, 1)
+	assert.Equal(t, "remote-parent", response.Sources[0].ExternalID)
+	require.Len(t, response.Sources[0].Logs, 1)
+	assert.Equal(t, "apply complete", response.Sources[0].Logs[0].Message)
+}
+
 func (m *mockTernClient) Cutover(ctx context.Context, req *ternv1.CutoverRequest) (*ternv1.CutoverResponse, error) {
 	m.cutoverReq = req
 	if m.cutoverResp != nil {

--- a/pkg/api/log_handlers.go
+++ b/pkg/api/log_handlers.go
@@ -164,16 +164,20 @@ func (s *Service) handleDeploymentLogs(w http.ResponseWriter, r *http.Request, a
 			continue
 		}
 		matched = true
-		if op.ExternalID == "" {
+		externalID := op.ExternalID
+		if externalID == "" && len(ops) == 1 {
+			externalID = apply.ExternalID
+		}
+		if externalID == "" {
 			// An operation without a remote apply id ran on the control plane;
 			// its logs live in control-plane storage, not behind this fan-out.
 			s.logger.Debug("skipping operation without a remote apply id for data-plane logs", append(apply.LogAttrs(), "operation", "read_deployment_logs", "operation_deployment", deployment, "operation_key", op.OperationKey, "target", op.Target)...)
 			continue
 		}
-		key := op.Target + "\x00" + op.ExternalID
+		key := op.Target + "\x00" + externalID
 		fetch := fetches[key]
 		if fetch == nil {
-			fetch = &deploymentLogFetch{target: op.Target, externalID: op.ExternalID}
+			fetch = &deploymentLogFetch{target: op.Target, externalID: externalID}
 			fetches[key] = fetch
 		}
 		fetch.operations = append(fetch.operations, &apitypes.LogOperationProvenance{OperationKey: op.OperationKey, Target: op.Target, OperationKind: op.OperationKind})


### PR DESCRIPTION
## Why
Deployment log reads must support the existing single-operation remote apply model, where the remote apply identifier is stored on the parent apply.

## What
- Use the parent external ID when the apply has exactly one operation
- Keep operation-scoped IDs authoritative for multi-operation fan-out
- Cover the single-operation read-through path at the HTTP handler boundary

## Risk Assessment
Low — this only broadens the read-only deployment logs lookup and leaves apply execution and multi-operation routing unchanged.

Generated with Amp
