### PR TITLE
refactor(engine): move VSchema diff helpers to shared pkg/vschema package

### DIFF
--- a/pkg/engine/planetscale/branch.go
+++ b/pkg/engine/planetscale/branch.go
@@ -22,6 +22,7 @@ import (
 	"github.com/block/schemabot/pkg/lint"
 	"github.com/block/schemabot/pkg/psclient"
 	"github.com/block/schemabot/pkg/schema"
+	"github.com/block/schemabot/pkg/vschema"
 )
 
 // verifyBranchMatchesDesiredWithRetry retries verifyBranchMatchesDesired up to
@@ -262,13 +263,13 @@ func (e *Engine) diffKeyspace(ctx context.Context, client psclient.PSClient, org
 		if currentVSchema != nil {
 			currentVSchemaRaw = currentVSchema.Raw
 		}
-		vschemaChanged = VSchemaChanged(currentVSchemaRaw, content)
+		vschemaChanged = vschema.Changed(currentVSchemaRaw, content)
 		if vschemaChanged {
 			e.logger.Info("diffKeyspace: VSchema mismatch detected",
 				"keyspace", ks,
 				"branch", branch,
-				"current_normalized", normalizeVSchemaJSON(currentVSchemaRaw),
-				"desired_normalized", normalizeVSchemaJSON(content),
+				"current_normalized", vschema.Normalize(currentVSchemaRaw),
+				"desired_normalized", vschema.Normalize(content),
 			)
 		}
 	}

--- a/pkg/engine/planetscale/plan.go
+++ b/pkg/engine/planetscale/plan.go
@@ -15,6 +15,7 @@ import (
 	"github.com/block/schemabot/pkg/engine"
 	"github.com/block/schemabot/pkg/lint"
 	"github.com/block/schemabot/pkg/schema"
+	"github.com/block/schemabot/pkg/vschema"
 )
 
 // Plan computes the schema changes needed by diffing current schema against desired.
