### PR TITLE
fix(github): skip progress-comment edits whose visible content is unchanged

### DIFF
--- a/pkg/webhook/apply_comment_integration_test.go
+++ b/pkg/webhook/apply_comment_integration_test.go
@@ -1798,3 +1798,162 @@ func TestE2EInitialProgressCommentFinalizedForFastApply(t *testing.T) {
 		}
 	})
 }
+
+// A stagnant apply must not keep re-editing its progress comment forever, but
+// the requester actively watching a young comment must never see it freeze.
+// Renders of an unchanged status differ only in their stamped timestamps
+// ("Last updated" footer, attribution line), so once the comment ages past its
+// grace window, re-PATCHing spends GitHub write budget without showing the
+// reader anything new — a long-running apply parked at a barrier would
+// otherwise re-edit an identical comment forever. Inside the grace window the
+// observer keeps refreshing the footer even when nothing changed (an early
+// stall must not read as SchemaBot going silent); past it, unchanged renders
+// skip GitHub entirely and editing resumes the moment real progress changes
+// the render.
+func TestE2EStagnantApplySkipsIdenticalProgressEdits(t *testing.T) {
+	ctx := t.Context()
+
+	f := setupApplyCommentFixture(t, applyCommentFixtureParams{
+		repo:       "org/repo-dedupe",
+		pr:         143,
+		database:   "e2e_dedupe_db",
+		applyState: state.Apply.Running,
+	})
+	st, apply, task, capture, h := f.st, f.apply, f.task, f.capture, f.handler
+
+	// The handler posts the initial progress comment; the observer edits it
+	// from then on.
+	h.postAndTrackComment(ctx, "org/repo-dedupe", 143, 12345, apply, state.Comment.Progress, "initial progress")
+	progressID := requireCommentCreate(t, capture)
+
+	fake := clock.NewFake(task.CreatedAt)
+	obs := f.newObserver(st, fake)
+
+	// The first tick edits: the observer has never written this comment, so it
+	// cannot know the content is already current.
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, progressID, edited.CommentID)
+		assert.Contains(t, edited.Body, "50%")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the first tick to edit the progress comment")
+	}
+
+	// A stagnant tick while the comment is young still refreshes it: the
+	// requester is watching, and the footer must keep proving liveness.
+	fake.Advance(stagnantInterval + time.Second)
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, progressID, edited.CommentID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected an unchanged tick inside the grace window to refresh the comment")
+	}
+
+	// Age the comment past its grace window. This crossing tick also exceeds
+	// the heartbeat since the last write, so it refreshes once more and
+	// re-anchors the heartbeat.
+	fake.Advance(unchangedCommentGraceWindow + time.Second)
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, progressID, edited.CommentID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the grace-crossing tick to refresh the comment")
+	}
+
+	// Ticks past every cadence window with unchanged tasks render identical
+	// content; now that the comment is aged, none of them reaches GitHub.
+	for range 4 {
+		fake.Advance(stagnantInterval + time.Second)
+		obs.OnProgress(apply, []*storage.Task{task})
+	}
+	select {
+	case edited := <-capture.edits:
+		t.Fatalf("aged stagnant ticks with unchanged content must not edit; got edit on comment %d: %q", edited.CommentID, edited.Body)
+	default:
+		// expected: identical renders are skipped once the grace window passed
+	}
+
+	// Real row-copy progress changes the content, so the next tick edits again.
+	task.RowsCopied = 700
+	task.ProgressPercent = 70
+	fake.Advance(stagnantInterval + time.Second)
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, progressID, edited.CommentID)
+		assert.Contains(t, edited.Body, "70%")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the tick after real progress to edit the comment")
+	}
+
+	// Four edits reached GitHub: the first render, the young refresh, the
+	// grace-crossing refresh, and the progress change. Skipped ticks do not
+	// count as edits.
+	prog, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Progress)
+	require.NoError(t, err)
+	require.NotNil(t, prog)
+	assert.Equal(t, 4, prog.EditCount)
+}
+
+// The "Last updated" footer doubles as a liveness signal, so skipping
+// content-identical edits must not freeze a stalled apply's comment forever:
+// once the heartbeat interval elapses without a write, the next tick refreshes
+// the comment even though nothing visible changed, and skipping resumes from
+// that fresh write.
+func TestE2EStagnantApplyHeartbeatRefreshesComment(t *testing.T) {
+	ctx := t.Context()
+
+	f := setupApplyCommentFixture(t, applyCommentFixtureParams{
+		repo:       "org/repo-heartbeat",
+		pr:         144,
+		database:   "e2e_heartbeat_db",
+		applyState: state.Apply.Running,
+	})
+	st, apply, task, capture, h := f.st, f.apply, f.task, f.capture, f.handler
+
+	h.postAndTrackComment(ctx, "org/repo-heartbeat", 144, 12345, apply, state.Comment.Progress, "initial progress")
+	progressID := requireCommentCreate(t, capture)
+
+	fake := clock.NewFake(task.CreatedAt)
+	obs := f.newObserver(st, fake)
+
+	// The first tick edits and anchors the heartbeat.
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, progressID, edited.CommentID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the first tick to edit the progress comment")
+	}
+
+	// Once the heartbeat elapses, an unchanged render is written anyway so the
+	// "Last updated" footer proves the observer is still watching.
+	fake.Advance(unchangedCommentHeartbeat + time.Second)
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, progressID, edited.CommentID)
+		assert.Contains(t, edited.Body, "50%")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected an unchanged render to refresh the comment after the heartbeat elapsed")
+	}
+
+	// The refresh re-anchors the heartbeat: the next unchanged tick is skipped
+	// again.
+	fake.Advance(stagnantInterval + time.Second)
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		t.Fatalf("unchanged tick inside the heartbeat window must not edit; got %q", edited.Body)
+	default:
+		// expected: skipping resumes from the refreshed write
+	}
+
+	prog, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Progress)
+	require.NoError(t, err)
+	require.NotNil(t, prog)
+	assert.Equal(t, 2, prog.EditCount)
+}

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -77,6 +77,28 @@ type CommentObserver struct {
 	// but whose tracking write failed, so later ticks adopt it (retry the write
 	// with the known comment ID) instead of posting a duplicate.
 	pendingRotation *pendingProgressRotation
+
+	// lastWritten remembers, per GitHub comment ID, the content key
+	// (templates.CommentContentKey) of the body this observer last wrote and
+	// when it was confirmed written, so an edit whose visible content is
+	// unchanged is skipped instead of PATCHing an identical comment — until
+	// unchangedCommentHeartbeat elapses, when a refresh edit goes through so
+	// the "Last updated" footer keeps proving liveness. Guarded by its own
+	// mutex, not o.mu: editTrackedComment runs both under OnProgress (which
+	// holds o.mu) and from OnTerminal (which does not).
+	lastWrittenMu sync.Mutex
+	lastWritten   map[int64]writtenContent
+}
+
+// writtenContent records what an observer last wrote to a GitHub comment and
+// when, so unchanged re-renders can be skipped until the liveness heartbeat
+// elapses. firstWrittenAt is when this observer first wrote the comment; it
+// anchors the young-comment grace window and carries forward across edits, so
+// a rotation to a fresh comment ID starts a new grace window.
+type writtenContent struct {
+	contentKey     string
+	writtenAt      time.Time
+	firstWrittenAt time.Time
 }
 
 // pendingProgressRotation identifies a volume-rotation progress comment that
