### PR TITLE
fix(github): block merge and allow apply for vschema-only changes

### DIFF
--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -538,9 +538,28 @@ func (r *PlanResponse) LintErrors() []LintViolationResponse {
 func (r *PlanResponse) FlatTables() []*TableChangeResponse {
 	var tables []*TableChangeResponse
 	for _, sc := range r.Changes {
+		if sc == nil {
+			continue
+		}
 		tables = append(tables, sc.TableChanges...)
 	}
 	return tables
+}
+
+// HasChanges reports whether the plan carries any work an apply would execute:
+// table DDL in any namespace, or a VSchema update. Gates that decide whether a
+// plan is actionable must use this rather than counting table changes alone —
+// a VSchema-only plan has zero table changes but still requires an apply.
+func (r *PlanResponse) HasChanges() bool {
+	if len(r.FlatTables()) > 0 {
+		return true
+	}
+	for _, sc := range r.Changes {
+		if sc != nil && sc.HasVSchemaChange() {
+			return true
+		}
+	}
+	return false
 }
 
 // SchemaChangeResponse groups changes for a single namespace.

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -551,11 +551,11 @@ func (r *PlanResponse) FlatTables() []*TableChangeResponse {
 // plan is actionable must use this rather than counting table changes alone —
 // a VSchema-only plan has zero table changes but still requires an apply.
 func (r *PlanResponse) HasChanges() bool {
-	if len(r.FlatTables()) > 0 {
-		return true
-	}
 	for _, sc := range r.Changes {
-		if sc != nil && sc.HasVSchemaChange() {
+		if sc == nil {
+			continue
+		}
+		if len(sc.TableChanges) > 0 || sc.HasVSchemaChange() {
 			return true
 		}
 	}

--- a/pkg/apitypes/apitypes_test.go
+++ b/pkg/apitypes/apitypes_test.go
@@ -125,3 +125,73 @@ func TestPlanResponse_HasErrors(t *testing.T) {
 	resp.LintResults = append(resp.LintResults, &LintViolationResponse{Severity: "error"})
 	assert.True(t, resp.HasErrors())
 }
+
+func TestPlanResponse_HasChanges(t *testing.T) {
+	tests := []struct {
+		name string
+		resp *PlanResponse
+		want bool
+	}{
+		{
+			name: "no changes",
+			resp: &PlanResponse{Changes: []*SchemaChangeResponse{{Namespace: "testdb"}}},
+			want: false,
+		},
+		{
+			name: "table changes only",
+			resp: &PlanResponse{Changes: []*SchemaChangeResponse{{
+				Namespace:    "testdb",
+				TableChanges: []*TableChangeResponse{{TableName: "users", DDL: "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"}},
+			}}},
+			want: true,
+		},
+		{
+			name: "vschema diff only",
+			resp: &PlanResponse{Changes: []*SchemaChangeResponse{{
+				Namespace: "boardgames_sharded",
+				Metadata:  map[string]string{VSchemaDiffMetadataKey: "--- current\n+++ new\n+    \"xxhash\": {\"type\": \"xxhash\"}"},
+			}}},
+			want: true,
+		},
+		{
+			name: "vschema changed flag only",
+			resp: &PlanResponse{Changes: []*SchemaChangeResponse{{
+				Namespace: "boardgames_sharded",
+				Metadata:  map[string]string{VSchemaChangedMetadataKey: "true"},
+			}}},
+			want: true,
+		},
+		{
+			name: "vschema changed flag not true",
+			resp: &PlanResponse{Changes: []*SchemaChangeResponse{{
+				Namespace: "boardgames_sharded",
+				Metadata:  map[string]string{VSchemaChangedMetadataKey: "false"},
+			}}},
+			want: false,
+		},
+		{
+			name: "table changes and vschema",
+			resp: &PlanResponse{Changes: []*SchemaChangeResponse{{
+				Namespace:    "boardgames_sharded",
+				TableChanges: []*TableChangeResponse{{TableName: "games", DDL: "ALTER TABLE `games` ADD COLUMN `rating` int"}},
+				Metadata:     map[string]string{VSchemaDiffMetadataKey: "+ xxhash"},
+			}}},
+			want: true,
+		},
+		{
+			name: "nil change entry",
+			resp: &PlanResponse{Changes: []*SchemaChangeResponse{nil}},
+			want: false,
+		},
+		{
+			name: "empty plan",
+			resp: &PlanResponse{},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.resp.HasChanges())
+		})
+	}
+}

--- a/pkg/apitypes/vschema.go
+++ b/pkg/apitypes/vschema.go
@@ -8,6 +8,19 @@ import "encoding/json"
 // so they render VSchema identically.
 const VSchemaChangesMetadataKey = "vschema_changes"
 
+// Plan change-metadata keys under which engines annotate a namespace's VSchema
+// work: a rendered diff, or a flag when the work is known without a rendered
+// diff. Either one marks the namespace as carrying a VSchema change.
+const (
+	VSchemaDiffMetadataKey    = "vschema"
+	VSchemaChangedMetadataKey = "vschema_changed"
+)
+
+// HasVSchemaChange reports whether this namespace's change carries VSchema work.
+func (sc *SchemaChangeResponse) HasVSchemaChange() bool {
+	return sc.Metadata[VSchemaDiffMetadataKey] != "" || sc.Metadata[VSchemaChangedMetadataKey] == "true"
+}
+
 // VSchemaChange is one keyspace's VSchema application state for display. Each
 // keyspace that changes its VSchema carries its own status and diff so a
 // multi-keyspace deploy renders each keyspace independently.

--- a/pkg/cmd/commands/apply.go
+++ b/pkg/cmd/commands/apply.go
@@ -134,16 +134,7 @@ func (cmd *ApplyCmd) Run(g *Globals) error {
 	}
 
 	// Check if there are any changes (DDL or VSchema)
-	hasChanges := len(planResult.FlatTables()) > 0
-	if !hasChanges {
-		for _, sc := range planResult.Changes {
-			if sc.Metadata["vschema"] != "" {
-				hasChanges = true
-				break
-			}
-		}
-	}
-	if !hasChanges {
+	if !planResult.HasChanges() {
 		fmt.Println("No changes. Your schema is up-to-date.")
 		return nil
 	}

--- a/pkg/cmd/commands/plan.go
+++ b/pkg/cmd/commands/plan.go
@@ -210,10 +210,10 @@ func writePlanBody(result *apitypes.PlanResponse, isApply bool) {
 	// Collect VSchema changes from metadata
 	var vschemaChanges []templates.VSchemaChange
 	for _, sc := range result.Changes {
-		if diff, ok := sc.Metadata["vschema"]; ok && diff != "" {
+		if sc.HasVSchemaChange() {
 			vschemaChanges = append(vschemaChanges, templates.VSchemaChange{
 				Keyspace: sc.Namespace,
-				Diff:     diff,
+				Diff:     sc.Metadata[apitypes.VSchemaDiffMetadataKey],
 			})
 		}
 	}
@@ -302,18 +302,7 @@ func writePlanBody(result *apitypes.PlanResponse, isApply bool) {
 
 // hasResultChanges returns true if the result has schema changes (DDL or VSchema).
 func hasResultChanges(result *apitypes.PlanResponse) bool {
-	if result == nil {
-		return false
-	}
-	if len(result.FlatTables()) > 0 {
-		return true
-	}
-	for _, sc := range result.Changes {
-		if sc.Metadata["vschema"] != "" {
-			return true
-		}
-	}
-	return false
+	return result != nil && result.HasChanges()
 }
 
 // sortEnvironments sorts environments with staging first, production second, then alphabetically.
@@ -339,7 +328,7 @@ func sortEnvironments(envs []string) {
 }
 
 // planFingerprint creates a string fingerprint of a plan result for deduplication.
-// Plans with identical DDL statements are considered the same.
+// Plans with identical DDL statements and VSchema updates are considered the same.
 func planFingerprint(result *apitypes.PlanResponse) string {
 	// Check for errors first
 	if len(result.Errors) > 0 {
@@ -347,22 +336,28 @@ func planFingerprint(result *apitypes.PlanResponse) string {
 		return "errors:" + string(data)
 	}
 
-	// Get DDL statements
-	tables := result.FlatTables()
-	if len(tables) == 0 {
+	var ddls []string
+	for _, tbl := range result.FlatTables() {
+		ddls = append(ddls, tbl.DDL)
+	}
+	var vschemas []string
+	for _, sc := range result.Changes {
+		if sc.HasVSchemaChange() {
+			vschemas = append(vschemas, sc.Namespace+":"+sc.Metadata[apitypes.VSchemaDiffMetadataKey])
+		}
+	}
+	if len(ddls) == 0 && len(vschemas) == 0 {
 		return "no-changes"
 	}
 
-	// Build fingerprint from DDL statements
-	var ddls []string
-	for _, tbl := range tables {
-		ddls = append(ddls, tbl.DDL)
-	}
-
-	// Sort DDLs to make fingerprint order-independent
+	// Sort to make the fingerprint order-independent
 	sort.Strings(ddls)
+	sort.Strings(vschemas)
 
-	data, _ := json.Marshal(ddls)
+	data, _ := json.Marshal(struct {
+		DDLs     []string `json:"ddls"`
+		VSchemas []string `json:"vschemas"`
+	}{ddls, vschemas})
 	return string(data)
 }
 

--- a/pkg/cmd/commands/plan_test.go
+++ b/pkg/cmd/commands/plan_test.go
@@ -197,6 +197,25 @@ func TestPlanFingerprint_DifferentPlans(t *testing.T) {
 	assert.NotEqual(t, fp1, fp2, "Expected different fingerprints for different plans")
 }
 
+func TestPlanFingerprint_VSchemaOnlyPlans(t *testing.T) {
+	vschemaOnly := func(diff string) *apitypes.PlanResponse {
+		return &apitypes.PlanResponse{
+			Changes: []*apitypes.SchemaChangeResponse{{
+				Namespace: "commerce",
+				Metadata:  map[string]string{apitypes.VSchemaDiffMetadataKey: diff},
+			}},
+		}
+	}
+
+	fp1 := planFingerprint(vschemaOnly(`+ "sequence": true`))
+	fp2 := planFingerprint(vschemaOnly(`+ "sequence": true`))
+	fpOther := planFingerprint(vschemaOnly(`- "sequence": true`))
+
+	assert.NotEqual(t, "no-changes", fp1, "a VSchema-only plan carries work and must not fingerprint as no-changes")
+	assert.Equal(t, fp1, fp2, "identical VSchema-only plans must dedupe")
+	assert.NotEqual(t, fp1, fpOther, "plans with differing VSchema diffs must not dedupe")
+}
+
 func TestPlanFingerprint_NoChanges(t *testing.T) {
 	plan := &apitypes.PlanResponse{}
 

--- a/pkg/cmd/commands/rollback.go
+++ b/pkg/cmd/commands/rollback.go
@@ -72,12 +72,12 @@ func (cmd *RollbackCmd) Run(g *Globals) error {
 		return fmt.Errorf("rollback plan has errors")
 	}
 
-	// Check if there are any changes
-	tables := planResult.FlatTables()
-	if len(tables) == 0 {
+	// Check if there are any changes (DDL or VSchema)
+	if !planResult.HasChanges() {
 		fmt.Println("No changes. Schema is already at the original state.")
 		return nil
 	}
+	tables := planResult.FlatTables()
 
 	// Step 2: Show the rollback plan
 	fmt.Println()
@@ -91,6 +91,11 @@ func (cmd *RollbackCmd) Run(g *Globals) error {
 	for _, tbl := range tables {
 		fmt.Printf("  %s (%s):\n", tbl.TableName, tbl.ChangeType)
 		fmt.Printf("    %s\n", tbl.DDL)
+	}
+	for _, sc := range planResult.Changes {
+		if sc.HasVSchemaChange() {
+			fmt.Printf("  %s: VSchema update\n", sc.Namespace)
+		}
 	}
 
 	// Show unsafe warning if any

--- a/pkg/webhook/apply_execute.go
+++ b/pkg/webhook/apply_execute.go
@@ -79,9 +79,10 @@ func (h *Handler) executeApply(
 		return
 	}
 
-	// No changes — release the lock (keyed on the pending intent this handler
-	// observed, so a lock re-pinned by a newer plan is preserved) and notify.
-	if len(planResp.FlatTables()) == 0 {
+	// No changes (neither table DDL nor a VSchema update) — release the lock
+	// (keyed on the pending intent this handler observed, so a lock re-pinned by
+	// a newer plan is preserved) and notify.
+	if !planResp.HasChanges() {
 		h.releaseApplyLockIfIntentUnchanged(ctx, repo, pr, database, dbType, environment, expectedPendingPlanID, "no changes to apply")
 		// The target already matches the PR schema — apply found nothing to do.
 		// Record the passing (no-change) check result and refresh the aggregate so

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -195,8 +195,9 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		return
 	}
 
-	// No changes — post a regular plan comment (no lock, no confirm footer)
-	if len(planResp.FlatTables()) == 0 {
+	// No changes (neither table DDL nor a VSchema update) — post a regular plan
+	// comment (no lock, no confirm footer)
+	if !planResp.HasChanges() {
 		commentData := buildPlanCommentData(schemaResult, planResp, environment, result.Tenant, requestedBy)
 		h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
 		return

--- a/pkg/webhook/check_records.go
+++ b/pkg/webhook/check_records.go
@@ -174,8 +174,7 @@ func (h *Handler) upsertPlanCheckRecord(ctx context.Context, client *ghclient.In
 			repo, pr, environment, schema.Type, schema.Database, headSHA, prInfo.HeadSHA)
 	}
 
-	tables := planResp.FlatTables()
-	hasChanges := len(tables) > 0
+	hasChanges := planResp.HasChanges()
 	driftBlocked := drift.blocks()
 
 	conclusion := planCheckConclusion(hasChanges, len(planResp.Errors) > 0, driftBlocked)

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -656,9 +656,9 @@ func buildPlanCommentData(schema *ghclient.SchemaRequestResult, planResp *apityp
 			ksData.Statements = append(ksData.Statements, t.DDL)
 		}
 		// Extract VSchema changes from metadata
-		if diff, ok := sc.Metadata["vschema"]; ok {
+		if sc.HasVSchemaChange() {
 			ksData.VSchemaChanged = true
-			ksData.VSchemaDiff = diff
+			ksData.VSchemaDiff = sc.Metadata[apitypes.VSchemaDiffMetadataKey]
 		}
 		data.Changes = append(data.Changes, ksData)
 	}

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/block/schemabot/pkg/api"
-	"github.com/block/schemabot/pkg/apitypes"
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/webhook/action"
@@ -180,7 +179,7 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 		return
 	}
 
-	if !rollbackPlanResponseHasChanges(planResp) {
+	if planResp == nil || !planResp.HasChanges() {
 		h.releaseRollbackLockAfterRejectedPlan(ctx, database, dbType, lockOwner, lockAcquiredByCommand)
 		h.postComment(repo, pr, installationID,
 			templates.RenderRollbackNothingToDo(database, environment, applyID))
@@ -527,21 +526,6 @@ func rollbackPlanIDFromLock(lock *storage.Lock) (string, bool) {
 	}
 	planID := strings.TrimPrefix(lock.PendingPlanID, rollbackPendingPlanPrefix)
 	return planID, planID != ""
-}
-
-func rollbackPlanResponseHasChanges(resp *apitypes.PlanResponse) bool {
-	if resp == nil {
-		return false
-	}
-	for _, sc := range resp.Changes {
-		if len(sc.TableChanges) > 0 {
-			return true
-		}
-		if sc.Metadata["vschema"] != "" || sc.Metadata["vschema_changed"] == "true" {
-			return true
-		}
-	}
-	return false
 }
 
 func (h *Handler) rollbackPlanForLock(ctx context.Context, lock *storage.Lock) (*storage.Plan, error) {

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/block/schemabot/pkg/api"
+	"github.com/block/schemabot/pkg/apitypes"
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/webhook/action"
@@ -223,9 +224,9 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 		for _, t := range sc.TableChanges {
 			nsData.Statements = append(nsData.Statements, t.DDL)
 		}
-		if diff, ok := sc.Metadata["vschema"]; ok {
+		if sc.HasVSchemaChange() {
 			nsData.VSchemaChanged = true
-			nsData.VSchemaDiff = diff
+			nsData.VSchemaDiff = sc.Metadata[apitypes.VSchemaDiffMetadataKey]
 		}
 		commentData.Changes = append(commentData.Changes, nsData)
 	}

--- a/pkg/webhook/vschema_only_check_integration_test.go
+++ b/pkg/webhook/vschema_only_check_integration_test.go
@@ -1,0 +1,123 @@
+//go:build integration
+
+package webhook
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+
+	gh "github.com/google/go-github/v86/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/api"
+	"github.com/block/schemabot/pkg/apitypes"
+	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/storage/mysqlstore"
+)
+
+// A Vitess plan whose only work is a VSchema update carries zero table changes,
+// but it still requires an apply: the stored check state must record pending
+// changes and block the PR (action_required), exactly as a DDL-bearing plan
+// would. A plan with no work at all must still record a passing check.
+func TestUpsertPlanCheckRecord_VSchemaOnlyPlanRequiresApply(t *testing.T) {
+	ctx := t.Context()
+
+	db, err := sql.Open("mysql", e2eSchemabotDSN)
+	require.NoError(t, err)
+	require.NoError(t, db.PingContext(ctx))
+	t.Cleanup(func() { assert.NoError(t, db.Close()) })
+
+	const (
+		repo    = "octocat/vschema-only-check"
+		pr      = 7
+		dbn     = "vschema_only_check_db"
+		env     = "staging"
+		headSHA = "vsha123"
+	)
+
+	clear := func(c context.Context) {
+		_, err := db.ExecContext(c, "DELETE FROM checks WHERE repository = ? AND pull_request = ?", repo, pr)
+		require.NoError(t, err)
+	}
+	clear(ctx)
+	// Cleanup runs after t.Context() is cancelled, so derive a non-cancelled
+	// context from it for the cleanup deletes.
+	t.Cleanup(func() { clear(context.WithoutCancel(ctx)) })
+
+	st := mysqlstore.New(db)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := api.New(st, &api.ServerConfig{}, nil, logger)
+
+	// The record path re-fetches the PR to confirm the plan's head SHA is still
+	// current; serve a PR pinned to the plan's SHA.
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	mux.HandleFunc("GET /repos/"+repo+"/pulls/7", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(gh.PullRequest{
+			Head: &gh.PullRequestBranch{Ref: new("feature-branch"), SHA: new(headSHA)},
+			Base: &gh.PullRequestBranch{Ref: new("main"), SHA: new("base456")},
+			User: &gh.User{Login: new("testuser")},
+		})
+	})
+
+	ghc := gh.NewClient(nil)
+	ghc.BaseURL, err = url.Parse(server.URL + "/")
+	require.NoError(t, err)
+	installClient := ghclient.NewInstallationClient(ghc, logger)
+	factory := &fakeClientFactory{client: installClient}
+	h := NewHandler(svc, factory, nil, logger)
+
+	schema := &ghclient.SchemaRequestResult{
+		Repository:  repo,
+		PullRequest: pr,
+		Database:    dbn,
+		Type:        "vitess",
+		HeadSHA:     headSHA,
+	}
+
+	t.Run("vschema-only plan records pending changes", func(t *testing.T) {
+		planResp := &apitypes.PlanResponse{
+			Changes: []*apitypes.SchemaChangeResponse{{
+				Namespace: "boardgames_sharded",
+				Metadata: map[string]string{
+					apitypes.VSchemaDiffMetadataKey: "--- current\n+++ new\n+    \"xxhash\": {\"type\": \"xxhash\"}",
+				},
+			}},
+		}
+
+		gotSHA, check, err := h.upsertPlanCheckRecord(ctx, installClient, repo, pr, schema, planResp, env, reviewDriftOutcome{})
+		require.NoError(t, err)
+		assert.Equal(t, headSHA, gotSHA)
+		require.NotNil(t, check)
+		assert.True(t, check.HasChanges, "a VSchema update is pending work")
+		assert.Equal(t, checkConclusionActionRequired, check.Conclusion, "an unapplied VSchema update must block the PR")
+		assert.Contains(t, check.ChangeSummary, "1 vschema update")
+
+		stored, err := st.Checks().Get(ctx, repo, pr, env, "vitess", dbn)
+		require.NoError(t, err)
+		require.NotNil(t, stored)
+		assert.True(t, stored.HasChanges)
+		assert.Equal(t, checkConclusionActionRequired, stored.Conclusion)
+	})
+
+	t.Run("plan with no work records success", func(t *testing.T) {
+		planResp := &apitypes.PlanResponse{
+			Changes: []*apitypes.SchemaChangeResponse{{Namespace: "boardgames_sharded"}},
+		}
+
+		_, check, err := h.upsertPlanCheckRecord(ctx, installClient, repo, pr, schema, planResp, env, reviewDriftOutcome{})
+		require.NoError(t, err)
+		require.NotNil(t, check)
+		assert.False(t, check.HasChanges)
+		assert.Equal(t, checkConclusionSuccess, check.Conclusion)
+	})
+}


### PR DESCRIPTION
## What broke

A Vitess plan whose only work is a VSchema update carries zero *table* changes. The change gates used "any table changes?" as the definition of "this plan has changes", so a vschema-only PR failed in both directions at once:

- **The check passed.** The stored plan-check recorded `success` / "Schema up to date" — the PR was mergeable with an unapplied VSchema change, even while the check's own Change column said "1 vschema update".
- **The apply refused.** `schemabot apply` (and the apply-confirm path) took the "no changes to apply" short-circuit, so the VSchema update could never be applied through the PR flow.

## The fix

`PlanResponse` gains a canonical `HasChanges()` that counts table DDL **and** per-namespace VSchema change metadata (the rendered diff, or the changed flag when no diff is rendered). Every gate that decides whether a plan is actionable now uses it:

```
plan result
   │
   ├─ table changes?  ──────────────┐
   │                                ├─ yes → check: action_required (blocks merge)
   ├─ vschema diff / changed flag? ─┘        apply: proceeds
   │
   └─ neither → check: success ("Schema up to date")
                apply: "no changes to apply"
```

- `pkg/webhook/check_records.go` — the stored plan-check conclusion blocks on a pending VSchema update.
- `pkg/webhook/apply_handlers.go` / `apply_execute.go` — the apply command and apply-confirm gates proceed for a vschema-only plan (the downstream apply path already supports it).
- `pkg/webhook/rollback.go` — drops its private copy of the same predicate in favor of the shared helper.
- `pkg/cmd/commands` — the CLI `plan`/`apply`/`rollback` no-changes gates and the multi-env plan-dedup fingerprint carry the same definition, so a vschema-only plan is actionable (and never deduped against a genuinely empty plan) from the CLI too.
- The PR-comment, rollback, and CLI plan renderers mark a keyspace's VSchema as changed via the shared predicate, which also covers changed-flag-only entries that carry no rendered diff.
- `FlatTables()` now skips nil change entries, matching its sibling accessors.

Covered by unit tests on the predicate and fingerprint plus a webhook integration test proving a vschema-only plan stores a blocking check while a plan with no work still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)