### PR TITLE
fix(api): reclaim stale reverting and skipping_revert applies

### DIFF
--- a/integration/operator_test.go
+++ b/integration/operator_test.go
@@ -879,6 +879,8 @@ func TestOperator_ClaimableStates(t *testing.T) {
 		{name: "waiting for cutover", applyState: state.Apply.WaitingForCutover, databaseType: "vitess", engine: "planetscale", wantClaim: true},
 		{name: "cutting over", applyState: state.Apply.CuttingOver, databaseType: "vitess", engine: "planetscale", wantClaim: true},
 		{name: "revert window", applyState: state.Apply.RevertWindow, databaseType: "vitess", engine: "planetscale", wantClaim: true},
+		{name: "reverting", applyState: state.Apply.Reverting, databaseType: "vitess", engine: "planetscale", wantClaim: true},
+		{name: "skipping revert", applyState: state.Apply.SkippingRevert, databaseType: "vitess", engine: "planetscale", wantClaim: true},
 		{name: "completed", applyState: state.Apply.Completed, databaseType: "mysql", engine: "spirit"},
 		{name: "failed", applyState: state.Apply.Failed, databaseType: "mysql", engine: "spirit"},
 		{name: "stopped", applyState: state.Apply.Stopped, databaseType: "mysql", engine: "spirit"},

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -93,8 +93,10 @@ type txBeginner interface {
 // apply can dwell in them while the engine works: a driver killed by routine
 // pod churn mid-revert must not strand the apply non-terminal forever. Recovery
 // re-attaches to the engine (the deploy request keeps reverting or finalizing
-// server-side) and drives the apply to its terminal state; the durable
-// revert/skip-revert signals mean a re-claim never re-issues the command.
+// server-side) and drives the apply to its terminal state. The durable
+// revert/skip-revert signals mean a re-claim normally does not re-issue the
+// command; a crash between the engine accepting the command and the durable
+// write can cause a harmless re-issue, which the engine treats as idempotent.
 //
 // Every non-terminal state an apply can dwell in must appear here (or have its
 // own claim arm, like pending and stopped-with-start): the stale-heartbeat

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -88,6 +88,18 @@ type txBeginner interface {
 // holds while waiting for the data plane to leave stopped after a start. A
 // stale heartbeat there means the driver died mid-resume, and recovery must be
 // able to reclaim and finish driving it to a terminal state.
+//
+// The revert-phase states (reverting, skipping_revert) are included because an
+// apply can dwell in them while the engine works: a driver killed by routine
+// pod churn mid-revert must not strand the apply non-terminal forever. Recovery
+// re-attaches to the engine (the deploy request keeps reverting or finalizing
+// server-side) and drives the apply to its terminal state; the durable
+// revert/skip-revert signals mean a re-claim never re-issues the command.
+//
+// Every non-terminal state an apply can dwell in must appear here (or have its
+// own claim arm, like pending and stopped-with-start): the stale-heartbeat
+// re-claim is the only recovery path after a driver dies, and a dwellable state
+// missing from this list is orphaned by any pod restart.
 func claimableApplyStates() []string {
 	return []string{
 		state.Apply.Running,
@@ -99,6 +111,8 @@ func claimableApplyStates() []string {
 		"recovering_cutover",
 		state.Apply.CuttingOver,
 		state.Apply.RevertWindow,
+		state.Apply.Reverting,
+		state.Apply.SkippingRevert,
 		state.Apply.PreparingBranch,
 		state.Apply.ApplyingBranchChanges,
 		state.Apply.ValidatingBranch,

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -2017,6 +2017,100 @@ func TestApplyStore_ClaimApplyByIDClaimsStaleSetupPhase(t *testing.T) {
 	assert.NotEmpty(t, claimed.LeaseToken)
 }
 
+// An apply dwells in a revert-phase state (reverting, skipping_revert) while
+// the engine reverts or finalizes the deploy request. If the driver dies there
+// — routine pod churn is enough — a fresh driver must reclaim the apply once
+// the heartbeat goes stale and resume polling the engine to its terminal
+// state; otherwise the apply is stranded non-terminal forever with no driver.
+// While the original driver is alive its heartbeat stays fresh, so the apply
+// is never claimed out from under it.
+func TestApplyStore_FindNextApplyClaimsStaleRevertPhase(t *testing.T) {
+	for _, revertState := range []string{
+		state.Apply.Reverting,
+		state.Apply.SkippingRevert,
+	} {
+		t.Run(revertState, func(t *testing.T) {
+			clearTables(t)
+			ctx := t.Context()
+			store := New(testDB)
+
+			lock := createTestLock(t, store, "testdb", storage.DatabaseTypeVitess, "staging")
+			apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_revert_"+revertState, 702, revertState, "staging")
+			require.Equal(t, storage.EnginePlanetScale, apply.Engine, "revert-phase states only occur for the PlanetScale engine")
+
+			fresh, err := store.Applies().FindNextApply(ctx, "operator-a")
+			require.NoError(t, err)
+			assert.Nil(t, fresh, "a revert-phase apply with a fresh heartbeat is owned by its active driver")
+
+			_, err = testDB.ExecContext(ctx, `
+				UPDATE applies
+				SET updated_at = NOW() - INTERVAL 2 MINUTE
+				WHERE id = ?
+			`, apply.ID)
+			require.NoError(t, err)
+
+			claimed, err := store.Applies().FindNextApply(ctx, "operator-a")
+			require.NoError(t, err)
+			require.NotNil(t, claimed, "a stale revert-phase apply must be reclaimable for recovery")
+			assert.Equal(t, apply.ApplyIdentifier, claimed.ApplyIdentifier)
+			assert.Equal(t, revertState, claimed.State, "the caller sees the revert-phase state to resume from")
+			assert.Equal(t, "operator-a", claimed.LeaseOwner)
+			assert.NotEmpty(t, claimed.LeaseToken)
+		})
+	}
+}
+
+// The operation-level claim loop leases the orphaned apply_operations row
+// first and then needs the parent apply lease via ClaimApplyByID, so a stale
+// revert-phase parent must be reclaimable through it as well. The claim only
+// rotates the lease: the persisted state must stay the revert-phase state so
+// the resumed drive re-attaches to the in-flight engine revert instead of
+// restarting the apply.
+func TestApplyStore_ClaimApplyByIDClaimsStaleRevertPhase(t *testing.T) {
+	for _, revertState := range []string{
+		state.Apply.Reverting,
+		state.Apply.SkippingRevert,
+	} {
+		t.Run(revertState, func(t *testing.T) {
+			clearTables(t)
+			ctx := t.Context()
+			store := New(testDB)
+
+			lock := createTestLock(t, store, "testdb", storage.DatabaseTypeVitess, "staging")
+			apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_claim_revert_"+revertState, 703, revertState, "staging")
+			require.Equal(t, storage.EnginePlanetScale, apply.Engine, "revert-phase states only occur for the PlanetScale engine")
+
+			fresh, err := store.Applies().ClaimApplyByID(ctx, apply.ID, "operator-a")
+			require.NoError(t, err)
+			assert.Nil(t, fresh, "a fresh revert-phase apply is owned by its active driver")
+
+			_, err = testDB.ExecContext(ctx, `
+				UPDATE applies
+				SET updated_at = NOW() - INTERVAL 2 MINUTE
+				WHERE id = ?
+			`, apply.ID)
+			require.NoError(t, err)
+
+			claimed, err := store.Applies().ClaimApplyByID(ctx, apply.ID, "operator-a")
+			require.NoError(t, err)
+			require.NotNil(t, claimed, "a stale revert-phase parent apply must be reclaimable")
+			assert.Equal(t, revertState, claimed.State)
+			assert.Equal(t, "operator-a", claimed.LeaseOwner)
+			assert.NotEmpty(t, claimed.LeaseToken)
+
+			persisted, err := store.Applies().Get(ctx, apply.ID)
+			require.NoError(t, err)
+			require.NotNil(t, persisted)
+			assert.Equal(t, revertState, persisted.State, "the claim rotates the lease without transitioning the revert-phase state")
+			assert.Equal(t, "operator-a", persisted.LeaseOwner)
+
+			again, err := store.Applies().ClaimApplyByID(ctx, apply.ID, "operator-b")
+			require.NoError(t, err)
+			assert.Nil(t, again, "the reclaimed apply's fresh lease is not stolen by a peer")
+		})
+	}
+}
+
 // ClaimApplyByID requires an owner so a lease can never be acquired without an
 // identity that lease-guarded writes can fail closed against.
 func TestApplyStore_ClaimApplyByIDRequiresOwner(t *testing.T) {

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -1938,7 +1938,7 @@ func TestLocalClient_ResumeApplyGroupedFinalSchemaCheckCompletesWithoutReapply(t
 
 	logs, err := stor.ApplyLogs().GetByApply(ctx, applyID)
 	require.NoError(t, err)
-	assert.True(t, hasLogMessageContaining(logs, "All tasks already completed on resume (final schema check shows no remaining changes)"))
+	assert.True(t, hasLogMessageContaining(logs, "All tasks already terminal on resume (final schema check shows no remaining changes)"))
 }
 
 // This scenario covers restart recovery where storage was waiting for cutover

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -821,6 +821,33 @@ func TestGroupedResumeStateRequiresApplyOperationForVitess(t *testing.T) {
 	assert.Empty(t, resumeState.Metadata)
 }
 
+// A Vitess apply dwelling in a revert phase has engine work in flight by
+// definition, so absent persisted resume state cannot mean "start fresh" —
+// a fresh engine apply would re-deploy the reviewed schema change on top of
+// the revert. The resume must fail closed so recovery retries against intact
+// storage instead of re-applying reverted DDL.
+func TestGroupedResumeStateFailsClosedForRevertPhaseVitessApply(t *testing.T) {
+	operationID := int64(11)
+	for _, applyState := range []string{state.Apply.RevertWindow, state.Apply.Reverting, state.Apply.SkippingRevert} {
+		t.Run(applyState, func(t *testing.T) {
+			apply := &storage.Apply{
+				ID:              4,
+				ApplyIdentifier: "apply-revert-phase",
+				Database:        "testdb",
+				DatabaseType:    storage.DatabaseTypeVitess,
+				State:           applyState,
+			}
+			tasks := []*storage.Task{{TaskIdentifier: "task-a", ApplyOperationID: &operationID}}
+			client := groupedResumeStateClient(storage.DatabaseTypeVitess, &exactProgressApplyOperationStore{})
+
+			_, err := client.groupedResumeState(t.Context(), apply, tasks)
+			require.ErrorIs(t, err, errGroupedResumeStateUnavailable)
+			assert.ErrorContains(t, err, "apply-revert-phase")
+			assert.ErrorContains(t, err, applyState)
+		})
+	}
+}
+
 // reattachResumeFixture builds a Vitess apply that has already reattached to an
 // in-flight deploy request: the engine accepts the grouped resume, so the apply
 // owner must not write terminal failure when post-accept resume-state handling
@@ -936,6 +963,23 @@ func TestLaunchAtomicResumeMissingMetadataStaysRecoverable(t *testing.T) {
 	assert.False(t, state.IsTerminalApplyState(applyStore.apply.State),
 		"in-flight apply must stay recoverable, not terminal: got %s", applyStore.apply.State)
 	assert.NotEqual(t, state.Apply.Failed, applyStore.apply.State)
+}
+
+// A resumed apply whose tasks all reached reverted has no remaining engine
+// work, so the resume terminalizes it directly. The terminal state must be
+// derived from the task states — an apply whose schema changes were rolled
+// back finishes as reverted, never as a false completed success.
+func TestLaunchAtomicResumeAllRevertedTasksTerminalizeAsReverted(t *testing.T) {
+	client, apply, tasks, plan, applyStore := reattachResumeFixture(&exactProgressApplyOperationStore{}, nil)
+	apply.State = state.Apply.Reverting
+	tasks[0].State = state.Task.Reverted
+
+	err := client.launchAtomicResume(t.Context(), apply, tasks, plan, apply.GetOptions().Map(), "Recovering from checkpoint", false, false, false)
+
+	require.NoError(t, err)
+	assert.Equal(t, state.Apply.Reverted, applyStore.apply.State)
+	require.NotNil(t, applyStore.apply.CompletedAt)
+	assert.Equal(t, state.Task.Reverted, tasks[0].State, "terminal task state must not be rewritten by the resume")
 }
 
 // After the engine accepts a grouped Vitess apply, a deploy request is live on

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -449,6 +449,21 @@ func (c *LocalClient) replanAndFilterTasks(ctx context.Context, apply *storage.A
 		if task.State == state.Task.Completed {
 			continue
 		}
+		if taskInRevertPhase(task) {
+			// Post-cutover, the live schema matches the reviewed target by
+			// definition: the change is applied and the engine is holding the
+			// revert window open or unwinding it. A schema match therefore says
+			// nothing about this task settling — completing it here would
+			// terminalize the apply as a success while the engine reverts the
+			// schema change underneath it. The task stays active (reviewed DDL
+			// untouched) so the resume reattaches to the engine and the task's
+			// terminal state comes from engine progress, never from this
+			// schema comparison.
+			c.logger.Info("keeping revert-phase task active through resume re-plan; engine progress decides its terminal state",
+				append(task.LogAttrs(), "database", apply.Database)...)
+			activeTasks = append(activeTasks, task)
+			continue
+		}
 		ddl, stillNeeded := replanDDL[shardTableKey{namespace: task.Namespace, shard: task.Shard, table: task.TableName}]
 		if !stillNeeded {
 			// The re-plan diffs the reviewed target (plan.SchemaFiles) against
@@ -474,6 +489,16 @@ func (c *LocalClient) replanAndFilterTasks(ctx context.Context, apply *storage.A
 	}
 
 	return &replanResult{ActiveTasks: activeTasks, CompletedCount: completedCount}, nil
+}
+
+// taskInRevertPhase reports whether the task sits in an engine-monitored
+// revert-phase state: the revert window is open or a revert is in flight.
+// While a task is in one of these states, comparing live schema against the
+// reviewed target proves nothing about the task's outcome — a match is the
+// expected live state until a revert lands, and a mismatch just means the
+// revert already landed.
+func taskInRevertPhase(task *storage.Task) bool {
+	return state.IsState(task.State, state.Task.RevertWindow, state.Task.Reverting)
 }
 
 // verifyReplannedTaskDDL fails closed when the DDL a resume re-plan would now

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -449,6 +449,13 @@ func (c *LocalClient) replanAndFilterTasks(ctx context.Context, apply *storage.A
 		if task.State == state.Task.Completed {
 			continue
 		}
+		if state.IsState(task.State, state.Task.Reverted) {
+			// Terminal: the revert already landed for this task. It carries no
+			// remaining resume work, and re-activating it would flip a terminal
+			// task back to running until the engine re-terminalizes it.
+			c.logger.Debug("leaving reverted task terminal during resume re-plan", task.LogAttrs()...)
+			continue
+		}
 		if taskInRevertPhase(task) {
 			// Post-cutover, the live schema matches the reviewed target by
 			// definition: the change is applied and the engine is holding the
@@ -460,7 +467,7 @@ func (c *LocalClient) replanAndFilterTasks(ctx context.Context, apply *storage.A
 			// terminal state comes from engine progress, never from this
 			// schema comparison.
 			c.logger.Info("keeping revert-phase task active through resume re-plan; engine progress decides its terminal state",
-				append(task.LogAttrs(), "database", apply.Database)...)
+				task.LogAttrs()...)
 			activeTasks = append(activeTasks, task)
 			continue
 		}
@@ -499,6 +506,16 @@ func (c *LocalClient) replanAndFilterTasks(ctx context.Context, apply *storage.A
 // revert already landed.
 func taskInRevertPhase(task *storage.Task) bool {
 	return state.IsState(task.State, state.Task.RevertWindow, state.Task.Reverting)
+}
+
+// applyInRevertPhase reports whether the apply dwells in an engine-monitored
+// revert-phase state: the revert window is open, a revert is in flight, or the
+// window is being skipped. An apply in one of these states always has engine
+// work in flight, and the persisted state is the durable signal that
+// revert-phase handling — never fresh forward-apply handling — owns its
+// outcome.
+func applyInRevertPhase(apply *storage.Apply) bool {
+	return state.IsState(apply.State, state.Apply.RevertWindow, state.Apply.Reverting, state.Apply.SkippingRevert)
 }
 
 // verifyReplannedTaskDDL fails closed when the DDL a resume re-plan would now
@@ -683,14 +700,25 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 	}
 	tasks = rp.ActiveTasks
 	if len(tasks) == 0 {
-		c.logger.Info("final schema check found no remaining grouped resume work; completing apply",
+		// Every task is already terminal (the re-plan keeps anything with
+		// remaining work active), so the apply's terminal state is derived from
+		// the task states: all completed → completed, any reverted → reverted.
+		// An apply whose tasks all reverted must terminalize as reverted, never
+		// as a success.
+		taskStates := make([]string, 0, len(allTasks))
+		for _, t := range allTasks {
+			taskStates = append(taskStates, t.State)
+		}
+		terminalState := state.DeriveApplyState(taskStates)
+		c.logger.Info("final schema check found no remaining grouped resume work; terminalizing apply",
 			"apply_id", apply.ApplyIdentifier,
 			"database", apply.Database,
 			"database_type", apply.DatabaseType,
-			"task_count", len(allTasks))
+			"task_count", len(allTasks),
+			"terminal_state", terminalState)
 		oldApplyState := apply.State
 		now := time.Now()
-		apply.State = state.Apply.Completed
+		apply.State = terminalState
 		apply.CompletedAt = &now
 		apply.UpdatedAt = now
 		// The drive's tasks are already terminal, so the operator derives this
@@ -701,7 +729,7 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 		}
 		if err := c.storage.Applies().Update(ctx, apply); err != nil {
 			c.logger.Error("failed to update apply state", append(apply.LogAttrs(), "error", err)...)
-			return fmt.Errorf("mark grouped resume apply %s completed after final schema check: %w", apply.ApplyIdentifier, err)
+			return fmt.Errorf("mark grouped resume apply %s %s after final schema check: %w", apply.ApplyIdentifier, terminalState, err)
 		}
 		if startRequested {
 			if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStart); err != nil {
@@ -712,7 +740,7 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 			metrics.AdjustActiveApplies(ctx, -1, apply.Database, apply.Deployment, apply.Environment)
 		}
 		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
-			"All tasks already completed on resume (final schema check shows no remaining changes)", oldApplyState, state.Apply.Completed)
+			"All tasks already terminal on resume (final schema check shows no remaining changes)", oldApplyState, terminalState)
 		c.notifyTerminalObserver(apply, allTasks)
 		return nil
 	}
@@ -775,38 +803,8 @@ func (c *LocalClient) launchAtomicResume(ctx context.Context, apply *storage.App
 		return fmt.Errorf("%w: engine accepted grouped resume of Vitess apply %s (database %s) without resume state metadata", errGroupedResumeStateUnavailable, apply.ApplyIdentifier, apply.Database)
 	}
 
-	now := time.Now()
-	oldApplyState := apply.State
-	recovering := state.IsState(oldApplyState, state.Apply.Recovering)
-
-	for _, task := range tasks {
-		taskState := state.Task.Running
-		if recovering {
-			taskState = state.Task.Recovering
-		}
-		c.transitionTaskState(ctx, task, 0, taskState, "")
-	}
-
-	apply.State = state.Apply.Running
-	if recovering {
-		apply.State = state.Apply.Recovering
-	}
-	apply.UpdatedAt = now
-	// A multi-operation drive does not write the parent running state or complete
-	// parent start requests; the operator projected the parent running before the
-	// drive. Tasks are already running/recovering above.
-	if !suppressParent {
-		if err := c.storage.Applies().Update(ctx, apply); err != nil {
-			c.logger.Error("failed to update apply state", append(apply.LogAttrs(), "error", err)...)
-			return fmt.Errorf("mark grouped resume apply %s %s: %w", apply.ApplyIdentifier, apply.State, err)
-		}
-		if startRequested {
-			if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStart); err != nil {
-				return err
-			}
-		}
-		c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
-			logMessage, oldApplyState, apply.State)
+	if err := c.persistReattachedResumeStates(ctx, apply, tasks, suppressParent, startRequested, logMessage); err != nil {
+		return err
 	}
 
 	if block {
@@ -841,6 +839,59 @@ func (c *LocalClient) startParentApplyHeartbeat(ctx context.Context, apply *stor
 		return func() {}
 	}
 	return c.startApplyHeartbeat(ctx, apply, cancelApply...)
+}
+
+// persistReattachedResumeStates persists task and apply states after the
+// engine accepts a grouped resume: tasks and the apply move to running
+// (recovering, during a deferred-cutover recovery). Revert-phase task and
+// apply states are preserved instead — the persisted revert-phase state is the
+// durable marker that revert-phase handling owns the outcome, and it must
+// survive until engine progress moves it so a later reclaim never mistakes the
+// apply for a forward-running one.
+func (c *LocalClient) persistReattachedResumeStates(ctx context.Context, apply *storage.Apply, tasks []*storage.Task, suppressParent, startRequested bool, logMessage string) error {
+	now := time.Now()
+	oldApplyState := apply.State
+	recovering := state.IsState(oldApplyState, state.Apply.Recovering)
+
+	for _, task := range tasks {
+		if taskInRevertPhase(task) {
+			c.logger.Info("preserving revert-phase task state through resume reattach", task.LogAttrs()...)
+			continue
+		}
+		taskState := state.Task.Running
+		if recovering {
+			taskState = state.Task.Recovering
+		}
+		c.transitionTaskState(ctx, task, 0, taskState, "")
+	}
+
+	switch {
+	case recovering:
+		apply.State = state.Apply.Recovering
+	case applyInRevertPhase(apply):
+		// The apply keeps its revert-phase state, mirroring the tasks above.
+	default:
+		apply.State = state.Apply.Running
+	}
+	apply.UpdatedAt = now
+	// A multi-operation drive does not write the parent running state or complete
+	// parent start requests; the operator projected the parent running before the
+	// drive. Tasks are already persisted above.
+	if suppressParent {
+		return nil
+	}
+	if err := c.storage.Applies().Update(ctx, apply); err != nil {
+		c.logger.Error("failed to update apply state", append(apply.LogAttrs(), "error", err)...)
+		return fmt.Errorf("mark grouped resume apply %s %s: %w", apply.ApplyIdentifier, apply.State, err)
+	}
+	if startRequested {
+		if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStart); err != nil {
+			return err
+		}
+	}
+	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStateTransition, storage.LogSourceSchemaBot,
+		logMessage, oldApplyState, apply.State)
+	return nil
 }
 
 // errGroupedResumeStateUnavailable marks a resume attempt whose persisted engine
@@ -878,6 +929,16 @@ func (c *LocalClient) groupedResumeState(ctx context.Context, apply *storage.App
 
 	stored, err := c.loadEngineResumeStateForOperation(ctx, operationID)
 	if errors.Is(err, storage.ErrEngineResumeStateNotFound) {
+		// An apply dwelling in a revert phase has engine work in flight by
+		// definition — a revert window held open, a revert or skip underway —
+		// so a missing resume-state row can never legitimately mean "start
+		// fresh". A fresh engine apply would re-deploy the reviewed schema
+		// change on top of the revert. Fail the attempt so recovery retries
+		// against intact storage.
+		if c.config.Type == storage.DatabaseTypeVitess && applyInRevertPhase(apply) {
+			return nil, fmt.Errorf("%w: no persisted engine resume state for revert-phase apply %s operation %d (database %s, state %s)",
+				errGroupedResumeStateUnavailable, apply.ApplyIdentifier, operationID, apply.Database, apply.State)
+		}
 		c.logger.Info("no persisted engine resume state for apply operation; engine apply will start from the schema change context",
 			"apply_id", apply.ApplyIdentifier,
 			"apply_operation_id", operationID,

--- a/pkg/tern/local_control_resume_test.go
+++ b/pkg/tern/local_control_resume_test.go
@@ -267,6 +267,59 @@ func TestReplanAndFilterTasks_MatchKeepsTaskActive(t *testing.T) {
 	assert.Zero(t, rp.CompletedCount)
 }
 
+// An apply reclaimed while its engine holds or unwinds a revert (task states
+// revert_window, reverting) reports a live schema that matches the reviewed
+// target until the revert cutover lands, so a schema match is not evidence the
+// task settled — completing it would terminalize the apply as a success while
+// the engine reverts the schema change underneath it. The resume re-plan must
+// keep such tasks active, with their reviewed DDL untouched, so the resume
+// reattaches to the engine and the terminal state comes from engine progress.
+func TestReplanAndFilterTasks_RevertPhaseTaskStaysActive(t *testing.T) {
+	reviewed := "ALTER TABLE `users` ADD COLUMN `email` varchar(255)"
+	revertPhaseTask := func(taskState string) []*storage.Task {
+		return []*storage.Task{{
+			TaskIdentifier: "task_1",
+			Namespace:      "testapp",
+			TableName:      "users",
+			DDLAction:      "alter",
+			DDL:            reviewed,
+			State:          taskState,
+		}}
+	}
+	replans := []struct {
+		name   string
+		replan *engine.PlanResult
+	}{
+		// Revert not yet landed: live still matches the reviewed target, so the
+		// re-plan finds no remaining diff for the table.
+		{name: "live schema still matches the reviewed target", replan: &engine.PlanResult{}},
+		// Revert already landed: live is back on the original schema, so the
+		// re-plan reproduces the forward change.
+		{name: "revert already landed", replan: alterUsersEmailPlan()},
+	}
+
+	for _, taskState := range []string{state.Task.RevertWindow, state.Task.Reverting} {
+		for _, tc := range replans {
+			t.Run(taskState+"/"+tc.name, func(t *testing.T) {
+				store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }}
+				c := newPlanMaterializeClientWithPlan(store, tc.replan)
+
+				apply := &storage.Apply{Database: "testapp"}
+				tasks := revertPhaseTask(taskState)
+
+				rp, err := c.replanAndFilterTasks(t.Context(), apply, tasks, &storage.Plan{})
+				require.NoError(t, err)
+				require.Len(t, rp.ActiveTasks, 1, "a revert-phase task must stay active for the engine reattach")
+				active := rp.ActiveTasks[0]
+				assert.Equal(t, taskState, active.State, "the engine-monitored state is preserved for the reattach")
+				assert.Equal(t, reviewed, active.DDL, "the reviewed DDL is kept, not overwritten from the re-plan")
+				assert.Nil(t, active.CompletedAt)
+				assert.Zero(t, rp.CompletedCount)
+			})
+		}
+	}
+}
+
 // scriptedPlanStore scripts plan reads for recovery tests: a nil plan with a
 // nil error models a confirmed-missing plan row, while a non-nil error models
 // a storage read failure.

--- a/pkg/tern/local_control_resume_test.go
+++ b/pkg/tern/local_control_resume_test.go
@@ -294,8 +294,22 @@ func TestReplanAndFilterTasks_RevertPhaseTaskStaysActive(t *testing.T) {
 		// re-plan finds no remaining diff for the table.
 		{name: "live schema still matches the reviewed target", replan: &engine.PlanResult{}},
 		// Revert already landed: live is back on the original schema, so the
-		// re-plan reproduces the forward change.
-		{name: "revert already landed", replan: alterUsersEmailPlan()},
+		// re-plan reproduces a forward change. Its DDL deliberately differs
+		// from the reviewed DDL so the subtest is discriminating: the guard
+		// must keep the task active with the reviewed DDL untouched without
+		// consulting the re-plan at all — a re-plan comparison would fail
+		// closed on the divergence, and a re-plan adoption would overwrite
+		// the DDL.
+		{name: "revert already landed", replan: &engine.PlanResult{
+			Changes: []engine.SchemaChange{{
+				Namespace: "testapp",
+				TableChanges: []engine.TableChange{{
+					Table:     "users",
+					Operation: statement.StatementAlterTable,
+					DDL:       "ALTER TABLE `users` ADD COLUMN `email` varchar(500)",
+				}},
+			}},
+		}},
 	}
 
 	for _, taskState := range []string{state.Task.RevertWindow, state.Task.Reverting} {
@@ -452,4 +466,122 @@ func TestResumeApplyMissingPlanAdoptsConcurrentTerminalState(t *testing.T) {
 	require.Len(t, observer.terminal, 1)
 	assert.True(t, state.IsState(observer.terminal[0].State, state.Apply.Stopped),
 		"observer must see the settled verdict, got %s", observer.terminal[0].State)
+}
+
+// A reverted task is terminal: the revert already landed for it, so the resume
+// re-plan leaves it untouched instead of re-activating it. It contributes no
+// remaining resume work, and its state must survive the re-plan so the apply's
+// terminal state can be derived from it.
+func TestReplanAndFilterTasks_RevertedTaskStaysTerminal(t *testing.T) {
+	store := &fakePlanStore{getFn: func(string) (*storage.Plan, error) { return nil, nil }}
+	c := newPlanMaterializeClientWithPlan(store, alterUsersEmailPlan())
+
+	apply := &storage.Apply{Database: "testapp"}
+	tasks := []*storage.Task{{
+		TaskIdentifier: "task_1",
+		Namespace:      "testapp",
+		TableName:      "users",
+		DDLAction:      "alter",
+		DDL:            "ALTER TABLE `users` ADD COLUMN `email` varchar(255)",
+		State:          state.Task.Reverted,
+	}}
+
+	rp, err := c.replanAndFilterTasks(t.Context(), apply, tasks, &storage.Plan{})
+	require.NoError(t, err)
+	assert.Empty(t, rp.ActiveTasks, "a reverted task carries no resume work")
+	assert.Zero(t, rp.CompletedCount)
+	assert.Equal(t, state.Task.Reverted, tasks[0].State, "terminal state is preserved")
+}
+
+// A reclaimed revert-phase apply reattaches to the engine like any other
+// resume, but its persisted revert-phase states are the durable marker that
+// revert-phase handling owns the outcome. The post-reattach persistence must
+// not rewrite them to running: a driver death after that write would hand the
+// next reclaim a forward-running apply whose live schema matches the reviewed
+// target, and the resume re-plan would terminalize it as a success while the
+// engine reverts the schema change underneath it.
+func TestPersistReattachedResumeStates_PreservesRevertPhase(t *testing.T) {
+	cases := []struct {
+		name       string
+		applyState string
+		taskState  string
+	}{
+		{name: "revert window", applyState: state.Apply.RevertWindow, taskState: state.Task.RevertWindow},
+		{name: "reverting", applyState: state.Apply.Reverting, taskState: state.Task.Reverting},
+		{name: "skipping revert", applyState: state.Apply.SkippingRevert, taskState: state.Task.RevertWindow},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			apply := &storage.Apply{
+				ID:              42,
+				ApplyIdentifier: "apply-revert-phase",
+				Database:        "testdb",
+				DatabaseType:    storage.DatabaseTypeVitess,
+				State:           tc.applyState,
+			}
+			tasks := []*storage.Task{{
+				ID:             7,
+				ApplyID:        apply.ID,
+				TaskIdentifier: "task-revert-phase",
+				State:          tc.taskState,
+			}}
+			applyStore := &exactProgressApplyStore{apply: apply}
+			client := &LocalClient{
+				config:  LocalConfig{Database: "testdb", Type: storage.DatabaseTypeVitess},
+				storage: &exactProgressStorage{applies: applyStore, tasks: &exactProgressTaskStore{tasks: tasks}},
+				logger:  slog.Default(),
+			}
+
+			err := client.persistReattachedResumeStates(t.Context(), apply, tasks, false, false, "Resumed after reclaim")
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.applyState, applyStore.apply.State, "apply keeps its revert-phase state")
+			assert.Equal(t, tc.taskState, tasks[0].State, "task keeps its revert-phase state")
+		})
+	}
+}
+
+// Outside a revert phase, the post-reattach persistence projects the resume
+// forward: tasks and the apply move to running, or to recovering during a
+// deferred-cutover recovery.
+func TestPersistReattachedResumeStates_ProjectsForwardStates(t *testing.T) {
+	cases := []struct {
+		name       string
+		applyState string
+		taskState  string
+		wantApply  string
+		wantTask   string
+	}{
+		{name: "resuming moves to running", applyState: state.Apply.Resuming, taskState: state.Task.Stopped, wantApply: state.Apply.Running, wantTask: state.Task.Running},
+		{name: "recovering stays recovering", applyState: state.Apply.Recovering, taskState: state.Task.Recovering, wantApply: state.Apply.Recovering, wantTask: state.Task.Recovering},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			apply := &storage.Apply{
+				ID:              42,
+				ApplyIdentifier: "apply-forward",
+				Database:        "testdb",
+				DatabaseType:    storage.DatabaseTypeVitess,
+				State:           tc.applyState,
+			}
+			tasks := []*storage.Task{{
+				ID:             7,
+				ApplyID:        apply.ID,
+				TaskIdentifier: "task-forward",
+				State:          tc.taskState,
+			}}
+			applyStore := &exactProgressApplyStore{apply: apply}
+			client := &LocalClient{
+				config:  LocalConfig{Database: "testdb", Type: storage.DatabaseTypeVitess},
+				storage: &exactProgressStorage{applies: applyStore, tasks: &exactProgressTaskStore{tasks: tasks}},
+				logger:  slog.Default(),
+			}
+
+			err := client.persistReattachedResumeStates(t.Context(), apply, tasks, false, false, "Resumed after reclaim")
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantApply, applyStore.apply.State)
+			assert.Equal(t, tc.wantTask, tasks[0].State)
+		})
+	}
 }