@@ -99,6 +121,22 @@ const (
 	activeInterval   = 5 * time.Second
 	stagnantInterval = 30 * time.Second
 	stagnantThresh   = 3 // consecutive unchanged ticks before slowing down
+
+	// unchangedCommentHeartbeat bounds how long an unchanged tracked comment
+	// may go without a re-edit. Content-identical edits are normally skipped
+	// to save GitHub write budget, but the "Last updated" footer doubles as a
+	// liveness signal: a periodic refresh keeps a stalled apply's comment from
+	// reading as abandoned. Content changes always edit immediately.
+	unchangedCommentHeartbeat = 10 * time.Minute
+
+	// unchangedCommentGraceWindow is how long a freshly written comment keeps
+	// refreshing on every tick even when its content is unchanged. A young
+	// comment is the one being actively watched — the requester just started
+	// or resumed the apply — and an early stall (setup, throttling) must not
+	// read as SchemaBot going silent, so unchanged-edit skipping only begins
+	// once the comment ages past this window. The cost is bounded: at most a
+	// few minutes of fast identical edits per comment.
+	unchangedCommentGraceWindow = 10 * time.Minute
 )
 
 // CommentObserverConfig holds the parameters for creating a CommentObserver.
@@ -191,6 +229,7 @@ func NewCommentObserver(cfg CommentObserverConfig) *CommentObserver {
 		logger:         cfg.Logger,
 		OnTerminalHook: cfg.OnTerminalHook,
 		clock:          clk,
+		lastWritten:    map[int64]writtenContent{},
 	}
 }
 
