### PR TITLE
feat(github): decay progress-comment edit cadence as the comment ages

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -2145,7 +2145,7 @@ To stop this schema change:
 schemabot stop apply-a1b2c3d4e5f6 -e staging
 ```
 
-_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
+_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC) · updates every ~5s_
 
 </details>
 

--- a/pkg/webhook/apply.go
+++ b/pkg/webhook/apply.go
@@ -189,8 +189,13 @@ func shardCommentTableKey(applyOperationID *int64, namespace, table string) stri
 // formatProgressComment renders the progress comment using the template system.
 // It is the no-operations fallback (load error, or the initial rollback comment),
 // so it carries no VSchema — the observer refreshes VSchema once operations load.
-func formatProgressComment(apply *storage.Apply, tasks []*storage.Task, shardsByTable map[string][]*storage.Task, tenant string) string {
-	return templates.RenderApplyStatusComment(buildApplyCommentData(apply, tasks, operationDisplay{}, shardsByTable, tenant))
+// updateCadence is the current spacing between automatic refreshes of the
+// comment, rendered beside the "Last updated" footer; zero renders no cadence
+// note (terminal finalizations).
+func formatProgressComment(apply *storage.Apply, tasks []*storage.Task, shardsByTable map[string][]*storage.Task, tenant string, updateCadence time.Duration) string {
+	data := buildApplyCommentData(apply, tasks, operationDisplay{}, shardsByTable, tenant)
+	data.UpdateCadence = updateCadence
+	return templates.RenderApplyStatusComment(data)
 }
 
 // formatSummaryComment renders the final summary comment for a terminal apply

--- a/pkg/webhook/apply_comment_integration_test.go
+++ b/pkg/webhook/apply_comment_integration_test.go
@@ -1723,7 +1723,7 @@ func TestE2EInitialProgressCommentFinalizedForFastApply(t *testing.T) {
 		pending := *apply
 		pending.State = state.Apply.Pending
 		h.postInitialProgressComment(ctx, apply.Repository, apply.PullRequest, apply.InstallationID, apply,
-			formatProgressComment(&pending, nil, nil, ""))
+			formatProgressComment(&pending, nil, nil, "", 0))
 
 		var created commentCreate
 		select {
@@ -1761,7 +1761,7 @@ func TestE2EInitialProgressCommentFinalizedForFastApply(t *testing.T) {
 		require.NoError(t, st.ApplyComments().IncrementEditCount(ctx, apply.ID, state.Comment.Progress))
 
 		h.postInitialProgressComment(ctx, apply.Repository, apply.PullRequest, apply.InstallationID, apply,
-			formatProgressComment(apply, nil, nil, ""))
+			formatProgressComment(apply, nil, nil, "", 0))
 
 		select {
 		case <-capture.creates:
@@ -1782,7 +1782,7 @@ func TestE2EInitialProgressCommentFinalizedForFastApply(t *testing.T) {
 		h, capture := newHandler(t)
 
 		h.postInitialProgressComment(ctx, apply.Repository, apply.PullRequest, apply.InstallationID, apply,
-			formatProgressComment(apply, nil, nil, ""))
+			formatProgressComment(apply, nil, nil, "", 0))
 
 		select {
 		case <-capture.creates:
@@ -1908,13 +1908,13 @@ func TestE2EStagnantApplyHeartbeatRefreshesComment(t *testing.T) {
 
 	f := setupApplyCommentFixture(t, applyCommentFixtureParams{
 		repo:       "org/repo-heartbeat",
-		pr:         144,
+		pr:         147,
 		database:   "e2e_heartbeat_db",
 		applyState: state.Apply.Running,
 	})
 	st, apply, task, capture, h := f.st, f.apply, f.task, f.capture, f.handler
 
-	h.postAndTrackComment(ctx, "org/repo-heartbeat", 144, 12345, apply, state.Comment.Progress, "initial progress")
+	h.postAndTrackComment(ctx, "org/repo-heartbeat", 147, 12345, apply, state.Comment.Progress, "initial progress")
 	progressID := requireCommentCreate(t, capture)
 
 	fake := clock.NewFake(task.CreatedAt)
@@ -1956,4 +1956,182 @@ func TestE2EStagnantApplyHeartbeatRefreshesComment(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, prog)
 	assert.Equal(t, 2, prog.EditCount)
+}
+
+// A progress comment that has been live for hours no longer needs
+// second-resolution updates: nobody watches a PR comment continuously for a
+// day, every edit spends the installation's shared GitHub write budget, and
+// the CLI is the high-resolution progress surface. The edit cadence therefore
+// decays with the age of the live progress comment — an old apply's rows can
+// advance on every tick and still reach GitHub only a few times per hour —
+// while a state change always publishes immediately, regardless of age.
+func TestE2EProgressEditCadenceDecaysWithCommentAge(t *testing.T) {
+	f := setupApplyCommentFixture(t, applyCommentFixtureParams{
+		repo:       "org/repo-decay",
+		pr:         144,
+		database:   "e2e_decay_db",
+		applyState: state.Apply.Running,
+	})
+	st, apply, task, capture, h := f.st, f.apply, f.task, f.capture, f.handler
+
+	h.postAndTrackComment(t.Context(), "org/repo-decay", 144, 12345, apply, state.Comment.Progress, "initial progress")
+	progressID := requireCommentCreate(t, capture)
+
+	fake := clock.NewFake(task.CreatedAt)
+	obs := f.newObserver(st, fake)
+
+	// The first tick anchors the comment's age and edits. The rendered footer
+	// advertises the fastest rung so a reader knows the expected refresh rate.
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, progressID, edited.CommentID)
+		assert.Contains(t, edited.Body, "updates every ~5s")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the first tick to edit the progress comment")
+	}
+
+	// Over an hour in, the cadence has decayed: row-copy progress alone no
+	// longer reaches GitHub every few seconds, and the footer advertises the
+	// slower rung so the wider gap reads as designed rather than as a stall.
+	fake.Advance(61 * time.Minute)
+	task.RowsCopied = 600
+	task.ProgressPercent = 60
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		assert.Contains(t, edited.Body, "60%")
+		assert.Contains(t, edited.Body, "updates every ~1m")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected an edit after a long-overdue interval")
+	}
+
+	fake.Advance(31 * time.Second)
+	task.RowsCopied = 650
+	task.ProgressPercent = 65
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		t.Fatalf("an hour-old comment must not edit again after 31s; got %q", edited.Body)
+	default:
+		// expected: the decayed cadence spaces edits minutes apart
+	}
+
+	// Once the decayed interval elapses, progress reaches GitHub again.
+	fake.Advance(time.Minute)
+	task.RowsCopied = 700
+	task.ProgressPercent = 70
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		assert.Contains(t, edited.Body, "70%")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected an edit once the decayed interval elapsed")
+	}
+
+	// Hours deeper in, the cadence has decayed further: the same spacing that
+	// published above is no longer enough.
+	fake.Advance(4 * time.Hour)
+	task.RowsCopied = 750
+	task.ProgressPercent = 75
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		assert.Contains(t, edited.Body, "75%")
+		assert.Contains(t, edited.Body, "updates every ~5m")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected an edit after hours without one")
+	}
+
+	fake.Advance(2 * time.Minute)
+	task.RowsCopied = 800
+	task.ProgressPercent = 80
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		t.Fatalf("a comment hours old must space edits further apart than minutes; got %q", edited.Body)
+	default:
+		// expected: deeper rungs of the schedule space edits further apart
+	}
+
+	fake.Advance(5 * time.Minute)
+	task.RowsCopied = 850
+	task.ProgressPercent = 85
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		assert.Contains(t, edited.Body, "85%")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected an edit once the deeper decayed interval elapsed")
+	}
+
+	// A state change bypasses the cadence entirely: it publishes one second
+	// after the previous edit even on an hours-old comment.
+	fake.Advance(time.Second)
+	apply.State = state.Apply.WaitingForCutover
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, progressID, edited.CommentID)
+		assert.Contains(t, edited.Body, "Waiting for Cutover")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected a state change to edit immediately")
+	}
+}
+
+// A rotation posts a fresh progress comment because someone just acted on the
+// apply (a resume after a stop, a volume change) and is watching the PR again,
+// so the fresh comment starts back at the fastest cadence even when the apply
+// itself has been running for hours.
+func TestE2EProgressRotationRestoresFastCadence(t *testing.T) {
+	ctx := t.Context()
+
+	f := setupApplyCommentFixture(t, applyCommentFixtureParams{
+		repo:       "org/repo-decay-rotate",
+		pr:         145,
+		database:   "e2e_decay_rotate_db",
+		applyState: state.Apply.Resuming,
+	})
+	st, apply, task, capture, h := f.st, f.apply, f.task, f.capture, f.handler
+
+	// Seed the pre-resume comments left by the stop: the progress comment
+	// frozen at "Stopped" and the stopped summary marker.
+	h.postAndTrackComment(ctx, "org/repo-decay-rotate", 145, 12345, apply, state.Comment.Progress, "Stopped at 21%")
+	requireCommentCreate(t, capture)
+	h.postAndTrackComment(ctx, "org/repo-decay-rotate", 145, 12345, apply, state.Comment.Summary, "Schema Change Stopped")
+	requireCommentCreate(t, capture)
+
+	fake := clock.NewFake(task.CreatedAt)
+	obs := f.newObserver(st, fake)
+
+	// The apply has been running long enough for the cadence to decay fully.
+	obs.progressCommentSince = task.CreatedAt
+	fake.Advance(7 * time.Hour)
+
+	// The resume tick rotates: a fresh progress comment is posted and the old
+	// one is frozen.
+	obs.OnProgress(apply, []*storage.Task{task})
+	newProgressID := requireCommentCreate(t, capture)
+	select {
+	case <-capture.edits: // the freeze edit on the superseded comment
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the superseded progress comment to be frozen")
+	}
+
+	// Six seconds later, real progress on the fresh comment publishes at the
+	// fastest cadence; the pre-rotation age no longer applies.
+	apply.State = state.Apply.Running
+	fake.Advance(6 * time.Second)
+	task.RowsCopied = 700
+	task.ProgressPercent = 70
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, newProgressID, edited.CommentID)
+		assert.Contains(t, edited.Body, "70%")
+		assert.Contains(t, edited.Body, "updates every ~5s",
+			"the fresh comment advertises the fastest rung again")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the fresh comment to edit at the fastest cadence")
+	}
 }

--- a/pkg/webhook/apply_test.go
+++ b/pkg/webhook/apply_test.go
@@ -35,7 +35,7 @@ func TestFormatProgressComment(t *testing.T) {
 		},
 	}
 
-	body := formatProgressComment(apply, tasks, nil, "")
+	body := formatProgressComment(apply, tasks, nil, "", 0)
 
 	// Template renders rich progress bars instead of a table
 	assert.Contains(t, body, "testdb")
@@ -59,7 +59,7 @@ func TestFormatProgressComment_NoTasks(t *testing.T) {
 		State:       state.Apply.Pending,
 	}
 
-	body := formatProgressComment(apply, nil, nil, "")
+	body := formatProgressComment(apply, nil, nil, "", 0)
 
 	assert.Contains(t, body, "testdb")
 	assert.Contains(t, body, "Starting")
@@ -74,7 +74,7 @@ func TestFormatProgressComment_WithError(t *testing.T) {
 		ErrorMessage: "connection refused",
 	}
 
-	body := formatProgressComment(apply, nil, nil, "")
+	body := formatProgressComment(apply, nil, nil, "", 0)
 
 	assert.Contains(t, body, "connection refused")
 	assert.Contains(t, body, "Failed")
@@ -107,7 +107,7 @@ func TestFormatProgressCommentCutoverState(t *testing.T) {
 		{TableName: "orders", State: state.Task.WaitingForCutover},
 	}
 
-	body := formatProgressComment(apply, tasks, nil, "")
+	body := formatProgressComment(apply, tasks, nil, "", 0)
 
 	assert.Contains(t, body, "Cutover")
 	assert.Contains(t, body, "testdb")
@@ -137,7 +137,7 @@ func TestFormatProgressCommentCutoverReadinessCountsOnlyParkedTables(t *testing.
 		{TableName: "orders", State: state.Task.Running},
 	}
 
-	body := formatProgressComment(apply, tasks, nil, "")
+	body := formatProgressComment(apply, tasks, nil, "", 0)
 
 	assert.Contains(t, body, "**1/2** table(s) ready for cutover — waiting on 1")
 	assert.Contains(t, body, "✅ Ready for cutover")

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -78,6 +78,14 @@ type CommentObserver struct {
 	// with the known comment ID) instead of posting a duplicate.
 	pendingRotation *pendingProgressRotation
 
+	// progressCommentSince is when the live progress comment became this
+	// drive's edit target — the base age for the decayed edit cadence. Zero
+	// until the first progress tick (set to that tick's time, so a recovered
+	// drive starts back at the fastest cadence); reset when a rotation posts a
+	// fresh progress comment, since a fresh comment means someone just acted
+	// on the apply and is watching the PR again.
+	progressCommentSince time.Time
+
 	// lastWritten remembers, per GitHub comment ID, the content key
 	// (templates.CommentContentKey) of the body this observer last wrote and
 	// when it was confirmed written, so an edit whose visible content is
@@ -138,6 +146,34 @@ const (
 	// few minutes of fast identical edits per comment.
 	unchangedCommentGraceWindow = 10 * time.Minute
 )
+
+// progressEditDecayStep is one rung of the age-decayed edit cadence: while the
+// live progress comment is younger than age, edits are spaced at least
+// interval apart.
+type progressEditDecayStep struct {
+	age      time.Duration
+	interval time.Duration
+}
+
+// progressEditDecaySchedule spaces progress-comment edits further apart as the
+// live progress comment ages. A fresh apply updates every few seconds while
+// the requester is watching the PR; a copy that has been running for hours is
+// being checked occasionally, and each edit spends shared GitHub write budget
+// (one comment editing every 5s for a week is thousands of writes per day
+// against per-installation rate limits). The CLI remains the high-resolution
+// progress surface. State transitions bypass the cadence entirely, so
+// slowdowns never delay a state change reaching the PR.
+var progressEditDecaySchedule = []progressEditDecayStep{
+	{age: 10 * time.Minute, interval: activeInterval},
+	{age: time.Hour, interval: 30 * time.Second},
+	{age: 2 * time.Hour, interval: time.Minute},
+	{age: 4 * time.Hour, interval: 2 * time.Minute},
+	{age: 6 * time.Hour, interval: 5 * time.Minute},
+}
+
+// progressEditDecayMaxInterval is the edit spacing once the live progress
+// comment is older than the last schedule step.
+const progressEditDecayMaxInterval = 10 * time.Minute
 
 // CommentObserverConfig holds the parameters for creating a CommentObserver.
 type CommentObserverConfig struct {
@@ -278,7 +314,9 @@ func (o *CommentObserver) OnProgress(apply *storage.Apply, tasks []*storage.Task
 	// hasCutoverComment unset so the next tick retries, instead of muting the
 	// observer for the rest of the drive over one transient GitHub error.
 	if currentState == state.Apply.CuttingOver && o.shouldDeferCutover(apply) && !o.hasCutoverComment {
-		body := o.formatStatusComment(apply, tasks)
+		// The cutover comment stays frozen until an operator triggers cutover, so
+		// it advertises no update cadence.
+		body := o.formatStatusComment(apply, tasks, 0)
 		if _, posted, _ := o.postAndTrackComment(apply, state.Comment.Cutover, body, nil); posted {
 			o.hasCutoverComment = true
 		}
@@ -300,6 +338,7 @@ func (o *CommentObserver) OnProgress(apply *storage.Apply, tasks []*storage.Task
 	if !state.IsTerminalApplyState(apply.State) && o.rotateProgressCommentForResume(apply, tasks) {
 		o.lastState = currentState
 		o.lastProgressPost = now
+		o.progressCommentSince = now
 		o.stagnantTicks = 0
 		return
 	}
@@ -311,34 +350,34 @@ func (o *CommentObserver) OnProgress(apply *storage.Apply, tasks []*storage.Task
 	if !state.IsTerminalApplyState(apply.State) && o.rotateProgressCommentForVolumeChange(apply, tasks) {
 		o.lastState = currentState
 		o.lastProgressPost = now
+		o.progressCommentSince = now
 		o.stagnantTicks = 0
 		return
 	}
 
 	// Adaptive rate limiting — ported from watchApplyProgress.
-	// Edit every 5s when progress is moving, slow to 30s when stagnant.
+	// Edits are spaced by the age-decayed cadence while progress is moving,
+	// and slowed further (never sped up) when it stagnates.
 	var totalRows int64
 	for _, t := range tasks {
 		totalRows += t.RowsCopied
 	}
 
-	interval := activeInterval
-	if o.stagnantTicks >= stagnantThresh {
-		interval = stagnantInterval
-	}
+	decayed := o.progressEditInterval(now)
 
 	if totalRows == o.lastRowsCopied && currentState == o.lastState {
 		o.stagnantTicks++
-		if o.stagnantTicks >= stagnantThresh && now.Sub(o.lastProgressPost) < stagnantInterval {
-			return // stagnant — skip edit
+		interval := decayed
+		if o.stagnantTicks >= stagnantThresh && interval < stagnantInterval {
+			interval = stagnantInterval
 		}
 		if now.Sub(o.lastProgressPost) < interval {
-			return // not time yet
+			return // stagnant — not time yet
 		}
 	} else {
 		o.stagnantTicks = 0
 		o.lastRowsCopied = totalRows
-		if now.Sub(o.lastProgressPost) < activeInterval && currentState == o.lastState {
+		if now.Sub(o.lastProgressPost) < decayed && currentState == o.lastState {
 			return // active but not time yet (unless state changed)
 		}
 	}
@@ -346,9 +385,36 @@ func (o *CommentObserver) OnProgress(apply *storage.Apply, tasks []*storage.Task
 	o.lastState = currentState
 	o.lastProgressPost = now
 
-	// Edit the progress comment
-	body := o.formatStatusComment(apply, tasks)
+	// Edit the progress comment, advertising the cadence that spaced this edit
+	// so the rendered footer matches the refresh rate the reader will observe.
+	body := o.formatStatusComment(apply, tasks, decayed)
 	o.editTrackedComment(apply, state.Comment.Progress, body)
+}
+
+// progressEditInterval returns the minimum spacing between progress-comment
+// edits per progressEditDecaySchedule, keyed to the age of the live progress
+// comment rather than the apply: a rotation posts a fresh comment because
+// someone just acted on the apply, so the new comment starts back at the
+// fastest cadence. Called with o.mu held; the first call anchors the age to
+// its own tick time.
+func (o *CommentObserver) progressEditInterval(now time.Time) time.Duration {
+	if o.progressCommentSince.IsZero() {
+		o.progressCommentSince = now
+	}
+	age := now.Sub(o.progressCommentSince)
+	for _, step := range progressEditDecaySchedule {
+		if age < step.age {
+			return step.interval
+		}
+	}
+	return progressEditDecayMaxInterval
+}
+
+// freshProgressCadence is the update cadence advertised on a newly posted
+// progress comment. A rotation resets the comment-age anchor, so the fresh
+// comment starts back at the fastest rung of the decay schedule.
+func (o *CommentObserver) freshProgressCadence() time.Duration {
+	return activeInterval
 }
 
 // OnTerminal is called when the apply reaches a terminal state.
@@ -393,7 +459,7 @@ func (o *CommentObserver) OnTerminal(apply *storage.Apply, tasks []*storage.Task
 		// This is the per-operation status freeze, not the apply-level summary, so
 		// it always runs; the aggregate publisher re-edits it with the full task
 		// set for multi-operation applies.
-		finalBody := o.statusCommentFromOps(apply, ops, opsErr, tasks, shardsByTable)
+		finalBody := o.statusCommentFromOps(apply, ops, opsErr, tasks, shardsByTable, 0)
 		o.editTrackedComment(apply, activeCommentState, finalBody)
 
 		// Post a separate summary comment. A new comment is more reliable than
@@ -456,11 +522,11 @@ func (o *CommentObserver) shouldPublishSeparateSummary(apply *storage.Apply, ops
 // single-deployment layout byte-for-byte. A load failure falls back to the
 // single-deployment layout so a transient storage error never blocks a comment
 // update.
-func (o *CommentObserver) formatStatusComment(apply *storage.Apply, tasks []*storage.Task) string {
+func (o *CommentObserver) formatStatusComment(apply *storage.Apply, tasks []*storage.Task, updateCadence time.Duration) string {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	ops, err := o.stor.ApplyOperations().ListByApply(ctx, o.applyID)
-	return o.statusCommentFromOps(apply, ops, err, tasks, o.shardsByTable(ctx, apply, ops))
+	return o.statusCommentFromOps(apply, ops, err, tasks, o.shardsByTable(ctx, apply, ops), updateCadence)
 }
 
 // shardsByTable loads an apply's per-shard detail rows and groups them by table
@@ -497,13 +563,13 @@ func (o *CommentObserver) shardsByTable(ctx context.Context, apply *storage.Appl
 // rows, applying the same single-deployment fallback as formatStatusComment when
 // the load failed. Callers that already hold the operation set (e.g. OnTerminal)
 // use this to avoid re-reading apply_operations.
-func (o *CommentObserver) statusCommentFromOps(apply *storage.Apply, ops []*storage.ApplyOperation, opsErr error, tasks []*storage.Task, shardsByTable map[string][]*storage.Task) string {
+func (o *CommentObserver) statusCommentFromOps(apply *storage.Apply, ops []*storage.ApplyOperation, opsErr error, tasks []*storage.Task, shardsByTable map[string][]*storage.Task, updateCadence time.Duration) string {
 	if opsErr != nil {
 		o.logger.Error("observer: failed to load apply operations for comment dispatch; rendering single-deployment layout",
 			"apply_id", o.applyID, "error", opsErr)
-		return formatProgressComment(apply, tasks, shardsByTable, o.tenant)
+		return formatProgressComment(apply, tasks, shardsByTable, o.tenant, updateCadence)
 	}
-	return formatApplyStatusComment(apply, ops, o.resolveReleased(apply, ops), tasks, o.resolveDisplay(apply, ops), shardsByTable, o.tenant)
+	return formatApplyStatusComment(apply, ops, o.resolveReleased(apply, ops), tasks, o.resolveDisplay(apply, ops), shardsByTable, o.tenant, updateCadence)
 }
 
 // resolveDisplay projects the apply's per-operation engine display state (VSchema
@@ -776,7 +842,7 @@ func (o *CommentObserver) rotateProgressCommentForResume(apply *storage.Apply, t
 		pendingFreeze = &tracked.GitHubCommentID
 	}
 
-	body := o.formatStatusComment(apply, tasks)
+	body := o.formatStatusComment(apply, tasks, o.freshProgressCadence())
 	newCommentID, posted, trackedNew := o.postAndTrackComment(apply, state.Comment.Progress, body, pendingFreeze)
 	if !posted {
 		// postAndTrackComment logged the failure. The summary marker is left in
@@ -935,7 +1001,7 @@ func (o *CommentObserver) rotateProgressCommentForVolumeChange(apply *storage.Ap
 		return false
 	}
 
-	body := o.formatStatusComment(apply, tasks)
+	body := o.formatStatusComment(apply, tasks, o.freshProgressCadence())
 	newCommentID, posted, trackedNew := o.postAndTrackComment(apply, state.Comment.Progress, body, &tracked.GitHubCommentID)
 	if !posted {
 		// postAndTrackComment logged the failure; the level mismatch persists,

--- a/pkg/webhook/comment_observer_test.go
+++ b/pkg/webhook/comment_observer_test.go
@@ -88,7 +88,7 @@ func TestCommentObserverRendersVSchemaFromEngineResumeState(t *testing.T) {
 
 	t.Run("progress comment shows the applying keyspace and diff", func(t *testing.T) {
 		body := observer(`{"vschema_status":"applying","vschema_diffs":[{"namespace":"commerce_sharded","diff":"+ \"xxhash\": {\"type\": \"xxhash\"}"}]}`).
-			formatStatusComment(psApply(state.Apply.Running), nil)
+			formatStatusComment(psApply(state.Apply.Running), nil, 0)
 		assert.Contains(t, body, "### VSchema")
 		assert.Contains(t, body, "**`commerce_sharded`**: Applying...")
 		assert.Contains(t, body, `+ "xxhash": {"type": "xxhash"}`)
@@ -104,19 +104,19 @@ func TestCommentObserverRendersVSchemaFromEngineResumeState(t *testing.T) {
 
 	t.Run("multi-keyspace renders each keyspace independently", func(t *testing.T) {
 		body := observer(`{"vschema_status":"applying","vschema_diffs":[{"namespace":"commerce","diff":"+ \"lookup\": {}"},{"namespace":"commerce_sharded","diff":"+ \"xxhash\": {}"}]}`).
-			formatStatusComment(psApply(state.Apply.Running), nil)
+			formatStatusComment(psApply(state.Apply.Running), nil, 0)
 		assert.Contains(t, body, "**`commerce`**: Applying...")
 		assert.Contains(t, body, "**`commerce_sharded`**: Applying...")
 	})
 
 	t.Run("no engine resume state renders no VSchema section", func(t *testing.T) {
-		body := observer("").formatStatusComment(psApply(state.Apply.Running), nil)
+		body := observer("").formatStatusComment(psApply(state.Apply.Running), nil, 0)
 		assert.NotContains(t, body, "### VSchema")
 	})
 
 	t.Run("non-PlanetScale apply skips VSchema projection", func(t *testing.T) {
 		body := observer(`{"vschema_status":"applying","vschema_diffs":[{"namespace":"x","diff":"+ y"}]}`).
-			formatStatusComment(runningApply(), nil)
+			formatStatusComment(runningApply(), nil, 0)
 		assert.NotContains(t, body, "### VSchema")
 	})
 }
@@ -129,7 +129,7 @@ func TestFormatStatusCommentRoutesMultiDeployment(t *testing.T) {
 		{ID: 2, Deployment: "us", State: state.ApplyOperation.Running},
 	}})
 
-	body := o.formatStatusComment(runningApply(), nil)
+	body := o.formatStatusComment(runningApply(), nil, 0)
 
 	assert.Contains(t, body, "**Deployments**: 1 completed, 1 running")
 	assert.Contains(t, body, "- ✅ eu — completed")
@@ -143,7 +143,7 @@ func TestFormatStatusCommentRoutesSingleDeployment(t *testing.T) {
 		{ID: 1, Deployment: "eu", State: state.ApplyOperation.Running},
 	}})
 
-	body := o.formatStatusComment(runningApply(), nil)
+	body := o.formatStatusComment(runningApply(), nil, 0)
 
 	assert.Contains(t, body, "## Schema Change Status")
 	assert.NotContains(t, body, "**Deployments**:")
@@ -154,7 +154,7 @@ func TestFormatStatusCommentRoutesSingleDeployment(t *testing.T) {
 func TestFormatStatusCommentFallsBackOnLoadError(t *testing.T) {
 	o := newDispatchTestObserver(&stubApplyOperationStore{err: errors.New("db unavailable")})
 
-	body := o.formatStatusComment(runningApply(), nil)
+	body := o.formatStatusComment(runningApply(), nil, 0)
 
 	assert.Contains(t, body, "## Schema Change Status")
 	assert.NotContains(t, body, "**Deployments**:")

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -573,7 +573,7 @@ func (h *Handler) postInitialProgressComment(ctx context.Context, repo string, p
 			append(apply.LogAttrs(), "error", err)...)
 		return
 	}
-	finalBody := formatProgressComment(apply, nil, nil, h.deploymentTenant())
+	finalBody := formatProgressComment(apply, nil, nil, h.deploymentTenant(), 0)
 	if err := client.EditIssueComment(ctx, repo, comment.GitHubCommentID, h.renderPRComment(finalBody)); err != nil {
 		h.logger.Error("failed to finalize progress comment for already-terminal apply",
 			append(apply.LogAttrs(), "github_comment_id", comment.GitHubCommentID, "error", err)...)

--- a/pkg/webhook/multi_apply.go
+++ b/pkg/webhook/multi_apply.go
@@ -37,17 +37,26 @@ func releasedForApply(ctx context.Context, stor storage.Storage, apply *storage.
 // ops must be in resolved deployment order (as returned by
 // ApplyOperations().ListByApply); tasks are the apply's tasks across all
 // deployments, regrouped per operation for the multi-deployment layout.
-func formatApplyStatusComment(apply *storage.Apply, ops []*storage.ApplyOperation, released bool, tasks []*storage.Task, displayByOp map[int64]operationDisplay, shardsByTable map[string][]*storage.Task, tenant string) string {
+// updateCadence is the current spacing between automatic refreshes of the
+// comment, rendered beside the "Last updated" footer; zero renders no cadence
+// note (terminal finalizations).
+func formatApplyStatusComment(apply *storage.Apply, ops []*storage.ApplyOperation, released bool, tasks []*storage.Task, displayByOp map[int64]operationDisplay, shardsByTable map[string][]*storage.Task, tenant string, updateCadence time.Duration) string {
 	// A sharded apply fans out across the shards of one keyspace within a single
 	// deployment, so it gets the shard-unit layout rather than the deployment-unit
 	// one — its operations differ by shard, not deployment.
 	if isShardedApply(ops) {
-		return templates.RenderShardedApplyComment(buildShardedApplyData(apply, ops, released, tasks, tenant))
+		data := buildShardedApplyData(apply, ops, released, tasks, tenant)
+		data.UpdateCadence = updateCadence
+		return templates.RenderShardedApplyComment(data)
 	}
 	if len(ops) <= 1 {
-		return templates.RenderApplyStatusComment(buildApplyCommentData(apply, tasks, singleOpDisplay(ops, displayByOp), shardsByTable, tenant))
+		data := buildApplyCommentData(apply, tasks, singleOpDisplay(ops, displayByOp), shardsByTable, tenant)
+		data.UpdateCadence = updateCadence
+		return templates.RenderApplyStatusComment(data)
 	}
-	return templates.RenderMultiDeploymentApplyComment(buildMultiApplyData(apply, ops, released, tasks, displayByOp, shardsByTable, tenant))
+	data := buildMultiApplyData(apply, ops, released, tasks, displayByOp, shardsByTable, tenant)
+	data.UpdateCadence = updateCadence
+	return templates.RenderMultiDeploymentApplyComment(data)
 }
 
 // formatApplySummaryComment renders the terminal summary PR comment for an apply,

--- a/pkg/webhook/multi_apply_test.go
+++ b/pkg/webhook/multi_apply_test.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"testing"
+	"time"
 
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
@@ -22,7 +23,7 @@ func runningApply() *storage.Apply {
 // An apply with no operation rows (legacy, predating apply_operations) renders
 // the single-deployment comment unchanged — no aggregate header.
 func TestFormatApplyStatusComment_NoOperationsRendersSingle(t *testing.T) {
-	out := formatApplyStatusComment(runningApply(), nil, false, nil, nil, nil, "")
+	out := formatApplyStatusComment(runningApply(), nil, false, nil, nil, nil, "", 0)
 	assert.Contains(t, out, "## Schema Change Status")
 	assert.NotContains(t, out, "**Deployments**:")
 }
@@ -33,7 +34,7 @@ func TestFormatApplyStatusComment_OneOperationRendersSingle(t *testing.T) {
 	ops := []*storage.ApplyOperation{
 		{ID: 1, Deployment: "eu", State: state.ApplyOperation.Running},
 	}
-	out := formatApplyStatusComment(runningApply(), ops, false, nil, nil, nil, "")
+	out := formatApplyStatusComment(runningApply(), ops, false, nil, nil, nil, "", 0)
 	assert.NotContains(t, out, "**Deployments**:")
 	assert.NotContains(t, out, "- 🔄 eu")
 }
@@ -45,7 +46,7 @@ func TestFormatApplyStatusComment_MultipleOperationsRendersMulti(t *testing.T) {
 		{ID: 1, Deployment: "eu", State: state.ApplyOperation.Completed, CutoverPolicy: storage.CutoverPolicyBarrier},
 		{ID: 2, Deployment: "us", State: state.ApplyOperation.Running, CutoverPolicy: storage.CutoverPolicyBarrier},
 	}
-	out := formatApplyStatusComment(runningApply(), ops, false, nil, nil, nil, "")
+	out := formatApplyStatusComment(runningApply(), ops, false, nil, nil, nil, "", 0)
 	assert.Contains(t, out, "## Schema Change Status")
 	assert.Contains(t, out, "**Deployments**: 1 completed, 1 running")
 	assert.Contains(t, out, "- ✅ eu — completed")
@@ -62,10 +63,10 @@ func TestFormatApplyStatusComment_ReleasedPauseRendersDegradedNotPaused(t *testi
 		{ID: 2, Deployment: "us", State: state.ApplyOperation.Pending, OnFailure: storage.OnFailurePause},
 	}
 
-	paused := formatApplyStatusComment(runningApply(), ops, false, nil, nil, nil, "")
+	paused := formatApplyStatusComment(runningApply(), ops, false, nil, nil, nil, "", 0)
 	assert.Contains(t, paused, "paused — eu failed; release or stop")
 
-	released := formatApplyStatusComment(runningApply(), ops, true, nil, nil, nil, "")
+	released := formatApplyStatusComment(runningApply(), ops, true, nil, nil, nil, "", 0)
 	assert.NotContains(t, released, "paused — eu failed; release or stop")
 }
 
@@ -222,4 +223,20 @@ func TestGroupTasksByOperation_SkipsUnlinkedTasks(t *testing.T) {
 	})
 	require.Len(t, grouped[1], 2)
 	assert.Len(t, grouped, 1)
+}
+
+// Both the single- and multi-deployment status layouts advertise the current
+// automatic-refresh cadence beside the "Last updated" footer, so a reader on a
+// long apply knows how far apart updates are expected in either layout.
+func TestFormatApplyStatusComment_RendersUpdateCadence(t *testing.T) {
+	single := formatApplyStatusComment(runningApply(), nil, false, nil, nil, nil, "", 2*time.Minute)
+	assert.Contains(t, single, "updates every ~2m")
+
+	ops := []*storage.ApplyOperation{
+		{ID: 1, Deployment: "eu", State: state.ApplyOperation.Running, CutoverPolicy: storage.CutoverPolicyBarrier},
+		{ID: 2, Deployment: "us", State: state.ApplyOperation.Running, CutoverPolicy: storage.CutoverPolicyBarrier},
+	}
+	multi := formatApplyStatusComment(runningApply(), ops, false, nil, nil, nil, "", 2*time.Minute)
+	assert.Contains(t, multi, "**Deployments**:")
+	assert.Contains(t, multi, "updates every ~2m")
 }

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -456,7 +456,7 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment 
 	// Post initial progress comment for the observer to edit. VSchema status is
 	// omitted on this first comment — the observer refreshes it from engine
 	// display metadata on the next progress tick.
-	progressBody := formatProgressComment(apply, nil, nil, h.deploymentTenant())
+	progressBody := formatProgressComment(apply, nil, nil, h.deploymentTenant(), activeInterval)
 	h.postInitialProgressComment(ctx, repo, pr, installationID, apply, progressBody)
 }
 

--- a/pkg/webhook/sharded_apply_test.go
+++ b/pkg/webhook/sharded_apply_test.go
@@ -22,7 +22,7 @@ func TestFormatApplyStatusComment_ShardedAttributionFromCaller(t *testing.T) {
 	oid := int64(1)
 	tasks := []*storage.Task{{ID: 1, ApplyID: 1, ApplyOperationID: &oid, Namespace: "cdb_resolute_sharded", TableName: "mutes", Shard: "-40", DDL: "ALTER TABLE `mutes` ADD INDEX a"}}
 
-	out := formatApplyStatusComment(apply, []*storage.ApplyOperation{op}, false, tasks, nil, nil, "")
+	out := formatApplyStatusComment(apply, []*storage.ApplyOperation{op}, false, tasks, nil, nil, "", 0)
 
 	assert.Contains(t, out, "by @morgo at", "attribution shows the clean username")
 	assert.NotContains(t, out, "github:", "the raw structured caller is not rendered")
@@ -100,7 +100,7 @@ func TestFormatApplyStatusComment_ShardedFailedSurfacesError(t *testing.T) {
 	}
 	tasks := []*storage.Task{task(1, 1, "-40"), task(2, 2, "40-80"), task(3, 3, "80-c0"), task(4, 4, "c0-")}
 
-	out := formatApplyStatusComment(apply, ops, false, tasks, nil, nil, "")
+	out := formatApplyStatusComment(apply, ops, false, tasks, nil, nil, "", 0)
 
 	assert.Contains(t, out, "## Schema Change Status", "uses the stable in-place status headline")
 	assert.Contains(t, out, "**Shards**:", "counts shards, not deployments")
@@ -127,7 +127,7 @@ func TestFormatApplyStatusComment_ShardedFailureFallsBackToTaskError(t *testing.
 	oid := int64(1)
 	tasks := []*storage.Task{{ID: 1, ApplyID: 1, ApplyOperationID: &oid, Namespace: "cdb_resolute_sharded", TableName: "mutes", Shard: "-40", DDL: "ALTER ...", ErrorMessage: gotZero}}
 
-	out := formatApplyStatusComment(apply, []*storage.ApplyOperation{op}, false, tasks, nil, nil, "")
+	out := formatApplyStatusComment(apply, []*storage.ApplyOperation{op}, false, tasks, nil, nil, "", 0)
 
 	assert.Contains(t, out, gotZero, "the task error is surfaced when the operation row has none")
 }
@@ -178,4 +178,20 @@ func TestBuildShardedApplyData_JoinsMultiTaskDDL(t *testing.T) {
 	require.Len(t, data.Cells, 1)
 	assert.Equal(t, "ALTER TABLE `mutes` ADD INDEX a\nALTER TABLE `mutes` ADD INDEX b", data.Cells[0].DDL,
 		"all non-empty task DDLs are joined in order")
+}
+
+// The sharded status layout advertises the current automatic-refresh cadence
+// beside the "Last updated" footer, matching the deployment-unit layouts.
+func TestFormatApplyStatusComment_ShardedRendersUpdateCadence(t *testing.T) {
+	apply := &storage.Apply{
+		ApplyIdentifier: "apply-x", Database: "cdb_resolute", Environment: "staging", State: state.Apply.Running,
+	}
+	op := &storage.ApplyOperation{ID: 1, ApplyID: 1, Deployment: "cake", OperationKey: "cdb_resolute_sharded/-40/mutes", State: state.ApplyOperation.Running, CutoverPolicy: storage.CutoverPolicyRolling, OnFailure: storage.OnFailureHalt}
+	oid := int64(1)
+	tasks := []*storage.Task{{ID: 1, ApplyID: 1, ApplyOperationID: &oid, Namespace: "cdb_resolute_sharded", TableName: "mutes", Shard: "-40", DDL: "ALTER TABLE `mutes` ADD INDEX a"}}
+
+	out := formatApplyStatusComment(apply, []*storage.ApplyOperation{op}, false, tasks, nil, nil, "", 5*time.Minute)
+
+	assert.Contains(t, out, "**Shards**:", "the shard-unit layout is selected")
+	assert.Contains(t, out, "updates every ~5m")
 }

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -101,6 +101,12 @@ type ApplyStatusCommentData struct {
 	// status vocabulary from "apply" to "rollback" so a completed rollback is
 	// announced as "Rollback Complete", never as a freshly applied schema change.
 	Rollback bool
+
+	// UpdateCadence is the current spacing between automatic refreshes of this
+	// comment, shown beside the "Last updated" footer so a reader knows how long
+	// to expect between updates as the cadence slows on a long apply. Zero
+	// renders no cadence note (terminal renders and one-shot comments).
+	UpdateCadence time.Duration
 }
 
 // RenderApplyStatusComment renders a PR comment for the current apply status.
@@ -152,7 +158,7 @@ func renderApplyStatusComment(data ApplyStatusCommentData, includeLastUpdated bo
 	// Footer with next actions
 	writeApplyFooter(&sb, data)
 	if includeLastUpdated && !state.IsTerminalApplyState(data.State) {
-		writeLastUpdatedFooter(&sb, renderedAt)
+		writeLastUpdatedFooter(&sb, renderedAt, data.UpdateCadence)
 	}
 
 	return sb.String()

--- a/pkg/webhook/templates/common.go
+++ b/pkg/webhook/templates/common.go
@@ -150,15 +150,23 @@ func writeAttributionLineAt(sb *strings.Builder, verb, user, timestamp, suffix s
 	}
 }
 
-func writeLastUpdatedFooter(sb *strings.Builder, timestamp string) {
+func writeLastUpdatedFooter(sb *strings.Builder, timestamp string, updateCadence time.Duration) {
 	if !strings.HasSuffix(sb.String(), "\n") {
 		sb.WriteString("\n")
 	}
+	// State the current refresh cadence so a reader watching a long apply knows
+	// how long to expect between updates as the cadence slows with comment age,
+	// instead of reading a widening gap as a stall.
+	cadenceNote := ""
+	if updateCadence > 0 {
+		cadenceNote = fmt.Sprintf(" · updates every ~%s", formatDuration(updateCadence))
+	}
 	escapedTimestamp := html.EscapeString(timestamp)
-	fmt.Fprintf(sb, "\n_Last updated: <relative-time datetime=\"%s\">%s</relative-time> (%s)_\n",
+	fmt.Fprintf(sb, "\n_Last updated: <relative-time datetime=\"%s\">%s</relative-time> (%s)%s_\n",
 		escapeRelativeTimeDatetime(timestamp),
 		escapedTimestamp,
-		escapedTimestamp)
+		escapedTimestamp,
+		cadenceNote)
 }
 
 func escapeRelativeTimeDatetime(timestamp string) string {

--- a/pkg/webhook/templates/common_test.go
+++ b/pkg/webhook/templates/common_test.go
@@ -81,3 +81,44 @@ func TestCommentContentKeyKeepsRevertCountdownLive(t *testing.T) {
 	assert.Contains(t, second, "Closes in 10m")
 	assert.NotEqual(t, CommentContentKey(first), CommentContentKey(second))
 }
+
+// A progress comment states its own refresh cadence beside the "Last updated"
+// footer, so a reader watching a long apply knows how far apart updates are
+// expected instead of reading a slowed cadence as a stall. Zero cadence
+// (terminal finalizations and one-shot renders) omits the note entirely.
+func TestLastUpdatedFooterShowsUpdateCadence(t *testing.T) {
+	withTemplateTimestamp(t, "2026-06-16 19:42:00 UTC")
+	data := ApplyStatusCommentData{
+		Database:      "testapp",
+		Environment:   "staging",
+		RequestedBy:   "octocat",
+		State:         state.Apply.Running,
+		UpdateCadence: 2 * time.Minute,
+	}
+
+	out := RenderApplyStatusComment(data)
+	assert.Contains(t, out, "(2026-06-16 19:42:00 UTC) · updates every ~2m_")
+
+	data.UpdateCadence = 0
+	out = RenderApplyStatusComment(data)
+	assert.Contains(t, out, "(2026-06-16 19:42:00 UTC)_")
+	assert.NotContains(t, out, "updates every")
+}
+
+// The cadence note is part of the visible content, so a cadence change alone
+// changes the content key: when the decay schedule moves to a slower rung, the
+// comment is edited once and its advertised cadence stays truthful.
+func TestCommentContentKeyChangesWithUpdateCadence(t *testing.T) {
+	withTemplateTimestamp(t, "2026-06-16 19:42:00 UTC")
+	render := func(cadence time.Duration) string {
+		return RenderApplyStatusComment(ApplyStatusCommentData{
+			Database:      "testapp",
+			Environment:   "staging",
+			RequestedBy:   "octocat",
+			State:         state.Apply.Running,
+			UpdateCadence: cadence,
+		})
+	}
+
+	assert.NotEqual(t, CommentContentKey(render(30*time.Second)), CommentContentKey(render(time.Minute)))
+}

--- a/pkg/webhook/templates/multi_apply.go
+++ b/pkg/webhook/templates/multi_apply.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"html"
 	"strings"
+	"time"
 
 	"github.com/block/schemabot/pkg/presentation"
 	"github.com/block/schemabot/pkg/state"
@@ -52,6 +53,12 @@ type MultiDeploymentApplyData struct {
 	// headline vocabulary from "apply" to "rollback", matching the
 	// single-deployment comment.
 	Rollback bool
+
+	// UpdateCadence is the current spacing between automatic refreshes of this
+	// comment, shown beside the "Last updated" footer so a reader knows how long
+	// to expect between updates as the cadence slows on a long apply. Zero
+	// renders no cadence note.
+	UpdateCadence time.Duration
 }
 
 // RenderMultiDeploymentApplyComment renders the PR comment for an apply that
@@ -82,7 +89,7 @@ func RenderMultiDeploymentApplyComment(data MultiDeploymentApplyData) string {
 	// Expandable per-deployment detail, in resolved order.
 	writeDeploymentSections(&sb, data, renderedAt)
 	if !state.IsTerminalApplyState(data.Model.State) {
-		writeLastUpdatedFooter(&sb, renderedAt)
+		writeLastUpdatedFooter(&sb, renderedAt, data.UpdateCadence)
 	}
 
 	return sb.String()

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -877,7 +877,9 @@ func PreviewCommentApplyProgress() string {
 	tables[1].PercentComplete = 62
 	tables[1].ETASeconds = 195
 	tables[2].Status = state.Task.Pending
-	return RenderApplyStatusComment(sampleApplyData(state.Apply.Running, tables))
+	data := sampleApplyData(state.Apply.Running, tables)
+	data.UpdateCadence = 5 * time.Second
+	return RenderApplyStatusComment(data)
 }
 
 // PreviewCommentApplyChecksumming renders an apply comment where a table has

--- a/pkg/webhook/templates/sharded_apply.go
+++ b/pkg/webhook/templates/sharded_apply.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"html"
 	"strings"
+	"time"
 
 	"github.com/block/schemabot/pkg/state"
 )
@@ -48,6 +49,12 @@ type ShardedApplyData struct {
 	// vocabulary from "apply" to "rollback", matching the single-deployment
 	// comment.
 	Rollback bool
+
+	// UpdateCadence is the current spacing between automatic refreshes of this
+	// comment, shown beside the "Last updated" footer so a reader knows how long
+	// to expect between updates as the cadence slows on a long apply. Zero
+	// renders no cadence note.
+	UpdateCadence time.Duration
 }
 
 // ShardStatus is one shard's aggregate status. Emoji/Label come from the same
@@ -120,7 +127,7 @@ func RenderShardedApplyComment(data ShardedApplyData) string {
 
 	writeShardedFooter(&sb, data)
 	if !state.IsTerminalApplyState(data.State) {
-		writeLastUpdatedFooter(&sb, renderedAt)
+		writeLastUpdatedFooter(&sb, renderedAt, data.UpdateCadence)
 	}
 	return sb.String()
 }


### PR DESCRIPTION
## Why this matters

An actively copying apply edits its PR progress comment every 5 seconds — ~720 writes per hour, per apply, for as long as the copy runs. Nobody watches a PR comment continuously for a day, and a single week-long schema change can, by itself, keep the installation near GitHub's secondary content-creation limit. The CLI is the high-resolution progress surface; the PR comment needs to stay current, not real-time.

## What it does

Spaces progress-comment edits further apart as the live progress comment ages:

| comment age | edit interval |
|---|---|
| < 10 minutes | 5s |
| < 1 hour | 30s |
| < 2 hours | 1m |
| < 4 hours | 2m |
| < 6 hours | 5m |
| older | 10m |

- The clock is anchored to the **live progress comment**, not the apply: a rotation (resume after a stop, volume change) posts a fresh comment because someone just acted on the apply, so the fresh comment starts back at the fastest cadence. A recovered drive also restarts fast.
- State transitions bypass the cadence entirely — a slowdown never delays "Waiting for Cutover" or a terminal state reaching the PR.
- The comment states its own cadence: the "Last updated" footer renders `· updates every ~2m` for the current rung, so a reader watching a long apply sees the widening gap as designed behavior rather than a stall. The note re-renders once at each rung transition, keeping the advertised cadence truthful.

Stacked on #757.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
