### PR TITLE
fix(github): show the revert-window countdown for remote applies

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -33,7 +33,7 @@ fi
 scripts/lint-fix.sh
 
 # Regenerate TEMPLATES.md if any template source files changed
-TEMPLATE_FILES=$(git diff --cached --name-only -- 'pkg/webhook/templates/*.go' 'pkg/cmd/templates/*.go')
+TEMPLATE_FILES=$(git diff --cached --name-only -- 'pkg/webhook/templates/*.go' 'pkg/cmd/internal/templates/*.go')
 if [ -n "$TEMPLATE_FILES" ]; then
     # Ensure Go is in PATH (hooks may not inherit the full user PATH)
     export PATH="$PATH:$HOME/go/bin:/usr/local/go/bin:/opt/homebrew/bin"

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -2858,19 +2858,19 @@ Deploy request: https://app.planetscale.com/acme/myapp/deploy-requests/42
 
 **Keyspace `testapp`**
 
-**`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✅ Complete (pending revert)
+**`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Complete (revert window open)
 
 ```sql
 ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
 ```
 
-**`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✅ Complete (pending revert)
+**`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Complete (revert window open)
 
 ```sql
 ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
 ```
 
-**`products`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✅ Complete (pending revert)
+**`products`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Complete (revert window open)
 
 ```sql
 ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
@@ -2909,19 +2909,19 @@ Deploy request: https://app.planetscale.com/acme/myapp/deploy-requests/42
 
 **Keyspace `testapp`**
 
-**`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✅ Complete (pending revert)
+**`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Complete (revert window open)
 
 ```sql
 ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
 ```
 
-**`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✅ Complete (pending revert)
+**`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Complete (revert window open)
 
 ```sql
 ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
 ```
 
-**`products`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✅ Complete (pending revert)
+**`products`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Complete (revert window open)
 
 ```sql
 ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
@@ -4966,7 +4966,7 @@ Vitess plan: Multi-keyspace with DDL + VSchema across keyspaces
 
   ── myapp_sharded ──
 
-     ~ orders: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✓ Complete (pending revert)
+     ~ orders: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Complete (revert window open)
        ALTER TABLE `orders` ADD INDEX `idx_total`(`total_cents`);
 
 

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -831,7 +831,7 @@ That command wasn't recognized. Available commands:
 ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
 ```
 
-**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
@@ -1941,7 +1941,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 **Status**: Applied
 
-**`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
@@ -2131,7 +2131,7 @@ Rows: 914,707 / 1,466,232 · ETA: 3m 15s
 ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 ```
 
-**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
@@ -2179,7 +2179,7 @@ ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
 ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 ```
 
-**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
@@ -2226,7 +2226,7 @@ Rows verified: 321,450 / 1,466,232
 ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 ```
 
-**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
@@ -2267,13 +2267,13 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 ```
 Rows: 87,231 / 523,140 · ETA: 7m 0s
 
-**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
 ```
 
-**`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
@@ -2375,19 +2375,19 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 **Schema `testapp`**
 
-**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
 ```
 
-**`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
 ```
 
-**`products`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`products`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
@@ -2442,7 +2442,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 Deploy request: https://app.planetscale.com/acme/myapp/deploy-requests/42
 
-**`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `users` ADD COLUMN `phone` varchar(20);
@@ -2536,7 +2536,7 @@ ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
 ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 ```
 
-**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
@@ -2622,7 +2622,7 @@ schemabot apply -e staging
 ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
 ```
 
-**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
@@ -2669,7 +2669,7 @@ ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
 ```
 Rows: 1,055,687 / 1,466,232
 
-**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
@@ -2705,7 +2705,7 @@ schemabot start apply-a1b2c3d4e5f6 -e staging
 ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
 ```
 
-**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
@@ -2732,7 +2732,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 
 **Schema `testapp`**
 
-**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
@@ -2858,19 +2858,19 @@ Deploy request: https://app.planetscale.com/acme/myapp/deploy-requests/42
 
 **Keyspace `testapp`**
 
-**`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✓ Complete (pending revert)
+**`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✅ Complete (pending revert)
 
 ```sql
 ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
 ```
 
-**`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✓ Complete (pending revert)
+**`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✅ Complete (pending revert)
 
 ```sql
 ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
 ```
 
