### PR TITLE
fix(tern): retry cutover quietly when the deploy request has not staged its changes

### DIFF
--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -143,6 +143,30 @@ func TestIsRetryable(t *testing.T) {
 
 }
 
+func TestIsNotReady(t *testing.T) {
+	t.Run("plain error is not a not-ready condition", func(t *testing.T) {
+		assert.False(t, IsNotReady(fmt.Errorf("connection refused")))
+	})
+
+	t.Run("NotReadyError is a not-ready condition", func(t *testing.T) {
+		err := NewNotReadyError("deploy request has not staged its changes yet")
+		assert.True(t, IsNotReady(err))
+	})
+
+	t.Run("wrapped NotReadyError is a not-ready condition", func(t *testing.T) {
+		err := fmt.Errorf("cutover deploy request #7: %w", NewNotReadyError("not staged"))
+		assert.True(t, IsNotReady(err))
+	})
+
+	t.Run("NotReadyError stays retryable", func(t *testing.T) {
+		assert.True(t, IsRetryable(NewNotReadyError("not staged")))
+	})
+
+	t.Run("nil is not a not-ready condition", func(t *testing.T) {
+		assert.False(t, IsNotReady(nil))
+	})
+}
+
 func TestIsTransientTransportError(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/engine/errors.go
+++ b/pkg/engine/errors.go
@@ -20,6 +20,32 @@ func NewPermanentError(msg string, args ...any) error {
 	return &PermanentError{Err: fmt.Errorf(msg, args...)}
 }
 
+// NotReadyError wraps an error to indicate the engine's backend was not yet
+// ready to accept the operation and is expected to accept it once it catches
+// up. Polling drives should treat this as an expected condition and reattempt
+// on a later tick rather than reporting the attempt as a failure.
+type NotReadyError struct {
+	Err error
+}
+
+func (e *NotReadyError) Error() string { return e.Err.Error() }
+func (e *NotReadyError) Unwrap() error { return e.Err }
+
+// NewNotReadyError wraps err as a not-ready error.
+func NewNotReadyError(msg string, args ...any) error {
+	return &NotReadyError{Err: fmt.Errorf(msg, args...)}
+}
+
+// IsNotReady reports whether err indicates the engine's backend was not yet
+// ready to accept the operation.
+func IsNotReady(err error) bool {
+	if err == nil {
+		return false
+	}
+	var notReady *NotReadyError
+	return errors.As(err, &notReady)
+}
+
 // IsRetryable returns true if the error should be retried by the operator.
 // All errors are retryable by default, and engines explicitly wrap only
 // permanent errors with PermanentError.

--- a/pkg/engine/planetscale/control.go
+++ b/pkg/engine/planetscale/control.go
@@ -85,12 +85,24 @@ func (e *Engine) Start(ctx context.Context, req *engine.ControlRequest) (*engine
 func (e *Engine) Cutover(ctx context.Context, req *engine.ControlRequest) (*engine.ControlResult, error) {
 	return e.controlDeployRequest(ctx, engine.ControlCutover, req, "cutover", "Cutover initiated for",
 		func(ctx context.Context, client psclient.PSClient, number uint64) (*ps.DeployRequest, error) {
-			return client.ApplyDeployRequest(ctx, &ps.ApplyDeployRequestRequest{
+			dr, err := client.ApplyDeployRequest(ctx, &ps.ApplyDeployRequestRequest{
 				Organization: credOrg(req.Credentials),
 				Database:     req.Database,
 				Number:       number,
 			})
+			if err != nil && isDeployNotStagedError(err) {
+				return nil, engine.NewNotReadyError("deploy request has not staged its changes yet: %w", err)
+			}
+			return dr, err
 		})
+}
+
+// isDeployNotStagedError reports whether the PlanetScale API rejected a
+// cutover because the deploy request has not staged its changes yet. The API
+// briefly reports pending_cutover before the staged changes are visible to the
+// apply endpoint, so the rejection clears on its own once staging completes.
+func isDeployNotStagedError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "changes have not been staged")
 }
 
 // Revert rolls back a completed schema change during the revert window.
@@ -150,6 +162,12 @@ func (e *Engine) controlDeployRequest(
 
 	dr, err := mutate(ctx, client, meta.DeployRequestID)
 	if err != nil {
+		// A not-ready rejection means the deploy request exists and will accept
+		// the operation once its backend catches up — the deleted-deploy-request
+		// hint would misdirect whoever reads the message.
+		if engine.IsNotReady(err) {
+			return nil, fmt.Errorf("%s deploy request #%d: %w", errVerb, meta.DeployRequestID, err)
+		}
 		return nil, fmt.Errorf("%s deploy request #%d (may have been deleted): %w", errVerb, meta.DeployRequestID, err)
 	}
 

--- a/pkg/engine/planetscale/control_test.go
+++ b/pkg/engine/planetscale/control_test.go
@@ -1,12 +1,18 @@
 package planetscale
 
 import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
 	"testing"
 
+	ps "github.com/planetscale/planetscale-go/planetscale"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/block/schemabot/pkg/engine"
+	"github.com/block/schemabot/pkg/psclient"
 )
 
 func TestStop_UsesDeployRequestCancel(t *testing.T) {
@@ -57,4 +63,72 @@ func TestStart_AcceptsDeferredDeploy(t *testing.T) {
 	// Fails because no PS client configured — but proves it didn't reject as "not supported"
 	assert.Error(t, err)
 	assert.NotContains(t, err.Error(), "not supported")
+}
+
+// applyDeployRequestErrorClient fails every cutover attempt with a fixed error.
+type applyDeployRequestErrorClient struct {
+	psclient.PSClient
+	err error
+}
+
+func (c *applyDeployRequestErrorClient) ApplyDeployRequest(context.Context, *ps.ApplyDeployRequestRequest) (*ps.DeployRequest, error) {
+	return nil, c.err
+}
+
+// A deploy request can report pending_cutover before its staged changes are
+// visible to the apply endpoint, so a cutover attempted in that window is
+// rejected with a not-staged error even though the deploy request is healthy
+// and will accept the cutover moments later. The engine classifies that
+// rejection as not-ready so the drive retries on the next progress tick
+// instead of reporting a cutover failure; any other rejection remains a plain
+// error carrying the deleted-deploy-request hint.
+func TestCutover_NotStagedRejectionIsNotReady(t *testing.T) {
+	meta, err := encodePSMetadata(&psMetadata{
+		BranchName:       "schemabot-mydb-abc",
+		DeployRequestID:  7,
+		DeployRequestURL: "https://example.test/deploys/7",
+	})
+	require.NoError(t, err)
+
+	controlReq := func() *engine.ControlRequest {
+		return &engine.ControlRequest{
+			Database:    "mydb",
+			ResumeState: &engine.ResumeState{Metadata: meta},
+			Credentials: &engine.Credentials{Metadata: map[string]string{
+				"organization": "org",
+				"token_name":   "tn",
+				"token_value":  "tv",
+			}},
+		}
+	}
+
+	newEngine := func(applyErr error) *Engine {
+		return NewWithClient(slog.New(slog.NewTextHandler(os.Stdout, nil)),
+			func(_, _ string) (psclient.PSClient, error) {
+				return &applyDeployRequestErrorClient{err: applyErr}, nil
+			})
+	}
+
+	t.Run("not-staged rejection reads as not-ready", func(t *testing.T) {
+		e := newEngine(errors.New("Unable to complete the deploy, deploy request changes have not been staged."))
+
+		_, err := e.Cutover(t.Context(), controlReq())
+
+		require.Error(t, err)
+		assert.True(t, engine.IsNotReady(err), "a not-staged rejection clears on its own once staging completes")
+		assert.Contains(t, err.Error(), "cutover deploy request #7")
+		assert.Contains(t, err.Error(), "changes have not been staged")
+		assert.NotContains(t, err.Error(), "may have been deleted")
+	})
+
+	t.Run("other rejection stays a plain error", func(t *testing.T) {
+		e := newEngine(errors.New("deploy request not found"))
+
+		_, err := e.Cutover(t.Context(), controlReq())
+
+		require.Error(t, err)
+		assert.False(t, engine.IsNotReady(err))
+		assert.Contains(t, err.Error(), "cutover deploy request #7 (may have been deleted)")
+		assert.Contains(t, err.Error(), "deploy request not found")
+	})
 }

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -784,7 +784,15 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		c.logger.Info("auto-triggering cutover (not in defer mode)", "apply_id", apply.ApplyIdentifier)
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventCutoverTriggered, storage.LogSourceSchemaBot,
 			"Auto-triggering cutover (defer_cutover not set)", "", "")
-		if _, err := eng.Cutover(ctx, controlReq); err != nil {
+		switch _, err := eng.Cutover(ctx, controlReq); {
+		case err == nil:
+		case engine.IsNotReady(err):
+			// The engine's backend advertised the cutover gate before it was
+			// ready to accept the cutover; the drive reattempts on the next
+			// progress tick, once it catches up.
+			c.logger.Info("auto-cutover not accepted yet; retrying at the next progress tick",
+				append(apply.LogAttrs(), "error", err)...)
+		default:
 			c.logger.Error("auto-cutover failed", append(apply.LogAttrs(), "error", err)...)
 		}
 	}

--- a/pkg/tern/local_apply_grouped.go
+++ b/pkg/tern/local_apply_grouped.go
@@ -781,20 +781,7 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 
 	// Auto-trigger cutover if waiting and not in defer mode
 	if result.State == engine.StateWaitingForCutover && !opts.DeferCutover {
-		c.logger.Info("auto-triggering cutover (not in defer mode)", "apply_id", apply.ApplyIdentifier)
-		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventCutoverTriggered, storage.LogSourceSchemaBot,
-			"Auto-triggering cutover (defer_cutover not set)", "", "")
-		switch _, err := eng.Cutover(ctx, controlReq); {
-		case err == nil:
-		case engine.IsNotReady(err):
-			// The engine's backend advertised the cutover gate before it was
-			// ready to accept the cutover; the drive reattempts on the next
-			// progress tick, once it catches up.
-			c.logger.Info("auto-cutover not accepted yet; retrying at the next progress tick",
-				append(apply.LogAttrs(), "error", err)...)
-		default:
-			c.logger.Error("auto-cutover failed", append(apply.LogAttrs(), "error", err)...)
-		}
+		c.autoTriggerCutover(ctx, eng, apply, controlReq, ps, now)
 	}
 
 	// Timeout: cancel the apply if waiting for manual deploy too long.
@@ -1110,6 +1097,49 @@ func (c *LocalClient) handleAtomicProgressTick(ctx context.Context, eng engine.E
 		return true
 	}
 	return false
+}
+
+// autoTriggerCutover fires the engine cutover for a drive that is not
+// deferring cutover, pacing the operator-visible signal around the backend's
+// staging window: the trigger event is recorded once per drive so retries do
+// not duplicate it, a not-ready rejection retries quietly on the next progress
+// tick, and a rejection that outlives the staging window escalates to Error
+// logging on every further tick plus a one-time timeline event, so a backend
+// that never stages the cutover pages instead of idling.
+func (c *LocalClient) autoTriggerCutover(ctx context.Context, eng engine.Engine, apply *storage.Apply, controlReq *engine.ControlRequest, ps *atomicPollState, now time.Time) {
+	if !ps.cutoverTriggerLogged {
+		c.logger.Info("auto-triggering cutover (not in defer mode)", "apply_id", apply.ApplyIdentifier)
+		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventCutoverTriggered, storage.LogSourceSchemaBot,
+			"Auto-triggering cutover (defer_cutover not set)", "", "")
+		ps.cutoverTriggerLogged = true
+	}
+	switch _, err := eng.Cutover(ctx, controlReq); {
+	case err == nil:
+		ps.cutoverNotReadySince = time.Time{}
+		ps.cutoverNotReadyEscalated = false
+	case engine.IsNotReady(err):
+		// The engine's backend advertised the cutover gate before it was ready
+		// to accept the cutover; the drive reattempts on the next progress
+		// tick, once it catches up.
+		if ps.cutoverNotReadySince.IsZero() {
+			ps.cutoverNotReadySince = now
+		}
+		notReadyFor := now.Sub(ps.cutoverNotReadySince)
+		if notReadyFor < cutoverNotReadyEscalationAfter {
+			c.logger.Info("auto-cutover not accepted yet; retrying at the next progress tick",
+				append(apply.LogAttrs(), "not_ready_for", notReadyFor, "error", err)...)
+			return
+		}
+		if !ps.cutoverNotReadyEscalated {
+			c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelError, storage.LogEventError, storage.LogSourceSchemaBot,
+				fmt.Sprintf("Cutover has not been accepted by the engine backend for %s; SchemaBot keeps retrying every progress tick", notReadyFor.Round(time.Second)), "", "")
+			ps.cutoverNotReadyEscalated = true
+		}
+		c.logger.Error("auto-cutover has been rejected as not-ready beyond the staging window; the engine backend is not staging the cutover and the drive keeps retrying",
+			append(apply.LogAttrs(), "not_ready_for", notReadyFor, "error", err)...)
+	default:
+		c.logger.Error("auto-cutover failed", append(apply.LogAttrs(), "error", err)...)
+	}
 }
 
 // markRevertSkipped records skip-revert on the apply so progress consumers know