@@ -601,6 +640,21 @@ func (o *CommentObserver) editTrackedComment(apply *storage.Apply, commentState 
 		// (e.g., first OnProgress tick before the handler posts it).
 		return
 	}
+
+	// Skip the edit when nothing the reader can see has changed. Renders of an
+	// unchanged status differ only in their rendered timestamps ("Last updated"
+	// footer, attribution line), so re-PATCHing spends GitHub write budget
+	// without changing the comment — a stagnant long-running apply would
+	// otherwise re-edit an identical comment forever. Young comments (inside
+	// their grace window) always edit so an early stall never reads as
+	// SchemaBot going silent, and skips lapse after unchangedCommentHeartbeat
+	// so the footer still refreshes periodically as a liveness signal.
+	// Expected and frequent, so no log; the edit count is not incremented
+	// because no edit happens.
+	contentKey := templates.CommentContentKey(body)
+	if o.skipUnchangedEdit(comment.GitHubCommentID, contentKey) {
+		return
+	}
 	if !o.leaseStillOwnsObserver(apply, "create GitHub client before edit") {
 		return
 	}
@@ -618,6 +672,7 @@ func (o *CommentObserver) editTrackedComment(apply *storage.Apply, commentState 
 		o.logError(apply, "observer: failed to edit comment", "error", err, "comment_state", commentState)
 		return
 	}
+	o.recordLastWritten(comment.GitHubCommentID, contentKey)
 	if !o.leaseStillOwnsObserver(apply, "record edited GitHub comment") {
 		return
 	}
@@ -626,6 +681,46 @@ func (o *CommentObserver) editTrackedComment(apply *storage.Apply, commentState 
 	if err := o.stor.ApplyComments().IncrementEditCount(o.contextWithApplyLease(ctx, apply), o.applyID, commentState); err != nil {
 		o.logError(apply, "observer: failed to increment edit count", "error", err, "comment_state", commentState)
 	}
+}
+
+// skipUnchangedEdit reports whether an edit may be skipped because its visible
+// content matches what this observer last wrote to the given GitHub comment
+// and that write is recent enough that the "Last updated" footer still proves
+// the observer is alive. A comment still inside its grace window always edits,
+// unchanged or not — young comments are the actively watched ones. A cache
+// miss — including a comment this observer never wrote, such as the
+// handler-posted initial progress comment — means the edit must proceed; only
+// a confirmed match may skip it, so uncertainty always degrades to an extra
+// edit, never a missed one.
+func (o *CommentObserver) skipUnchangedEdit(commentID int64, contentKey string) bool {
+	o.lastWrittenMu.Lock()
+	defer o.lastWrittenMu.Unlock()
+	last, ok := o.lastWritten[commentID]
+	if !ok {
+		return false
+	}
+	now := o.clock.Now()
+	if now.Sub(last.firstWrittenAt) < unchangedCommentGraceWindow {
+		return false
+	}
+	return last.contentKey == contentKey &&
+		now.Sub(last.writtenAt) < unchangedCommentHeartbeat
+}
+
+// recordLastWritten remembers the content key of a body confirmed written to a
+// GitHub comment (posted or edited) and when, keyed by the GitHub comment ID
+// so a rotation to a fresh comment never matches its predecessor's content.
+// The first record for a comment ID anchors its grace window; later records
+// carry the anchor forward.
+func (o *CommentObserver) recordLastWritten(commentID int64, contentKey string) {
+	o.lastWrittenMu.Lock()
+	defer o.lastWrittenMu.Unlock()
+	now := o.clock.Now()
+	firstWrittenAt := now
+	if prev, ok := o.lastWritten[commentID]; ok {
+		firstWrittenAt = prev.firstWrittenAt
+	}
+	o.lastWritten[commentID] = writtenContent{contentKey: contentKey, writtenAt: now, firstWrittenAt: firstWrittenAt}
 }
 
 // rotateProgressCommentForResume posts a fresh progress comment when a resumed