-**`products`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✓ Complete (pending revert)
+**`products`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✅ Complete (pending revert)
 
 ```sql
 ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
@@ -2909,19 +2909,19 @@ Deploy request: https://app.planetscale.com/acme/myapp/deploy-requests/42
 
 **Keyspace `testapp`**
 
-**`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✓ Complete (pending revert)
+**`orders`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✅ Complete (pending revert)
 
 ```sql
 ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
 ```
 
-**`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✓ Complete (pending revert)
+**`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✅ Complete (pending revert)
 
 ```sql
 ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
 ```
 
-**`products`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✓ Complete (pending revert)
+**`products`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✅ Complete (pending revert)
 
 ```sql
 ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
@@ -6008,7 +6008,7 @@ Rows: 914,707 / 1,466,232 · ETA: 3m 15s
 ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 ```
 
-**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
@@ -6081,19 +6081,19 @@ schemabot apply -e production
 
 **Schema `testapp`**
 
-**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
 ```
 
-**`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
 ```
 
-**`products`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`products`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
@@ -6121,7 +6121,7 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
 ```
 
-**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
@@ -6190,19 +6190,19 @@ _No details available yet._
 
 **Schema `testapp`**
 
-**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
 ```
 
-**`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
 ```
 
-**`products`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`products`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
@@ -6224,19 +6224,19 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 
 **Schema `testapp`**
 
-**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
 ```
 
-**`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
 ```
 
-**`products`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`products`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
@@ -6258,19 +6258,19 @@ ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);
 
 **Schema `testapp`**
 
-**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`orders`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `orders` ADD INDEX `idx_user_id`(`user_id`);
 ```
 
-**`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`users`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `users` ADD INDEX `idx_email`(`email`);
 ```
 
-**`products`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✓ Complete
+**`products`**: 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 ✅ Complete
 
 ```sql
 ALTER TABLE `products` ADD INDEX `idx_price`(`price_cents`);

