### PR TITLE
fix(github): rotate in a fresh progress comment after a deferred cutover

### DIFF
--- a/pkg/webhook/apply_comment_integration_test.go
+++ b/pkg/webhook/apply_comment_integration_test.go
@@ -1127,6 +1127,317 @@ func TestE2EControlPhaseRotationReconcilesPendingFreezeFromPriorDrive(t *testing
 	}
 }
 
+// When a deferred cutover completes into a still-active apply (the revert
+// window), the observer unmutes and posts a fresh progress comment tracking
+// the post-cutover phase — the operator issued the cutover command, so its
+// effect belongs at the bottom of the PR timeline. The spent cutover prompt is
+// frozen into a collapsed details block pointing at the fresh comment, its
+// stored row is superseded so no later observer treats it as the live comment,
+// and later progress edits land on the fresh comment.
+func TestE2EDeferredCutoverRotatesProgressComment(t *testing.T) {
+	ctx := t.Context()
+
+	// The apply copied all rows and paused at the deferred-cutover gate: the
+	// progress comment froze and the cutover prompt was posted.
+	f := setupApplyCommentFixture(t, applyCommentFixtureParams{
+		repo:       "org/repo-cutover-rotate",
+		pr:         146,
+		database:   "e2e_cutover_rotate_db",
+		applyState: state.Apply.WaitingForCutover,
+	})
+	st, apply, task, capture, h := f.st, f.apply, f.task, f.capture, f.handler
+
+	h.postAndTrackComment(ctx, "org/repo-cutover-rotate", 146, 12345, apply, state.Comment.Progress, "Copy complete — waiting for cutover")
+	preCutoverProgressID := requireCommentCreate(t, capture)
+	h.postAndTrackComment(ctx, "org/repo-cutover-rotate", 146, 12345, apply, state.Comment.Cutover, "Ready for cutover — run `schemabot cutover` to proceed")
+	cutoverPromptID := requireCommentCreate(t, capture)
+
+	fake := clock.NewFake(task.CreatedAt)
+	obs := f.newObserver(st, fake)
+
+	// The operator ran the cutover and it completed into the revert window.
+	// The first progress tick past the gate rotates: fresh comment in, prompt
+	// folded.
+	apply.State = state.Apply.RevertWindow
+	task.State = state.Task.RevertWindow
+	obs.OnProgress(apply, []*storage.Task{task})
+
+	var newProgressID int64
+	select {
+	case created := <-capture.creates:
+		newProgressID = created.ID
+		assert.Contains(t, created.Body, "Schema Change Status — Staging")
+		assert.Contains(t, created.Body, "**Status**: Revert Window")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected a new progress comment to be posted when the deferred cutover completes")
+	}
+	assert.NotEqual(t, cutoverPromptID, newProgressID, "the rotation must post a new comment, not reuse the cutover prompt")
+	assert.NotEqual(t, preCutoverProgressID, newProgressID, "the rotation must post a new comment, not reuse the frozen progress comment")
+
+	// The spent cutover prompt is frozen into a collapsed details block
+	// pointing at its successor, with the prompt preserved inside the fold.
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, cutoverPromptID, edited.CommentID, "the freeze edit lands on the cutover prompt")
+		assert.Contains(t, edited.Body, "Cutover complete")
+		assert.Contains(t, edited.Body, fmt.Sprintf("#issuecomment-%d", newProgressID), "the frozen prompt links to its successor")
+		assert.Contains(t, edited.Body, "<details>")
+		assert.Contains(t, edited.Body, "Ready for cutover", "the prompt body is preserved inside the fold")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the cutover prompt to be frozen")
+	}
+
+	// The progress row tracks the new comment with no freeze left owing and
+	// records the post-cutover phase; the cutover row is consumed so no later
+	// observer treats the folded prompt as the live comment.
+	prog, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Progress)
+	require.NoError(t, err)
+	require.NotNil(t, prog)
+	assert.Equal(t, newProgressID, prog.GitHubCommentID)
+	assert.Nil(t, prog.PendingFreezeCommentID)
+	require.NotNil(t, prog.PostedPhase)
+	assert.Equal(t, "revert_window", *prog.PostedPhase, "the fresh comment records the post-cutover phase")
+	cutoverRow, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Cutover)
+	require.NoError(t, err)
+	require.NotNil(t, cutoverRow)
+	assert.NotNil(t, cutoverRow.SupersededAt, "the cutover row is superseded once its prompt is folded")
+
+	// A later tick edits the fresh comment in place — the observer is unmuted
+	// and the rotation happened exactly once.
+	fake.Advance(activeInterval + time.Second)
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, newProgressID, edited.CommentID, "later edits land on the fresh comment")
+	case created := <-capture.creates:
+		t.Fatalf("a deferred cutover must rotate exactly once; got another new comment %d", created.ID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected an in-place edit of the fresh progress comment on the next tick")
+	}
+
+	// A fresh observer — a later drive claim after a restart — finds the
+	// superseded cutover row and the recorded post-cutover phase, stays
+	// unmuted, and edits the tracked comment in place.
+	obs2 := f.newObserver(st, fake)
+	task.RowsCopied = 900
+	task.ProgressPercent = 90
+	fake.Advance(activeInterval + time.Second)
+	obs2.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, newProgressID, edited.CommentID, "a fresh observer edits the tracked comment in place")
+	case created := <-capture.creates:
+		t.Fatalf("a fresh observer must not rotate for a cutover already tracked; got new comment %d", created.ID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the fresh observer to edit the tracked progress comment")
+	}
+}
+
+// A post-cutover rotation whose fresh comment lands but whose cutover-row
+// supersede write fails must not re-mute the observer: the rotation already
+// happened, so the still-live row is stale. Later ticks keep editing the
+// fresh comment while retrying the supersede, and once storage heals the row
+// is consumed so later observers neither re-mute on the folded prompt nor
+// complete it on terminal.
+func TestE2EDeferredCutoverSupersedeRetriedUntilItLands(t *testing.T) {
+	ctx := t.Context()
+
+	f := setupApplyCommentFixture(t, applyCommentFixtureParams{
+		repo:       "org/repo-cutover-supersede-retry",
+		pr:         149,
+		database:   "e2e_cutover_supersede_retry_db",
+		applyState: state.Apply.WaitingForCutover,
+	})
+	st, apply, task, capture, h := f.st, f.apply, f.task, f.capture, f.handler
+
+	h.postAndTrackComment(ctx, "org/repo-cutover-supersede-retry", 149, 12345, apply, state.Comment.Progress, "Copy complete — waiting for cutover")
+	requireCommentCreate(t, capture)
+	h.postAndTrackComment(ctx, "org/repo-cutover-supersede-retry", 149, 12345, apply, state.Comment.Cutover, "Ready for cutover")
+	cutoverPromptID := requireCommentCreate(t, capture)
+
+	failingStorage := &failingCommentSupersedeStorage{Storage: st}
+	fake := clock.NewFake(task.CreatedAt)
+	obs := f.newObserver(failingStorage, fake)
+
+	// The cutover completes into the revert window. The rotation posts the
+	// fresh comment and folds the prompt, but consuming the cutover row fails.
+	apply.State = state.Apply.RevertWindow
+	task.State = state.Task.RevertWindow
+	obs.OnProgress(apply, []*storage.Task{task})
+
+	var freshProgressID int64
+	select {
+	case created := <-capture.creates:
+		freshProgressID = created.ID
+		assert.Contains(t, created.Body, "**Status**: Revert Window")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the rotation to post a fresh progress comment")
+	}
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, cutoverPromptID, edited.CommentID, "the freeze edit lands on the cutover prompt")
+		assert.Contains(t, edited.Body, "Cutover complete")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the cutover prompt to be frozen")
+	}
+	cutoverRow, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Cutover)
+	require.NoError(t, err)
+	require.NotNil(t, cutoverRow)
+	require.Nil(t, cutoverRow.SupersededAt, "the injected outage keeps the cutover row live")
+
+	// While the outage lasts, later ticks keep editing the fresh comment — the
+	// still-live cutover row is known-stale to this observer — and never post
+	// a duplicate rotation.
+	task.RowsCopied = 700
+	task.ProgressPercent = 70
+	fake.Advance(activeInterval + time.Second)
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, freshProgressID, edited.CommentID, "progress edits land on the fresh comment while the supersede is owed")
+	case created := <-capture.creates:
+		t.Fatalf("a deferred cutover must rotate exactly once; got another new comment %d", created.ID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected an in-place edit of the fresh progress comment during the outage")
+	}
+
+	// Once storage heals, the next tick's retry consumes the cutover row while
+	// the tick still edits the fresh comment in place.
+	failingStorage.heal()
+	task.RowsCopied = 800
+	task.ProgressPercent = 80
+	fake.Advance(activeInterval + time.Second)
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, freshProgressID, edited.CommentID)
+	case created := <-capture.creates:
+		t.Fatalf("the supersede retry must not post a comment; got %d", created.ID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected an in-place edit of the fresh progress comment after healing")
+	}
+	cutoverRow, err = st.ApplyComments().Get(ctx, apply.ID, state.Comment.Cutover)
+	require.NoError(t, err)
+	require.NotNil(t, cutoverRow)
+	assert.NotNil(t, cutoverRow.SupersededAt, "the retried supersede consumes the cutover row once storage heals")
+}
+
+// A fresh rotation comment that posted but was never recorded (a storage
+// outage between the post and the tracking write) is adopted before the
+// cutover prompt posts and before the post-cutover rotation runs, in the same
+// order the comments landed on the PR. The tracked row therefore always moves
+// forward — prior comment, adopted comment, post-cutover comment — and never
+// regresses to a stale comment after a newer one was tracked.
+func TestE2EPendingRotationAdoptedBeforeCutoverPrompt(t *testing.T) {
+	ctx := t.Context()
+
+	f := setupApplyCommentFixture(t, applyCommentFixtureParams{
+		repo:       "org/repo-pending-adoption-cutover",
+		pr:         150,
+		database:   "e2e_pending_adoption_cutover_db",
+		applyState: state.Apply.Running,
+		volume:     3,
+	})
+	st, apply, task, capture, h := f.st, f.apply, f.task, f.capture, f.handler
+
+	h.postAndTrackComment(ctx, "org/repo-pending-adoption-cutover", 150, 12345, apply, state.Comment.Progress, "Copying at volume 3")
+	initialProgressID := requireCommentCreate(t, capture)
+
+	failingStorage := &failingCommentUpsertStorage{Storage: st}
+	fake := clock.NewFake(task.CreatedAt)
+	obs := f.newObserver(failingStorage, fake)
+
+	// A volume change posts a fresh comment, but recording it as the tracked
+	// comment fails — it stays pending adoption.
+	apply.SetOptions(storage.ApplyOptions{Volume: 5, DeferCutover: true})
+	fake.Advance(activeInterval + time.Second)
+	obs.OnProgress(apply, []*storage.Task{task})
+
+	var volumeProgressID int64
+	select {
+	case created := <-capture.creates:
+		volumeProgressID = created.ID
+		assert.Contains(t, created.Body, "Volume: 5/11")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the volume change to post a fresh progress comment")
+	}
+
+	// Storage heals and the apply reaches the deferred-cutover gate on the
+	// same tick. The pending comment is adopted first — freezing its
+	// predecessor — and only then does the cutover prompt post, matching the
+	// order the comments sit on the PR.
+	failingStorage.heal()
+	apply.State = state.Apply.CuttingOver
+	fake.Advance(activeInterval + time.Second)
+	obs.OnProgress(apply, []*storage.Task{task})
+
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, initialProgressID, edited.CommentID, "adoption freezes the pending comment's predecessor")
+		assert.Contains(t, edited.Body, fmt.Sprintf("#issuecomment-%d", volumeProgressID), "the frozen comment links to its adopted successor")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the pending comment's predecessor to be frozen at the gate tick")
+	}
+	var cutoverPromptID int64
+	select {
+	case created := <-capture.creates:
+		cutoverPromptID = created.ID
+		assert.Contains(t, created.Body, "**Status**: Cutting Over")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the cutover prompt to be posted at the gate")
+	}
+	prog, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Progress)
+	require.NoError(t, err)
+	require.NotNil(t, prog)
+	assert.Equal(t, volumeProgressID, prog.GitHubCommentID, "the tracked row records the adopted comment before the gate")
+
+	// The cutover completes into the revert window: the post-cutover rotation
+	// posts a fresh comment tracking the new phase and folds the spent prompt.
+	apply.State = state.Apply.RevertWindow
+	task.State = state.Task.RevertWindow
+	fake.Advance(activeInterval + time.Second)
+	obs.OnProgress(apply, []*storage.Task{task})
+
+	var postCutoverProgressID int64
+	select {
+	case created := <-capture.creates:
+		postCutoverProgressID = created.ID
+		assert.Contains(t, created.Body, "**Status**: Revert Window")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the post-cutover rotation to post a fresh progress comment")
+	}
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, cutoverPromptID, edited.CommentID, "the freeze edit lands on the cutover prompt")
+		assert.Contains(t, edited.Body, "Cutover complete")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the cutover prompt to be frozen")
+	}
+
+	// The tracked row records the post-cutover comment and a later tick edits
+	// it in place: nothing regresses the row to the adopted comment.
+	prog, err = st.ApplyComments().Get(ctx, apply.ID, state.Comment.Progress)
+	require.NoError(t, err)
+	require.NotNil(t, prog)
+	assert.Equal(t, postCutoverProgressID, prog.GitHubCommentID, "the tracked row records the post-cutover comment")
+	require.NotNil(t, prog.PostedPhase)
+	assert.Equal(t, "revert_window", *prog.PostedPhase)
+	assert.Nil(t, prog.PendingFreezeCommentID)
+
+	task.RowsCopied = 900
+	task.ProgressPercent = 90
+	fake.Advance(activeInterval + time.Second)
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, postCutoverProgressID, edited.CommentID, "later edits land on the post-cutover comment")
+	case created := <-capture.creates:
+		t.Fatalf("no further rotation is owed; got new comment %d", created.ID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected an in-place edit of the post-cutover comment")
+	}
+}
+
 // A control-phase rotation whose fresh comment posts to the PR but fails to
 // be recorded as the tracked comment must not freeze the prior comment: the
 // tracked row still points at it, so later progress edits land there. While
