### PR TITLE
feat(github): record posted control phase on tracked comments

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -3137,6 +3137,132 @@ schemabot start apply-a1b2c3d4e5f6 -e staging
 </details>
 
 <details>
+<summary><a name="revert-superseded-progress-comment"></a><strong>Revert: Superseded Progress Comment</strong></summary>
+
+
+Schema change reverting — the revert is tracked in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
+
+<details>
+<summary>Progress before the revert</summary>
+
+## Schema Change Status — Staging
+
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
+
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: Revert Window
+
+**`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✓ Complete (pending revert)
+
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+```
+
+
+---
+
+To skip revert and keep changes:
+```
+schemabot skip-revert apply-a1b2c3d4e5f6 -e staging
+```
+
+To revert:
+```
+schemabot revert apply-a1b2c3d4e5f6 -e staging
+```
+
+_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
+
+
+</details>
+
+</details>
+
+<details>
+<summary><a name="skip-revert-superseded-progress-comment"></a><strong>Skip Revert: Superseded Progress Comment</strong></summary>
+
+
+Revert skipped — the schema change is finalizing in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
+
+<details>
+<summary>Progress before the revert was skipped</summary>
+
+## Schema Change Status — Staging
+
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
+
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: Revert Window
+
+**`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✓ Complete (pending revert)
+
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+```
+
+
+---
+
+To skip revert and keep changes:
+```
+schemabot skip-revert apply-a1b2c3d4e5f6 -e staging
+```
+
+To revert:
+```
+schemabot revert apply-a1b2c3d4e5f6 -e staging
+```
+
+_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
+
+
+</details>
+
+</details>
+
+<details>
+<summary><a name="cutover-complete-superseded-cutover-prompt"></a><strong>Cutover Complete: Superseded Cutover Prompt</strong></summary>
+
+
+Cutover complete — progress continues in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
+
+<details>
+<summary>Cutover prompt</summary>
+
+## Schema Change Status — Staging
+
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
+
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: Waiting for Cutover
+
+**0/1** table(s) ready for cutover — waiting on 1
+
+**`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Waiting for cutover
+
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+```
+
+
+---
+
+To proceed with cutover:
+```
+schemabot cutover apply-a1b2c3d4e5f6 -e staging
+```
+
+_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
+
+
+</details>
+
+</details>
+
+<details>
 <summary><a name="retry-superseded-progress-comment-generic"></a><strong>Retry: Superseded Progress Comment (Generic)</strong></summary>
 
 
@@ -5825,6 +5951,135 @@ Paused — to resume from where it stopped:
 ```
 schemabot start apply-a1b2c3d4e5f6 -e staging
 ```