--- a/pkg/cmd/internal/templates/progress.go
+++ b/pkg/cmd/internal/templates/progress.go
@@ -545,7 +545,7 @@ func FormatTableProgressWithActivity(t TableProgress, activityBar, activityLabel
 		return b.String()
 	case state.Apply.RevertWindow:
 		bar := ui.ProgressBarWaitingCutover() // yellow — complete but revert available
-		fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s ✓ Complete (pending revert)\n", t.TableName, bar)
+		fmt.Fprintf(&b, indentTable+progressSymbol(t.ChangeType)+"%s: %s Complete (revert window open)\n", t.TableName, bar)
 		if t.DDL != "" {
 			b.WriteString(formatProgressDDL(t.DDL))
 		}

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -951,6 +951,7 @@ func TestGRPCClientMirrorsRemoteDisplayMetadata(t *testing.T) {
 	display := map[string]string{
 		"deploy_request_url": "https://app.planetscale.com/org/db/deploy-requests/106",
 		"branch_name":        "schemabot-db",
+		"revert_expires_at":  "2026-06-29T18:30:00Z",
 	}
 
 	t.Run("multi-operation preserves the remote-apply-id context", func(t *testing.T) {
@@ -967,6 +968,7 @@ func TestGRPCClientMirrorsRemoteDisplayMetadata(t *testing.T) {
 		got, err := PSDisplayMetadata(ops.ops[7].EngineResumeMetadata)
 		require.NoError(t, err)
 		assert.Equal(t, "https://app.planetscale.com/org/db/deploy-requests/106", got["deploy_request_url"])
+		assert.Equal(t, "2026-06-29T18:30:00Z", got["revert_expires_at"], "the revert-window deadline must survive the mirror so the PR comment can show the countdown")
 		assert.Equal(t, "remote-apply-xyz", ops.ops[7].EngineResumeContext, "the remote apply id must survive the display-metadata write")
 
 		// A second poll with the same metadata skips the redundant write.

--- a/pkg/tern/state_converters.go
+++ b/pkg/tern/state_converters.go
@@ -403,13 +403,14 @@ func PSDisplayMetadata(resumeStateMetadata string) (map[string]string, error) {
 
 // PSDisplayMetadataStorageBlob converts a progress response's display
 // metadata — the map a data-plane progress poll returns (deploy_request_url, the
-// encoded VSchema status, instant/deferred flags) — back into the stored
-// psMetadataForStorage JSON that the PR comment's display projection
-// (resolveDisplayByOperation → PSDisplayMetadata) reads. For a remote (gRPC)
-// apply the engine runs in the data plane, so its resume metadata never lands on
-// the control-plane operation; mirroring these display fields is how the comment
-// surfaces the deploy-request link and VSchema status. Returns "" when there is
-// nothing worth storing, so callers leave the operation's metadata untouched.
+// encoded VSchema status, instant/deferred flags, the revert-window deadline) —
+// back into the stored psMetadataForStorage JSON that the PR comment's display
+// projection (resolveDisplayByOperation → PSDisplayMetadata) reads. For a remote
+// (gRPC) apply the engine runs in the data plane, so its resume metadata never
+// lands on the control-plane operation; mirroring these display fields is how
+// the comment surfaces the deploy-request link, VSchema status, and revert-window
+// countdown. Returns "" when there is nothing worth storing, so callers leave
+// the operation's metadata untouched.
 func PSDisplayMetadataStorageBlob(md map[string]string) (string, error) {
 	if len(md) == 0 {
 		return "", nil
@@ -419,6 +420,13 @@ func PSDisplayMetadataStorageBlob(md map[string]string) (string, error) {
 		DeployRequestURL: md["deploy_request_url"],
 		IsInstant:        md["is_instant"] == "true",
 		DeferredDeploy:   md["deferred_deploy"] == "true",
+	}
+	if raw := md["revert_expires_at"]; raw != "" {
+		expires, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			return "", fmt.Errorf("parse revert_expires_at %q from display metadata: %w", raw, err)
+		}
+		m.RevertExpiresAt = &expires
 	}
 	changes, err := apitypes.ParseVSchemaChanges(md)
 	if err != nil {
@@ -430,7 +438,7 @@ func PSDisplayMetadataStorageBlob(md map[string]string) (string, error) {
 		}
 		m.VSchemaDiffs = append(m.VSchemaDiffs, vschemaKeyspaceDiff{Namespace: ch.Namespace, Diff: ch.Diff})
 	}
-	if m.DeployRequestURL == "" && m.BranchName == "" && !m.IsInstant && !m.DeferredDeploy && len(m.VSchemaDiffs) == 0 {
+	if m.DeployRequestURL == "" && m.BranchName == "" && !m.IsInstant && !m.DeferredDeploy && len(m.VSchemaDiffs) == 0 && m.RevertExpiresAt == nil {
 		return "", nil
 	}
 	encoded, err := json.Marshal(m)

--- a/pkg/tern/state_converters_test.go
+++ b/pkg/tern/state_converters_test.go
@@ -150,9 +150,11 @@ func TestPSDisplayMetadataStorageBlobRoundTrip(t *testing.T) {
 	assert.Equal(t, "applied", changes[0].Status)
 }
 
-// The revert-window deadline alone is worth storing: during the revert window a
-// remote apply's progress response may carry only revert_expires_at as display
-// state, and the PR comment needs it to render the countdown.
+// The revert-window deadline is a display field in its own right: the
+// "nothing worth storing" guard counts revert_expires_at like the other
+// display fields, so a map carrying only the deadline still yields a blob
+// rather than being discarded as empty. (Live progress responses carry the
+// deploy-request URL alongside the deadline; this pins the guard itself.)
 func TestPSDisplayMetadataStorageBlobRevertExpiresOnly(t *testing.T) {
 	blob, err := PSDisplayMetadataStorageBlob(map[string]string{
 		"revert_expires_at": "2026-06-29T18:30:00Z",
@@ -165,9 +167,11 @@ func TestPSDisplayMetadataStorageBlobRevertExpiresOnly(t *testing.T) {
 	assert.Equal(t, "2026-06-29T18:30:00Z", got["revert_expires_at"])
 }
 
-// A malformed revert-window deadline is surfaced as an error rather than being
-// silently dropped or stored corrupt, so the mirror logs it and retries on the
-// next poll with the rest of the display state intact.
+// A malformed revert-window deadline fails the whole conversion rather than
+// storing a corrupt or partial blob: the mirror logs the error and persists
+// nothing from that poll, leaving any previously stored blob as-is. A value
+// that no writer emits is a loud version-skew tripwire, not display state to
+// degrade around.
 func TestPSDisplayMetadataStorageBlobBadRevertExpires(t *testing.T) {
 	_, err := PSDisplayMetadataStorageBlob(map[string]string{
 		"deploy_request_url": "https://app.planetscale.com/org/db/deploy-requests/106",

--- a/pkg/tern/state_converters_test.go
+++ b/pkg/tern/state_converters_test.go
@@ -128,6 +128,7 @@ func TestPSDisplayMetadataStorageBlobRoundTrip(t *testing.T) {
 		"branch_name":                      "schemabot-db-7",
 		"deploy_request_url":               "https://app.planetscale.com/org/db/deploy-requests/106",
 		"is_instant":                       "true",
+		"revert_expires_at":                "2026-06-29T18:30:00Z",
 		apitypes.VSchemaChangesMetadataKey: encodedVSchema,
 	}
 
@@ -140,12 +141,39 @@ func TestPSDisplayMetadataStorageBlobRoundTrip(t *testing.T) {
 	assert.Equal(t, "https://app.planetscale.com/org/db/deploy-requests/106", got["deploy_request_url"])
 	assert.Equal(t, "schemabot-db-7", got["branch_name"])
 	assert.Equal(t, "true", got["is_instant"])
+	assert.Equal(t, "2026-06-29T18:30:00Z", got["revert_expires_at"])
 
 	changes, err := apitypes.ParseVSchemaChanges(got)
 	require.NoError(t, err)
 	require.Len(t, changes, 1)
 	assert.Equal(t, "commerce_sharded", changes[0].Namespace)
 	assert.Equal(t, "applied", changes[0].Status)
+}
+
+// The revert-window deadline alone is worth storing: during the revert window a
+// remote apply's progress response may carry only revert_expires_at as display
+// state, and the PR comment needs it to render the countdown.
+func TestPSDisplayMetadataStorageBlobRevertExpiresOnly(t *testing.T) {
+	blob, err := PSDisplayMetadataStorageBlob(map[string]string{
+		"revert_expires_at": "2026-06-29T18:30:00Z",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, blob)
+
+	got, err := PSDisplayMetadata(blob)
+	require.NoError(t, err)
+	assert.Equal(t, "2026-06-29T18:30:00Z", got["revert_expires_at"])
+}
+
+// A malformed revert-window deadline is surfaced as an error rather than being
+// silently dropped or stored corrupt, so the mirror logs it and retries on the
+// next poll with the rest of the display state intact.
+func TestPSDisplayMetadataStorageBlobBadRevertExpires(t *testing.T) {
+	_, err := PSDisplayMetadataStorageBlob(map[string]string{
+		"deploy_request_url": "https://app.planetscale.com/org/db/deploy-requests/106",
+		"revert_expires_at":  "not-a-timestamp",
+	})
+	require.ErrorContains(t, err, "revert_expires_at")
 }
 
 // A display map with nothing worth storing yields an empty blob, so the caller

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -715,8 +715,10 @@ func renderTableProgress(sb *strings.Builder, table TableProgressData, applyAtte
 		writeDDLLine(sb, table.DDL)
 
 	case state.Task.RevertWindow:
+		// Deliberately no checkmark: the change is applied but not final while
+		// the revert window is open, and a checkmark reads as "done, walk away".
 		bar := ui.ProgressBarWaitingCutover()
-		fmt.Fprintf(sb, "**`%s`**: %s \u2705 Complete (pending revert)\n", table.TableName, bar)
+		fmt.Fprintf(sb, "**`%s`**: %s Complete (revert window open)\n", table.TableName, bar)
 		writeDDLLine(sb, table.DDL)
 
 	case state.Task.Reverting:

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -651,7 +651,7 @@ func renderTableProgress(sb *strings.Builder, table TableProgressData, applyAtte
 
 	case state.Task.Completed:
 		bar := ui.ProgressBarComplete()
-		fmt.Fprintf(sb, "**`%s`**: %s \u2713 Complete\n", table.TableName, bar)
+		fmt.Fprintf(sb, "**`%s`**: %s \u2705 Complete\n", table.TableName, bar)
 		writeDDLLine(sb, table.DDL)
 
 	case state.Task.Checksumming:
@@ -716,7 +716,7 @@ func renderTableProgress(sb *strings.Builder, table TableProgressData, applyAtte
 
 	case state.Task.RevertWindow:
 		bar := ui.ProgressBarWaitingCutover()
-		fmt.Fprintf(sb, "**`%s`**: %s \u2713 Complete (pending revert)\n", table.TableName, bar)
+		fmt.Fprintf(sb, "**`%s`**: %s \u2705 Complete (pending revert)\n", table.TableName, bar)
 		writeDDLLine(sb, table.DDL)
 
 	case state.Task.Reverting:

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -1874,7 +1874,7 @@ func TestRenderApplyStatusComment_RevertWindow(t *testing.T) {
 	result := RenderApplyStatusComment(data)
 
 	assert.Contains(t, result, "## Schema Change Status")
-	assert.Contains(t, result, "Complete (pending revert)")
+	assert.Contains(t, result, "Complete (revert window open)")
 	assert.Contains(t, result, "schemabot revert apply-abc123 -e staging")
 	assert.Contains(t, result, "schemabot skip-revert apply-abc123 -e staging")
 	// Skip-revert (finalize) is the likelier action, so it is offered before revert.

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -343,7 +343,7 @@ func TestRenderApplyStatusComment_Running(t *testing.T) {
 
 	// Per-table checks
 	assert.Contains(t, result, "**`orders`**")
-	assert.Contains(t, result, "✓ Complete")
+	assert.Contains(t, result, "✅ Complete")
 	assert.Contains(t, result, "🟩") // green bar for completed
 
 	assert.Contains(t, result, "**`users`**")
@@ -732,7 +732,7 @@ func TestRenderApplyStatusComment_Completed(t *testing.T) {
 	assert.Contains(t, result, "**`orders`**")
 	// Progress summary line
 	assert.Contains(t, result, "📊 2/2 complete")
-	// Each table has "✓ Complete" = 2 total
+	// Each table has "✅ Complete" = 2 total
 	assert.Equal(t, 2, strings.Count(result, "Complete"))
 	assert.NotContains(t, result, "Last updated")
 }
@@ -1006,7 +1006,7 @@ func TestRenderApplyStatusComment_Resuming(t *testing.T) {
 	assert.NotContains(t, result, "21%", "the indeterminate resume window must not show the stale pre-stop percent")
 	assert.NotContains(t, result, "21,000 / 100,000", "the indeterminate resume window must not show stale row counts")
 	// An already-terminal table keeps its final state during resume.
-	assert.Contains(t, result, "✓ Complete")
+	assert.Contains(t, result, "✅ Complete")
 }
 
 // A cancelled schema change (e.g. a PlanetScale deploy request that was stopped,


### PR DESCRIPTION
## Why this matters

For applies dispatched to a remote data plane, the PR status comment showed **Status: Revert Window** with no "Closes in Xm Ys" countdown, so the operator had no idea how long they had left to revert. Locally-driven applies were unaffected, which made the gap easy to miss: the engine stamps the deadline into its resume metadata and projects it into the progress response's display map, but the control-plane mirror that persists remote display metadata dropped `revert_expires_at` on the floor.

The per-table line for that state also overstated finality: "✓ Complete (pending revert)" reads as done-and-final while the change is still revertable, and "(pending revert)" reads as if a revert is queued when nothing happens unless the operator acts.

## What it does

- `PSDisplayMetadataStorageBlob` now carries `revert_expires_at` through the remote display mirror into the stored projection the comment renders from, and treats the deadline alone as worth storing. A malformed timestamp is a hard error rather than a silently missing countdown.
- The revert-window table line renders as **Complete (revert window open)** — no checkmark, so ✅ stays reserved for the final completed state; the header's `Revert Window | Closes in Xm Ys` carries the countdown. The CLI progress view renders the same line. The genuinely-completed table line uses ✅ to match the comment's other glyphs.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)