### PR TITLE
fix(github): estimate row-copy ETA when the provider reports none

### DIFF
--- a/pkg/engine/planetscale/progress.go
+++ b/pkg/engine/planetscale/progress.go
@@ -478,7 +478,7 @@ func (e *Engine) queryVitessMigrations(ctx context.Context, client psclient.PSCl
 		return nil, 0
 	}
 
-	return aggregateShardProgress(allRows)
+	return aggregateShardProgress(allRows, time.Now())
 }
 
 // showVitessMigrationsForKeyspace connects to vtgate and runs
@@ -685,9 +685,27 @@ func parseInt64(s string) (int64, error) {
 	return strconv.ParseInt(s, 10, 64)
 }
 
+// estimateETASeconds projects a copy ETA from the copy rate so far:
+// elapsed * remaining / copied. The provider reports eta_seconds as -1 (or 0)
+// while it considers the ETA unknown, so an actively-copying shard could
+// otherwise show no ETA for its entire copy phase. Returns 0 (unknown) unless
+// the shard has a start time, positive elapsed time, and at least one copied
+// row to derive a rate from.
+func estimateETASeconds(startedAt *time.Time, now time.Time, rowsCopied, tableRows int64) int64 {
+	if startedAt == nil || rowsCopied <= 0 || tableRows <= rowsCopied {
+		return 0
+	}
+	elapsed := now.Sub(*startedAt).Seconds()
+	if elapsed <= 0 {
+		return 0
+	}
+	return int64(elapsed * float64(tableRows-rowsCopied) / float64(rowsCopied))
+}
+
 // aggregateShardProgress groups SHOW VITESS_MIGRATIONS rows by migration_uuid