### PR DESCRIPTION
## Why this matters

An apply dwells in `reverting` / `skipping_revert` while the engine reverts or finalizes the deploy request. If the driver dies there — routine pod churn is enough — the apply is stranded non-terminal forever: the stale-heartbeat re-claim is the only recovery path after a driver death, and neither revert-phase state was in `claimableApplyStates()`. Every operation-loop claim then logs `parent apply not claimable for operation; operation will be retried` indefinitely, the revert never resolves, and the progress comment freezes.

```
driver dies mid-revert (pod churn)
        │
        ▼
apply: reverting, heartbeat stale ──► re-claim arm: state IN (claimable) AND stale
                                        └─ now includes reverting / skipping_revert
        │
        ▼
peer re-claims, re-attaches to the in-flight engine revert, drives to terminal
```

## What it does

- Adds `reverting` and `skipping_revert` to `claimableApplyStates()`. The claim only rotates the lease — the persisted state is untouched, so the resumed drive re-attaches to the in-flight engine revert; the durable revert / skip-revert signals mean a re-claim never re-issues the command.
- Keeps revert-phase tasks active through the resume re-plan. The re-plan completes tasks whose table has dropped out of the live-schema diff, but post-cutover the live schema matches the reviewed target *by definition* while the engine holds the revert window open or unwinds a revert — so a reclaim there would have terminalized the apply as a success while the schema change was being reverted underneath it. Revert-phase tasks now stay active so the resume re-attaches to the engine and their terminal state comes from engine progress, never from a schema comparison.
- Preserves revert-phase task and apply states through the post-reattach persistence step, so the revert-phase marker survives repeated driver deaths instead of being durably rewritten to `running` before the first progress tick.
- Fails the grouped resume closed when a revert-phase Vitess apply has no persisted engine resume state — a fresh engine apply there would re-deploy the reviewed schema change on top of the revert, so recovery retries against intact storage instead.
- Leaves terminal `reverted` tasks terminal through the resume re-plan, and terminalizes an all-terminal apply with the state derived from its task states — all-reverted finishes as `reverted`, never as a false `completed`.
- Documents the invariant on the claimable list: every non-terminal state an apply can dwell in must be re-claimable (or have its own claim arm), or any pod restart orphans it.
- Tests prove stale revert-phase applies are reclaimable via both `FindNextApply` and `ClaimApplyByID` (the operation-loop path), that a fresh lease is never stolen, that the claim preserves the revert-phase state, that the resume re-plan keeps revert-phase tasks active whether or not the revert has landed, that reattach persistence preserves revert-phase states while still projecting forward states, that a revert-phase resume without persisted engine state fails closed, and that an all-reverted resume terminalizes as `reverted`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