--- a/pkg/tern/local_apply_sequential.go
+++ b/pkg/tern/local_apply_sequential.go
@@ -243,6 +243,14 @@ const (
 	// defaultRevertWindowDuration is the default revert window period.
 	// 30 minutes matches PlanetScale's default.
 	defaultRevertWindowDuration = 30 * time.Minute
+
+	// cutoverNotReadyEscalationAfter is how long consecutive not-ready cutover
+	// rejections stay at Info before the drive escalates to Error logging and
+	// records a timeline event. The window between a backend advertising the
+	// cutover gate and accepting a cutover normally lasts seconds; a rejection
+	// persisting this long means the backend is not staging the cutover and an
+	// operator needs to investigate.
+	cutoverNotReadyEscalationAfter = 2 * time.Minute
 )
 
 // atomicPollState tracks mutable state across polling ticks in atomic mode.
@@ -257,6 +265,21 @@ type atomicPollState struct {
 
 	// revertSkipped is set after SkipRevert is called to prevent repeated calls.
 	revertSkipped bool
+
+	// cutoverTriggerLogged is set after the drive records the auto-cutover
+	// trigger event, so retries of a not-yet-accepted cutover do not fill the
+	// user-visible timeline with duplicate triggers.
+	cutoverTriggerLogged bool
+
+	// cutoverNotReadySince is when the engine backend first rejected an
+	// auto-cutover as not ready; cleared when a cutover is accepted. Used to
+	// escalate when the normally seconds-long staging window persists.
+	cutoverNotReadySince time.Time
+
+	// cutoverNotReadyEscalated is set once the not-ready window has outlived
+	// cutoverNotReadyEscalationAfter and the timeline event was written, so
+	// that event is recorded once while the Error log repeats every tick.
+	cutoverNotReadyEscalated bool
 
 	// consecutiveErrors tracks progress poll failures to fail fast when the
 	// engine is unreachable (e.g., branch deleted mid-apply).

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -1741,6 +1742,141 @@ func TestLocalClient_ProcessPendingCutoverControlRequestFailsRejectedRequest(t *
 	require.Len(t, controlRequests.requests, 1)
 	assert.Equal(t, storage.ControlRequestFailed, controlRequests.requests[0].Status)
 	assert.Equal(t, "not ready for cutover", controlRequests.requests[0].ErrorMessage)
+}
+
+// A cutover request that the engine backend rejects because it has not yet
+// staged the cutover must stay pending: the drive retries it on the next
+// progress tick and the operator's command takes effect without being
+// re-issued. The rejected attempt records neither a trigger nor a failure in
+// the user-visible timeline — only the accepted attempt does.
+func TestLocalClient_ProcessPendingCutoverControlRequestRetriesWhenCutoverNotReady(t *testing.T) {
+	apply := &storage.Apply{
+		ID:              131,
+		ApplyIdentifier: "apply-cutover-not-ready-local",
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+		State:           state.Apply.WaitingForCutover,
+	}
+	task := &storage.Task{
+		ID:             464,
+		ApplyID:        apply.ID,
+		TaskIdentifier: "task-cutover-not-ready-local",
+		Database:       "testdb",
+		Namespace:      "testdb",
+		DatabaseType:   storage.DatabaseTypeMySQL,
+		TableName:      "users",
+		State:          state.Task.WaitingForCutover,
+	}
+	controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationCutover,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "cli:alice",
+	}}}
+	fakeEngine := &fakeControlEngine{cutoverErr: engine.NewNotReadyError("changes have not been staged")}
+	logs := &mockApplyLogStore{}
+	client := &LocalClient{
+		config: LocalConfig{
+			Database: "testdb",
+			Type:     storage.DatabaseTypeMySQL,
+		},
+		storage: &exactProgressStorage{
+			applies:         &exactProgressApplyStore{apply: apply},
+			tasks:           &exactProgressTaskStore{tasks: []*storage.Task{task}},
+			logs:            logs,
+			controlRequests: controlRequests,
+		},
+		spiritEngine: fakeEngine,
+		logger:       slog.Default(),
+	}
+
+	require.NoError(t, client.processPendingCutoverControlRequest(t.Context(), apply))
+	assert.Equal(t, 1, fakeEngine.cutoverCount)
+	pending, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationCutover)
+	require.NoError(t, err)
+	require.NotNil(t, pending, "a not-ready rejection must keep the cutover request pending for the next tick")
+	assert.Equal(t, storage.ControlRequestPending, pending.Status)
+	assert.False(t, hasLogMessageContaining(logs.logs, "Cutover failed"), "a not-ready rejection must not record a failure in the timeline")
+	assert.False(t, hasLogMessageContaining(logs.logs, "Cutover triggered"), "a rejected attempt must not record a trigger in the timeline")
+
+	// The backend finishes staging: the still-pending request is accepted on
+	// the next tick and completes.
+	fakeEngine.cutoverErr = nil
+	require.NoError(t, client.processPendingCutoverControlRequest(t.Context(), apply))
+	assert.Equal(t, 2, fakeEngine.cutoverCount)
+	pending, err = controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationCutover)
+	require.NoError(t, err)
+	assert.Nil(t, pending, "the accepted cutover must complete the pending request")
+	assert.True(t, hasLogMessageContaining(logs.logs, "Cutover triggered (caller: cli:alice)"))
+}
+
+// The drive's auto-cutover records one trigger in the timeline per drive and
+// retries quietly while the engine backend stages the cutover. A rejection
+// that outlives the staging window records a one-time timeline error and
+// escalates to Error logging on every further tick, so a backend that never
+// stages the cutover is visible to operators instead of idling; the retry
+// loop itself never stops, and an accepted cutover resets the escalation.
+func TestLocalClient_AutoTriggerCutoverEscalatesWhenNotReadyPersists(t *testing.T) {
+	apply := &storage.Apply{
+		ID:              132,
+		ApplyIdentifier: "apply-auto-cutover-escalate",
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeVitess,
+		Environment:     "staging",
+		State:           state.Apply.WaitingForCutover,
+	}
+	fakeEngine := &fakeControlEngine{cutoverErr: engine.NewNotReadyError("changes have not been staged")}
+	logs := &mockApplyLogStore{}
+	client := &LocalClient{
+		config: LocalConfig{Database: "testdb", Type: storage.DatabaseTypeVitess},
+		storage: &exactProgressStorage{
+			applies: &exactProgressApplyStore{apply: apply},
+			logs:    logs,
+		},
+		planetscaleEngine: fakeEngine,
+		logger:            slog.Default(),
+	}
+	controlReq := &engine.ControlRequest{Database: apply.Database}
+	pollState := &atomicPollState{}
+	start := time.Now()
+
+	// Within the staging window: retries stay quiet and the trigger event is
+	// recorded exactly once.
+	client.autoTriggerCutover(t.Context(), fakeEngine, apply, controlReq, pollState, start)
+	client.autoTriggerCutover(t.Context(), fakeEngine, apply, controlReq, pollState, start.Add(time.Second))
+	assert.Equal(t, 2, fakeEngine.cutoverCount)
+	assert.Equal(t, 1, countLogMessagesContaining(logs.logs, "Auto-triggering cutover"), "retries must not duplicate the trigger event")
+	assert.False(t, hasLogMessageContaining(logs.logs, "has not been accepted by the engine backend"), "no escalation within the staging window")
+
+	// Beyond the staging window: the timeline records the stall exactly once
+	// while the drive keeps retrying every tick.
+	client.autoTriggerCutover(t.Context(), fakeEngine, apply, controlReq, pollState, start.Add(cutoverNotReadyEscalationAfter))
+	client.autoTriggerCutover(t.Context(), fakeEngine, apply, controlReq, pollState, start.Add(cutoverNotReadyEscalationAfter+time.Second))
+	assert.Equal(t, 4, fakeEngine.cutoverCount, "escalation must not stop the retry loop")
+	assert.Equal(t, 1, countLogMessagesContaining(logs.logs, "has not been accepted by the engine backend"), "the escalation event is recorded once")
+	for _, log := range logs.logs {
+		if strings.Contains(log.Message, "has not been accepted by the engine backend") {
+			assert.Equal(t, storage.LogLevelError, log.Level, "the escalation event must be operator-visible at Error level")
+		}
+	}
+
+	// The backend accepts: the not-ready tracking resets so a later staging
+	// window escalates on its own clock.
+	fakeEngine.cutoverErr = nil
+	client.autoTriggerCutover(t.Context(), fakeEngine, apply, controlReq, pollState, start.Add(cutoverNotReadyEscalationAfter+2*time.Second))
+	assert.True(t, pollState.cutoverNotReadySince.IsZero(), "an accepted cutover must clear the not-ready clock")
+	assert.False(t, pollState.cutoverNotReadyEscalated, "an accepted cutover must re-arm the escalation event")
+}
+
+func countLogMessagesContaining(logs []*storage.ApplyLog, want string) int {
+	count := 0
+	for _, log := range logs {
+		if strings.Contains(log.Message, want) {
+			count++
+		}
+	}
+	return count
 }
 
 func TestLocalClient_StopRejectsVitessCancelledApply(t *testing.T) {

--- a/pkg/tern/local_control.go
+++ b/pkg/tern/local_control.go
@@ -154,6 +154,19 @@ func (c *LocalClient) cutover(ctx context.Context, req *ternv1.CutoverRequest, c
 		return nil, fmt.Errorf("build cutover request for apply %d: %w", task.ApplyID, err)
 	}
 
+	result, err := eng.Cutover(ctx, controlReq)
+	if engine.IsNotReady(err) {
+		// The engine's backend advertised the cutover gate before it was ready
+		// to accept the cutover — a self-clearing condition, not a failure. No
+		// timeline event is written for the rejected attempt: the caller
+		// classifies this error and retries, so recording every attempt would
+		// fill the user-visible timeline with triggers that had no effect.
+		return nil, fmt.Errorf("cutover not accepted yet: %w", err)
+	}
+
+	// The trigger event is recorded once the backend has accepted the attempt
+	// into flight or definitively failed it, so the timeline shows one trigger
+	// per effective attempt rather than one per not-ready retry.
 	logMessage := "Cutover triggered"
 	if caller != "" {
 		logMessage += callerApplyLogSuffix(caller)
@@ -161,7 +174,6 @@ func (c *LocalClient) cutover(ctx context.Context, req *ternv1.CutoverRequest, c
 	c.logApplyEvent(ctx, task.ApplyID, nil, storage.LogLevelInfo, storage.LogEventCutoverTriggered, storage.LogSourceSchemaBot,
 		logMessage, "", "")
 
-	result, err := eng.Cutover(ctx, controlReq)
 	if err != nil {
 		c.logApplyEvent(ctx, task.ApplyID, nil, storage.LogLevelError, storage.LogEventError, storage.LogSourceSchemaBot,
 			fmt.Sprintf("Cutover failed: %v", err), "", "")
@@ -289,6 +301,15 @@ func (c *LocalClient) processPendingCutoverControlRequest(ctx context.Context, a
 		ApplyId:     apply.ApplyIdentifier,
 		Environment: apply.Environment,
 	}, controlRequestCaller(controlReq))
+	if engine.IsNotReady(err) {
+		// The engine's backend has not finished staging the cutover; the
+		// rejection clears on its own. Leave the request pending so the next
+		// progress tick retries it — terminally failing it would strand a
+		// deferred cutover until an operator notices and re-issues the command.
+		c.logger.Info("pending cutover request not accepted yet by engine backend; retrying at the next progress tick",
+			append(apply.LogAttrs(), "requested_by", controlRequestCaller(controlReq), "error", err)...)
+		return nil
+	}
 	if err != nil {
 		errorMessage := err.Error()
 		if failErr := failPendingControlRequests(ctx, c.storage, apply, storage.ControlOperationCutover, errorMessage); failErr != nil {


### PR DESCRIPTION
## Why this matters

PlanetScale can report a deploy request as `pending_cutover` a beat before its staged changes are visible to the apply endpoint. When a cutover fires in that window, the API rejects it with "deploy request changes have not been staged" — an expected, self-clearing condition. Today that rejection is logged as a cutover **failure** (with a misleading "may have been deleted" hint), paging operators for an apply that completes normally on the next progress tick — and a queued cutover command hitting the same window is terminally failed, stranding a deferred cutover until a human notices and re-issues it.

## What it does

- Adds `engine.NotReadyError` / `IsNotReady`: a retryable classification for "the backend advertised the gate before it was ready to accept the operation".
- The PlanetScale engine classifies the not-staged rejection as not-ready and drops the deleted-deploy-request hint from its message, since the deploy request demonstrably exists.
- The drive's auto-cutover records its trigger event once per drive and retries not-ready rejections quietly at Info. A rejection that outlives the staging window records a one-time timeline error and escalates to Error logging on every further tick, so a backend that never stages the cutover still pages.
- A durable cutover request (deferred/operator-initiated) rejected as not-ready stays **pending** — the next progress tick retries it instead of terminally failing the command. The timeline records the trigger only for the attempt the backend accepts (or definitively fails), not one per retry.

```
poll tick: pending_cutover → Cutover()
  ├─ ok                 → cutover proceeds
  ├─ NotReady (staging) → request stays pending, Info log, re-fires next tick
  │    └─ persists past staging window → one timeline error + Error log every tick (pages)
  └─ other error        → terminal failure, Error log (pages)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