@@ -977,6 +1072,7 @@ func (o *CommentObserver) postAndTrackComment(apply *storage.Apply, commentState
 		o.logError(apply, "observer: failed to post comment", "error", err, "comment_state", commentState)
 		return 0, false, false
 	}
+	o.recordLastWritten(commentID, templates.CommentContentKey(body))
 	if !o.leaseStillOwnsObserver(apply, "record posted GitHub comment") {
 		// The comment is live on the PR; only the tracking write is being
 		// skipped. Report it posted-but-untracked — the contract callers use to

--- a/pkg/webhook/templates/common.go
+++ b/pkg/webhook/templates/common.go
@@ -3,6 +3,7 @@ package templates
 import (
 	"fmt"
 	"html"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -66,6 +67,25 @@ type SupportChannelData struct {
 // currentTimestamp returns the current UTC time formatted for PR comments.
 func currentTimestamp() string {
 	return TimestampFunc()
+}
+
+// renderedTimestampPattern matches the timestamps templates stamp into comment
+// bodies at render time: the "2006-01-02 15:04:05 UTC" display form (TimestampFunc,
+// startedAtDisplay) and the RFC3339 form inside <relative-time> datetime
+// attributes. CommentContentKey collapses both so renders that differ only in
+// when they happened compare equal.
+var renderedTimestampPattern = regexp.MustCompile(`\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?: UTC|Z)`)
+
+// CommentContentKey returns a comparison key for a rendered comment body: the
+// body with every rendered timestamp collapsed to a placeholder. The "Last
+// updated" footer and attribution lines re-stamp the render time on every
+// render, so byte comparison of raw bodies always differs; equal content keys
+// mean an edit would change nothing else the reader can see. Values that must
+// keep updating between otherwise-identical renders — such as the revert-window
+// countdown — are durations, not timestamps, so they stay in the key and their
+// comments keep being edited.
+func CommentContentKey(body string) string {
+	return renderedTimestampPattern.ReplaceAllString(body, "<timestamp>")
 }
 
 // RenderSupportChannelFooter appends a support-channel footer to a rendered PR comment.

--- a/pkg/webhook/templates/common_test.go
+++ b/pkg/webhook/templates/common_test.go
@@ -1,0 +1,83 @@
+package templates
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/block/schemabot/pkg/state"
+)
+
+// A progress comment re-stamps its rendered timestamps ("Last updated" footer,
+// attribution line) on every render, so raw bodies from two renders of the same
+// status never compare equal. The content key collapses those timestamps: equal
+// keys mean an edit would change nothing else the reader can see.
+func TestCommentContentKeyEqualForUnchangedStatus(t *testing.T) {
+	data := ApplyStatusCommentData{
+		Database:    "testapp",
+		Environment: "staging",
+		ApplyID:     "apply_123",
+		RequestedBy: "octocat",
+		State:       state.Apply.Running,
+		Tables: []TableProgressData{
+			{TableName: "users", Status: state.Task.Running, PercentComplete: 50, RowsCopied: 500, RowsTotal: 1000},
+		},
+	}
+
+	withTemplateTimestamp(t, "2026-06-16 19:42:00 UTC")
+	first := RenderApplyStatusComment(data)
+	withTemplateTimestamp(t, "2026-06-16 19:42:30 UTC")
+	second := RenderApplyStatusComment(data)
+
+	assert.NotEqual(t, first, second, "renders at different times differ in their stamped timestamps")
+	assert.Equal(t, CommentContentKey(first), CommentContentKey(second))
+	assert.Contains(t, CommentContentKey(first), "50%", "the key keeps the progress content")
+	assert.NotContains(t, CommentContentKey(first), "19:42:00", "the key collapses rendered timestamps")
+}
+
+// Real progress changes must always change the content key, so the observer
+// keeps editing whenever the reader would see something new.
+func TestCommentContentKeyChangesWithProgress(t *testing.T) {
+	withTemplateTimestamp(t, "2026-06-16 19:42:00 UTC")
+	render := func(percent int, rows int64) string {
+		return RenderApplyStatusComment(ApplyStatusCommentData{
+			Database:    "testapp",
+			Environment: "staging",
+			RequestedBy: "octocat",
+			State:       state.Apply.Running,
+			Tables: []TableProgressData{
+				{TableName: "users", Status: state.Task.Running, PercentComplete: percent, RowsCopied: rows, RowsTotal: 1000},
+			},
+		})
+	}
+
+	assert.NotEqual(t, CommentContentKey(render(50, 500)), CommentContentKey(render(70, 700)))
+}
+
+// The revert-window countdown is a duration, not a timestamp, so it survives
+// into the content key: two renders of an otherwise-unchanged revert window
+// have different keys and the comment keeps being edited as the window closes.
+func TestCommentContentKeyKeepsRevertCountdownLive(t *testing.T) {
+	withTemplateTimestamp(t, "2026-06-16 19:42:00 UTC")
+	expires := time.Date(2026, 6, 16, 20, 0, 0, 0, time.UTC)
+	data := ApplyStatusCommentData{
+		Database:        "testapp",
+		Environment:     "staging",
+		RequestedBy:     "octocat",
+		State:           state.Apply.RevertWindow,
+		RevertExpiresAt: expires.Format(time.RFC3339),
+	}
+
+	originalNow := NowFunc
+	t.Cleanup(func() { NowFunc = originalNow })
+
+	NowFunc = func() time.Time { return expires.Add(-20 * time.Minute) }
+	first := RenderApplyStatusComment(data)
+	NowFunc = func() time.Time { return expires.Add(-10 * time.Minute) }
+	second := RenderApplyStatusComment(data)
+
+	assert.Contains(t, first, "Closes in 20m")
+	assert.Contains(t, second, "Closes in 10m")
+	assert.NotEqual(t, CommentContentKey(first), CommentContentKey(second))
+}


### PR DESCRIPTION
## Why this matters

A stagnant apply re-edits its PR progress comment every 30 seconds forever, even though every render is byte-identical except for two re-stamped timestamps (the "Last updated" footer and the attribution line). Each of those PATCHes spends the installation's shared GitHub write budget — under the secondary content-creation limit, a handful of stalled long-running applies is real pressure — while changing nothing a reader can see.

## What it does

- Adds `templates.CommentContentKey`, which collapses rendered timestamps out of a comment body. Two renders of an unchanged status produce equal keys; any real change (rows, state, checksum) produces a different key. Durations such as the revert-window countdown survive in the key, so comments where the passage of time *is* the information keep editing live.
- The observer remembers the content key it last wrote per GitHub comment ID and skips edits whose key is unchanged. A cache miss (e.g. the handler-posted initial comment) always edits — uncertainty degrades to an extra edit, never a missed one.
- A comment younger than 10 minutes always edits, even when unchanged. Young comments are the ones people actively watch — apply just started, setup phase, first rows copying — and an early stall must not read as SchemaBot going silent. The grace cost is bounded (a stagnant young comment refreshes at most every 30s for 10 minutes), and rotation-created comments get a fresh window since a new comment means someone just acted.
- Past the grace window, the "Last updated" footer doubles as a liveness signal, so skips lapse after a 10-minute heartbeat: a stalled apply's comment still refreshes a few times an hour to show SchemaBot is watching, instead of freezing indefinitely.

```
tick → render → content key
        comment <10m old ──── edit (grace: always fresh while watched)
        key unchanged  ─┬─ written <10m ago → skip (no PATCH)
                        └─ written ≥10m ago → edit (liveness refresh)
        key changed    ──── edit immediately
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