@@ -80,7 +81,7 @@ func (e *Engine) Plan(ctx context.Context, req *engine.PlanRequest) (*engine.Pla
 
 			if vschemaChanged {
 				sc.Metadata["vschema_changed"] = "true"
-				sc.Metadata["vschema"] = VSchemaDiff(currentVSchemaRaw, ns.Files["vschema.json"])
+				sc.Metadata["vschema"] = vschema.Diff(currentVSchemaRaw, ns.Files["vschema.json"])
 				if strings.TrimSpace(currentVSchemaRaw) == "" {
 					currentVSchemaRaw = "{}"
 				}

--- a/pkg/vschema/diff.go
+++ b/pkg/vschema/diff.go
@@ -1,4 +1,10 @@
-package planetscale
+// Package vschema compares and renders diffs of Vitess VSchema JSON
+// documents. Comparison is semantic: whitespace, key ordering, and proto
+// zero-value fields (e.g. "sharded": false) are ignored, matching how Vitess
+// stores VSchema. Any Vitess-family engine can use these helpers to decide
+// whether a desired VSchema differs from the live one and to render the
+// change for operators.
+package vschema
 
 import (
 	"bytes"
@@ -10,19 +16,19 @@ import (
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 )
 
-// VSchemaChanged returns true if the current and desired VSchema JSON strings
+// Changed returns true if the current and desired VSchema JSON strings
 // differ semantically (ignoring whitespace and key ordering).
-func VSchemaChanged(current, desired string) bool {
-	current = normalizeVSchemaJSON(current)
-	desired = normalizeVSchemaJSON(desired)
+func Changed(current, desired string) bool {
+	current = Normalize(current)
+	desired = Normalize(desired)
 	return current != desired
 }
 
-// VSchemaDiff returns a unified diff between the current and desired VSchema
+// Diff returns a unified diff between the current and desired VSchema
 // JSON strings. Returns empty string if they are identical.
-func VSchemaDiff(current, desired string) string {
-	currentPretty := prettyJSON(normalizeVSchemaJSON(current))
-	desiredPretty := prettyJSON(normalizeVSchemaJSON(desired))
+func Diff(current, desired string) string {
+	currentPretty := prettyJSON(Normalize(current))
+	desiredPretty := prettyJSON(Normalize(desired))
 
 	if currentPretty == desiredPretty {
 		return ""
@@ -42,11 +48,11 @@ func VSchemaDiff(current, desired string) string {
 	return text
 }
 
-// normalizeVSchemaJSON normalizes a VSchema JSON string for comparison.
+// Normalize canonicalizes a VSchema JSON string for comparison.
 // Uses Vitess protobuf round-trip to strip proto zero-value fields (e.g.,
 // "sharded": false) that are semantically equivalent to being absent.
 // This matches the approach used for VSchema comparison in the tern layer.
-func normalizeVSchemaJSON(s string) string {
+func Normalize(s string) string {
 	if s == "" {
 		return "{}"
 	}

--- a/pkg/vschema/diff.go
+++ b/pkg/vschema/diff.go
@@ -9,6 +9,7 @@ package vschema
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 
 	"github.com/pmezard/go-difflib/difflib"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -41,9 +42,13 @@ func Diff(current, desired string) string {
 		ToFile:   "new",
 		Context:  3,
 	}
+	// The two documents differ at this point, so an empty result would be
+	// indistinguishable from "no change". Surface rendering failure with a
+	// fixed placeholder instead (never the raw error, which could carry
+	// internal detail into PR-facing output).
 	text, err := difflib.GetUnifiedDiffString(diff)
 	if err != nil {
-		return ""
+		return "(VSchema diff unavailable)"
 	}
 	return text
 }
@@ -53,6 +58,7 @@ func Diff(current, desired string) string {
 // "sharded": false) that are semantically equivalent to being absent.
 // This matches the approach used for VSchema comparison in the tern layer.
 func Normalize(s string) string {
+	s = strings.TrimSpace(s)
 	if s == "" {
 		return "{}"
 	}

--- a/pkg/vschema/diff_test.go
+++ b/pkg/vschema/diff_test.go
@@ -1,4 +1,4 @@
-package planetscale
+package vschema
 
 import (
 	"testing"
@@ -9,7 +9,7 @@ import (
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 )
 
-func TestVSchemaChanged(t *testing.T) {
+func TestChanged(t *testing.T) {
 	tests := []struct {
 		name     string
 		current  string
@@ -92,13 +92,13 @@ func TestVSchemaChanged(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := VSchemaChanged(tt.current, tt.desired)
+			got := Changed(tt.current, tt.desired)
 			assert.Equal(t, tt.expected, got)
 		})
 	}
 }
 
-func TestVSchemaDiff(t *testing.T) {
+func TestDiff(t *testing.T) {
 	tests := []struct {
 		name           string
 		current        string
@@ -142,7 +142,7 @@ func TestVSchemaDiff(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			diff := VSchemaDiff(tt.current, tt.desired)
+			diff := Diff(tt.current, tt.desired)
 			if tt.expectEmpty {
 				assert.Empty(t, diff, "expected empty diff")
 				return
@@ -155,107 +155,107 @@ func TestVSchemaDiff(t *testing.T) {
 	}
 }
 
-func TestNormalizeVSchemaJSON_Deterministic(t *testing.T) {
+func TestNormalize_Deterministic(t *testing.T) {
 	// Same VSchema with different key ordering should normalize identically
 	a := `{"tables":{"users":{},"orders":{}},"vindexes":{"hash":{"type":"hash"}},"sharded":true}`
 	b := `{"sharded":true,"vindexes":{"hash":{"type":"hash"}},"tables":{"orders":{},"users":{}}}`
 
-	assert.Equal(t, normalizeVSchemaJSON(a), normalizeVSchemaJSON(b),
+	assert.Equal(t, Normalize(a), Normalize(b),
 		"same VSchema with different key order should normalize identically")
 }
 
-func TestNormalizeVSchemaJSON_RepeatedCalls(t *testing.T) {
+func TestNormalize_RepeatedCalls(t *testing.T) {
 	// Normalizing the same string multiple times should always produce the same result
 	vs := `{"sharded":true,"vindexes":{"hash":{"type":"hash"}},"tables":{"users":{"column_vindexes":[{"column":"id","name":"hash"}]}}}`
-	first := normalizeVSchemaJSON(vs)
+	first := Normalize(vs)
 	for range 10 {
-		assert.Equal(t, first, normalizeVSchemaJSON(vs),
+		assert.Equal(t, first, Normalize(vs),
 			"repeated normalization should be stable")
 	}
 }
 
-func TestVSchemaChanged_RoundTrip(t *testing.T) {
+func TestChanged_RoundTrip(t *testing.T) {
 	// Normalize, then compare against the normalized form — should not detect a change
 	vs := `{"sharded":true,"vindexes":{"hash":{"type":"hash"}},"tables":{"users":{"column_vindexes":[{"column":"id","name":"hash"}]},"orders":{"column_vindexes":[{"column":"user_id","name":"hash"}]}}}`
-	normalized := normalizeVSchemaJSON(vs)
-	assert.False(t, VSchemaChanged(vs, normalized),
+	normalized := Normalize(vs)
+	assert.False(t, Changed(vs, normalized),
 		"original vs normalized should not be detected as changed")
-	assert.False(t, VSchemaChanged(normalized, vs),
+	assert.False(t, Changed(normalized, vs),
 		"normalized vs original should not be detected as changed")
 }
 
-func TestVSchemaChanged_SequenceTablesUnsharded(t *testing.T) {
+func TestChanged_SequenceTablesUnsharded(t *testing.T) {
 	// Simulates the testapp keyspace: sequence tables only, unsharded
 	fileVSchema := `{"tables":{"users_seq":{"type":"sequence"},"orders_seq":{"type":"sequence"},"products_seq":{"type":"sequence"}}}`
 	// API might return with different formatting or field ordering
 	apiVSchema := `{"tables": {"orders_seq": {"type": "sequence"}, "products_seq": {"type": "sequence"}, "users_seq": {"type": "sequence"}}}`
 
-	assert.False(t, VSchemaChanged(apiVSchema, fileVSchema),
+	assert.False(t, Changed(apiVSchema, fileVSchema),
 		"sequence tables VSchema should match regardless of key ordering or whitespace")
 }
 
-func TestVSchemaChanged_ShardedWithVindexes(t *testing.T) {
+func TestChanged_ShardedWithVindexes(t *testing.T) {
 	// Simulates testapp_sharded: full VSchema with vindexes and column_vindexes
 	fileVSchema := `{"sharded":true,"vindexes":{"hash":{"type":"hash"}},"tables":{"users":{"column_vindexes":[{"column":"id","name":"hash"}],"auto_increment":{"column":"id","sequence":"users_seq"}},"orders":{"column_vindexes":[{"column":"user_id","name":"hash"}],"auto_increment":{"column":"id","sequence":"orders_seq"}},"products":{"column_vindexes":[{"column":"id","name":"hash"}],"auto_increment":{"column":"id","sequence":"products_seq"}}}}`
 	// API returns same content, different ordering
 	apiVSchema := `{"vindexes":{"hash":{"type":"hash"}},"sharded":true,"tables":{"products":{"auto_increment":{"sequence":"products_seq","column":"id"},"column_vindexes":[{"name":"hash","column":"id"}]},"users":{"auto_increment":{"sequence":"users_seq","column":"id"},"column_vindexes":[{"name":"hash","column":"id"}]},"orders":{"auto_increment":{"sequence":"orders_seq","column":"id"},"column_vindexes":[{"name":"hash","column":"user_id"}]}}}`
 
-	assert.False(t, VSchemaChanged(apiVSchema, fileVSchema),
+	assert.False(t, Changed(apiVSchema, fileVSchema),
 		"same sharded VSchema with different key ordering should not be detected as changed")
 }
 
-func TestVSchemaChanged_EmptyTables(t *testing.T) {
+func TestChanged_EmptyTables(t *testing.T) {
 	// Some tables have empty config {} — should be identical
 	fileVSchema := `{"tables":{"users":{}}}`
 	apiVSchema := `{"tables":{"users":{}}}`
-	assert.False(t, VSchemaChanged(apiVSchema, fileVSchema))
+	assert.False(t, Changed(apiVSchema, fileVSchema))
 }
 
-func TestVSchemaChanged_ProtoDefaultStripping(t *testing.T) {
+func TestChanged_ProtoDefaultStripping(t *testing.T) {
 	// "sharded": false is a proto default — normalizer should strip it
 	withShardedFalse := `{"sharded":false,"tables":{"users":{"type":"sequence"}}}`
 	withoutSharded := `{"tables":{"users":{"type":"sequence"}}}`
-	assert.False(t, VSchemaChanged(withShardedFalse, withoutSharded),
+	assert.False(t, Changed(withShardedFalse, withoutSharded),
 		"sharded:false (proto default) vs absent should not be detected as changed")
 }
 
-func TestVSchemaChanged_RealDifference(t *testing.T) {
+func TestChanged_RealDifference(t *testing.T) {
 	// Actual VSchema change: adding a table entry
 	before := `{"tables":{"users":{"type":"sequence"}}}`
 	after := `{"tables":{"users":{"type":"sequence"},"orders":{"type":"sequence"}}}`
-	assert.True(t, VSchemaChanged(before, after),
+	assert.True(t, Changed(before, after),
 		"adding a table should be detected as a real change")
 }
 
-func TestVSchemaChanged_RealDifference_RemoveTable(t *testing.T) {
+func TestChanged_RealDifference_RemoveTable(t *testing.T) {
 	before := `{"tables":{"users":{"type":"sequence"},"orders":{"type":"sequence"}}}`
 	after := `{"tables":{"users":{"type":"sequence"}}}`
-	assert.True(t, VSchemaChanged(before, after),
+	assert.True(t, Changed(before, after),
 		"removing a table should be detected as a real change")
 }
 
-func TestVSchemaChanged_ProtojsonRoundTrip(t *testing.T) {
+func TestChanged_ProtojsonRoundTrip(t *testing.T) {
 	fileVSchema := `{"tables":{"users_seq":{"type":"sequence"},"orders_seq":{"type":"sequence"},"products_seq":{"type":"sequence"}}}`
 	var ks vschemapb.Keyspace
 	require.NoError(t, protojson.Unmarshal([]byte(fileVSchema), &ks))
 	apiBytes, err := protojson.Marshal(&ks)
 	require.NoError(t, err)
 	apiVSchema := string(apiBytes)
-	t.Logf("file normalized: %s", normalizeVSchemaJSON(fileVSchema))
-	t.Logf("api normalized:  %s", normalizeVSchemaJSON(apiVSchema))
-	assert.False(t, VSchemaChanged(apiVSchema, fileVSchema),
+	t.Logf("file normalized: %s", Normalize(fileVSchema))
+	t.Logf("api normalized:  %s", Normalize(apiVSchema))
+	assert.False(t, Changed(apiVSchema, fileVSchema),
 		"protojson round-trip should not produce a false positive")
 }
 
-func TestVSchemaChanged_ProtojsonRoundTrip_Sharded(t *testing.T) {
+func TestChanged_ProtojsonRoundTrip_Sharded(t *testing.T) {
 	fileVSchema := `{"sharded":true,"vindexes":{"hash":{"type":"hash"}},"tables":{"users":{"column_vindexes":[{"column":"id","name":"hash"}],"auto_increment":{"column":"id","sequence":"users_seq"}},"orders":{"column_vindexes":[{"column":"user_id","name":"hash"}],"auto_increment":{"column":"id","sequence":"orders_seq"}}}}`
 	var ks vschemapb.Keyspace
 	require.NoError(t, protojson.Unmarshal([]byte(fileVSchema), &ks))
 	apiBytes, err := protojson.Marshal(&ks)
 	require.NoError(t, err)
 	apiVSchema := string(apiBytes)
-	t.Logf("file normalized: %s", normalizeVSchemaJSON(fileVSchema))
-	t.Logf("api normalized:  %s", normalizeVSchemaJSON(apiVSchema))
-	assert.False(t, VSchemaChanged(apiVSchema, fileVSchema),
+	t.Logf("file normalized: %s", Normalize(fileVSchema))
+	t.Logf("api normalized:  %s", Normalize(apiVSchema))
+	assert.False(t, Changed(apiVSchema, fileVSchema),
 		"protojson round-trip of sharded VSchema should not produce a false positive")
 }

--- a/pkg/vschema/diff_test.go
+++ b/pkg/vschema/diff_test.go
@@ -47,6 +47,18 @@ func TestChanged(t *testing.T) {
 			expected: false,
 		},
 		{
+			name:     "whitespace-only vs empty object",
+			current:  "  \n  ",
+			desired:  "{}",
+			expected: false,
+		},
+		{
+			name:     "surrounding whitespace ignored",
+			current:  "\n  {\"sharded\": true}  \n",
+			desired:  `{"sharded": true}`,
+			expected: false,
+		},
+		{
 			name:     "empty vs empty tables",
 			current:  "{}",
 			desired:  `{"tables": {}}`,


### PR DESCRIPTION
## Why this matters

The VSchema comparison and diff-rendering helpers (`VSchemaChanged`, `VSchemaDiff`, and the JSON normalizer) lived inside the PlanetScale engine, but nothing about them is PlanetScale-specific — they normalize VSchema JSON through the Vitess protobuf types and render a unified diff. Keeping them engine-private means other Vitess-family engines cannot populate the `vschema` plan-metadata key, so their PR plan comments and CLI output show "VSchema update" with no diff body while PlanetScale plans show the full rendered diff.

## What it does

- Moves the helpers to a new `pkg/vschema` package as `vschema.Changed`, `vschema.Diff`, and `vschema.Normalize`, with tests moved alongside.
- Updates the PlanetScale engine to import the package directly — a move, not a re-export.
- Hardens two edge cases: `Normalize` now trims surrounding whitespace so a whitespace-only VSchema compares as empty (matching its documented whitespace-insensitive semantics), and `Diff` returns a fixed placeholder instead of an empty string if unified-diff rendering fails, so a render failure is never indistinguishable from "no change".

This unblocks any engine that plans VSchema changes to produce the same rendered diff the plan comment and CLI templates already display.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)