@@ -1416,6 +1727,36 @@ func (s *failingCommentUpsertStorage) ApplyComments() storage.ApplyCommentStore 
 }
 
 func (s *failingCommentUpsertStorage) heal() { s.healed.Store(true) }
+
+// failingCommentSupersedeStore wraps an ApplyCommentStore so every Supersede
+// fails until the outage is healed, modeling a storage outage between posting
+// the post-cutover rotation comment and consuming the cutover row. Reads and
+// every other write pass through.
+type failingCommentSupersedeStore struct {
+	storage.ApplyCommentStore
+	healed *atomic.Bool
+}
+
+func (s *failingCommentSupersedeStore) Supersede(ctx context.Context, applyID int64, commentState string) error {
+	if s.healed.Load() {
+		return s.ApplyCommentStore.Supersede(ctx, applyID, commentState)
+	}
+	return errors.New("injected comment supersede failure")
+}
+
+// failingCommentSupersedeStorage serves the failing comment store while
+// passing every other store through to the real storage. heal ends the outage
+// so later Supersedes land.
+type failingCommentSupersedeStorage struct {
+	storage.Storage
+	healed atomic.Bool
+}
+
+func (s *failingCommentSupersedeStorage) ApplyComments() storage.ApplyCommentStore {
+	return &failingCommentSupersedeStore{ApplyCommentStore: s.Storage.ApplyComments(), healed: &s.healed}
+}
+
+func (s *failingCommentSupersedeStorage) heal() { s.healed.Store(true) }
 
 // A volume-change rotation whose fresh comment posts to the PR but fails to be
 // recorded as the tracked comment must not freeze the prior comment: the