-// and produces per-table progress with per-shard breakdown.
-func aggregateShardProgress(rows []vitessMigrationRow) ([]engine.TableProgress, int) {
+// and produces per-table progress with per-shard breakdown. now anchors the
+// copy-rate ETA estimate for shards whose provider-reported ETA is unknown.
+func aggregateShardProgress(rows []vitessMigrationRow, now time.Time) ([]engine.TableProgress, int) {
 	type tableKey struct {
 		keyspace string
 		table    string
@@ -753,9 +771,6 @@ func aggregateShardProgress(rows []vitessMigrationRow) ([]engine.TableProgress, 
 		tableState := state.Vitess.Complete
 		for i, sh := range shards {
 			tblTableRows += sh.tableRows
-			if sh.etaSeconds > maxETA {
-				maxETA = sh.etaSeconds
-			}
 			if !sh.isImmediate {
 				isInstant = false
 			}
@@ -774,6 +789,17 @@ func aggregateShardProgress(rows []vitessMigrationRow) ([]engine.TableProgress, 
 			shardState := sh.status
 			if sh.status == state.Vitess.Running && sh.readyToComplete {
 				shardState = state.Vitess.ReadyToComplete
+			}
+
+			// Prefer the provider-reported ETA, normalizing its -1 "unknown"
+			// sentinel to 0; while it is unknown for a shard that is still
+			// copying, estimate one from the copy rate so far.
+			shardETA := max(sh.etaSeconds, 0)
+			if shardETA == 0 && shardState == state.Vitess.Running {
+				shardETA = estimateETASeconds(sh.startedAt, now, sh.rowsCopied, sh.tableRows)
+			}
+			if shardETA > maxETA {
+				maxETA = shardETA
 			}
 
 			shardPct := min(sh.progress, 100)
@@ -795,7 +821,7 @@ func aggregateShardProgress(rows []vitessMigrationRow) ([]engine.TableProgress, 
 				Progress:        shardPct,
 				RowsCopied:      shardCopied,
 				RowsTotal:       sh.tableRows,
-				ETASeconds:      sh.etaSeconds,
+				ETASeconds:      shardETA,
 				CutoverAttempts: sh.cutoverAttempts,
 			}
 

--- a/pkg/engine/planetscale/progress.go
+++ b/pkg/engine/planetscale/progress.go
@@ -791,12 +791,18 @@ func aggregateShardProgress(rows []vitessMigrationRow, now time.Time) ([]engine.
 				shardState = state.Vitess.ReadyToComplete
 			}
 
-			// Prefer the provider-reported ETA, normalizing its -1 "unknown"
-			// sentinel to 0; while it is unknown for a shard that is still
-			// copying, estimate one from the copy rate so far.
-			shardETA := max(sh.etaSeconds, 0)
-			if shardETA == 0 && shardState == state.Vitess.Running {
-				shardETA = estimateETASeconds(sh.startedAt, now, sh.rowsCopied, sh.tableRows)
+			// A copy ETA is only meaningful while a shard is still copying:
+			// after ready_to_complete/complete the copy is done (any reported
+			// value is stale), and queued/failed shards have no copy to
+			// project. For a copying shard, prefer the provider-reported ETA,
+			// normalizing its -1 "unknown" sentinel to 0; while it is unknown,
+			// estimate one from the copy rate so far.
+			var shardETA int64
+			if shardState == state.Vitess.Running {
+				shardETA = max(sh.etaSeconds, 0)
+				if shardETA == 0 {
+					shardETA = estimateETASeconds(sh.startedAt, now, sh.rowsCopied, sh.tableRows)
+				}
 			}
 			if shardETA > maxETA {
 				maxETA = shardETA

--- a/pkg/engine/planetscale/progress_test.go
+++ b/pkg/engine/planetscale/progress_test.go
@@ -17,7 +17,7 @@ func TestAggregateShardProgress(t *testing.T) {
 			{MigrationUUID: "uuid-1", Keyspace: "commerce", Shard: "80-", Table: "orders", Status: "running", RowsCopied: 3000, TableRows: 10000, Progress: 30},
 		}
 
-		tables, overall := aggregateShardProgress(rows)
+		tables, overall := aggregateShardProgress(rows, time.Now())
 		require.Len(t, tables, 1)
 		assert.Equal(t, "orders", tables[0].Table)
 		assert.Equal(t, state.Vitess.Running, tables[0].State)
@@ -37,7 +37,7 @@ func TestAggregateShardProgress(t *testing.T) {
 			{MigrationUUID: "uuid-2", Keyspace: "commerce", Shard: "80-", Table: "items", Status: "complete", IsImmediate: true},
 		}
 
-		tables, overall := aggregateShardProgress(rows)
+		tables, overall := aggregateShardProgress(rows, time.Now())
 		require.Len(t, tables, 1)
 		assert.Equal(t, state.Vitess.Complete, tables[0].State)
 		assert.Equal(t, 100, tables[0].Progress)
@@ -51,7 +51,7 @@ func TestAggregateShardProgress(t *testing.T) {
 			{MigrationUUID: "uuid-1", Keyspace: "commerce", Shard: "80-", Table: "orders", Status: "complete", RowsCopied: 10000, TableRows: 10000},
 		}
 
-		tables, _ := aggregateShardProgress(rows)
+		tables, _ := aggregateShardProgress(rows, time.Now())
 		require.Len(t, tables, 1)
 		// One shard running means table is running
 		assert.Equal(t, state.Vitess.Running, tables[0].State)
@@ -63,7 +63,7 @@ func TestAggregateShardProgress(t *testing.T) {
 			{MigrationUUID: "uuid-1", Keyspace: "commerce", Shard: "80-", Table: "orders", Status: "failed"},
 		}
 
-		tables, _ := aggregateShardProgress(rows)
+		tables, _ := aggregateShardProgress(rows, time.Now())
 		require.Len(t, tables, 1)
 		assert.Equal(t, state.Vitess.Failed, tables[0].State)
 	})
@@ -74,7 +74,7 @@ func TestAggregateShardProgress(t *testing.T) {
 			{MigrationUUID: "uuid-1", Keyspace: "commerce", Shard: "80-", Table: "orders", Status: "running", ReadyToComplete: true},
 		}
 
-		tables, _ := aggregateShardProgress(rows)
+		tables, _ := aggregateShardProgress(rows, time.Now())
 		require.Len(t, tables, 1)
 		assert.Equal(t, state.Vitess.ReadyToComplete, tables[0].State)
 		// Shards should show derived state
@@ -87,7 +87,7 @@ func TestAggregateShardProgress(t *testing.T) {
 			{MigrationUUID: "uuid-2", Keyspace: "commerce", Shard: "0", Table: "items", Status: "running", RowsCopied: 50, TableRows: 200},
 		}
 
-		tables, overall := aggregateShardProgress(rows)
+		tables, overall := aggregateShardProgress(rows, time.Now())
 		require.Len(t, tables, 2)
 		assert.Equal(t, "orders", tables[0].Table)
 		assert.Equal(t, "items", tables[1].Table)
@@ -102,7 +102,7 @@ func TestAggregateShardProgress(t *testing.T) {
 			{MigrationUUID: "uuid-1", Keyspace: "commerce", Shard: "80-", Table: "orders", Status: "running", ReadyToComplete: true, Progress: 97, RowsCopied: 9700, TableRows: 10000},
 		}
 
-		tables, _ := aggregateShardProgress(rows)
+		tables, _ := aggregateShardProgress(rows, time.Now())
 		require.Len(t, tables, 1)
 		assert.Equal(t, state.Vitess.ReadyToComplete, tables[0].State)
 		assert.Equal(t, 100, tables[0].Progress)
@@ -119,7 +119,7 @@ func TestAggregateShardProgress(t *testing.T) {
 			{MigrationUUID: "uuid-1", Keyspace: "commerce", Shard: "-", Table: "users", Status: "complete", RowsCopied: 284953, TableRows: 284953},
 		}
 
-		tables, overall := aggregateShardProgress(rows)
+		tables, overall := aggregateShardProgress(rows, time.Now())
 		require.Len(t, tables, 1)
 		assert.Equal(t, 100, tables[0].Progress)
 		assert.Equal(t, 100, tables[0].Shards[0].Progress)
@@ -133,7 +133,7 @@ func TestAggregateShardProgress(t *testing.T) {
 			{MigrationUUID: "uuid-1", Keyspace: "commerce", Shard: "80-", Table: "orders", Status: "running", ReadyToComplete: false, Progress: 50, RowsCopied: 5000, TableRows: 10000},
 		}
 
-		tables, _ := aggregateShardProgress(rows)
+		tables, _ := aggregateShardProgress(rows, time.Now())
 		require.Len(t, tables, 1)
 		assert.Equal(t, state.Vitess.Running, tables[0].State)
 		// First shard (ready_to_complete) should be clamped to 100%
@@ -152,11 +152,103 @@ func TestAggregateShardProgress(t *testing.T) {
 			{MigrationUUID: "uuid-1", Keyspace: "commerce", Shard: "-", Table: "orders", Status: "running", Progress: 99, RowsCopied: 12000, TableRows: 10000},
 		}
 
-		tables, overall := aggregateShardProgress(rows)
+		tables, overall := aggregateShardProgress(rows, time.Now())
 		require.Len(t, tables, 1)
 		assert.Equal(t, state.Vitess.Running, tables[0].State)
 		assert.Equal(t, 100, tables[0].Progress)
 		assert.Equal(t, 100, overall)
+	})
+}
+
+// The provider reports eta_seconds as -1 (or 0) while it considers the ETA
+// unknown, which for some providers persists across the entire copy phase.
+// A shard that is actively copying must still surface an ETA in the PR status
+// comment and CLI, so the aggregation estimates one from the copy rate so far
+// (elapsed * remaining / copied) whenever the reported value is non-positive.
+func TestAggregateShardProgress_ETAEstimate(t *testing.T) {
+	now := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	started := now.Add(-10 * time.Minute)
+
+	t.Run("unknown provider ETA is estimated from copy rate", func(t *testing.T) {
+		// 25% copied in 10 minutes → 30 minutes remaining.
+		rows := []vitessMigrationRow{
+			{MigrationUUID: "uuid-1", Keyspace: "commerce", Shard: "-80", Table: "orders", Status: "running",
+				ETASeconds: -1, RowsCopied: 25_000_000, TableRows: 100_000_000, Progress: 25, StartedAt: &started},
+		}
+
+		tables, _ := aggregateShardProgress(rows, now)
+		require.Len(t, tables, 1)
+		assert.Equal(t, int64(1800), tables[0].ETASeconds)
+		require.Len(t, tables[0].Shards, 1)
+		assert.Equal(t, int64(1800), tables[0].Shards[0].ETASeconds)
+	})
+
+	t.Run("provider-reported ETA wins over the estimate", func(t *testing.T) {
+		rows := []vitessMigrationRow{
+			{MigrationUUID: "uuid-1", Keyspace: "commerce", Shard: "-80", Table: "orders", Status: "running",
+				ETASeconds: 542, RowsCopied: 25_000_000, TableRows: 100_000_000, Progress: 25, StartedAt: &started},
+		}
+
+		tables, _ := aggregateShardProgress(rows, now)
+		require.Len(t, tables, 1)
+		assert.Equal(t, int64(542), tables[0].ETASeconds)
+		assert.Equal(t, int64(542), tables[0].Shards[0].ETASeconds)
+	})
+
+	t.Run("table ETA is the slowest shard's estimate", func(t *testing.T) {
+		// -80 is 50% done (10 min remaining); 80- is 25% done (30 min remaining).
+		rows := []vitessMigrationRow{
+			{MigrationUUID: "uuid-1", Keyspace: "commerce", Shard: "-80", Table: "orders", Status: "running",
+				ETASeconds: -1, RowsCopied: 50_000_000, TableRows: 100_000_000, Progress: 50, StartedAt: &started},
+			{MigrationUUID: "uuid-1", Keyspace: "commerce", Shard: "80-", Table: "orders", Status: "running",
+				ETASeconds: -1, RowsCopied: 25_000_000, TableRows: 100_000_000, Progress: 25, StartedAt: &started},
+		}
+
+		tables, _ := aggregateShardProgress(rows, now)
+		require.Len(t, tables, 1)
+		assert.Equal(t, int64(1800), tables[0].ETASeconds)
+		assert.Equal(t, int64(600), tables[0].Shards[0].ETASeconds)
+		assert.Equal(t, int64(1800), tables[0].Shards[1].ETASeconds)
+	})
+
+	t.Run("no estimate before any rows are copied", func(t *testing.T) {
+		rows := []vitessMigrationRow{
+			{MigrationUUID: "uuid-1", Keyspace: "commerce", Shard: "-80", Table: "orders", Status: "running",
+				ETASeconds: -1, RowsCopied: 0, TableRows: 100_000_000, StartedAt: &started},
+		}
+
+		tables, _ := aggregateShardProgress(rows, now)
+		require.Len(t, tables, 1)
+		assert.Zero(t, tables[0].ETASeconds)
+		assert.Zero(t, tables[0].Shards[0].ETASeconds)
+	})
+
+	t.Run("no estimate without a start time", func(t *testing.T) {
+		rows := []vitessMigrationRow{
+			{MigrationUUID: "uuid-1", Keyspace: "commerce", Shard: "-80", Table: "orders", Status: "running",
+				ETASeconds: -1, RowsCopied: 25_000_000, TableRows: 100_000_000, Progress: 25},
+		}
+
+		tables, _ := aggregateShardProgress(rows, now)
+		require.Len(t, tables, 1)
+		assert.Zero(t, tables[0].ETASeconds)
+	})
+
+	t.Run("no estimate once a shard is done copying", func(t *testing.T) {
+		// ready_to_complete and complete shards are past the copy phase; a
+		// fabricated ETA there would contradict the rendered 100% state.
+		rows := []vitessMigrationRow{
+			{MigrationUUID: "uuid-1", Keyspace: "commerce", Shard: "-80", Table: "orders", Status: "running",
+				ReadyToComplete: true, ETASeconds: -1, RowsCopied: 99_000_000, TableRows: 100_000_000, Progress: 99, StartedAt: &started},
+			{MigrationUUID: "uuid-1", Keyspace: "commerce", Shard: "80-", Table: "orders", Status: "complete",
+				ETASeconds: -1, RowsCopied: 100_000_000, TableRows: 100_000_000, Progress: 100, StartedAt: &started},
+		}
+
+		tables, _ := aggregateShardProgress(rows, now)
+		require.Len(t, tables, 1)
+		assert.Zero(t, tables[0].ETASeconds)
+		assert.Zero(t, tables[0].Shards[0].ETASeconds)
+		assert.Zero(t, tables[0].Shards[1].ETASeconds)
 	})
 }
 

--- a/pkg/engine/planetscale/progress_test.go
+++ b/pkg/engine/planetscale/progress_test.go
@@ -234,12 +234,13 @@ func TestAggregateShardProgress_ETAEstimate(t *testing.T) {
 		assert.Zero(t, tables[0].ETASeconds)
 	})
 
-	t.Run("no estimate once a shard is done copying", func(t *testing.T) {
-		// ready_to_complete and complete shards are past the copy phase; a
-		// fabricated ETA there would contradict the rendered 100% state.
+	t.Run("no ETA once a shard is done copying", func(t *testing.T) {
+		// ready_to_complete and complete shards are past the copy phase; any
+		// ETA there — estimated or a stale provider value — would contradict
+		// the rendered 100% state.
 		rows := []vitessMigrationRow{
 			{MigrationUUID: "uuid-1", Keyspace: "commerce", Shard: "-80", Table: "orders", Status: "running",
-				ReadyToComplete: true, ETASeconds: -1, RowsCopied: 99_000_000, TableRows: 100_000_000, Progress: 99, StartedAt: &started},
+				ReadyToComplete: true, ETASeconds: 37, RowsCopied: 99_000_000, TableRows: 100_000_000, Progress: 99, StartedAt: &started},
 			{MigrationUUID: "uuid-1", Keyspace: "commerce", Shard: "80-", Table: "orders", Status: "complete",
 				ETASeconds: -1, RowsCopied: 100_000_000, TableRows: 100_000_000, Progress: 100, StartedAt: &started},
 		}
@@ -249,6 +250,23 @@ func TestAggregateShardProgress_ETAEstimate(t *testing.T) {
 		assert.Zero(t, tables[0].ETASeconds)
 		assert.Zero(t, tables[0].Shards[0].ETASeconds)
 		assert.Zero(t, tables[0].Shards[1].ETASeconds)
+	})
+
+	t.Run("stale ETA on a finished shard does not inflate the table ETA", func(t *testing.T) {
+		// The copying shard's estimate defines the table ETA even when a
+		// finished sibling still carries a larger provider-reported value.
+		rows := []vitessMigrationRow{
+			{MigrationUUID: "uuid-1", Keyspace: "commerce", Shard: "-80", Table: "orders", Status: "running",
+				ReadyToComplete: true, ETASeconds: 5000, RowsCopied: 100_000_000, TableRows: 100_000_000, Progress: 100, StartedAt: &started},
+			{MigrationUUID: "uuid-1", Keyspace: "commerce", Shard: "80-", Table: "orders", Status: "running",
+				ETASeconds: -1, RowsCopied: 50_000_000, TableRows: 100_000_000, Progress: 50, StartedAt: &started},
+		}
+
+		tables, _ := aggregateShardProgress(rows, now)
+		require.Len(t, tables, 1)
+		assert.Equal(t, int64(600), tables[0].ETASeconds)
+		assert.Zero(t, tables[0].Shards[0].ETASeconds)
+		assert.Equal(t, int64(600), tables[0].Shards[1].ETASeconds)
 	})
 }
 


### PR DESCRIPTION
## Why this matters

For PlanetScale schema changes, the PR status comment and CLI showed rows copied and per-shard percentages but no ETA for the entire copy phase — on a 150M-row table that's a multi-hour apply with no indication of when it will finish. The provider's `SHOW VITESS_MIGRATIONS` reports `eta_seconds = -1` (unknown) even while `progress` and `rows_copied` update normally, and SchemaBot correctly suppresses non-positive ETAs, so nothing ever rendered.

## What it does

In the per-shard aggregation (`pkg/engine/planetscale/progress.go`), when a shard is still copying and the provider reports no ETA, estimate one from the shard's copy rate so far — `elapsed × remaining / copied`, the same projection Vitess uses server-side. A provider-reported ETA always wins when present; no ETA is fabricated for shards that are ready to cut over, complete, or haven't copied a row yet. The table-level ETA remains the slowest shard's value. Because this happens at engine aggregation, the estimate flows through stored task and per-shard rows to the PR comment and CLI unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)