+
+
+</details>
+
+
+</details>
+
+<details>
+<summary><a name="revert-superseded-progress-comment"></a><strong>Revert: Superseded Progress Comment</strong></summary>
+
+
+Schema change reverting — the revert is tracked in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
+
+<details>
+<summary>Progress before the revert</summary>
+
+## Schema Change Status — Staging
+
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
+
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: Revert Window
+
+**`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✓ Complete (pending revert)
+
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+```
+
+
+---
+
+To skip revert and keep changes:
+```
+schemabot skip-revert apply-a1b2c3d4e5f6 -e staging
+```
+
+To revert:
+```
+schemabot revert apply-a1b2c3d4e5f6 -e staging
+```
+
+_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
+
+
+</details>
+
+
+</details>
+
+<details>
+<summary><a name="skip-revert-superseded-progress-comment"></a><strong>Skip Revert: Superseded Progress Comment</strong></summary>
+
+
+Revert skipped — the schema change is finalizing in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
+
+<details>
+<summary>Progress before the revert was skipped</summary>
+
+## Schema Change Status — Staging
+
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
+
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: Revert Window
+
+**`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 ✓ Complete (pending revert)
+
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+```
+
+
+---
+
+To skip revert and keep changes:
+```
+schemabot skip-revert apply-a1b2c3d4e5f6 -e staging
+```
+
+To revert:
+```
+schemabot revert apply-a1b2c3d4e5f6 -e staging
+```
+
+_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
+
+
+</details>
+
+
+</details>
+
+<details>
+<summary><a name="cutover-complete-superseded-cutover-prompt"></a><strong>Cutover Complete: Superseded Cutover Prompt</strong></summary>
+
+
+Cutover complete — progress continues in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
+
+<details>
+<summary>Cutover prompt</summary>
+
+## Schema Change Status — Staging
+
+**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
+
+*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+**Status**: Waiting for Cutover
+
+**0/1** table(s) ready for cutover — waiting on 1
+
+**`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Waiting for cutover
+
+```sql
+ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
+```
+
+
+---
+
+To proceed with cutover:
+```
+schemabot cutover apply-a1b2c3d4e5f6 -e staging
+```
+
+_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
 
 
 </details>

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -82,6 +82,9 @@ func previewCommentAllOutput() {
 		{"VOLUME COMMAND INVALID LEVEL", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeInvalidLevel()) }},
 		{"VOLUME CHANGED: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeSupersededProgress()) }},
 		{"RESUMED: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentResumeSupersededProgress()) }},
+		{"REVERT: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentRevertSupersededProgress()) }},
+		{"SKIP REVERT: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentSkipRevertSupersededProgress()) }},
+		{"CUTOVER COMPLETE: SUPERSEDED CUTOVER PROMPT", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverSuperseded()) }},
 		{"RETRY: SUPERSEDED PROGRESS COMMENT (GENERIC)", func() { fmt.Print(webhooktemplates.PreviewCommentSupersededProgress()) }},
 		{"SUMMARY: COMPLETED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryCompleted()) }},
 		{"SUMMARY: FAILED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryFailed()) }},
@@ -138,6 +141,9 @@ func previewApplyCommandAllOutput() {
 		{"VOLUME COMMAND INVALID LEVEL", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeInvalidLevel()) }},
 		{"VOLUME CHANGED: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeSupersededProgress()) }},
 		{"RESUMED: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentResumeSupersededProgress()) }},
+		{"REVERT: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentRevertSupersededProgress()) }},
+		{"SKIP REVERT: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentSkipRevertSupersededProgress()) }},
+		{"CUTOVER COMPLETE: SUPERSEDED CUTOVER PROMPT", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverSuperseded()) }},
 		{"RETRY: SUPERSEDED PROGRESS COMMENT (GENERIC)", func() { fmt.Print(webhooktemplates.PreviewCommentSupersededProgress()) }},
 		{"CHECKS GATE: NOT PASSING", func() {
 			fmt.Print(webhooktemplates.RenderApplyBlockedByNonPassingChecks("staging", []webhooktemplates.BlockingCheck{
@@ -276,6 +282,9 @@ func previewCommentApplyFlowAllOutput() {
 		{"VOLUME COMMAND INVALID LEVEL", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeInvalidLevel()) }},
 		{"VOLUME CHANGED: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeSupersededProgress()) }},
 		{"RESUMED: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentResumeSupersededProgress()) }},
+		{"REVERT: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentRevertSupersededProgress()) }},
+		{"SKIP REVERT: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentSkipRevertSupersededProgress()) }},
+		{"CUTOVER COMPLETE: SUPERSEDED CUTOVER PROMPT", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverSuperseded()) }},
 		{"RETRY: SUPERSEDED PROGRESS COMMENT (GENERIC)", func() { fmt.Print(webhooktemplates.PreviewCommentSupersededProgress()) }},
 		// Summaries
 		{"SUMMARY: COMPLETED", func() { fmt.Print(webhooktemplates.PreviewCommentSummaryCompleted()) }},

--- a/pkg/schema/mysql/apply_comments.sql
+++ b/pkg/schema/mysql/apply_comments.sql
@@ -4,6 +4,7 @@ CREATE TABLE `apply_comments` (
   `comment_state` varchar(50) NOT NULL,
   `github_comment_id` bigint NOT NULL,
   `posted_volume` int DEFAULT NULL,
+  `posted_phase` varchar(32) DEFAULT NULL,
   `pending_freeze_github_comment_id` bigint DEFAULT NULL,
   `edit_count` int NOT NULL DEFAULT '0',
   `last_edited_at` datetime DEFAULT NULL,

--- a/pkg/storage/mysqlstore/apply_comments.go
+++ b/pkg/storage/mysqlstore/apply_comments.go
@@ -14,7 +14,7 @@ import (
 )
 
 // applyCommentColumns lists all columns for SELECT queries.
-const applyCommentColumns = `id, apply_id, comment_state, github_comment_id, posted_volume, pending_freeze_github_comment_id, edit_count, last_edited_at, superseded_at, created_at, updated_at`
+const applyCommentColumns = `id, apply_id, comment_state, github_comment_id, posted_volume, posted_phase, pending_freeze_github_comment_id, edit_count, last_edited_at, superseded_at, created_at, updated_at`
 
 // applyCommentStore implements storage.ApplyCommentStore using MySQL.
 type applyCommentStore struct {
@@ -24,8 +24,9 @@ type applyCommentStore struct {
 
 // Upsert creates or updates a comment record.
 // On conflict (same apply_id + comment_state), updates the github_comment_id,
-// posted_volume, and pending_freeze_github_comment_id so the row always
-// describes the currently tracked comment and the freeze it may still owe.
+// posted_volume, posted_phase, and pending_freeze_github_comment_id so the
+// row always describes the currently tracked comment and the freeze it may
+// still owe.
 func (s *applyCommentStore) Upsert(ctx context.Context, comment *storage.ApplyComment) error {
 	lease, hasLease, err := applyLeaseFromContext(ctx, comment.ApplyID)
 	if err != nil {
@@ -36,23 +37,24 @@ func (s *applyCommentStore) Upsert(ctx context.Context, comment *storage.ApplyCo
 		[]UpsertAssignment{
 			{Column: "github_comment_id"},
 			{Column: "posted_volume"},
+			{Column: "posted_phase"},
 			{Column: "pending_freeze_github_comment_id"},
 			{Column: "superseded_at", Expr: "NULL"},
 		},
 	)
 	if !hasLease {
 		_, err := s.db.ExecContext(ctx, `