--- a/pkg/webhook/apply_comment_integration_test.go
+++ b/pkg/webhook/apply_comment_integration_test.go
@@ -1322,6 +1322,444 @@ func TestE2EDeferredCutoverSupersedeRetriedUntilItLands(t *testing.T) {
 	assert.NotNil(t, cutoverRow.SupersededAt, "the retried supersede consumes the cutover row once storage heals")
 }
 
+// While the cutover prompt is live and unanswered, states that do not follow
+// from a completed cutover — a restart recovery re-copying the parked apply, a
+// retryable failure at the gate, the gate state itself — keep the observer
+// muted: no fresh progress comment is posted and the prompt is never folded
+// under a false "Cutover complete" record. Only a post-cutover phase (revert
+// window, reverting, skipping revert) proves the operator's cutover happened
+// and unmutes.
+func TestE2EDeferredCutoverPromptStaysMutedWithoutCutover(t *testing.T) {
+	ctx := t.Context()
+
+	f := setupApplyCommentFixture(t, applyCommentFixtureParams{
+		repo:       "org/repo-cutover-muted",
+		pr:         151,
+		database:   "e2e_cutover_muted_db",
+		applyState: state.Apply.WaitingForCutover,
+	})
+	st, apply, task, capture, h := f.st, f.apply, f.task, f.capture, f.handler
+
+	h.postAndTrackComment(ctx, "org/repo-cutover-muted", 151, 12345, apply, state.Comment.Progress, "Copy complete — waiting for cutover")
+	preCutoverProgressID := requireCommentCreate(t, capture)
+	h.postAndTrackComment(ctx, "org/repo-cutover-muted", 151, 12345, apply, state.Comment.Cutover, "Ready for cutover")
+	requireCommentCreate(t, capture)
+
+	fake := clock.NewFake(task.CreatedAt)
+
+	// Each state is observed by a fresh observer — a restart recovery hands
+	// the apply to a new drive claim, which must rediscover the live prompt
+	// and stay muted rather than mistake its own arrival for a cutover.
+	for _, applyState := range []string{state.Apply.Running, state.Apply.FailedRetryable, state.Apply.WaitingForCutover} {
+		obs := f.newObserver(st, fake)
+		apply.State = applyState
+		fake.Advance(activeInterval + time.Second)
+		obs.OnProgress(apply, []*storage.Task{task})
+		select {
+		case created := <-capture.creates:
+			t.Fatalf("state %q must not rotate while the prompt is unanswered; got new comment %d: %s", applyState, created.ID, created.Body)
+		case edited := <-capture.edits:
+			t.Fatalf("state %q must not edit while the prompt is unanswered; got an edit of %d: %s", applyState, edited.CommentID, edited.Body)
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+
+	// The prompt row stays live — the gate is still waiting for its answer —
+	// and the tracked progress comment is untouched, recording no post-cutover
+	// phase.
+	cutoverRow, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Cutover)
+	require.NoError(t, err)
+	require.NotNil(t, cutoverRow)
+	assert.Nil(t, cutoverRow.SupersededAt, "the prompt row stays live while no cutover happened")
+	prog, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Progress)
+	require.NoError(t, err)
+	require.NotNil(t, prog)
+	assert.Equal(t, preCutoverProgressID, prog.GitHubCommentID, "the tracked progress comment is unchanged")
+	assert.False(t, postCutoverPhase(trackedPhase(prog)), "no post-cutover phase is recorded without a cutover")
+}
+
+// An apply stopped at the deferred-cutover gate completes the prompt itself:
+// the terminal edit turns the prompt into the stop record and consumes its
+// row, so the prompt is never folded under a false "Cutover complete" record.
+// When the operator resumes, the consumed row no longer mutes the fresh
+// observer, and the summary marker triggers the resume rotation: the resumed
+// apply is tracked in a fresh progress comment at the bottom of the PR while
+// the stop record stays intact on the timeline.
+func TestE2EStopAtCutoverGateThenResumeRotatesFreshComment(t *testing.T) {
+	ctx := t.Context()
+
+	f := setupApplyCommentFixture(t, applyCommentFixtureParams{
+		repo:       "org/repo-cutover-stop-resume",
+		pr:         152,
+		database:   "e2e_cutover_stop_resume_db",
+		applyState: state.Apply.WaitingForCutover,
+	})
+	st, apply, task, capture, h := f.st, f.apply, f.task, f.capture, f.handler
+
+	h.postAndTrackComment(ctx, "org/repo-cutover-stop-resume", 152, 12345, apply, state.Comment.Progress, "Copy complete — waiting for cutover")
+	preStopProgressID := requireCommentCreate(t, capture)
+	h.postAndTrackComment(ctx, "org/repo-cutover-stop-resume", 152, 12345, apply, state.Comment.Cutover, "Ready for cutover")
+	cutoverPromptID := requireCommentCreate(t, capture)
+
+	fake := clock.NewFake(task.CreatedAt)
+	obs := f.newObserver(st, fake)
+
+	// The operator stops the apply at the gate. The prompt is the active
+	// comment, so the terminal edit lands there as the stop record.
+	apply.State = state.Apply.Stopped
+	task.State = state.Task.Stopped
+	obs.OnTerminal(apply, []*storage.Task{task})
+
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, cutoverPromptID, edited.CommentID, "the stop record lands on the prompt")
+		assert.Contains(t, edited.Body, "Schema Change Stopped")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the cutover prompt to be edited into the stop record")
+	}
+	select {
+	case created := <-capture.creates:
+		t.Fatalf("a stop at the gate completes the prompt itself; got a new comment %d: %s", created.ID, created.Body)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// The stop consumes the prompt row — its call to action is void — and the
+	// summary marker records the stop record as the terminal publish.
+	cutoverRow, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Cutover)
+	require.NoError(t, err)
+	require.NotNil(t, cutoverRow)
+	assert.NotNil(t, cutoverRow.SupersededAt, "the stop consumes the prompt row")
+	marker, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Summary)
+	require.NoError(t, err)
+	require.NotNil(t, marker)
+	assert.Equal(t, cutoverPromptID, marker.GitHubCommentID, "the summary marker records the stop record")
+
+	// The operator starts the apply again and a later drive claims it. The
+	// fresh observer finds the consumed prompt row — no mute — and the live
+	// summary marker triggers the resume rotation.
+	apply.State = state.Apply.Resuming
+	task.State = state.Task.Running
+	obs2 := f.newObserver(st, fake)
+	fake.Advance(activeInterval + time.Second)
+	obs2.OnProgress(apply, []*storage.Task{task})
+
+	var resumedProgressID int64
+	select {
+	case created := <-capture.creates:
+		resumedProgressID = created.ID
+		assert.Contains(t, created.Body, "Schema Change Status — Staging")
+		assert.Contains(t, created.Body, "**Status**: Resuming")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the resume to post a fresh progress comment")
+	}
+	assert.NotEqual(t, cutoverPromptID, resumedProgressID, "the resumed apply gets its own comment; the stop record is not reused")
+
+	// The pre-stop progress comment — not the stop record — is folded pointing
+	// at the fresh comment.
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, preStopProgressID, edited.CommentID, "the freeze edit lands on the pre-stop progress comment")
+		assert.Contains(t, edited.Body, fmt.Sprintf("#issuecomment-%d", resumedProgressID), "the frozen comment links to its successor")
+		assert.NotContains(t, edited.Body, "Cutover complete", "nothing renders a cutover that never happened")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the pre-stop progress comment to be frozen")
+	}
+
+	// The summary marker is consumed and later ticks edit the fresh comment —
+	// the stop record is never touched again.
+	marker, err = st.ApplyComments().Get(ctx, apply.ID, state.Comment.Summary)
+	require.NoError(t, err)
+	require.NotNil(t, marker)
+	assert.NotNil(t, marker.SupersededAt, "the resume consumes the summary marker")
+
+	apply.State = state.Apply.Running
+	task.RowsCopied = 700
+	task.ProgressPercent = 70
+	fake.Advance(activeInterval + time.Second)
+	obs2.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, resumedProgressID, edited.CommentID, "later edits land on the fresh comment")
+	case created := <-capture.creates:
+		t.Fatalf("a resume rotates exactly once; got another new comment %d", created.ID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected an in-place edit of the fresh progress comment")
+	}
+}
+
+// A post-cutover rotation whose fresh comment posts to the PR but fails to be
+// recorded as the tracked comment must not fold the prompt or consume the
+// cutover row: the row is the durable marker that the rotation is owed, and
+// the fold marker rides the tracking write. While the outage lasts, later
+// ticks retry only the tracking write (adoption) — never another post — so
+// duplicates stay bounded at one. Once storage heals, the next tick adopts the
+// already-live fresh comment: the tracked row records it with the post-cutover
+// phase, the prompt is folded pointing at it, the cutover row is consumed, and
+// progress edits move to the adopted comment.
+func TestE2EDeferredCutoverUntrackedFreshCommentAdoptedWhenStorageHeals(t *testing.T) {
+	ctx := t.Context()
+
+	f := setupApplyCommentFixture(t, applyCommentFixtureParams{
+		repo:       "org/repo-cutover-untracked",
+		pr:         153,
+		database:   "e2e_cutover_untracked_db",
+		applyState: state.Apply.WaitingForCutover,
+	})
+	st, apply, task, capture, h := f.st, f.apply, f.task, f.capture, f.handler
+
+	h.postAndTrackComment(ctx, "org/repo-cutover-untracked", 153, 12345, apply, state.Comment.Progress, "Copy complete — waiting for cutover")
+	preCutoverProgressID := requireCommentCreate(t, capture)
+	h.postAndTrackComment(ctx, "org/repo-cutover-untracked", 153, 12345, apply, state.Comment.Cutover, "Ready for cutover")
+	cutoverPromptID := requireCommentCreate(t, capture)
+
+	failingStorage := &failingCommentUpsertStorage{Storage: st}
+	fake := clock.NewFake(task.CreatedAt)
+	obs := f.newObserver(failingStorage, fake)
+
+	// The cutover completes into the revert window. The fresh comment posts,
+	// but recording it as the tracked comment fails — the prompt must not be
+	// folded and the cutover row must stay live.
+	apply.State = state.Apply.RevertWindow
+	task.State = state.Task.RevertWindow
+	obs.OnProgress(apply, []*storage.Task{task})
+
+	var freshProgressID int64
+	select {
+	case created := <-capture.creates:
+		freshProgressID = created.ID
+		assert.Contains(t, created.Body, "**Status**: Revert Window")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the rotation to post a fresh progress comment")
+	}
+	select {
+	case edited := <-capture.edits:
+		t.Fatalf("no comment may be edited when the fresh comment was not tracked; got an edit of %d: %s", edited.CommentID, edited.Body)
+	case <-time.After(100 * time.Millisecond):
+	}
+	cutoverRow, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Cutover)
+	require.NoError(t, err)
+	require.NotNil(t, cutoverRow)
+	assert.Nil(t, cutoverRow.SupersededAt, "the cutover row stays live while the rotation is untracked")
+	prog, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Progress)
+	require.NoError(t, err)
+	require.NotNil(t, prog)
+	assert.Equal(t, preCutoverProgressID, prog.GitHubCommentID, "the tracked row still points at the pre-cutover comment")
+
+	// While the outage lasts, a later tick retries only the tracking write —
+	// no duplicate post, no fold, no progress edit past the still-live prompt.
+	fake.Advance(activeInterval + time.Second)
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case created := <-capture.creates:
+		t.Fatalf("an untracked rotation must not repost; got another new comment %d", created.ID)
+	case edited := <-capture.edits:
+		t.Fatalf("no comment may be edited while adoption is owed; got an edit of %d: %s", edited.CommentID, edited.Body)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Once storage heals, the next tick adopts the already-live fresh comment:
+	// the prompt is folded pointing at it and the cutover row is consumed.
+	failingStorage.heal()
+	fake.Advance(activeInterval + time.Second)
+	obs.OnProgress(apply, []*storage.Task{task})
+
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, cutoverPromptID, edited.CommentID, "the freeze edit lands on the cutover prompt")
+		assert.Contains(t, edited.Body, "Cutover complete")
+		assert.Contains(t, edited.Body, fmt.Sprintf("#issuecomment-%d", freshProgressID), "the frozen prompt links to its adopted successor")
+	case created := <-capture.creates:
+		t.Fatalf("adoption must not post another comment; got %d", created.ID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the cutover prompt to be frozen after adoption")
+	}
+	prog, err = st.ApplyComments().Get(ctx, apply.ID, state.Comment.Progress)
+	require.NoError(t, err)
+	require.NotNil(t, prog)
+	assert.Equal(t, freshProgressID, prog.GitHubCommentID, "the tracked row records the adopted comment")
+	require.NotNil(t, prog.PostedPhase)
+	assert.Equal(t, "revert_window", *prog.PostedPhase, "adoption records the post-cutover phase durably")
+	assert.Nil(t, prog.PendingFreezeCommentID)
+	cutoverRow, err = st.ApplyComments().Get(ctx, apply.ID, state.Comment.Cutover)
+	require.NoError(t, err)
+	require.NotNil(t, cutoverRow)
+	assert.NotNil(t, cutoverRow.SupersededAt, "the cutover row is consumed once the rotation is tracked")
+
+	// Later ticks edit the adopted comment in place.
+	task.RowsCopied = 900
+	task.ProgressPercent = 90
+	fake.Advance(activeInterval + time.Second)
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, freshProgressID, edited.CommentID, "progress edits move to the adopted comment")
+	case created := <-capture.creates:
+		t.Fatalf("no further rotation is owed; got new comment %d", created.ID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected an in-place edit of the adopted comment")
+	}
+}
+
+// When the apply reaches a terminal state while the cutover row still reads
+// live but the tracked progress comment records a post-cutover phase, the row
+// is a spent prompt whose supersede write never landed: the rotation already
+// happened and the fresh progress comment is the active one. The terminal
+// publish completes the fresh comment and posts the summary — it must not
+// overwrite the folded prompt — and consumes the stale row.
+func TestE2EDeferredCutoverStaleCutoverRowRoutesTerminalToFreshComment(t *testing.T) {
+	ctx := t.Context()
+
+	f := setupApplyCommentFixture(t, applyCommentFixtureParams{
+		repo:       "org/repo-cutover-stale-terminal",
+		pr:         154,
+		database:   "e2e_cutover_stale_terminal_db",
+		applyState: state.Apply.WaitingForCutover,
+	})
+	st, apply, task, capture, h := f.st, f.apply, f.task, f.capture, f.handler
+
+	h.postAndTrackComment(ctx, "org/repo-cutover-stale-terminal", 154, 12345, apply, state.Comment.Progress, "Copy complete — waiting for cutover")
+	requireCommentCreate(t, capture)
+	h.postAndTrackComment(ctx, "org/repo-cutover-stale-terminal", 154, 12345, apply, state.Comment.Cutover, "Ready for cutover")
+	cutoverPromptID := requireCommentCreate(t, capture)
+
+	// The cutover completes into the revert window and the rotation lands —
+	// fresh comment tracked, prompt folded — but consuming the cutover row
+	// fails, leaving it live.
+	failingStorage := &failingCommentSupersedeStorage{Storage: st}
+	fake := clock.NewFake(task.CreatedAt)
+	obs := f.newObserver(failingStorage, fake)
+	apply.State = state.Apply.RevertWindow
+	task.State = state.Task.RevertWindow
+	obs.OnProgress(apply, []*storage.Task{task})
+
+	var freshProgressID int64
+	select {
+	case created := <-capture.creates:
+		freshProgressID = created.ID
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the rotation to post a fresh progress comment")
+	}
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, cutoverPromptID, edited.CommentID, "the freeze edit lands on the cutover prompt")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the cutover prompt to be frozen")
+	}
+
+	// The revert window expires and the apply completes. A fresh observer —
+	// only its terminal callback runs — reads the stale live row, sees the
+	// tracked comment's post-cutover phase, and routes the terminal publish to
+	// the fresh comment.
+	apply.State = state.Apply.Completed
+	task.State = state.Task.Completed
+	obs2 := f.newObserver(st, fake)
+	obs2.OnTerminal(apply, []*storage.Task{task})
+
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, freshProgressID, edited.CommentID, "the terminal freeze lands on the fresh progress comment, not the folded prompt")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the fresh progress comment to be edited to its final rendering")
+	}
+	select {
+	case created := <-capture.creates:
+		assert.Contains(t, created.Body, "Schema Change Applied")
+		assert.Contains(t, created.Body, apply.ApplyIdentifier)
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected a summary comment for the completed apply")
+	}
+	select {
+	case edited := <-capture.edits:
+		t.Fatalf("the folded prompt must not be overwritten on terminal; got an edit of %d: %s", edited.CommentID, edited.Body)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// The stale row is consumed on the way through.
+	cutoverRow, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Cutover)
+	require.NoError(t, err)
+	require.NotNil(t, cutoverRow)
+	assert.NotNil(t, cutoverRow.SupersededAt, "the terminal publish consumes the stale cutover row")
+}
+
+// A fresh observer on a later drive claim that finds the cutover row still
+// live but the tracked progress comment recording a post-cutover phase treats
+// the row as a spent prompt whose supersede write never landed: it consumes
+// the row without rotating again — the recorded phase is the durable proof the
+// rotation already happened — and progress edits continue on the fresh
+// comment.
+func TestE2EDeferredCutoverFreshObserverConsumesStaleCutoverRow(t *testing.T) {
+	ctx := t.Context()
+
+	f := setupApplyCommentFixture(t, applyCommentFixtureParams{
+		repo:       "org/repo-cutover-stale-row",
+		pr:         155,
+		database:   "e2e_cutover_stale_row_db",
+		applyState: state.Apply.WaitingForCutover,
+	})
+	st, apply, task, capture, h := f.st, f.apply, f.task, f.capture, f.handler
+
+	h.postAndTrackComment(ctx, "org/repo-cutover-stale-row", 155, 12345, apply, state.Comment.Progress, "Copy complete — waiting for cutover")
+	requireCommentCreate(t, capture)
+	h.postAndTrackComment(ctx, "org/repo-cutover-stale-row", 155, 12345, apply, state.Comment.Cutover, "Ready for cutover")
+	cutoverPromptID := requireCommentCreate(t, capture)
+
+	// The cutover completes into the revert window and the rotation lands —
+	// fresh comment tracked, prompt folded — but consuming the cutover row
+	// fails, leaving it live for the next drive claim to find.
+	failingStorage := &failingCommentSupersedeStorage{Storage: st}
+	fake := clock.NewFake(task.CreatedAt)
+	obs := f.newObserver(failingStorage, fake)
+	apply.State = state.Apply.RevertWindow
+	task.State = state.Task.RevertWindow
+	obs.OnProgress(apply, []*storage.Task{task})
+
+	var freshProgressID int64
+	select {
+	case created := <-capture.creates:
+		freshProgressID = created.ID
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the rotation to post a fresh progress comment")
+	}
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, cutoverPromptID, edited.CommentID, "the freeze edit lands on the cutover prompt")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the cutover prompt to be frozen")
+	}
+
+	// A fresh observer claims the drive. Its first tick reads the live row,
+	// sees the tracked comment's recorded post-cutover phase, and consumes the
+	// row instead of rotating again — no duplicate comment, no second fold.
+	obs2 := f.newObserver(st, fake)
+	fake.Advance(activeInterval + time.Second)
+	obs2.OnProgress(apply, []*storage.Task{task})
+	select {
+	case created := <-capture.creates:
+		t.Fatalf("a fresh observer must not rotate for a cutover already tracked; got new comment %d", created.ID)
+	case edited := <-capture.edits:
+		t.Fatalf("a fresh observer must not re-fold; got an edit of %d: %s", edited.CommentID, edited.Body)
+	case <-time.After(100 * time.Millisecond):
+	}
+	cutoverRow, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Cutover)
+	require.NoError(t, err)
+	require.NotNil(t, cutoverRow)
+	assert.NotNil(t, cutoverRow.SupersededAt, "the fresh observer consumes the stale cutover row")
+
+	// The next tick edits the fresh comment in place — the observer is unmuted.
+	task.RowsCopied = 900
+	task.ProgressPercent = 90
+	fake.Advance(activeInterval + time.Second)
+	obs2.OnProgress(apply, []*storage.Task{task})
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, freshProgressID, edited.CommentID, "progress edits continue on the fresh comment")
+	case created := <-capture.creates:
+		t.Fatalf("no further rotation is owed; got new comment %d", created.ID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected an in-place edit of the fresh progress comment")
+	}
+}
+
 // A fresh rotation comment that posted but was never recorded (a storage
 // outage between the post and the tracking write) is adopted before the
 // cutover prompt posts and before the post-cutover rotation runs, in the same

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -70,6 +70,12 @@ type CommentObserver struct {
 	// per-drive rotation flags.
 	rotatedPhases map[string]bool
 
+	// cutoverRotated marks that this observer already rotated in a fresh
+	// progress comment after a deferred cutover completed (or confirmed the
+	// tracked comment postdates the cutover), so later ticks skip the storage
+	// re-read.
+	cutoverRotated bool
+
 	// trackedPostedVolume caches the tracked progress comment's recorded level
 	// (valid only when trackedPostedVolumeKnown) so the per-tick volume-change
 	// check answers from memory instead of a storage read under the mutex. The
@@ -233,19 +239,40 @@ func (o *CommentObserver) OnProgress(apply *storage.Apply, tasks []*storage.Task
 	now := o.clock.Now()
 	currentState := apply.State
 
-	// Check if a cutover comment was posted by an external handler.
-	// This must happen before the CuttingOver branch below — without it,
-	// the observer would post a duplicate cutover comment.
+	// Check if a cutover comment was posted by an external handler. A
+	// superseded row is an already-rotated-away prompt from an earlier drive,
+	// not a live cutover comment — treating it as live would re-mute the
+	// observer. This must happen before the CuttingOver branch below — without
+	// it, the observer would post a duplicate cutover comment.
 	if !o.hasCutoverComment {
 		checkCtx, checkCancel := context.WithTimeout(context.Background(), 2*time.Second)
 		cutover, err := o.stor.ApplyComments().Get(checkCtx, o.applyID, state.Comment.Cutover)
 		if err != nil {
 			o.logError(apply, "observer: failed to check for cutover comment", "error", err)
-		} else if cutover != nil {
-			o.hasCutoverComment = true
+		} else if cutover != nil && cutover.SupersededAt == nil {
+			if o.cutoverRotated {
+				// This observer already rotated away from the prompt, so the row
+				// can only still read live because its supersede write failed.
+				// Retry consuming it and keep editing the fresh comment instead
+				// of re-muting on the spent prompt.
+				o.logInfo(apply, "observer: cutover comment still live after rotation; retrying supersede")
+				o.supersedeCutoverComment(checkCtx, apply)
+			} else {
+				o.hasCutoverComment = true
+			}
 		}
 		checkCancel()
 	}
+
+	// A prior tick's rotation comment may be live on the PR but untracked.
+	// Adopt it before considering any rotation — including the post-cutover
+	// one below — so the tracking write is retried with the known comment ID
+	// instead of a rotation reading the stale tracked row and posting a
+	// duplicate, or a later adoption overwriting the row a rotation just
+	// wrote. While adoption keeps failing, rotations stay blocked but the
+	// tick's normal progress edit below still lands on the prior comment —
+	// the tracked one.
+	adopted := o.pendingRotation == nil || o.adoptPendingRotationComment(apply)
 
 	// Post cutover comment when entering cutting_over with defer_cutover,
 	// but only if one hasn't been posted already. A failed post leaves
@@ -260,19 +287,28 @@ func (o *CommentObserver) OnProgress(apply *storage.Apply, tasks []*storage.Task
 		return
 	}
 
-	// If cutover was triggered, stop editing — the progress comment is frozen
-	// and OnTerminal will handle the cutover comment completion.
+	// While the cutover prompt is live and the apply is still at the cutover
+	// gate, stop editing — the prompt is the active comment and the progress
+	// comment stays frozen. Once the apply moves past the gate (the operator
+	// issued the cutover and it completed into a still-active state such as
+	// the revert window), rotate a fresh progress comment in: the prompt's
+	// call to action is spent, and the operator looks at the bottom of the PR
+	// for the effect of the cutover command. Terminal states are left to
+	// OnTerminal, which completes the cutover comment itself.
 	if o.hasCutoverComment {
+		if state.IsTerminalApplyState(apply.State) ||
+			state.IsState(apply.State, state.Apply.CuttingOver, state.Apply.WaitingForCutover) {
+			return
+		}
+		if adopted && o.rotateProgressCommentAfterCutover(apply, tasks) {
+			o.lastState = currentState
+			o.lastProgressPost = now
+			o.stagnantTicks = 0
+		}
 		return
 	}
 
-	// A prior tick's rotation comment may be live on the PR but untracked.
-	// Adopt it before considering any rotation, so the tracking write is
-	// retried with the known comment ID instead of a rotation reading the
-	// stale tracked row and posting a duplicate. While adoption keeps failing,
-	// rotations stay blocked but the tick's normal progress edit below still
-	// lands on the prior comment — the tracked one.
-	if o.pendingRotation == nil || o.adoptPendingRotationComment(apply) {
+	if adopted {
 		// A summary comment present while the apply is active again means the apply
 		// was stopped and has resumed — stopped is the only terminal state that
 		// returns to active. Post a fresh progress comment to track the resumed row
@@ -370,10 +406,12 @@ func (o *CommentObserver) OnTerminal(apply *storage.Apply, tasks []*storage.Task
 	activeCommentState := state.Comment.Progress
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+	// A superseded cutover row was already rotated away into a fold — the
+	// tracked progress comment is the active one, not the spent prompt.
 	cutover, err := o.stor.ApplyComments().Get(ctx, o.applyID, state.Comment.Cutover)
 	if err != nil {
 		o.logError(apply, "observer: failed to check for cutover comment on terminal", "error", err)
-	} else if cutover != nil {
+	} else if cutover != nil && cutover.SupersededAt == nil {
 		activeCommentState = state.Comment.Cutover
 	}
 
@@ -793,8 +831,8 @@ func controlPhase(applyState string) string {
 // operator-origin signal (see phaseIsOperatorIssued). The cutover-driven
 // phases are not listed here: entering the revert window after an
 // auto-cutover involves no operator command (the comment transitions in
-// place), and while a deferred-cutover prompt is live the observer does not
-// edit progress comments.
+// place), and the operator-triggered deferred cutover rotates through
+// rotateProgressCommentAfterCutover, keyed on the cutover prompt comment.
 func phaseRotatesProgressComment(phase string) bool {
 	return phase == phaseReverting || phase == phaseSkippingRevert
 }
@@ -818,6 +856,13 @@ func (o *CommentObserver) phaseIsOperatorIssued(ctx context.Context, phase strin
 		return false, fmt.Errorf("load skip-revert control request: %w", err)
 	}
 	return req != nil, nil
+}
+
+// postCutoverPhase reports whether a recorded phase means the comment was
+// posted after the apply moved past the cutover gate — the durable sign that a
+// post-cutover rotation already happened.
+func postCutoverPhase(phase string) bool {
+	return phase == phaseRevertWindow || phase == phaseReverting || phase == phaseSkippingRevert
 }
 
 // trackedPhase returns the phase recorded on a tracked comment row, treating
@@ -954,6 +999,110 @@ func supersededReasonForPhase(phase string) supersededProgressReason {
 	return supersededByRevert
 }
 
+// rotateProgressCommentAfterCutover posts a fresh progress comment when a
+// deferred cutover has completed into a still-active apply (e.g. the revert
+// window): the operator issued the cutover command, so the post-cutover phase
+// belongs in a new comment at the bottom of the PR timeline, with the spent
+// cutover prompt frozen into a fold pointing at it. The live cutover row is
+// the durable marker that this rotation is owed — it is consumed (superseded)
+// only after the fresh comment lands, so a crash retries on the next tick, and
+// a fresh observer on a later drive claim finds either the superseded row or
+// the tracked comment's recorded post-cutover phase and does not rotate again.
+// Returns true when it posted the fresh comment.
+func (o *CommentObserver) rotateProgressCommentAfterCutover(apply *storage.Apply, tasks []*storage.Task) bool {
+	if o.cutoverRotated {
+		// This observer already rotated after the cutover (or confirmed the
+		// tracked comment postdates it). Guard against re-reading storage on
+		// later ticks; a fresh observer on a later drive claim starts unset
+		// and re-checks the durable record.
+		return false
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cutover, err := o.stor.ApplyComments().Get(ctx, o.applyID, state.Comment.Cutover)
+	if err != nil {
+		o.logError(apply, "observer: failed to load cutover comment before post-cutover rotation", "error", err)
+		return false
+	}
+	if cutover == nil {
+		// The prompt posted but its tracking write failed, so its comment ID is
+		// unknown and cannot be folded or superseded. Unmute so progress edits
+		// resume in the existing tracked comment — degraded (the spent prompt
+		// stays unfolded) but not silent.
+		o.logError(apply, "observer: cutover comment untracked after cutover completed; resuming progress edits without rotation")
+		o.cutoverRotated = true
+		o.hasCutoverComment = false
+		return false
+	}
+
+	tracked, err := o.stor.ApplyComments().Get(ctx, o.applyID, state.Comment.Progress)
+	if err != nil {
+		o.logError(apply, "observer: failed to load tracked progress comment before post-cutover rotation", "error", err)
+		return false
+	}
+
+	if cutover.SupersededAt != nil || (tracked != nil && postCutoverPhase(trackedPhase(tracked))) {
+		// The rotation already happened — a prior drive (or an earlier tick
+		// whose supersede write raced a crash) posted the post-cutover comment.
+		// Retry any fold still owed, then resume normal editing.
+		if tracked != nil && tracked.PendingFreezeCommentID != nil {
+			o.freezeSupersededProgressComment(apply, *tracked.PendingFreezeCommentID, tracked.GitHubCommentID,
+				supersededByPriorRotation, 0)
+		}
+		if cutover.SupersededAt == nil {
+			o.supersedeCutoverComment(ctx, apply)
+		}
+		o.cutoverRotated = true
+		o.hasCutoverComment = false
+		return false
+	}
+
+	if tracked != nil && tracked.PendingFreezeCommentID != nil {
+		// A superseded comment from an earlier rotation is still owed its
+		// frozen rendering — the freeze edit failed or the pod died before it
+		// landed. Retry it now; on success the marker is cleared.
+		o.freezeSupersededProgressComment(apply, *tracked.PendingFreezeCommentID, tracked.GitHubCommentID,
+			supersededByPriorRotation, 0)
+	}
+
+	body := o.formatStatusComment(apply, tasks)
+	newCommentID, posted, trackedNew := o.postAndTrackComment(apply, state.Comment.Progress, body, &cutover.GitHubCommentID)
+	if !posted {
+		// postAndTrackComment logged the failure. The live cutover row is left
+		// in place — it is the durable signal that this rotation is owed — so
+		// the next tick retries.
+		return false
+	}
+	o.cutoverRotated = true
+	o.hasCutoverComment = false
+
+	if trackedNew {
+		o.freezeSupersededProgressComment(apply, cutover.GitHubCommentID, newCommentID, supersededByCutover, 0)
+	}
+	// When the fresh comment posted but its tracking write failed
+	// (postAndTrackComment logged it), the cutover prompt must not be folded:
+	// no freeze marker was recorded (it rides the tracking write), so a fold
+	// now could never be retried and the fresh comment would be untracked.
+
+	o.supersedeCutoverComment(ctx, apply)
+
+	o.logger.Info("observer: posted fresh progress comment after deferred cutover",
+		"apply_id", o.applyID, "repo", o.repo, "pr", o.pr, "state", apply.State)
+	return true
+}
+
+// supersedeCutoverComment consumes the live cutover row after a post-cutover
+// rotation. Failure is logged and left for the durable dedupe to absorb: the
+// tracked comment's recorded post-cutover phase stops a later observer from
+// rotating again even while the row still reads live.
+func (o *CommentObserver) supersedeCutoverComment(ctx context.Context, apply *storage.Apply) {
+	if err := o.stor.ApplyComments().Supersede(o.contextWithApplyLease(ctx, apply), o.applyID, state.Comment.Cutover); err != nil {
+		o.logError(apply, "observer: failed to supersede cutover comment after post-cutover rotation", "error", err)
+	}
+}
+
 // supersededProgressReason names why a tracked progress comment was rotated
 // away from, selecting the frozen rendering written over it.
 type supersededProgressReason int
@@ -963,6 +1112,10 @@ const (
 	supersededByResume
 	supersededByRevert
 	supersededBySkipRevert
+	// supersededByCutover freezes the spent cutover prompt after a deferred
+	// cutover completed into a still-active apply, pointing at the fresh
+	// progress comment that tracks the post-cutover phase.
+	supersededByCutover
 	// supersededByPriorRotation is the retry reason: the pending-freeze marker
 	// records which comment is owed a fold but not which rotation superseded
 	// it, so a retry renders the generic fold instead of guessing a headline.
@@ -990,6 +1143,13 @@ func (o *CommentObserver) frozenSupersededProgressBody(reason supersededProgress
 		})
 	case supersededBySkipRevert:
 		return templates.RenderSkipRevertSupersededProgressComment(templates.SupersededProgressData{
+			Repo:         o.repo,
+			PR:           o.pr,
+			NewCommentID: newCommentID,
+			PreviousBody: previousBody,
+		})
+	case supersededByCutover:
+		return templates.RenderCutoverSupersededComment(templates.SupersededProgressData{
 			Repo:         o.repo,
 			PR:           o.pr,
 			NewCommentID: newCommentID,

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -287,17 +287,19 @@ func (o *CommentObserver) OnProgress(apply *storage.Apply, tasks []*storage.Task
 		return
 	}
 
-	// While the cutover prompt is live and the apply is still at the cutover
-	// gate, stop editing — the prompt is the active comment and the progress
-	// comment stays frozen. Once the apply moves past the gate (the operator
-	// issued the cutover and it completed into a still-active state such as
-	// the revert window), rotate a fresh progress comment in: the prompt's
-	// call to action is spent, and the operator looks at the bottom of the PR
-	// for the effect of the cutover command. Terminal states are left to
-	// OnTerminal, which completes the cutover comment itself.
+	// While the cutover prompt is live, stop editing — the prompt is the
+	// active comment and the progress comment stays frozen. Rotate a fresh
+	// progress comment in only when the apply has provably moved past the
+	// cutover gate into a post-cutover phase (revert window, reverting,
+	// skipping revert): the prompt's call to action is spent, and the operator
+	// looks at the bottom of the PR for the effect of the cutover command.
+	// Terminal states are left to OnTerminal, which completes the cutover
+	// comment itself. Every other state keeps the observer muted — a restart
+	// recovery re-copying a parked apply, a retryable failure at the gate, a
+	// stop — because no cutover has happened, so a rotation would fold the
+	// unanswered prompt under a false "Cutover complete" record.
 	if o.hasCutoverComment {
-		if state.IsTerminalApplyState(apply.State) ||
-			state.IsState(apply.State, state.Apply.CuttingOver, state.Apply.WaitingForCutover) {
+		if !postCutoverPhase(controlPhase(apply.State)) {
 			return
 		}
 		if adopted && o.rotateProgressCommentAfterCutover(apply, tasks) {
@@ -413,6 +415,21 @@ func (o *CommentObserver) OnTerminal(apply *storage.Apply, tasks []*storage.Task
 		o.logError(apply, "observer: failed to check for cutover comment on terminal", "error", err)
 	} else if cutover != nil && cutover.SupersededAt == nil {
 		activeCommentState = state.Comment.Cutover
+		// A live row whose tracked progress comment records a post-cutover
+		// phase is a spent prompt whose supersede write failed: the rotation
+		// already happened and the fresh progress comment is the active one.
+		// Consume the stale row and complete the fresh comment instead of
+		// overwriting the folded prompt with the terminal summary — this
+		// durable check covers a fresh observer whose only call is OnTerminal.
+		// On a tracked-row read failure the prompt stays the active comment,
+		// the same routing a genuinely died-at-the-gate apply gets.
+		tracked, terr := o.stor.ApplyComments().Get(ctx, o.applyID, state.Comment.Progress)
+		if terr != nil {
+			o.logError(apply, "observer: failed to load tracked progress comment on terminal; completing the cutover comment", "error", terr)
+		} else if tracked != nil && postCutoverPhase(trackedPhase(tracked)) {
+			o.supersedeCutoverComment(ctx, apply)
+			activeCommentState = state.Comment.Progress
+		}
 	}
 
 	// Load the operation rows once and reuse them for the ownership decision and
@@ -432,6 +449,14 @@ func (o *CommentObserver) OnTerminal(apply *storage.Apply, tasks []*storage.Task
 		finalBody := o.summaryCommentFromOps(ctx, apply, ops, opsErr, tasks, shardsByTable)
 		o.editTrackedComment(apply, activeCommentState, finalBody)
 		o.markSummaryPosted(apply, activeCommentState)
+		if state.IsState(apply.State, state.Apply.Stopped) {
+			// Stopped is the only terminal state that returns to active. The
+			// prompt now carries the stop record, so consume its row —
+			// otherwise a resumed drive finds a live prompt row and mutes
+			// behind the stop record instead of tracking the resumed copy in
+			// the fresh comment the resume rotation posts.
+			o.supersedeCutoverComment(ctx, apply)
+		}
 	} else {
 		// Edit the progress comment to its final state (completed bars / error).
 		// This is the per-operation status freeze, not the apply-level summary, so
@@ -1075,21 +1100,35 @@ func (o *CommentObserver) rotateProgressCommentAfterCutover(apply *storage.Apply
 		// the next tick retries.
 		return false
 	}
+	if !trackedNew {
+		// The fresh comment is on the PR, but the tracked row still points at
+		// the pre-cutover comment and the live cutover row remains the durable
+		// marker that this rotation is owed. Remember the fresh comment so the
+		// next tick adopts it — retrying only the tracking write, never
+		// another post — after which the already-rotated branch above folds
+		// the prompt and consumes the row. Consuming the row now would orphan
+		// the fresh comment: nothing else adopts an untracked comment, and no
+		// recorded phase would stop a later observer from rotating again. The
+		// prompt is not folded either: the freeze marker rides the tracking
+		// write, so a fold now could never be retried.
+		o.pendingRotation = &pendingProgressRotation{
+			commentID:           newCommentID,
+			volume:              apply.GetOptions().Volume,
+			phase:               controlPhase(apply.State),
+			reason:              supersededByCutover,
+			supersededCommentID: cutover.GitHubCommentID,
+		}
+		o.logError(apply, "observer: fresh post-cutover progress comment posted but not tracked; the cutover prompt stays live until the next tick adopts the fresh comment",
+			"github_comment_id", newCommentID)
+		return true
+	}
 	o.cutoverRotated = true
 	o.hasCutoverComment = false
 
-	if trackedNew {
-		o.freezeSupersededProgressComment(apply, cutover.GitHubCommentID, newCommentID, supersededByCutover, 0)
-	}
-	// When the fresh comment posted but its tracking write failed
-	// (postAndTrackComment logged it), the cutover prompt must not be folded:
-	// no freeze marker was recorded (it rides the tracking write), so a fold
-	// now could never be retried and the fresh comment would be untracked.
-
+	o.freezeSupersededProgressComment(apply, cutover.GitHubCommentID, newCommentID, supersededByCutover, 0)
 	o.supersedeCutoverComment(ctx, apply)
 
-	o.logger.Info("observer: posted fresh progress comment after deferred cutover",
-		"apply_id", o.applyID, "repo", o.repo, "pr", o.pr, "state", apply.State)
+	o.logInfo(apply, "observer: posted fresh progress comment after deferred cutover", "state", apply.State)
 	return true
 }
 


### PR DESCRIPTION
## Why this matters

A deferred cutover that completed into a still-active apply (the revert window) left the observer muted on the spent cutover prompt: the revert-window countdown never rendered anywhere and the operator had no live comment to watch — the worst of the control-operation UX gaps.

## What it does

When the apply provably moves past the cutover gate into a post-cutover phase (revert window, reverting, skipping revert), the observer unmutes, posts a fresh progress comment tracking that phase, folds the spent prompt ("Cutover complete"), and supersedes its stored row so later observers neither re-mute on it nor complete it on terminal. Every other state keeps the observer muted while the prompt is unanswered — a restart recovery re-copying a parked apply, a retryable failure at the gate — because no cutover happened, so nothing may render a "Cutover complete" record. Auto-cutover applies don't rotate — no operator command was issued.

```
copy → [cutover prompt posted, progress frozen]      (gate: observer mutes)
         │ operator cutover completes → revert window
         ▼
       [prompt folded "Cutover complete"]  [fresh progress comment ← live]
```

Degraded paths hold the line:
- The live cutover row is the durable marker that the rotation is owed — consumed only after the fresh comment lands *and is tracked*, so a crash retries next tick, and the tracked comment's recorded post-cutover phase dedupes across drives.
- A rotation comment that posts but fails its tracking write stays pending: the prompt is not folded and the row is not consumed; a later tick adopts the already-live comment — retrying only the tracking write, never another post — then folds the prompt and consumes the row.
- A row whose supersede write failed after the rotation is known-stale: progress ticks retry consuming it and keep editing the fresh comment, and the terminal publish routes on the recorded phase — completing the fresh comment instead of overwriting the folded prompt.
- A stop at the gate completes the prompt itself as the stop record and consumes its row, so a resumed drive tracks the resumed copy in a fresh comment instead of muting behind the stop record.
- Pending (posted-but-untracked) rotation comments are adopted before the cutover prompt posts and before the post-cutover rotation runs, so the tracked row always moves forward and never regresses to a stale comment after a newer one was tracked.

The degraded paths are pinned by storage-outage integration tests (failing Supersede / failing Upsert wrappers).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)

