### PR TITLE
feat(github): add configurable floor for progress-comment edit cadence

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,8 +16,10 @@
 - [Pending Drops](#pending-drops)
 - [Storage Schema Changes](#storage-schema-changes)
 - [Support Channel](#support-channel)
+- [Progress Comment Edit Cadence](#progress-comment-edit-cadence)
 - [Repository Allowlist](#repository-allowlist)
 - [PR Checks Gate](#pr-checks-gate)
+- [Base Branch Schema Freshness](#base-branch-schema-freshness)
 - [Review Gate](#review-gate)
 - [Authentication](#authentication)
   - [OIDC (Bearer tokens)](#oidc-bearer-tokens)
@@ -365,6 +367,33 @@ support_channel:
 Both `name` and `url` are required when `support_channel` is configured. The
 URL must be an absolute `http` or `https` link with no credentials, whitespace,
 or Markdown link delimiters. When omitted, SchemaBot comments are unchanged.
+
+## Progress Comment Edit Cadence
+
+While an apply runs, SchemaBot edits the PR progress comment on a built-in
+cadence that decays with the age of the comment: young comments update every
+few seconds, and long-running applies settle to an edit every few minutes.
+Each edit consumes GitHub API budget, so a server hosting many concurrent
+long-running applies can set a floor over that cadence:
+
+```yaml
+progress_comment_min_edit_interval: 2m  # default: unset (no floor)
+```
+
+The value is a Go duration string (`30s`, `2m`, `10m`). When set, no progress
+comment is edited more often than this interval, regardless of the built-in
+cadence. State changes (for example `Running` → `Waiting for Cutover`) always
+publish immediately — the floor spaces out progress-percentage noise, not
+state transitions.
+
+The progress comment states its effective cadence beside its "Last updated"
+footer (`updates every ~2m`), so PR readers see the configured floor rather
+than wondering why updates slowed down.
+
+Leave it unset for normal operation. Set it during a GitHub rate-limit
+incident, or permanently on servers that host many concurrent long-running
+applies. Users who need high-resolution progress can watch the apply from the
+SchemaBot CLI, which polls the server directly and is unaffected.
 
 ## Repository Allowlist
 

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -83,6 +83,15 @@ type ServerConfig struct {
 	// SchemaBot so PR authors know where to ask operators for help.
 	SupportChannel SupportChannelConfig `yaml:"support_channel,omitempty"`
 
+	// ProgressCommentMinEditInterval is the minimum spacing between GitHub
+	// edits of an apply's progress comment, as a Go duration string (e.g.
+	// "60s", "10m"). It is a floor over the built-in age-decayed edit cadence,
+	// giving operators a valve to slow all progress-comment traffic — for
+	// example during a GitHub rate-limit incident — without a code change.
+	// State-change updates always publish immediately and are unaffected; the
+	// CLI remains the high-resolution progress surface. Empty means no floor.
+	ProgressCommentMinEditInterval string `yaml:"progress_comment_min_edit_interval,omitempty"`
+
 	// DefaultReviewers are GitHub teams/users required to review schema changes.
 	DefaultReviewers []string `yaml:"default_reviewers"`
 
@@ -236,6 +245,22 @@ func (c *ServerConfig) PendingDropsRetention() (time.Duration, error) {
 	}
 	if d <= 0 {
 		return 0, fmt.Errorf("pending_drops.retention must be positive, got %q", c.PendingDrops.Retention)
+	}
+	return d, nil
+}
+
+// ProgressCommentMinEditIntervalDuration returns the configured floor for
+// progress-comment edit spacing, or zero when no floor is configured.
+func (c *ServerConfig) ProgressCommentMinEditIntervalDuration() (time.Duration, error) {
+	if c.ProgressCommentMinEditInterval == "" {
+		return 0, nil
+	}
+	d, err := time.ParseDuration(c.ProgressCommentMinEditInterval)
+	if err != nil {
+		return 0, fmt.Errorf("parse progress_comment_min_edit_interval %q: %w", c.ProgressCommentMinEditInterval, err)
+	}
+	if d < 0 {
+		return 0, fmt.Errorf("progress_comment_min_edit_interval must not be negative, got %q", c.ProgressCommentMinEditInterval)
 	}
 	return d, nil
 }
@@ -937,6 +962,9 @@ func (c *ServerConfig) Validate() error {
 		if _, err := c.PendingDropsRetention(); err != nil {
 			return err
 		}
+	}
+	if _, err := c.ProgressCommentMinEditIntervalDuration(); err != nil {
+		return err
 	}
 
 	// Validate Databases if present. An environment is either local mode

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -3547,3 +3547,50 @@ func TestKnownEnvironments(t *testing.T) {
 		assert.False(t, cfg.IsEnvironmentKnown("staging"))
 	})
 }
+
+// The progress-comment edit floor is an operator incident valve: it must
+// accept normal durations, reject unparseable or negative values at config
+// load, and default to no floor when unset.
+func TestProgressCommentMinEditInterval(t *testing.T) {
+	t.Run("unset means no floor", func(t *testing.T) {
+		cfg := ServerConfig{}
+		d, err := cfg.ProgressCommentMinEditIntervalDuration()
+		require.NoError(t, err)
+		assert.Equal(t, time.Duration(0), d)
+	})
+
+	t.Run("configured floor parses", func(t *testing.T) {
+		cfg := ServerConfig{ProgressCommentMinEditInterval: "10m"}
+		d, err := cfg.ProgressCommentMinEditIntervalDuration()
+		require.NoError(t, err)
+		assert.Equal(t, 10*time.Minute, d)
+	})
+
+	t.Run("unparseable value rejected", func(t *testing.T) {
+		cfg := ServerConfig{ProgressCommentMinEditInterval: "fast"}
+		_, err := cfg.ProgressCommentMinEditIntervalDuration()
+		assert.ErrorContains(t, err, "progress_comment_min_edit_interval")
+	})
+
+	t.Run("negative value rejected", func(t *testing.T) {
+		cfg := ServerConfig{ProgressCommentMinEditInterval: "-30s"}
+		_, err := cfg.ProgressCommentMinEditIntervalDuration()
+		assert.ErrorContains(t, err, "must not be negative")
+	})
+
+	t.Run("validate rejects invalid interval", func(t *testing.T) {
+		cfg := ServerConfig{
+			Databases: map[string]DatabaseConfig{
+				"mydb": {
+					Type: "mysql",
+					Environments: map[string]EnvironmentConfig{
+						"staging": {DSN: "root:pass@tcp(localhost:3306)/mydb"},
+					},
+				},
+			},
+			ProgressCommentMinEditInterval: "not-a-duration",
+		}
+		err := cfg.Validate()
+		assert.ErrorContains(t, err, "progress_comment_min_edit_interval")
+	})
+}

--- a/pkg/webhook/apply_comment_integration_test.go
+++ b/pkg/webhook/apply_comment_integration_test.go
@@ -2135,3 +2135,82 @@ func TestE2EProgressRotationRestoresFastCadence(t *testing.T) {
 		t.Fatal("expected the fresh comment to edit at the fastest cadence")
 	}
 }
+
+// During a GitHub rate-limit incident, operators need one valve that slows
+// every apply's progress-comment traffic at once, without a code change: the
+// configured minimum edit interval floors the built-in cadence, so even a
+// fresh, fast-moving apply spaces its edits by the floor. State changes still
+// publish immediately — slowing progress noise must never delay the reader
+// learning that an apply changed state.
+func TestE2EConfiguredFloorSlowsProgressEdits(t *testing.T) {
+	f := setupApplyCommentFixture(t, applyCommentFixtureParams{
+		repo:       "org/repo-floor",
+		pr:         146,
+		database:   "e2e_floor_db",
+		applyState: state.Apply.Running,
+	})
+	st, apply, task, capture, h := f.st, f.apply, f.task, f.capture, f.handler
+
+	h.postAndTrackComment(t.Context(), "org/repo-floor", 146, 12345, apply, state.Comment.Progress, "initial progress")
+	progressID := requireCommentCreate(t, capture)
+
+	fake := clock.NewFake(task.CreatedAt)
+	obs := NewCommentObserver(CommentObserverConfig{
+		GHClient:        f.factory,
+		Storage:         st,
+		Repo:            apply.Repository,
+		PR:              apply.PullRequest,
+		InstallationID:  apply.InstallationID,
+		ApplyID:         apply.ID,
+		MinEditInterval: 2 * time.Minute,
+		Logger:          f.logger,
+		Clock:           fake,
+	})
+
+	// The first tick edits and anchors the cadence.
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, progressID, edited.CommentID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the first tick to edit the progress comment")
+	}
+
+	// A fresh apply would normally edit again a few seconds later; the floor
+	// holds the edit back even though rows advanced.
+	fake.Advance(30 * time.Second)
+	task.RowsCopied = 600
+	task.ProgressPercent = 60
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		t.Fatalf("the configured floor must hold back progress edits; got %q", edited.Body)
+	default:
+		// expected: the floor spaces edits by at least the configured interval
+	}
+
+	// Once the floor elapses, progress publishes — and the footer advertises
+	// the floored cadence, not the decay schedule's faster rung.
+	fake.Advance(2 * time.Minute)
+	task.RowsCopied = 700
+	task.ProgressPercent = 70
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		assert.Contains(t, edited.Body, "70%")
+		assert.Contains(t, edited.Body, "updates every ~2m")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected an edit once the configured floor elapsed")
+	}
+
+	// A state change bypasses the floor and publishes immediately.
+	fake.Advance(time.Second)
+	apply.State = state.Apply.WaitingForCutover
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		assert.Contains(t, edited.Body, "Waiting for Cutover")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected a state change to bypass the configured floor")
+	}
+}

--- a/pkg/webhook/apply_execute.go
+++ b/pkg/webhook/apply_execute.go
@@ -145,15 +145,16 @@ func (h *Handler) executeApply(
 	// Set observer before queuing the apply so ExecuteApply can register it on
 	// the durable apply row before operator dispatch starts.
 	observer := NewCommentObserver(CommentObserverConfig{
-		GHClient:       factory,
-		Storage:        h.service.Storage(),
-		Repo:           repo,
-		PR:             pr,
-		InstallationID: installationID,
-		DeferCutover:   options["defer_cutover"] == "true",
-		SupportChannel: h.supportChannel(),
-		Tenant:         h.deploymentTenant(),
-		Logger:         h.logger,
+		GHClient:        factory,
+		Storage:         h.service.Storage(),
+		Repo:            repo,
+		PR:              pr,
+		InstallationID:  installationID,
+		DeferCutover:    options["defer_cutover"] == "true",
+		SupportChannel:  h.supportChannel(),
+		MinEditInterval: h.progressCommentMinEditInterval(),
+		Tenant:          h.deploymentTenant(),
+		Logger:          h.logger,
 		OnTerminalHook: func(apply *storage.Apply) {
 			// refreshChecksForTerminalApply routes a completed rollback straight
 			// to action_required. The observer registered here can be consumed by

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -31,7 +31,11 @@ type CommentObserver struct {
 	deferCutover   bool
 	supportChannel api.SupportChannelConfig
 	tenant         string
-	logger         interface {
+
+	// minEditInterval is the operator-configured floor over the age-decayed
+	// progress-comment edit cadence. Zero means no floor.
+	minEditInterval time.Duration
+	logger          interface {
 		Info(msg string, args ...any)
 		Error(msg string, args ...any)
 	}
@@ -192,6 +196,12 @@ type CommentObserverConfig struct {
 	// deployments.
 	Tenant string
 
+	// MinEditInterval is the operator-configured floor over the age-decayed
+	// progress-comment edit cadence (server config
+	// progress_comment_min_edit_interval). Zero means no floor. State-change
+	// updates bypass the cadence and are unaffected.
+	MinEditInterval time.Duration
+
 	Logger interface {
 		Info(msg string, args ...any)
 		Error(msg string, args ...any)
@@ -252,20 +262,21 @@ func (o *CommentObserver) logInfo(apply *storage.Apply, msg string, args ...any)
 func NewCommentObserver(cfg CommentObserverConfig) *CommentObserver {
 	clk := clock.Default(cfg.Clock)
 	return &CommentObserver{
-		ghClient:       cfg.GHClient,
-		stor:           cfg.Storage,
-		repo:           cfg.Repo,
-		pr:             cfg.PR,
-		installationID: cfg.InstallationID,
-		applyID:        cfg.ApplyID,
-		applyLease:     cfg.ApplyLease,
-		deferCutover:   cfg.DeferCutover,
-		supportChannel: cfg.SupportChannel,
-		tenant:         cfg.Tenant,
-		logger:         cfg.Logger,
-		OnTerminalHook: cfg.OnTerminalHook,
-		clock:          clk,
-		lastWritten:    map[int64]writtenContent{},
+		ghClient:        cfg.GHClient,
+		stor:            cfg.Storage,
+		repo:            cfg.Repo,
+		pr:              cfg.PR,
+		installationID:  cfg.InstallationID,
+		applyID:         cfg.ApplyID,
+		applyLease:      cfg.ApplyLease,
+		deferCutover:    cfg.DeferCutover,
+		supportChannel:  cfg.SupportChannel,
+		minEditInterval: cfg.MinEditInterval,
+		tenant:          cfg.Tenant,
+		logger:          cfg.Logger,
+		OnTerminalHook:  cfg.OnTerminalHook,
+		clock:           clk,
+		lastWritten:     map[int64]writtenContent{},
 	}
 }
 
@@ -395,25 +406,36 @@ func (o *CommentObserver) OnProgress(apply *storage.Apply, tasks []*storage.Task
 // edits per progressEditDecaySchedule, keyed to the age of the live progress
 // comment rather than the apply: a rotation posts a fresh comment because
 // someone just acted on the apply, so the new comment starts back at the
-// fastest cadence. Called with o.mu held; the first call anchors the age to
-// its own tick time.
+// fastest cadence. The operator-configured minEditInterval floors the
+// schedule, so during an incident a deployment can slow every apply's
+// progress edits at once. Called with o.mu held; the first call anchors the
+// age to its own tick time.
 func (o *CommentObserver) progressEditInterval(now time.Time) time.Duration {
 	if o.progressCommentSince.IsZero() {
 		o.progressCommentSince = now
 	}
 	age := now.Sub(o.progressCommentSince)
+	interval := progressEditDecayMaxInterval
 	for _, step := range progressEditDecaySchedule {
 		if age < step.age {
-			return step.interval
+			interval = step.interval
+			break
 		}
 	}
-	return progressEditDecayMaxInterval
+	if o.minEditInterval > interval {
+		interval = o.minEditInterval
+	}
+	return interval
 }
 
 // freshProgressCadence is the update cadence advertised on a newly posted
 // progress comment. A rotation resets the comment-age anchor, so the fresh
-// comment starts back at the fastest rung of the decay schedule.
+// comment starts back at the fastest rung of the decay schedule — floored by
+// the operator-configured minimum, which governs fresh comments too.
 func (o *CommentObserver) freshProgressCadence() time.Duration {
+	if o.minEditInterval > activeInterval {
+		return o.minEditInterval
+	}
 	return activeInterval
 }
 

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -259,16 +259,17 @@ func NewHandlerWithDispatch(service *api.Service, ghClients github.ClientSet, we
 				"pr", apply.PullRequest)
 			service.SetApplyObserver(apply.Database, apply.Deployment, apply.Environment, apply.ID,
 				NewCommentObserver(CommentObserverConfig{
-					GHClient:       factory,
-					Storage:        service.Storage(),
-					Repo:           apply.Repository,
-					PR:             apply.PullRequest,
-					InstallationID: apply.InstallationID,
-					ApplyID:        apply.ID,
-					ApplyLease:     apply.Lease(),
-					SupportChannel: h.supportChannel(),
-					Tenant:         h.deploymentTenant(),
-					Logger:         logger,
+					GHClient:        factory,
+					Storage:         service.Storage(),
+					Repo:            apply.Repository,
+					PR:              apply.PullRequest,
+					InstallationID:  apply.InstallationID,
+					ApplyID:         apply.ID,
+					ApplyLease:      apply.Lease(),
+					SupportChannel:  h.supportChannel(),
+					MinEditInterval: h.progressCommentMinEditInterval(),
+					Tenant:          h.deploymentTenant(),
+					Logger:          logger,
 					OnTerminalHook: func(a *storage.Apply) {
 						h.refreshChecksForTerminalApply(context.Background(), a, "recovered apply")
 					},

--- a/pkg/webhook/issue_comment.go
+++ b/pkg/webhook/issue_comment.go
@@ -686,6 +686,24 @@ func (h *Handler) supportChannel() api.SupportChannelConfig {
 	return cfg.SupportChannel
 }
 
+// progressCommentMinEditInterval returns the operator-configured floor for
+// progress-comment edit spacing, or zero when no floor is configured. The
+// value is validated at config load, so a parse failure here means the
+// running config was replaced without validation; the floor is dropped (the
+// built-in cadence applies) and the bad value logged rather than guessed at.
+func (h *Handler) progressCommentMinEditInterval() time.Duration {
+	cfg := h.config()
+	if cfg == nil {
+		return 0
+	}
+	d, err := cfg.ProgressCommentMinEditIntervalDuration()
+	if err != nil {
+		h.logger.Warn("invalid progress_comment_min_edit_interval; progress comments will edit at the built-in cadence", "error", err)
+		return 0
+	}
+	return d
+}
+
 func appendSupportChannelFooter(body string, support api.SupportChannelConfig) string {
 	if !support.Enabled() || !shouldShowSupportChannel(body) {
 		return body

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -372,15 +372,16 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment 
 	}
 
 	observer := NewCommentObserver(CommentObserverConfig{
-		GHClient:       factory,
-		Storage:        h.service.Storage(),
-		Repo:           repo,
-		PR:             pr,
-		InstallationID: installationID,
-		DeferCutover:   options["defer_cutover"] == "true",
-		SupportChannel: h.supportChannel(),
-		Tenant:         h.deploymentTenant(),
-		Logger:         h.logger,
+		GHClient:        factory,
+		Storage:         h.service.Storage(),
+		Repo:            repo,
+		PR:              pr,
+		InstallationID:  installationID,
+		DeferCutover:    options["defer_cutover"] == "true",
+		SupportChannel:  h.supportChannel(),
+		MinEditInterval: h.progressCommentMinEditInterval(),
+		Tenant:          h.deploymentTenant(),
+		Logger:          h.logger,
 		OnTerminalHook: func(a *storage.Apply) {
 			// refreshChecksForTerminalApply routes a completed rollback straight
 			// to action_required so the stored check state never passes through
@@ -456,7 +457,8 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment 
 	// Post initial progress comment for the observer to edit. VSchema status is
 	// omitted on this first comment — the observer refreshes it from engine
 	// display metadata on the next progress tick.
-	progressBody := formatProgressComment(apply, nil, nil, h.deploymentTenant(), activeInterval)
+	progressBody := formatProgressComment(apply, nil, nil, h.deploymentTenant(),
+		max(activeInterval, h.progressCommentMinEditInterval()))
 	h.postInitialProgressComment(ctx, repo, pr, installationID, apply, progressBody)
 }
 


### PR DESCRIPTION
## Why this matters

The built-in edit cadence is a fixed policy. During a GitHub rate-limit incident — or on a server hosting many concurrent long-running applies — operators need one valve that slows every apply's progress-comment traffic at once, without a code change or redeploy of new logic.

## What it does

Adds a server config setting that floors the built-in age-decayed cadence:

```yaml
progress_comment_min_edit_interval: 2m  # Go duration; default unset (no floor)
```

- No progress comment is edited more often than the configured interval, regardless of the built-in cadence.
- State changes still publish immediately — the floor spaces out progress noise, not state transitions.
- The cadence the progress comment advertises in its "Last updated" footer reflects the floor, so PR readers see the configured interval rather than wondering why updates slowed down.
- Invalid or negative values are rejected at config validation; an invalid value read at runtime logs a warning and falls back to the built-in cadence.
- Documented in `docs/configuration.md`; users needing high-resolution progress use the CLI, which polls the server directly and is unaffected.

Stacked on #758.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