-			INSERT INTO apply_comments (apply_id, comment_state, github_comment_id, posted_volume, pending_freeze_github_comment_id)
-			VALUES (?, ?, ?, ?, ?)
-			`+upsert, comment.ApplyID, comment.CommentState, comment.GitHubCommentID, comment.PostedVolume, comment.PendingFreezeCommentID)
+			INSERT INTO apply_comments (apply_id, comment_state, github_comment_id, posted_volume, posted_phase, pending_freeze_github_comment_id)
+			VALUES (?, ?, ?, ?, ?, ?)
+			`+upsert, comment.ApplyID, comment.CommentState, comment.GitHubCommentID, comment.PostedVolume, comment.PostedPhase, comment.PendingFreezeCommentID)
 		return err
 	}
 
 	result, err := s.db.ExecContext(ctx, `
-		INSERT INTO apply_comments (apply_id, comment_state, github_comment_id, posted_volume, pending_freeze_github_comment_id)
-		SELECT ?, ?, ?, ?, ? FROM applies a
+		INSERT INTO apply_comments (apply_id, comment_state, github_comment_id, posted_volume, posted_phase, pending_freeze_github_comment_id)
+		SELECT ?, ?, ?, ?, ?, ? FROM applies a
 		WHERE a.id = ? AND a.lease_token = ?
-		`+upsert, comment.ApplyID, comment.CommentState, comment.GitHubCommentID, comment.PostedVolume, comment.PendingFreezeCommentID, comment.ApplyID, lease.Token)
+		`+upsert, comment.ApplyID, comment.CommentState, comment.GitHubCommentID, comment.PostedVolume, comment.PostedPhase, comment.PendingFreezeCommentID, comment.ApplyID, lease.Token)
 	if err != nil {
 		return err
 	}
@@ -309,7 +311,7 @@ func scanApplyCommentInto(s scanner) (*storage.ApplyComment, error) {
 	var comment storage.ApplyComment
 	err := s.Scan(
 		&comment.ID, &comment.ApplyID, &comment.CommentState,
-		&comment.GitHubCommentID, &comment.PostedVolume, &comment.PendingFreezeCommentID, &comment.EditCount,
+		&comment.GitHubCommentID, &comment.PostedVolume, &comment.PostedPhase, &comment.PendingFreezeCommentID, &comment.EditCount,
 		&comment.LastEditedAt, &comment.SupersededAt, &comment.CreatedAt, &comment.UpdatedAt,
 	)
 	if err != nil {

--- a/pkg/storage/mysqlstore/apply_comments_test.go
+++ b/pkg/storage/mysqlstore/apply_comments_test.go
@@ -22,11 +22,13 @@ func TestApplyCommentStore_Upsert(t *testing.T) {
 	apply := createTestApply(t, store, lock, "apply_comment_upsert", 1)
 
 	postedVolume := 3
+	noPhase := ""
 	comment := &storage.ApplyComment{
 		ApplyID:         apply.ID,
 		CommentState:    state.Comment.Progress,
 		GitHubCommentID: 111222333,
 		PostedVolume:    &postedVolume,
+		PostedPhase:     &noPhase,
 	}
 
 	// Insert
@@ -41,25 +43,33 @@ func TestApplyCommentStore_Upsert(t *testing.T) {
 	assert.Equal(t, int64(111222333), retrieved.GitHubCommentID)
 	require.NotNil(t, retrieved.PostedVolume)
 	assert.Equal(t, 3, *retrieved.PostedVolume)
+	require.NotNil(t, retrieved.PostedPhase)
+	assert.Empty(t, *retrieved.PostedPhase)
 	assert.NotZero(t, retrieved.ID)
 	assert.NotZero(t, retrieved.CreatedAt)
 	assert.NotZero(t, retrieved.UpdatedAt)
 
-	// Upsert with new comment ID and level (simulates a volume-change rotation)
+	// Upsert with new comment ID, level, and control phase (simulates a
+	// rotation to a fresh comment)
 	comment.GitHubCommentID = 444555666
 	newVolume := 5
 	comment.PostedVolume = &newVolume
+	reverting := "reverting"
+	comment.PostedPhase = &reverting
 	require.NoError(t, store.ApplyComments().Upsert(ctx, comment))
 
-	// Verify upsert updated the comment ID and recorded level
+	// Verify upsert updated the comment ID and recorded level and phase
 	retrieved, err = store.ApplyComments().Get(ctx, apply.ID, state.Comment.Progress)
 	require.NoError(t, err)
 	require.NotNil(t, retrieved)
 	assert.Equal(t, int64(444555666), retrieved.GitHubCommentID)
 	require.NotNil(t, retrieved.PostedVolume)
 	assert.Equal(t, 5, *retrieved.PostedVolume)
+	require.NotNil(t, retrieved.PostedPhase)
+	assert.Equal(t, "reverting", *retrieved.PostedPhase)
 
-	// A summary comment carries no level; the column stays NULL and reads back nil.
+	// A summary comment carries no level or control phase; the columns stay
+	// NULL and read back nil.
 	summary := &storage.ApplyComment{
 		ApplyID:         apply.ID,
 		CommentState:    state.Comment.Summary,
@@ -70,6 +80,7 @@ func TestApplyCommentStore_Upsert(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, retrieved)
 	assert.Nil(t, retrieved.PostedVolume)
+	assert.Nil(t, retrieved.PostedPhase)
 }
 
 func TestApplyCommentStore_Get(t *testing.T) {

--- a/pkg/storage/mysqlstore/apply_comments_test.go
+++ b/pkg/storage/mysqlstore/apply_comments_test.go
@@ -54,7 +54,7 @@ func TestApplyCommentStore_Upsert(t *testing.T) {
 	comment.GitHubCommentID = 444555666
 	newVolume := 5
 	comment.PostedVolume = &newVolume
-	reverting := "reverting"
+	reverting := state.Apply.Reverting
 	comment.PostedPhase = &reverting
 	require.NoError(t, store.ApplyComments().Upsert(ctx, comment))
 
@@ -66,7 +66,7 @@ func TestApplyCommentStore_Upsert(t *testing.T) {
 	require.NotNil(t, retrieved.PostedVolume)
 	assert.Equal(t, 5, *retrieved.PostedVolume)
 	require.NotNil(t, retrieved.PostedPhase)
-	assert.Equal(t, "reverting", *retrieved.PostedPhase)
+	assert.Equal(t, state.Apply.Reverting, *retrieved.PostedPhase)
 
 	// A summary comment carries no level or control phase; the columns stay
 	// NULL and read back nil.

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -1135,6 +1135,16 @@ type ApplyComment struct {
 	// for rows that predate volume tracking — nil never triggers a rotation.
 	PostedVolume *int
 
+	// PostedPhase records the control-operation phase the apply was in when a
+	// progress comment was posted (e.g. reverting, skipping revert, the
+	// post-cutover revert window) — empty when the apply was in no such phase.
+	// An apply in a control phase whose tracked progress comment records a
+	// different phase predates that phase, so the observer rotates in a fresh
+	// comment to track it. Nil (a comment state where the phase is not
+	// meaningful, or a row predating phase tracking) is treated the same as
+	// empty: the comment still predates whatever phase the apply is in now.
+	PostedPhase *string
+
 	// PendingFreezeCommentID records the GitHub comment ID of a progress
 	// comment this row's comment superseded whose frozen rendering has not yet
 	// landed on GitHub. It is written in the same upsert that tracks the

--- a/pkg/webhook/check_cleanup_integration_test.go
+++ b/pkg/webhook/check_cleanup_integration_test.go
@@ -18,10 +18,28 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/block/schemabot/pkg/api"
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 )
+
+// waitForStoredAggregate polls until the stored global-aggregate check row for
+// the PR reports the given status and conclusion, then returns it for further
+// assertions. The aggregate Check Run is created on GitHub before the stored
+// row is upserted, so a test that has just observed the Check Run must poll
+// for the stored state instead of reading it once.
+func waitForStoredAggregate(t *testing.T, svc *api.Service, repo string, pr int, status, conclusion string) *storage.Check {
+	t.Helper()
+	var aggregate *storage.Check
+	require.Eventuallyf(t, func() bool {
+		var err error
+		aggregate, err = svc.Storage().Checks().Get(t.Context(), repo, pr, aggregateSentinel, aggregateSentinel, aggregateSentinel)
+		return err == nil && aggregate != nil && aggregate.Status == status && aggregate.Conclusion == conclusion
+	}, webhookIntegrationPollDeadline, 100*time.Millisecond,
+		"stored aggregate check state should report status %q and conclusion %q after the aggregate Check Run is published", status, conclusion)
+	return aggregate
+}
 
 // TestE2EPRCloseCleanup verifies PR-close cleanup against real storage. While
 // the PR has a running apply, closing it retains the database lock (so no other
@@ -281,12 +299,8 @@ func TestE2EReconcileStaleInProgressCheck(t *testing.T) {
 		t.Fatal("timed out waiting for aggregate check run")
 	}
 
-	aggregate, err := svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1, aggregateSentinel, aggregateSentinel, aggregateSentinel)
-	require.NoError(t, err)
-	require.NotNil(t, aggregate)
+	aggregate := waitForStoredAggregate(t, svc, "octocat/hello-world", 1, checkStatusInProgress, "")
 	assert.Equal(t, "abc123", aggregate.HeadSHA)
-	assert.Equal(t, checkStatusInProgress, aggregate.Status)
-	assert.Empty(t, aggregate.Conclusion)
 }
 
 // TestE2EReconcileStaleInProgressCheckFailure verifies startup/webhook
@@ -598,12 +612,8 @@ func TestE2EPRCloseReopenRetainsStartedApplyBlock(t *testing.T) {
 		}
 	}
 
-	aggregate, err := svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1, aggregateSentinel, aggregateSentinel, aggregateSentinel)
-	require.NoError(t, err)
-	require.NotNil(t, aggregate)
+	aggregate := waitForStoredAggregate(t, svc, "octocat/hello-world", 1, checkStatusCompleted, checkConclusionActionRequired)
 	assert.Equal(t, "abc123", aggregate.HeadSHA)
-	assert.Equal(t, checkStatusCompleted, aggregate.Status)
-	assert.Equal(t, checkConclusionActionRequired, aggregate.Conclusion)
 }
 
 // TestE2EUnmergedCloseRetainsSuccessfulApplyOwnedCheck verifies that closing a
@@ -745,10 +755,6 @@ func TestE2EUnmergedCloseRetainsSuccessfulApplyOwnedCheck(t *testing.T) {
 		}
 	}
 
-	aggregate, err := svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1, aggregateSentinel, aggregateSentinel, aggregateSentinel)
-	require.NoError(t, err)
-	require.NotNil(t, aggregate)
+	aggregate := waitForStoredAggregate(t, svc, "octocat/hello-world", 1, checkStatusCompleted, checkConclusionActionRequired)
 	assert.Equal(t, "abc123", aggregate.HeadSHA)
-	assert.Equal(t, checkStatusCompleted, aggregate.Status)
-	assert.Equal(t, checkConclusionActionRequired, aggregate.Conclusion)
 }

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -728,7 +728,7 @@ const (
 func (o *CommentObserver) frozenSupersededProgressBody(reason supersededProgressReason, volume int, newCommentID int64, previousBody string) string {
 	switch reason {
 	case supersededByResume:
-		return templates.RenderResumeSupersededProgressComment(templates.ResumeSupersededProgressData{
+		return templates.RenderResumeSupersededProgressComment(templates.SupersededProgressData{
 			Repo:         o.repo,
 			PR:           o.pr,
 			NewCommentID: newCommentID,

--- a/pkg/webhook/templates/issue_comment.go
+++ b/pkg/webhook/templates/issue_comment.go
@@ -315,6 +315,29 @@ type VolumeSupersededProgressData struct {
 // freeze retry can tell an already-frozen comment from a live one.
 const volumeSupersededPrefix = "⏩ Volume changed to"
 
+// supersededFoldMarker is the successor-link text renderSupersededFold embeds
+// in the headline of every frozen body. IsSupersededProgressComment requires
+// it alongside a flavor prefix, so a live comment that merely opens with the
+// same words as a prefix is never misread as already frozen.
+const supersededFoldMarker = " [a new progress comment](https://github.com/"
+
+// SupersededProgressData contains the data every superseded-comment fold
+// shares: where the successor comment lives and the superseded comment's last
+// rendered body. Rotation flavors with no flavor-specific data render directly
+// from it; flavors that carry extra data (volume) keep their own struct.
+type SupersededProgressData struct {
+	// Repo is the "owner/name" repository, used to link the successor comment.
+	Repo string
+	// PR is the pull request number, used to link the successor comment.
+	PR int
+	// NewCommentID is the GitHub comment ID of the fresh comment that now
+	// tracks the schema change.
+	NewCommentID int64
+	// PreviousBody is the superseded comment's last rendered body, preserved
+	// inside the folded details block.
+	PreviousBody string
+}
+
 // renderSupersededFold renders the frozen body written over a superseded
 // comment: a headline pointing at the successor comment, with the superseded
 // comment's last rendered body preserved inside a collapsed details block.
@@ -322,7 +345,7 @@ const volumeSupersededPrefix = "⏩ Volume changed to"
 // (which must start with that flavor's superseded prefix) and fold label.
 func renderSupersededFold(headline, foldLabel, repo string, pr int, newCommentID int64, previousBody string) string {
 	return fmt.Sprintf(
-		"%s [a new progress comment](https://github.com/%s/pull/%d#issuecomment-%d).\n\n"+
+		"%s"+supersededFoldMarker+"%s/pull/%d#issuecomment-%d).\n\n"+
 			"<details>\n<summary>%s</summary>\n\n%s\n\n</details>\n",
 		headline, repo, pr, newCommentID, foldLabel, previousBody)
 }
@@ -337,21 +360,6 @@ func RenderVolumeSupersededProgressComment(data VolumeSupersededProgressData) st
 		data.Repo, data.PR, data.NewCommentID, data.PreviousBody)
 }
 
-// ResumeSupersededProgressData contains data for freezing a progress comment
-// that a resume has superseded.
-type ResumeSupersededProgressData struct {
-	// Repo is the "owner/name" repository, used to link the successor comment.
-	Repo string
-	// PR is the pull request number, used to link the successor comment.
-	PR int
-	// NewCommentID is the GitHub comment ID of the fresh progress comment now
-	// tracking the schema change.
-	NewCommentID int64
-	// PreviousBody is the superseded comment's last rendered body, preserved
-	// inside the folded details block.
-	PreviousBody string
-}
-
 // resumeSupersededPrefix opens every frozen body written when a resume
 // superseded a progress comment; IsSupersededProgressComment keys on it so a
 // freeze retry can tell an already-frozen comment from a live one.
@@ -362,24 +370,9 @@ const resumeSupersededPrefix = "▶️ Schema change resumed"
 // comment's final pre-stop progress stays on the PR as a record, collapsed
 // into a details block, with a pointer to the comment where progress
 // continues.
-func RenderResumeSupersededProgressComment(data ResumeSupersededProgressData) string {
+func RenderResumeSupersededProgressComment(data SupersededProgressData) string {
 	return renderSupersededFold(resumeSupersededPrefix+" — progress continues in", "Progress before the stop",
 		data.Repo, data.PR, data.NewCommentID, data.PreviousBody)
-}
-
-// RevertSupersededProgressData contains data for freezing a progress comment
-// that a user revert has superseded.
-type RevertSupersededProgressData struct {
-	// Repo is the "owner/name" repository, used to link the successor comment.
-	Repo string
-	// PR is the pull request number, used to link the successor comment.
-	PR int
-	// NewCommentID is the GitHub comment ID of the fresh progress comment now
-	// tracking the revert.
-	NewCommentID int64
-	// PreviousBody is the superseded comment's last rendered body, preserved
-	// inside the folded details block.
-	PreviousBody string
 }
 
 // revertSupersededPrefix opens every frozen body written when a revert
@@ -392,24 +385,9 @@ const revertSupersededPrefix = "Schema change reverting"
 // comment's final pre-revert progress stays on the PR as a record, collapsed
 // into a details block, with a pointer to the comment where the revert is
 // tracked.
-func RenderRevertSupersededProgressComment(data RevertSupersededProgressData) string {
+func RenderRevertSupersededProgressComment(data SupersededProgressData) string {
 	return renderSupersededFold(revertSupersededPrefix+" — the revert is tracked in", "Progress before the revert",
 		data.Repo, data.PR, data.NewCommentID, data.PreviousBody)
-}
-
-// SkipRevertSupersededProgressData contains data for freezing a progress
-// comment that a user skip-revert has superseded.
-type SkipRevertSupersededProgressData struct {
-	// Repo is the "owner/name" repository, used to link the successor comment.
-	Repo string
-	// PR is the pull request number, used to link the successor comment.
-	PR int
-	// NewCommentID is the GitHub comment ID of the fresh progress comment now
-	// tracking the finalization.
-	NewCommentID int64
-	// PreviousBody is the superseded comment's last rendered body, preserved
-	// inside the folded details block.
-	PreviousBody string
 }
 
 // skipRevertSupersededPrefix opens every frozen body written when a
@@ -422,25 +400,9 @@ const skipRevertSupersededPrefix = "Revert skipped"
 // old comment's final revert-window rendering stays on the PR as a record,
 // collapsed into a details block, with a pointer to the comment where the
 // finalization is tracked.
-func RenderSkipRevertSupersededProgressComment(data SkipRevertSupersededProgressData) string {
+func RenderSkipRevertSupersededProgressComment(data SupersededProgressData) string {
 	return renderSupersededFold(skipRevertSupersededPrefix+" — the schema change is finalizing in", "Progress before the revert was skipped",
 		data.Repo, data.PR, data.NewCommentID, data.PreviousBody)
-}
-
-// CutoverSupersededCommentData contains data for freezing a cutover prompt
-// comment once the triggered cutover has completed and a fresh progress
-// comment tracks the apply again.
-type CutoverSupersededCommentData struct {
-	// Repo is the "owner/name" repository, used to link the successor comment.
-	Repo string
-	// PR is the pull request number, used to link the successor comment.
-	PR int
-	// NewCommentID is the GitHub comment ID of the fresh progress comment now
-	// tracking the apply after cutover.
-	NewCommentID int64
-	// PreviousBody is the superseded cutover comment's last rendered body,
-	// preserved inside the folded details block.
-	PreviousBody string
 }
 
 // cutoverSupersededPrefix opens every frozen body written when a completed
@@ -454,26 +416,9 @@ const cutoverSupersededPrefix = "Cutover complete"
 // apply continues (e.g. into its revert window). The prompt stays on the PR as
 // a record, collapsed into a details block, with a pointer to the comment
 // where progress is tracked.
-func RenderCutoverSupersededComment(data CutoverSupersededCommentData) string {
+func RenderCutoverSupersededComment(data SupersededProgressData) string {
 	return renderSupersededFold(cutoverSupersededPrefix+" — progress continues in", "Cutover prompt",
 		data.Repo, data.PR, data.NewCommentID, data.PreviousBody)
-}
-
-// SupersededProgressData contains data for freezing a progress comment when
-// the rotation that superseded it is no longer known — the retry path for a
-// freeze owed by an earlier rotation, where only the owed comment ID was
-// recorded.
-type SupersededProgressData struct {
-	// Repo is the "owner/name" repository, used to link the successor comment.
-	Repo string
-	// PR is the pull request number, used to link the successor comment.
-	PR int
-	// NewCommentID is the GitHub comment ID of the fresh progress comment now
-	// tracking the schema change.
-	NewCommentID int64
-	// PreviousBody is the superseded comment's last rendered body, preserved
-	// inside the folded details block.
-	PreviousBody string
 }
 
 // genericSupersededPrefix opens every frozen body written when the superseding
@@ -493,8 +438,16 @@ func RenderSupersededProgressComment(data SupersededProgressData) string {
 
 // IsSupersededProgressComment reports whether a comment body is already a
 // frozen superseded rendering — any rotation flavor — so a freeze retry does
-// not wrap a frozen body in a second fold.
+// not wrap a frozen body in a second fold. A frozen body opens with a flavor
+// prefix and carries the successor link on that same headline; both are
+// required, so a live body that merely opens with the same words as a prefix
+// (e.g. an edited comment starting "Cutover complete") is never mistaken for
+// a frozen one and skipped by a freeze retry.
 func IsSupersededProgressComment(body string) bool {
+	headline, _, _ := strings.Cut(body, "\n")
+	if !strings.Contains(headline, supersededFoldMarker) {
+		return false
+	}
 	for _, prefix := range []string{
 		volumeSupersededPrefix,
 		resumeSupersededPrefix,
@@ -503,7 +456,7 @@ func IsSupersededProgressComment(body string) bool {
 		cutoverSupersededPrefix,
 		genericSupersededPrefix,
 	} {
-		if strings.HasPrefix(body, prefix) {
+		if strings.HasPrefix(headline, prefix) {
 			return true
 		}
 	}

--- a/pkg/webhook/templates/issue_comment.go
+++ b/pkg/webhook/templates/issue_comment.go
@@ -315,15 +315,26 @@ type VolumeSupersededProgressData struct {
 // freeze retry can tell an already-frozen comment from a live one.
 const volumeSupersededPrefix = "⏩ Volume changed to"
 
+// renderSupersededFold renders the frozen body written over a superseded
+// comment: a headline pointing at the successor comment, with the superseded
+// comment's last rendered body preserved inside a collapsed details block.
+// Every rotation flavor shares this shape and differs only in its headline
+// (which must start with that flavor's superseded prefix) and fold label.
+func renderSupersededFold(headline, foldLabel, repo string, pr int, newCommentID int64, previousBody string) string {
+	return fmt.Sprintf(
+		headline+" [a new progress comment](https://github.com/%s/pull/%d#issuecomment-%d).\n\n"+
+			"<details>\n<summary>%s</summary>\n\n%s\n\n</details>\n",
+		repo, pr, newCommentID, foldLabel, previousBody)
+}
+
 // RenderVolumeSupersededProgressComment renders the frozen body written over a
 // progress comment once a volume change rotates in a fresh one. The old
 // comment's final progress stays on the PR as a record, collapsed into a
 // details block, with a pointer to the comment where progress continues.
 func RenderVolumeSupersededProgressComment(data VolumeSupersededProgressData) string {
-	return fmt.Sprintf(
-		volumeSupersededPrefix+" **%d/%d** — progress continues in [a new progress comment](https://github.com/%s/pull/%d#issuecomment-%d).\n\n"+
-			"<details>\n<summary>Progress before the volume change</summary>\n\n%s\n\n</details>\n",
-		data.Volume, storage.MaxVolume, data.Repo, data.PR, data.NewCommentID, data.PreviousBody)
+	headline := fmt.Sprintf("%s **%d/%d** — progress continues in", volumeSupersededPrefix, data.Volume, storage.MaxVolume)
+	return renderSupersededFold(headline, "Progress before the volume change",
+		data.Repo, data.PR, data.NewCommentID, data.PreviousBody)
 }
 
 // ResumeSupersededProgressData contains data for freezing a progress comment
@@ -352,9 +363,99 @@ const resumeSupersededPrefix = "▶️ Schema change resumed"
 // into a details block, with a pointer to the comment where progress
 // continues.
 func RenderResumeSupersededProgressComment(data ResumeSupersededProgressData) string {
-	return fmt.Sprintf(
-		resumeSupersededPrefix+" — progress continues in [a new progress comment](https://github.com/%s/pull/%d#issuecomment-%d).\n\n"+
-			"<details>\n<summary>Progress before the stop</summary>\n\n%s\n\n</details>\n",
+	return renderSupersededFold(resumeSupersededPrefix+" — progress continues in", "Progress before the stop",
+		data.Repo, data.PR, data.NewCommentID, data.PreviousBody)
+}
+
+// RevertSupersededProgressData contains data for freezing a progress comment
+// that a user revert has superseded.
+type RevertSupersededProgressData struct {
+	// Repo is the "owner/name" repository, used to link the successor comment.
+	Repo string
+	// PR is the pull request number, used to link the successor comment.
+	PR int
+	// NewCommentID is the GitHub comment ID of the fresh progress comment now
+	// tracking the revert.
+	NewCommentID int64
+	// PreviousBody is the superseded comment's last rendered body, preserved
+	// inside the folded details block.
+	PreviousBody string
+}
+
+// revertSupersededPrefix opens every frozen body written when a revert
+// superseded a progress comment; IsSupersededProgressComment keys on it so a
+// freeze retry can tell an already-frozen comment from a live one.
+const revertSupersededPrefix = "Schema change reverting"
+
+// RenderRevertSupersededProgressComment renders the frozen body written over a
+// progress comment once a user revert rotates in a fresh one. The old
+// comment's final pre-revert progress stays on the PR as a record, collapsed
+// into a details block, with a pointer to the comment where the revert is
+// tracked.
+func RenderRevertSupersededProgressComment(data RevertSupersededProgressData) string {
+	return renderSupersededFold(revertSupersededPrefix+" — the revert is tracked in", "Progress before the revert",
+		data.Repo, data.PR, data.NewCommentID, data.PreviousBody)
+}
+
+// SkipRevertSupersededProgressData contains data for freezing a progress
+// comment that a user skip-revert has superseded.
+type SkipRevertSupersededProgressData struct {
+	// Repo is the "owner/name" repository, used to link the successor comment.
+	Repo string
+	// PR is the pull request number, used to link the successor comment.
+	PR int
+	// NewCommentID is the GitHub comment ID of the fresh progress comment now
+	// tracking the finalization.
+	NewCommentID int64
+	// PreviousBody is the superseded comment's last rendered body, preserved
+	// inside the folded details block.
+	PreviousBody string
+}
+
+// skipRevertSupersededPrefix opens every frozen body written when a
+// skip-revert superseded a progress comment; IsSupersededProgressComment keys
+// on it so a freeze retry can tell an already-frozen comment from a live one.
+const skipRevertSupersededPrefix = "Revert skipped"
+
+// RenderSkipRevertSupersededProgressComment renders the frozen body written
+// over a progress comment once a user skip-revert rotates in a fresh one. The
+// old comment's final revert-window rendering stays on the PR as a record,
+// collapsed into a details block, with a pointer to the comment where the
+// finalization is tracked.
+func RenderSkipRevertSupersededProgressComment(data SkipRevertSupersededProgressData) string {
+	return renderSupersededFold(skipRevertSupersededPrefix+" — the schema change is finalizing in", "Progress before the revert was skipped",
+		data.Repo, data.PR, data.NewCommentID, data.PreviousBody)
+}
+
+// CutoverSupersededCommentData contains data for freezing a cutover prompt
+// comment once the triggered cutover has completed and a fresh progress
+// comment tracks the apply again.
+type CutoverSupersededCommentData struct {
+	// Repo is the "owner/name" repository, used to link the successor comment.
+	Repo string
+	// PR is the pull request number, used to link the successor comment.
+	PR int
+	// NewCommentID is the GitHub comment ID of the fresh progress comment now
+	// tracking the apply after cutover.
+	NewCommentID int64
+	// PreviousBody is the superseded cutover comment's last rendered body,
+	// preserved inside the folded details block.
+	PreviousBody string
+}
+
+// cutoverSupersededPrefix opens every frozen body written when a completed
+// cutover superseded the cutover prompt comment; IsSupersededProgressComment
+// keys on it so a freeze retry can tell an already-frozen comment from a live
+// one.
+const cutoverSupersededPrefix = "Cutover complete"
+
+// RenderCutoverSupersededComment renders the frozen body written over the
+// cutover prompt comment once the operator's cutover has completed and the
+// apply continues (e.g. into its revert window). The prompt stays on the PR as
+// a record, collapsed into a details block, with a pointer to the comment
+// where progress is tracked.
+func RenderCutoverSupersededComment(data CutoverSupersededCommentData) string {
+	return renderSupersededFold(cutoverSupersededPrefix+" — progress continues in", "Cutover prompt",
 		data.Repo, data.PR, data.NewCommentID, data.PreviousBody)
 }
 
@@ -386,19 +487,27 @@ const genericSupersededPrefix = "⏭️ Progress comment superseded"
 // a record, collapsed into a details block, with a pointer to the comment
 // where progress continues.
 func RenderSupersededProgressComment(data SupersededProgressData) string {
-	return fmt.Sprintf(
-		genericSupersededPrefix+" — progress continues in [a new progress comment](https://github.com/%s/pull/%d#issuecomment-%d).\n\n"+
-			"<details>\n<summary>Earlier progress</summary>\n\n%s\n\n</details>\n",
+	return renderSupersededFold(genericSupersededPrefix+" — progress continues in", "Earlier progress",
 		data.Repo, data.PR, data.NewCommentID, data.PreviousBody)
 }
 
 // IsSupersededProgressComment reports whether a comment body is already a
-// frozen superseded-progress rendering — either flavor — so a freeze retry
-// does not wrap a frozen body in a second fold.
+// frozen superseded rendering — any rotation flavor — so a freeze retry does
+// not wrap a frozen body in a second fold.
 func IsSupersededProgressComment(body string) bool {
-	return strings.HasPrefix(body, volumeSupersededPrefix) ||
-		strings.HasPrefix(body, resumeSupersededPrefix) ||
-		strings.HasPrefix(body, genericSupersededPrefix)
+	for _, prefix := range []string{
+		volumeSupersededPrefix,
+		resumeSupersededPrefix,
+		revertSupersededPrefix,
+		skipRevertSupersededPrefix,
+		cutoverSupersededPrefix,
+		genericSupersededPrefix,
+	} {
+		if strings.HasPrefix(body, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // RenderCutoverCommandAccepted renders the acknowledgement posted when a PR

--- a/pkg/webhook/templates/issue_comment.go
+++ b/pkg/webhook/templates/issue_comment.go
@@ -322,9 +322,9 @@ const volumeSupersededPrefix = "⏩ Volume changed to"
 // (which must start with that flavor's superseded prefix) and fold label.
 func renderSupersededFold(headline, foldLabel, repo string, pr int, newCommentID int64, previousBody string) string {
 	return fmt.Sprintf(
-		headline+" [a new progress comment](https://github.com/%s/pull/%d#issuecomment-%d).\n\n"+
+		"%s [a new progress comment](https://github.com/%s/pull/%d#issuecomment-%d).\n\n"+
 			"<details>\n<summary>%s</summary>\n\n%s\n\n</details>\n",
-		repo, pr, newCommentID, foldLabel, previousBody)
+		headline, repo, pr, newCommentID, foldLabel, previousBody)
 }
 
 // RenderVolumeSupersededProgressComment renders the frozen body written over a

--- a/pkg/webhook/templates/issue_comment_test.go
+++ b/pkg/webhook/templates/issue_comment_test.go
@@ -215,7 +215,7 @@ func TestRenderVolumeSupersededProgressComment(t *testing.T) {
 // and folds the final pre-stop progress into a details block so the record
 // stays on the PR without looking live.
 func TestRenderResumeSupersededProgressComment(t *testing.T) {
-	rendered := RenderResumeSupersededProgressComment(ResumeSupersededProgressData{
+	rendered := RenderResumeSupersededProgressComment(SupersededProgressData{
 		Repo:         "acme/testapp",
 		PR:           42,
 		NewCommentID: 2222222222,
@@ -254,22 +254,38 @@ func TestRenderSupersededProgressComment(t *testing.T) {
 
 // TestIsSupersededProgressComment verifies the frozen-body predicate accepts
 // every frozen flavor — so a freeze retry never folds a frozen body inside a
-// second fold — and rejects a live progress body.
+// second fold — and rejects live bodies, including ones that open with the
+// same words as a flavor prefix, so a freeze retry never skips a comment that
+// still needs folding.
 func TestIsSupersededProgressComment(t *testing.T) {
-	volume := RenderVolumeSupersededProgressComment(VolumeSupersededProgressData{
-		Volume: 8, Repo: "acme/testapp", PR: 42, NewCommentID: 1, PreviousBody: "old",
-	})
-	resume := RenderResumeSupersededProgressComment(ResumeSupersededProgressData{
+	shared := SupersededProgressData{
 		Repo: "acme/testapp", PR: 42, NewCommentID: 1, PreviousBody: "old",
-	})
-	generic := RenderSupersededProgressComment(SupersededProgressData{
-		Repo: "acme/testapp", PR: 42, NewCommentID: 1, PreviousBody: "old",
-	})
-	assert.True(t, IsSupersededProgressComment(volume), "a volume-frozen body is recognized as frozen")
-	assert.True(t, IsSupersededProgressComment(resume), "a resume-frozen body is recognized as frozen")
-	assert.True(t, IsSupersededProgressComment(generic), "a generic-frozen body is recognized as frozen")
-	assert.False(t, IsSupersededProgressComment("## Schema Change Status — Staging"),
-		"a live progress body is not frozen")
+	}
+	frozen := map[string]string{
+		"volume": RenderVolumeSupersededProgressComment(VolumeSupersededProgressData{
+			Volume: 8, Repo: "acme/testapp", PR: 42, NewCommentID: 1, PreviousBody: "old",
+		}),
+		"resume":      RenderResumeSupersededProgressComment(shared),
+		"revert":      RenderRevertSupersededProgressComment(shared),
+		"skip-revert": RenderSkipRevertSupersededProgressComment(shared),
+		"cutover":     RenderCutoverSupersededComment(shared),
+		"generic":     RenderSupersededProgressComment(shared),
+	}
+	for flavor, body := range frozen {
+		assert.Truef(t, IsSupersededProgressComment(body),
+			"a %s-frozen body is recognized as frozen", flavor)
+	}
+
+	live := map[string]string{
+		"progress body":            "## Schema Change Status — Staging",
+		"cutover-complete wording": "Cutover complete — the schema change is finalizing.",
+		"reverting wording":        "Schema change reverting — see the table below.",
+		"skip-revert wording":      "Revert skipped by the operator.",
+	}
+	for name, body := range live {
+		assert.Falsef(t, IsSupersededProgressComment(body),
+			"a live %s is not frozen", name)
+	}
 }
 
 func TestRenderRevertCommandAccepted(t *testing.T) {

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -1479,7 +1479,7 @@ func PreviewCommentResumeSupersededProgress() string {
 	table.RowsTotal = 7200000
 	table.PercentComplete = 32
 	data := sampleSingleApplyData(state.Apply.Stopped, table)
-	return RenderResumeSupersededProgressComment(ResumeSupersededProgressData{
+	return RenderResumeSupersededProgressComment(SupersededProgressData{
 		Repo:         "acme/testapp",
 		PR:           42,
 		NewCommentID: 2222222222,
@@ -1497,7 +1497,7 @@ func PreviewCommentRevertSupersededProgress() string {
 	table.RowsTotal = 7200000
 	table.PercentComplete = 100
 	data := sampleSingleApplyData(state.Apply.RevertWindow, table)
-	return RenderRevertSupersededProgressComment(RevertSupersededProgressData{
+	return RenderRevertSupersededProgressComment(SupersededProgressData{
 		Repo:         "acme/testapp",
 		PR:           42,
 		NewCommentID: 2222222222,
@@ -1516,7 +1516,7 @@ func PreviewCommentSkipRevertSupersededProgress() string {
 	table.RowsTotal = 7200000
 	table.PercentComplete = 100
 	data := sampleSingleApplyData(state.Apply.RevertWindow, table)
-	return RenderSkipRevertSupersededProgressComment(SkipRevertSupersededProgressData{
+	return RenderSkipRevertSupersededProgressComment(SupersededProgressData{
 		Repo:         "acme/testapp",
 		PR:           42,
 		NewCommentID: 2222222222,
@@ -1535,7 +1535,7 @@ func PreviewCommentCutoverSuperseded() string {
 	table.RowsTotal = 7200000
 	table.PercentComplete = 100
 	data := sampleSingleApplyData(state.Apply.WaitingForCutover, table)
-	return RenderCutoverSupersededComment(CutoverSupersededCommentData{
+	return RenderCutoverSupersededComment(SupersededProgressData{
 		Repo:         "acme/testapp",
 		PR:           42,
 		NewCommentID: 2222222222,

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -1487,6 +1487,62 @@ func PreviewCommentResumeSupersededProgress() string {
 	})
 }
 
+// PreviewCommentRevertSupersededProgress renders an old progress comment after
+// a user revert froze it: the final revert-window rendering collapses into a
+// details block under a pointer to the fresh comment now tracking the revert.
+func PreviewCommentRevertSupersededProgress() string {
+	table := sampleSingleTable()
+	table.Status = state.Task.RevertWindow
+	table.RowsCopied = 7200000
+	table.RowsTotal = 7200000
+	table.PercentComplete = 100
+	data := sampleSingleApplyData(state.Apply.RevertWindow, table)
+	return RenderRevertSupersededProgressComment(RevertSupersededProgressData{
+		Repo:         "acme/testapp",
+		PR:           42,
+		NewCommentID: 2222222222,
+		PreviousBody: RenderApplyStatusComment(data),
+	})
+}
+
+// PreviewCommentSkipRevertSupersededProgress renders an old progress comment
+// after a skip-revert froze it: the final revert-window rendering collapses
+// into a details block under a pointer to the fresh comment now tracking the
+// finalizing schema change.
+func PreviewCommentSkipRevertSupersededProgress() string {
+	table := sampleSingleTable()
+	table.Status = state.Task.RevertWindow
+	table.RowsCopied = 7200000
+	table.RowsTotal = 7200000
+	table.PercentComplete = 100
+	data := sampleSingleApplyData(state.Apply.RevertWindow, table)
+	return RenderSkipRevertSupersededProgressComment(SkipRevertSupersededProgressData{
+		Repo:         "acme/testapp",
+		PR:           42,
+		NewCommentID: 2222222222,
+		PreviousBody: RenderApplyStatusComment(data),
+	})
+}
+
+// PreviewCommentCutoverSuperseded renders a spent cutover prompt after a
+// deferred cutover completed into a still-active apply: the prompt collapses
+// into a details block under a pointer to the fresh comment now tracking the
+// post-cutover phase.
+func PreviewCommentCutoverSuperseded() string {
+	table := sampleSingleTable()
+	table.Status = state.Task.WaitingForCutover
+	table.RowsCopied = 7200000
+	table.RowsTotal = 7200000
+	table.PercentComplete = 100
+	data := sampleSingleApplyData(state.Apply.WaitingForCutover, table)
+	return RenderCutoverSupersededComment(CutoverSupersededCommentData{
+		Repo:         "acme/testapp",
+		PR:           42,
+		NewCommentID: 2222222222,
+		PreviousBody: RenderApplyStatusComment(data),
+	})
+}
+
 // PreviewCommentSupersededProgress renders an old progress comment after a
 // freeze retry folded it without knowing which rotation superseded it: the
 // final progress collapses into a details block under a pointer to the fresh


### PR DESCRIPTION
## Why this matters

Comment rotation — posting a fresh progress comment at the bottom of the PR when an operator command takes effect — needs a durable, cross-pod signal for whether the tracked comment predates the operation. Volume changes already record `posted_volume`; control operations (revert, skip-revert, deferred cutover) have no equivalent, so rotation for them can't be made restart- and re-claim-safe.

## What it does

- Adds `posted_phase` to `apply_comments` (with `ApplyComment.PostedPhase` plumbing): the control phase the apply was in when the tracked comment was posted. Rows predating the column read as no phase, which downstream consumers treat as "predates whatever phase the apply is in now".
- Extracts the shared superseded-fold rendering: every rotation flavor freezes the comment it supersedes into a collapsed details block headlined with a pointer at its successor, differing only in headline and fold label. Adds the revert, skip-revert, and cutover-complete fold flavors alongside the existing volume/resume/generic ones, and extends `IsSupersededProgressComment` to recognize all of them so freeze retries never double-fold a body.

Storage and template plumbing only — no observer behavior changes. The rotation logic that consumes the phase lands in the stacked follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)