### PR TITLE
fix(tern): reconcile already-terminal remote applies on cancel rejection

### DIFF
--- a/pkg/api/operator.go
+++ b/pkg/api/operator.go
@@ -556,11 +556,11 @@ func (s *Service) recoverSingleApplyOperation(ctx context.Context, driverID int,
 		return
 	}
 
-	// If the derived state above settled the apply terminally and a stop is still
-	// pending, complete it now so the request does not linger after the rollout
-	// has stopped.
-	if err := s.completePendingStopIfApplyResolved(applyLeaseCtx, driverID, finalApply.ID); err != nil {
-		s.logger.Error("operator: failed to complete pending stop request for resolved apply",
+	// If the derived state above settled the apply terminally and a stop or
+	// cancel is still pending, complete it now so the request does not linger
+	// after the rollout has resolved.
+	if err := s.completePendingControlRequestsIfApplyResolved(applyLeaseCtx, driverID, finalApply.ID); err != nil {
+		s.logger.Error("operator: failed to complete pending control requests for resolved apply",
 			append(finalApply.LogAttrs(),
 				"driver", driverID, "apply_operation_id", op.ID, "operation_deployment", op.Deployment, "error", err)...)
 		return
@@ -728,13 +728,13 @@ func (s *Service) driveClaimedMultiOperation(ctx context.Context, driverID int, 
 	}
 
 	// Publish the apply-level terminal summary if this drive's projection won the
-	// swap that terminalized the parent. Do this before stop-request cleanup: the
-	// summary depends only on the apply being terminal, and a later cleanup error
-	// must not suppress it.
+	// swap that terminalized the parent. Do this before control-request cleanup:
+	// the summary depends only on the apply being terminal, and a later cleanup
+	// error must not suppress it.
 	s.publishTerminalSummaryIfWon(operationLeaseCtx, driverID, finalApply, result)
 
-	if err := s.completePendingStopIfApplyResolved(operationLeaseCtx, driverID, finalApply.ID); err != nil {
-		s.logger.Error("operator: failed to complete pending stop request for resolved apply",
+	if err := s.completePendingControlRequestsIfApplyResolved(operationLeaseCtx, driverID, finalApply.ID); err != nil {
+		s.logger.Error("operator: failed to complete pending control requests for resolved apply",
 			append(finalApply.LogAttrs(),
 				"driver", driverID, "apply_operation_id", op.ID,
 				"operation_deployment", op.Deployment, "error", err)...)
@@ -904,8 +904,8 @@ func (s *Service) recoverApplyPendingStop(ctx context.Context, driverID int, own
 	// summary; publish it if this projection won the terminal swap.
 	s.publishTerminalSummaryIfWon(applyLeaseCtx, driverID, finalApply, result)
 
-	if err := s.completePendingStopIfApplyResolved(applyLeaseCtx, driverID, finalApply.ID); err != nil {
-		s.logger.Error("operator: failed to complete pending stop request after stop reconciliation",
+	if err := s.completePendingControlRequestsIfApplyResolved(applyLeaseCtx, driverID, finalApply.ID); err != nil {
+		s.logger.Error("operator: failed to complete pending control requests after stop reconciliation",
 			append(finalApply.LogAttrs(),
 				"driver", driverID, "error", err)...)
 		return true
@@ -948,37 +948,58 @@ func (s *Service) markPendingOperationsStopped(ctx context.Context, driverID int
 	return nil
 }
 
-// completePendingStopIfApplyResolved completes a pending stop control request
-// once the apply has settled to a terminal state, so the request does not stay
-// pending forever after the rollout stops. The apply is reloaded because the
-// derived-state write operates on a copy and does not mutate the caller's row.
-// No-op when the apply is still non-terminal or no stop is pending.
-func (s *Service) completePendingStopIfApplyResolved(ctx context.Context, driverID int, applyID int64) error {
+// completePendingControlRequestsIfApplyResolved completes pending stop and
+// cancel control requests once the apply has settled to a terminal state, so
+// the requests do not stay pending forever after the rollout resolves. The
+// apply is reloaded because the derived-state write operates on a copy and
+// does not mutate the caller's row. A pending stop completes at any terminal
+// state. A pending cancel completes only when the terminal state is not
+// stopped: a stopped apply remains cancellable, so its pending cancel must
+// stay deliverable for the next drive. No-op when the apply is still
+// non-terminal or nothing is pending.
+func (s *Service) completePendingControlRequestsIfApplyResolved(ctx context.Context, driverID int, applyID int64) error {
 	apply, err := s.storage.Applies().Get(ctx, applyID)
 	if err != nil {
-		return fmt.Errorf("reload apply %d before completing pending stop: %w", applyID, err)
+		return fmt.Errorf("reload apply %d before completing pending control requests: %w", applyID, err)
 	}
 	if apply == nil {
-		return fmt.Errorf("reload apply %d before completing pending stop: %w", applyID, storage.ErrApplyNotFound)
+		return fmt.Errorf("reload apply %d before completing pending control requests: %w", applyID, storage.ErrApplyNotFound)
 	}
 	if !state.IsTerminalApplyState(apply.State) {
 		return nil
 	}
 
-	controlReq, err := s.storage.ControlRequests().GetPending(ctx, apply.ID, storage.ControlOperationStop)
+	if err := s.completePendingRequestForResolvedApply(ctx, driverID, apply, storage.ControlOperationStop); err != nil {
+		return err
+	}
+	if state.IsState(apply.State, state.Apply.Stopped) {
+		s.logger.Debug("operator: leaving pending cancel request deliverable for stopped apply",
+			"driver", driverID, "apply_id", apply.ApplyIdentifier,
+			"database", apply.Database, "environment", apply.Environment, "state", apply.State)
+		return nil
+	}
+	return s.completePendingRequestForResolvedApply(ctx, driverID, apply, storage.ControlOperationCancel)
+}
+
+// completePendingRequestForResolvedApply completes one pending control request
+// for an apply the caller has already established as resolved for that
+// operation. No-op when no request of that operation is pending.
+func (s *Service) completePendingRequestForResolvedApply(ctx context.Context, driverID int, apply *storage.Apply, op storage.ControlOperation) error {
+	controlReq, err := s.storage.ControlRequests().GetPending(ctx, apply.ID, op)
 	if err != nil {
-		return fmt.Errorf("load pending stop request for resolved apply %s (%d): %w", apply.ApplyIdentifier, apply.ID, err)
+		return fmt.Errorf("load pending %s request for resolved apply %s (%d): %w", op, apply.ApplyIdentifier, apply.ID, err)
 	}
 	if controlReq == nil {
 		return nil
 	}
 
-	if err := s.storage.ControlRequests().CompletePending(ctx, apply.ID, storage.ControlOperationStop); err != nil {
-		return fmt.Errorf("complete pending stop request for resolved apply %s (%d): %w", apply.ApplyIdentifier, apply.ID, err)
+	if err := s.storage.ControlRequests().CompletePending(ctx, apply.ID, op); err != nil {
+		return fmt.Errorf("complete pending %s request for resolved apply %s (%d): %w", op, apply.ApplyIdentifier, apply.ID, err)
 	}
-	s.logger.Info("operator: completed pending stop request for resolved apply",
+	s.logger.Info("operator: completed pending control request for resolved apply",
 		"driver", driverID, "apply_id", apply.ApplyIdentifier,
-		"database", apply.Database, "environment", apply.Environment, "state", apply.State)
+		"database", apply.Database, "environment", apply.Environment,
+		"state", apply.State, "operation", op)
 	return nil
 }
 

--- a/pkg/api/operator_test.go
+++ b/pkg/api/operator_test.go
@@ -781,20 +781,18 @@ func TestUpdateApplyStateFromOperations_ReturnsProjectionResult(t *testing.T) {
 	}
 }
 
-// fakeControlRequestStore is a minimal ControlRequestStore for stop
-// reconciliation tests: GetPending returns the configured pending stop request,
-// and CompletePending records the operations it was asked to complete.
+// fakeControlRequestStore is a minimal ControlRequestStore for control-request
+// reconciliation tests: GetPending returns the configured pending request for
+// the operation, and CompletePending records the operations it was asked to
+// complete.
 type fakeControlRequestStore struct {
 	storage.ControlRequestStore
-	pendingStop *storage.ApplyControlRequest
-	completed   []storage.ControlOperation
+	pending   map[storage.ControlOperation]*storage.ApplyControlRequest
+	completed []storage.ControlOperation
 }
 
 func (s *fakeControlRequestStore) GetPending(_ context.Context, _ int64, op storage.ControlOperation) (*storage.ApplyControlRequest, error) {
-	if op == storage.ControlOperationStop {
-		return s.pendingStop, nil
-	}
-	return nil, nil
+	return s.pending[op], nil
 }
 
 func (s *fakeControlRequestStore) CompletePending(_ context.Context, _ int64, op storage.ControlOperation) error {
@@ -817,8 +815,9 @@ func (s *markPendingStoppedRecordingStore) MarkPendingStoppedByApply(_ context.C
 	return s.count, nil
 }
 
-// getApplyStore returns a fixed apply from Get so completePendingStopIfApplyResolved
-// can be driven against a chosen terminal/non-terminal state.
+// getApplyStore returns a fixed apply from Get so
+// completePendingControlRequestsIfApplyResolved can be driven against a chosen
+// terminal/non-terminal state.
 type getApplyStore struct {
 	storage.ApplyStore
 	apply *storage.Apply
@@ -855,8 +854,8 @@ func TestStopPendingOperationsForPendingStop(t *testing.T) {
 
 	t.Run("stops pending siblings when a stop is pending", func(t *testing.T) {
 		ops := &markPendingStoppedRecordingStore{count: 2}
-		control := &fakeControlRequestStore{pendingStop: &storage.ApplyControlRequest{
-			ApplyID: apply.ID, Operation: storage.ControlOperationStop, Status: storage.ControlRequestPending,
+		control := &fakeControlRequestStore{pending: map[storage.ControlOperation]*storage.ApplyControlRequest{
+			storage.ControlOperationStop: {ApplyID: apply.ID, Operation: storage.ControlOperationStop, Status: storage.ControlRequestPending},
 		}}
 		svc := newStopReconcileTestService(&getApplyStore{}, ops, control)
 
@@ -867,7 +866,7 @@ func TestStopPendingOperationsForPendingStop(t *testing.T) {
 
 	t.Run("no-op when no stop is pending", func(t *testing.T) {
 		ops := &markPendingStoppedRecordingStore{}
-		control := &fakeControlRequestStore{pendingStop: nil}
+		control := &fakeControlRequestStore{}
 		svc := newStopReconcileTestService(&getApplyStore{}, ops, control)
 
 		require.NoError(t, svc.stopPendingOperationsForPendingStop(t.Context(), 1, apply))
@@ -875,39 +874,72 @@ func TestStopPendingOperationsForPendingStop(t *testing.T) {
 	})
 }
 
-// TestCompletePendingStopIfApplyResolved verifies the operator completes a
-// pending stop request only once the apply has settled terminally.
-func TestCompletePendingStopIfApplyResolved(t *testing.T) {
-	pendingStop := func() *storage.ApplyControlRequest {
-		return &storage.ApplyControlRequest{ApplyID: 9, Operation: storage.ControlOperationStop, Status: storage.ControlRequestPending}
+// TestCompletePendingControlRequestsIfApplyResolved verifies the operator
+// completes pending stop and cancel requests only once the apply has settled
+// terminally, and keeps a pending cancel deliverable when the terminal state
+// is stopped — a stopped apply remains cancellable, so completing the cancel
+// there would consume a command the next drive still has to deliver.
+func TestCompletePendingControlRequestsIfApplyResolved(t *testing.T) {
+	pendingRequest := func(op storage.ControlOperation) *storage.ApplyControlRequest {
+		return &storage.ApplyControlRequest{ApplyID: 9, Operation: op, Status: storage.ControlRequestPending}
 	}
 
 	t.Run("completes the stop when the apply is terminal", func(t *testing.T) {
 		applies := &getApplyStore{apply: &storage.Apply{ID: 9, ApplyIdentifier: "apply-done", State: state.Apply.Failed}}
-		control := &fakeControlRequestStore{pendingStop: pendingStop()}
+		control := &fakeControlRequestStore{pending: map[storage.ControlOperation]*storage.ApplyControlRequest{
+			storage.ControlOperationStop: pendingRequest(storage.ControlOperationStop),
+		}}
 		svc := newStopReconcileTestService(applies, &markPendingStoppedRecordingStore{}, control)
 
-		require.NoError(t, svc.completePendingStopIfApplyResolved(t.Context(), 1, 9))
+		require.NoError(t, svc.completePendingControlRequestsIfApplyResolved(t.Context(), 1, 9))
 		require.Len(t, control.completed, 1, "a terminal apply with a pending stop completes the request")
 		assert.Equal(t, storage.ControlOperationStop, control.completed[0])
 	})
 
-	t.Run("leaves the stop pending while the apply is non-terminal", func(t *testing.T) {
-		applies := &getApplyStore{apply: &storage.Apply{ID: 9, ApplyIdentifier: "apply-running", State: state.Apply.Running}}
-		control := &fakeControlRequestStore{pendingStop: pendingStop()}
+	t.Run("completes the cancel when the apply is terminal", func(t *testing.T) {
+		applies := &getApplyStore{apply: &storage.Apply{ID: 9, ApplyIdentifier: "apply-done", State: state.Apply.Cancelled}}
+		control := &fakeControlRequestStore{pending: map[storage.ControlOperation]*storage.ApplyControlRequest{
+			storage.ControlOperationCancel: pendingRequest(storage.ControlOperationCancel),
+		}}
 		svc := newStopReconcileTestService(applies, &markPendingStoppedRecordingStore{}, control)
 
-		require.NoError(t, svc.completePendingStopIfApplyResolved(t.Context(), 1, 9))
-		assert.Empty(t, control.completed, "a non-terminal apply must not complete the stop request")
+		require.NoError(t, svc.completePendingControlRequestsIfApplyResolved(t.Context(), 1, 9))
+		require.Len(t, control.completed, 1, "a terminal apply with a pending cancel completes the request")
+		assert.Equal(t, storage.ControlOperationCancel, control.completed[0])
 	})
 
-	t.Run("no-op when no stop is pending", func(t *testing.T) {
-		applies := &getApplyStore{apply: &storage.Apply{ID: 9, ApplyIdentifier: "apply-done", State: state.Apply.Failed}}
-		control := &fakeControlRequestStore{pendingStop: nil}
+	t.Run("keeps the cancel pending when the apply settled stopped", func(t *testing.T) {
+		applies := &getApplyStore{apply: &storage.Apply{ID: 9, ApplyIdentifier: "apply-stopped", State: state.Apply.Stopped}}
+		control := &fakeControlRequestStore{pending: map[storage.ControlOperation]*storage.ApplyControlRequest{
+			storage.ControlOperationStop:   pendingRequest(storage.ControlOperationStop),
+			storage.ControlOperationCancel: pendingRequest(storage.ControlOperationCancel),
+		}}
 		svc := newStopReconcileTestService(applies, &markPendingStoppedRecordingStore{}, control)
 
-		require.NoError(t, svc.completePendingStopIfApplyResolved(t.Context(), 1, 9))
-		assert.Empty(t, control.completed, "no pending stop means nothing to complete")
+		require.NoError(t, svc.completePendingControlRequestsIfApplyResolved(t.Context(), 1, 9))
+		require.Len(t, control.completed, 1, "a stopped apply completes the stop but must keep the cancel deliverable")
+		assert.Equal(t, storage.ControlOperationStop, control.completed[0])
+	})
+
+	t.Run("leaves both requests pending while the apply is non-terminal", func(t *testing.T) {
+		applies := &getApplyStore{apply: &storage.Apply{ID: 9, ApplyIdentifier: "apply-running", State: state.Apply.Running}}
+		control := &fakeControlRequestStore{pending: map[storage.ControlOperation]*storage.ApplyControlRequest{
+			storage.ControlOperationStop:   pendingRequest(storage.ControlOperationStop),
+			storage.ControlOperationCancel: pendingRequest(storage.ControlOperationCancel),
+		}}
+		svc := newStopReconcileTestService(applies, &markPendingStoppedRecordingStore{}, control)
+
+		require.NoError(t, svc.completePendingControlRequestsIfApplyResolved(t.Context(), 1, 9))
+		assert.Empty(t, control.completed, "a non-terminal apply must not complete any control request")
+	})
+
+	t.Run("no-op when nothing is pending", func(t *testing.T) {
+		applies := &getApplyStore{apply: &storage.Apply{ID: 9, ApplyIdentifier: "apply-done", State: state.Apply.Failed}}
+		control := &fakeControlRequestStore{}
+		svc := newStopReconcileTestService(applies, &markPendingStoppedRecordingStore{}, control)
+
+		require.NoError(t, svc.completePendingControlRequestsIfApplyResolved(t.Context(), 1, 9))
+		assert.Empty(t, control.completed, "no pending requests means nothing to complete")
 	})
 }
 

--- a/pkg/tern/control_requests.go
+++ b/pkg/tern/control_requests.go
@@ -49,16 +49,22 @@ func completePendingControlRequests(ctx context.Context, store storage.Storage, 
 // requests that a terminal apply moots: a pending stop is settled (the apply
 // can no longer be stopped), a pending revert or skip-revert can no longer
 // act because the revert window is gone, and a pending volume adjustment has
-// no running copy left to retune. Sweeping them keeps a request issued moments
-// before the apply settled — or one that lost to a contradictory command —
-// from lingering pending forever.
+// no running copy left to retune. A pending cancel is mooted by every terminal
+// state except stopped — a stopped apply remains cancellable, so its pending
+// cancel stays deliverable for the next drive. Sweeping the mooted requests
+// keeps a request issued moments before the apply settled — or one that lost
+// to a contradictory command — from lingering pending forever.
 func completePendingRequestsForTerminalApply(ctx context.Context, store storage.Storage, apply *storage.Apply) error {
-	for _, op := range []storage.ControlOperation{
+	ops := []storage.ControlOperation{
 		storage.ControlOperationStop,
 		storage.ControlOperationRevert,
 		storage.ControlOperationSkipRevert,
 		storage.ControlOperationVolume,
-	} {
+	}
+	if !state.IsState(apply.State, state.Apply.Stopped) {
+		ops = append(ops, storage.ControlOperationCancel)
+	}
+	for _, op := range ops {
 		if err := completePendingControlRequests(ctx, store, apply, op); err != nil {
 			return err
 		}

--- a/pkg/tern/control_requests_test.go
+++ b/pkg/tern/control_requests_test.go
@@ -10,10 +10,11 @@ import (
 )
 
 // A terminal apply moots every pending window/stop control request: a stop is
-// settled, and a revert or skip-revert can no longer act once the revert window
+// settled, a revert or skip-revert can no longer act once the revert window
 // is gone — including a request that lost to a contradictory command (e.g. a
-// revert still pending after skip-revert finalized the apply). The sweep
-// completes all of them so no request lingers pending forever.
+// revert still pending after skip-revert finalized the apply) — and a cancel
+// has nothing left to terminate. The sweep completes all of them so no request
+// lingers pending forever.
 func TestCompletePendingRequestsForTerminalApply(t *testing.T) {
 	apply := &storage.Apply{
 		ID:              7,
@@ -26,6 +27,7 @@ func TestCompletePendingRequestsForTerminalApply(t *testing.T) {
 		storage.ControlOperationStop,
 		storage.ControlOperationRevert,
 		storage.ControlOperationSkipRevert,
+		storage.ControlOperationCancel,
 	}
 	requests := make([]*storage.ApplyControlRequest, 0, len(sweptOps))
 	for _, op := range sweptOps {
@@ -47,4 +49,32 @@ func TestCompletePendingRequestsForTerminalApply(t *testing.T) {
 		require.NotNil(t, swept)
 		assert.Equal(t, storage.ControlRequestCompleted, swept.Status)
 	}
+}
+
+// A stopped apply is terminal but remains cancellable: the sweep must complete
+// the mooted stop while keeping a pending cancel deliverable, so a cancel
+// issued against the stopped apply is still delivered by the next drive
+// instead of being silently consumed.
+func TestCompletePendingRequestsForStoppedApplyKeepsCancelPending(t *testing.T) {
+	apply := &storage.Apply{
+		ID:              7,
+		ApplyIdentifier: "apply-stopped-sweep",
+		Database:        "testdb",
+		Environment:     "staging",
+		State:           state.Apply.Stopped,
+	}
+	controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{
+		{ApplyID: apply.ID, Operation: storage.ControlOperationStop, Status: storage.ControlRequestPending},
+		{ApplyID: apply.ID, Operation: storage.ControlOperationCancel, Status: storage.ControlRequestPending},
+	}}
+	store := &mockStorage{controlRequests: controlRequests}
+
+	require.NoError(t, completePendingRequestsForTerminalApply(t.Context(), store, apply))
+
+	pendingStop, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationStop)
+	require.NoError(t, err)
+	assert.Nil(t, pendingStop, "the stop is mooted once the apply settles stopped")
+	pendingCancel, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationCancel)
+	require.NoError(t, err)
+	assert.NotNil(t, pendingCancel, "a stopped apply remains cancellable; the pending cancel must stay deliverable")
 }

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -1012,41 +1012,42 @@ func (c *GRPCClient) processPendingCancelOrStopControlRequest(ctx context.Contex
 }
 
 func (c *GRPCClient) completeRemoteStopFromTerminalProgress(ctx context.Context, apply *storage.Apply, controlReq *storage.ApplyControlRequest, scope applyTaskScope) (bool, error) {
+	// Route the remote apply id through the scope: an operation-scoped drive
+	// tracks its remote apply on the operation, not on the parent apply's
+	// ExternalID.
+	remoteID := scope.remoteApplyID(apply)
 	progress, err := c.client.Progress(ctx, &ternv1.ProgressRequest{
-		ApplyId:     scope.remoteApplyID(apply),
+		ApplyId:     remoteID,
 		Environment: apply.Environment,
 	})
 	if err != nil {
 		slog.Warn("remote gRPC stop error could not be reconciled from progress",
-			"apply_id", apply.ApplyIdentifier,
-			"external_id", apply.ExternalID,
-			"database", apply.Database,
-			"environment", apply.Environment,
-			"requested_by", controlRequestCaller(controlReq),
-			"error", err)
+			append(apply.LogAttrs(),
+				"remote_apply_id", remoteID,
+				"requested_by", controlRequestCaller(controlReq),
+				"error", err)...)
 		return false, nil
 	}
 	if progress.State == ternv1.State_STATE_NO_ACTIVE_CHANGE || !isTerminalProtoState(progress.State) {
 		slog.Warn("remote gRPC stop error found nonterminal progress; durable stop request remains pending for operator retry",
-			"apply_id", apply.ApplyIdentifier,
-			"external_id", apply.ExternalID,
-			"database", apply.Database,
-			"environment", apply.Environment,
-			"requested_by", controlRequestCaller(controlReq),
-			"remote_state", progress.State.String(),
-			"remote_state_number", int32(progress.State))
+			append(apply.LogAttrs(),
+				"remote_apply_id", remoteID,
+				"requested_by", controlRequestCaller(controlReq),
+				"remote_state", progress.State.String(),
+				"remote_state_number", int32(progress.State))...)
 		return false, nil
 	}
 	remoteState := ProtoStateToStorage(progress.State)
 	if remoteState == "" {
-		return false, fmt.Errorf("sync remote gRPC stop for apply %s remote %s after stop error: unmapped remote state %s", apply.ApplyIdentifier, apply.ExternalID, remoteApplyStateDescription(progress.State))
+		return false, fmt.Errorf("sync remote gRPC stop for apply %s remote %s after stop error: unmapped remote state %s", apply.ApplyIdentifier, remoteID, remoteApplyStateDescription(progress.State))
 	}
 	now := time.Now()
-	priorState, priorStartedAt, priorUpdatedAt := apply.State, apply.StartedAt, apply.UpdatedAt
+	priorState, priorStartedAt, priorUpdatedAt, priorErrorMessage := apply.State, apply.StartedAt, apply.UpdatedAt, apply.ErrorMessage
 	if apply.StartedAt == nil && !state.IsState(remoteState, state.Apply.Pending) {
 		apply.StartedAt = &now
 	}
 	apply.State = applyStateFromRemoteProgress(apply.State, remoteState, false)
+	apply.ErrorMessage = remoteProgressErrorMessage(apply.State, progress.ErrorMessage, apply.ErrorMessage)
 	apply.UpdatedAt = now
 	if err := c.reconcileTerminalRemoteProgress(ctx, apply, progress.Tables, now, scope); err != nil {
 		return false, err
@@ -1058,7 +1059,7 @@ func (c *GRPCClient) completeRemoteStopFromTerminalProgress(ctx context.Context,
 	// terminal remote state does not leak onto the shared apply and let a later
 	// stop pass treat the parent as terminal.
 	if scope.suppressesDirectParentApplyWrites() {
-		apply.State, apply.StartedAt, apply.UpdatedAt = priorState, priorStartedAt, priorUpdatedAt
+		apply.State, apply.StartedAt, apply.UpdatedAt, apply.ErrorMessage = priorState, priorStartedAt, priorUpdatedAt, priorErrorMessage
 		logOperationDriveLeavesParentStop(apply, scope)
 		return true, nil
 	}
@@ -1066,7 +1067,7 @@ func (c *GRPCClient) completeRemoteStopFromTerminalProgress(ctx context.Context,
 		return false, err
 	}
 	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested,
-		fmt.Sprintf("Remote stop request completed from terminal progress after stop error%s", callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
+		fmt.Sprintf("Remote stop request completed from terminal progress (remote state: %s) after stop error%s", remoteState, callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
 	return true, nil
 }
 
@@ -1077,8 +1078,8 @@ func (c *GRPCClient) completeRemoteStopFromTerminalProgress(ctx context.Context,
 // requested outcome already happened, so the drive must reconcile the stored
 // apply to the remote's terminal state and complete the durable cancel request
 // instead of failing the resume and leaving the apply claimable forever. A
-// remote that is still active keeps the durable request pending for the next
-// drive to retry.
+// remote that is still active — or stopped, since stopped remotes remain
+// cancellable — keeps the durable request pending for the next drive to retry.
 func (c *GRPCClient) completeRemoteCancelFromTerminalProgress(ctx context.Context, apply *storage.Apply, controlReq *storage.ApplyControlRequest, scope applyTaskScope) (bool, error) {
 	// Route the remote apply id through the scope: an operation-scoped drive
 	// tracks its remote apply on the operation, not on the parent apply's
@@ -1090,23 +1091,31 @@ func (c *GRPCClient) completeRemoteCancelFromTerminalProgress(ctx context.Contex
 	})
 	if err != nil {
 		slog.Warn("remote gRPC cancel error could not be reconciled from progress",
-			"apply_id", apply.ApplyIdentifier,
-			"remote_apply_id", remoteID,
-			"database", apply.Database,
-			"environment", apply.Environment,
-			"requested_by", controlRequestCaller(controlReq),
-			"error", err)
+			append(apply.LogAttrs(),
+				"remote_apply_id", remoteID,
+				"requested_by", controlRequestCaller(controlReq),
+				"error", err)...)
 		return false, nil
 	}
 	if progress.State == ternv1.State_STATE_NO_ACTIVE_CHANGE || !isTerminalProtoState(progress.State) {
 		slog.Warn("remote gRPC cancel error found nonterminal progress; durable cancel request remains pending for operator retry",
-			"apply_id", apply.ApplyIdentifier,
-			"remote_apply_id", remoteID,
-			"database", apply.Database,
-			"environment", apply.Environment,
-			"requested_by", controlRequestCaller(controlReq),
-			"remote_state", progress.State.String(),
-			"remote_state_number", int32(progress.State))
+			append(apply.LogAttrs(),
+				"remote_apply_id", remoteID,
+				"requested_by", controlRequestCaller(controlReq),
+				"remote_state", progress.State.String(),
+				"remote_state_number", int32(progress.State))...)
+		return false, nil
+	}
+	// A stopped remote is not a cancel outcome: the data plane accepts Cancel
+	// for stopped applies, so the failed Cancel cannot have been an
+	// already-terminal rejection. Completing the request here would consume a
+	// deliverable cancel and let a pending start resume a change the user
+	// cancelled. Keep the durable request pending for retry.
+	if progress.State == ternv1.State_STATE_STOPPED {
+		slog.Warn("remote gRPC cancel error found stopped progress; stopped remotes remain cancellable so the durable cancel request remains pending for retry",
+			append(apply.LogAttrs(),
+				"remote_apply_id", remoteID,
+				"requested_by", controlRequestCaller(controlReq))...)
 		return false, nil
 	}
 	remoteState := ProtoStateToStorage(progress.State)
@@ -1114,11 +1123,12 @@ func (c *GRPCClient) completeRemoteCancelFromTerminalProgress(ctx context.Contex
 		return false, fmt.Errorf("sync remote gRPC cancel for apply %s remote %s after cancel error: unmapped remote state %s", apply.ApplyIdentifier, remoteID, remoteApplyStateDescription(progress.State))
 	}
 	now := time.Now()
-	priorState, priorStartedAt, priorUpdatedAt := apply.State, apply.StartedAt, apply.UpdatedAt
+	priorState, priorStartedAt, priorUpdatedAt, priorErrorMessage := apply.State, apply.StartedAt, apply.UpdatedAt, apply.ErrorMessage
 	if apply.StartedAt == nil && !state.IsState(remoteState, state.Apply.Pending) {
 		apply.StartedAt = &now
 	}
 	apply.State = applyStateFromRemoteProgress(apply.State, remoteState, false)
+	apply.ErrorMessage = remoteProgressErrorMessage(apply.State, progress.ErrorMessage, apply.ErrorMessage)
 	apply.UpdatedAt = now
 	if err := c.reconcileTerminalRemoteProgress(ctx, apply, progress.Tables, now, scope); err != nil {
 		return false, err
@@ -1130,7 +1140,7 @@ func (c *GRPCClient) completeRemoteCancelFromTerminalProgress(ctx context.Contex
 	// terminal remote state does not leak onto the shared apply and let a later
 	// cancel pass treat the parent as terminal.
 	if scope.suppressesDirectParentApplyWrites() {
-		apply.State, apply.StartedAt, apply.UpdatedAt = priorState, priorStartedAt, priorUpdatedAt
+		apply.State, apply.StartedAt, apply.UpdatedAt, apply.ErrorMessage = priorState, priorStartedAt, priorUpdatedAt, priorErrorMessage
 		logOperationDriveLeavesParentCancel(apply, scope)
 		return true, nil
 	}
@@ -1138,7 +1148,7 @@ func (c *GRPCClient) completeRemoteCancelFromTerminalProgress(ctx context.Contex
 		return false, err
 	}
 	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventCancelRequested,
-		fmt.Sprintf("Remote cancel request completed from terminal progress after cancel error%s", callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
+		fmt.Sprintf("Remote cancel request completed from terminal progress (remote state: %s) after cancel error%s", remoteState, callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
 	return true, nil
 }
 

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -1080,14 +1080,18 @@ func (c *GRPCClient) completeRemoteStopFromTerminalProgress(ctx context.Context,
 // remote that is still active keeps the durable request pending for the next
 // drive to retry.
 func (c *GRPCClient) completeRemoteCancelFromTerminalProgress(ctx context.Context, apply *storage.Apply, controlReq *storage.ApplyControlRequest, scope applyTaskScope) (bool, error) {
+	// Route the remote apply id through the scope: an operation-scoped drive
+	// tracks its remote apply on the operation, not on the parent apply's
+	// ExternalID.
+	remoteID := scope.remoteApplyID(apply)
 	progress, err := c.client.Progress(ctx, &ternv1.ProgressRequest{
-		ApplyId:     scope.remoteApplyID(apply),
+		ApplyId:     remoteID,
 		Environment: apply.Environment,
 	})
 	if err != nil {
 		slog.Warn("remote gRPC cancel error could not be reconciled from progress",
 			"apply_id", apply.ApplyIdentifier,
-			"external_id", apply.ExternalID,
+			"remote_apply_id", remoteID,
 			"database", apply.Database,
 			"environment", apply.Environment,
 			"requested_by", controlRequestCaller(controlReq),
@@ -1097,7 +1101,7 @@ func (c *GRPCClient) completeRemoteCancelFromTerminalProgress(ctx context.Contex
 	if progress.State == ternv1.State_STATE_NO_ACTIVE_CHANGE || !isTerminalProtoState(progress.State) {
 		slog.Warn("remote gRPC cancel error found nonterminal progress; durable cancel request remains pending for operator retry",
 			"apply_id", apply.ApplyIdentifier,
-			"external_id", apply.ExternalID,
+			"remote_apply_id", remoteID,
 			"database", apply.Database,
 			"environment", apply.Environment,
 			"requested_by", controlRequestCaller(controlReq),
@@ -1107,7 +1111,7 @@ func (c *GRPCClient) completeRemoteCancelFromTerminalProgress(ctx context.Contex
 	}
 	remoteState := ProtoStateToStorage(progress.State)
 	if remoteState == "" {
-		return false, fmt.Errorf("sync remote gRPC cancel for apply %s remote %s after cancel error: unmapped remote state %s", apply.ApplyIdentifier, apply.ExternalID, remoteApplyStateDescription(progress.State))
+		return false, fmt.Errorf("sync remote gRPC cancel for apply %s remote %s after cancel error: unmapped remote state %s", apply.ApplyIdentifier, remoteID, remoteApplyStateDescription(progress.State))
 	}
 	now := time.Now()
 	priorState, priorStartedAt, priorUpdatedAt := apply.State, apply.StartedAt, apply.UpdatedAt

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -953,6 +953,11 @@ func (c *GRPCClient) processPendingCancelControlRequest(ctx context.Context, app
 	}
 	resp, err := c.client.Cancel(ctx, &ternv1.CancelRequest{ApplyId: remoteID, Environment: apply.Environment})
 	if err != nil {
+		if completed, completeErr := c.completeRemoteCancelFromTerminalProgress(ctx, apply, controlReq, scope); completeErr == nil && completed {
+			return true, nil
+		} else if completeErr != nil {
+			return true, fmt.Errorf("request remote gRPC cancel for apply %s remote %s: %w; terminal progress reconciliation also failed: %w", apply.ApplyIdentifier, remoteID, err, completeErr)
+		}
 		return true, fmt.Errorf("request remote gRPC cancel for apply %s remote %s: %w", apply.ApplyIdentifier, remoteID, err)
 	}
 	if resp == nil || !resp.Accepted {
@@ -1062,6 +1067,74 @@ func (c *GRPCClient) completeRemoteStopFromTerminalProgress(ctx context.Context,
 	}
 	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested,
 		fmt.Sprintf("Remote stop request completed from terminal progress after stop error%s", callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
+	return true, nil
+}
+
+// completeRemoteCancelFromTerminalProgress reconciles a failed remote cancel
+// against the remote's actual progress. A remote apply that is already
+// terminal (for example a cancel consumed on a previous drive before the
+// driver could persist it) rejects a re-sent Cancel; that rejection means the
+// requested outcome already happened, so the drive must reconcile the stored
+// apply to the remote's terminal state and complete the durable cancel request
+// instead of failing the resume and leaving the apply claimable forever. A
+// remote that is still active keeps the durable request pending for the next
+// drive to retry.
+func (c *GRPCClient) completeRemoteCancelFromTerminalProgress(ctx context.Context, apply *storage.Apply, controlReq *storage.ApplyControlRequest, scope applyTaskScope) (bool, error) {
+	progress, err := c.client.Progress(ctx, &ternv1.ProgressRequest{
+		ApplyId:     scope.remoteApplyID(apply),
+		Environment: apply.Environment,
+	})
+	if err != nil {
+		slog.Warn("remote gRPC cancel error could not be reconciled from progress",
+			"apply_id", apply.ApplyIdentifier,
+			"external_id", apply.ExternalID,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"requested_by", controlRequestCaller(controlReq),
+			"error", err)
+		return false, nil
+	}
+	if progress.State == ternv1.State_STATE_NO_ACTIVE_CHANGE || !isTerminalProtoState(progress.State) {
+		slog.Warn("remote gRPC cancel error found nonterminal progress; durable cancel request remains pending for operator retry",
+			"apply_id", apply.ApplyIdentifier,
+			"external_id", apply.ExternalID,
+			"database", apply.Database,
+			"environment", apply.Environment,
+			"requested_by", controlRequestCaller(controlReq),
+			"remote_state", progress.State.String(),
+			"remote_state_number", int32(progress.State))
+		return false, nil
+	}
+	remoteState := ProtoStateToStorage(progress.State)
+	if remoteState == "" {
+		return false, fmt.Errorf("sync remote gRPC cancel for apply %s remote %s after cancel error: unmapped remote state %s", apply.ApplyIdentifier, apply.ExternalID, remoteApplyStateDescription(progress.State))
+	}
+	now := time.Now()
+	priorState, priorStartedAt, priorUpdatedAt := apply.State, apply.StartedAt, apply.UpdatedAt
+	if apply.StartedAt == nil && !state.IsState(remoteState, state.Apply.Pending) {
+		apply.StartedAt = &now
+	}
+	apply.State = applyStateFromRemoteProgress(apply.State, remoteState, false)
+	apply.UpdatedAt = now
+	if err := c.reconcileTerminalRemoteProgress(ctx, apply, progress.Tables, now, scope); err != nil {
+		return false, err
+	}
+	// An operation-only drive owns only its operation: the apply-level cancel
+	// request is shared across siblings and completed by the operator projection
+	// once the parent derives terminal. Leave it pending here and restore the
+	// in-memory parent apply fields the driver does not own, so this operation's
+	// terminal remote state does not leak onto the shared apply and let a later
+	// cancel pass treat the parent as terminal.
+	if scope.suppressesDirectParentApplyWrites() {
+		apply.State, apply.StartedAt, apply.UpdatedAt = priorState, priorStartedAt, priorUpdatedAt
+		logOperationDriveLeavesParentCancel(apply, scope)
+		return true, nil
+	}
+	if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationCancel); err != nil {
+		return false, err
+	}
+	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventCancelRequested,
+		fmt.Sprintf("Remote cancel request completed from terminal progress after cancel error%s", callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
 	return true, nil
 }
 

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -526,6 +526,7 @@ type capturingTernServer struct {
 	progressError     string
 	progressErr       error
 	startErr          error
+	cancelErr         error
 	cutoverErr        error
 	cutoverAccepted   bool
 	cutoverMessage    string
@@ -573,7 +574,11 @@ func (s *capturingTernServer) Stop(_ context.Context, req *ternv1.StopRequest) (
 func (s *capturingTernServer) Cancel(_ context.Context, req *ternv1.CancelRequest) (*ternv1.CancelResponse, error) {
 	s.mu.Lock()
 	s.cancelApplyID = req.ApplyId
+	err := s.cancelErr
 	s.mu.Unlock()
+	if err != nil {
+		return nil, err
+	}
 	return &ternv1.CancelResponse{Accepted: true}, nil
 }
 
@@ -2021,6 +2026,191 @@ func TestGRPCClient_ProcessPendingCancelOperationLeavesApplyCancelPending(t *tes
 	require.NoError(t, err)
 	assert.True(t, handled)
 	assert.Equal(t, "remote-op-west", server.getCancelApplyID())
+	assert.Equal(t, state.Task.Cancelled, task.State)
+	assert.Equal(t, state.Apply.Running, apply.State)
+	cancelReq, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationCancel)
+	require.NoError(t, err)
+	assert.NotNil(t, cancelReq)
+}
+
+func TestGRPCClient_ProcessPendingCancelReconcilesAlreadyTerminalRemote(t *testing.T) {
+	// A remote apply whose cancel was already consumed (for example on a prior
+	// drive that lost its lease before persisting) rejects a re-sent Cancel.
+	// The drive must treat that rejection as "the requested outcome already
+	// happened": reconcile the stored apply to the remote terminal state and
+	// complete the durable cancel request, so the apply reaches a terminal
+	// state instead of failing every future resume.
+	server := &capturingTernServer{
+		cancelErr:        status.Error(codes.Internal, "apply remote-grpc-cancel is already terminal (state: cancelled)"),
+		progressState:    ternv1.State_STATE_CANCELLED,
+		progressStateSet: true,
+		progressTables: []*ternv1.TableProgress{{
+			Namespace: "default",
+			TableName: "users",
+			Status:    state.Task.Cancelled,
+		}},
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              7,
+		ApplyIdentifier: "apply-grpc-cancel",
+		ExternalID:      "remote-grpc-cancel",
+		PlanID:          99,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+		State:           state.Apply.Running,
+	}
+	task := &storage.Task{
+		ID:             11,
+		TaskIdentifier: "task-users",
+		ApplyID:        apply.ID,
+		Namespace:      "default",
+		TableName:      "users",
+		State:          state.Task.Running,
+	}
+	controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationCancel,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "cli:alice",
+	}}}
+	storedApply := *apply
+	applyStore := &mockApplyStore{apply: &storedApply}
+	logs := &mockApplyLogStore{}
+	client.storage = &mockStorage{
+		applies:         applyStore,
+		tasks:           &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:            logs,
+		controlRequests: controlRequests,
+	}
+
+	handled, err := client.processPendingCancelControlRequest(t.Context(), apply, wholeApplyTaskScope())
+	require.NoError(t, err)
+	assert.True(t, handled)
+	assert.Equal(t, state.Apply.Cancelled, applyStore.apply.State)
+	assert.Equal(t, state.Task.Cancelled, task.State)
+	assert.True(t, hasLogEvent(logs.logs, storage.LogEventCancelRequested))
+	cancelReq, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationCancel)
+	require.NoError(t, err)
+	assert.Nil(t, cancelReq)
+}
+
+func TestGRPCClient_ProcessPendingCancelKeepsRequestWhenRemoteStillActive(t *testing.T) {
+	// A cancel rejection with the remote still actively running is a real
+	// failure: the durable cancel request must stay pending for the next drive
+	// to retry, and the stored apply must not be marked terminal.
+	server := &capturingTernServer{
+		cancelErr:        status.Error(codes.Unavailable, "data plane restarting"),
+		progressState:    ternv1.State_STATE_RUNNING,
+		progressStateSet: true,
+		progressTables: []*ternv1.TableProgress{{
+			Namespace: "default",
+			TableName: "users",
+			Status:    state.Task.Running,
+		}},
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              7,
+		ApplyIdentifier: "apply-grpc-cancel",
+		ExternalID:      "remote-grpc-cancel",
+		PlanID:          99,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+		State:           state.Apply.Running,
+	}
+	controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationCancel,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "cli:alice",
+	}}}
+	storedApply := *apply
+	applyStore := &mockApplyStore{apply: &storedApply}
+	client.storage = &mockStorage{
+		applies:         applyStore,
+		tasks:           &mockTaskStore{},
+		logs:            &mockApplyLogStore{},
+		controlRequests: controlRequests,
+	}
+
+	handled, err := client.processPendingCancelControlRequest(t.Context(), apply, wholeApplyTaskScope())
+	require.Error(t, err)
+	assert.True(t, handled)
+	assert.Equal(t, state.Apply.Running, applyStore.apply.State)
+	cancelReq, getErr := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationCancel)
+	require.NoError(t, getErr)
+	assert.NotNil(t, cancelReq)
+}
+
+func TestGRPCClient_ProcessPendingCancelAlreadyTerminalRemoteLeavesApplyCancelPendingForOperation(t *testing.T) {
+	// The already-terminal reconcile must respect operation-drive ownership: a
+	// multi-deployment apply has one durable cancel request shared by every
+	// deployment, so an operation drive reconciling its own already-cancelled
+	// remote must cancel only its operation's tasks and leave both the parent
+	// apply state and the shared cancel request for the siblings.
+	server := &capturingTernServer{
+		cancelErr:        status.Error(codes.Internal, "apply remote-op-west is already terminal (state: cancelled)"),
+		progressState:    ternv1.State_STATE_CANCELLED,
+		progressStateSet: true,
+		progressTables: []*ternv1.TableProgress{{
+			Namespace: "default",
+			TableName: "users",
+			Status:    state.Task.Cancelled,
+		}},
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              7,
+		ApplyIdentifier: "apply-multi-op-cancel",
+		PlanID:          99,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+		State:           state.Apply.Running,
+	}
+	operationID := int64(42)
+	task := &storage.Task{
+		ID:               11,
+		TaskIdentifier:   "task-users",
+		ApplyID:          apply.ID,
+		ApplyOperationID: &operationID,
+		Namespace:        "default",
+		TableName:        "users",
+		State:            state.Task.Running,
+	}
+	operation := &storage.ApplyOperation{ID: operationID, ApplyID: apply.ID, Deployment: "west", State: state.ApplyOperation.Running, EngineResumeContext: "remote-op-west"}
+	operationStore := &mockApplyOperationStore{ops: map[int64]*storage.ApplyOperation{
+		operationID: operation,
+		43:          {ID: 43, ApplyID: apply.ID, Deployment: "east", State: state.ApplyOperation.Running, EngineResumeContext: "remote-op-east"},
+	}}
+	controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationCancel,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "cli:alice",
+	}}}
+	storedApply := *apply
+	client.storage = &mockStorage{
+		applies:         &mockApplyStore{apply: &storedApply},
+		tasks:           &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:            &mockApplyLogStore{},
+		controlRequests: controlRequests,
+		operations:      operationStore,
+	}
+	scope := applyTaskScope{applyOperationID: operationID, operation: operation, multiOperation: true}
+
+	handled, err := client.processPendingCancelControlRequest(t.Context(), apply, scope)
+	require.NoError(t, err)
+	assert.True(t, handled)
 	assert.Equal(t, state.Task.Cancelled, task.State)
 	assert.Equal(t, state.Apply.Running, apply.State)
 	cancelReq, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationCancel)

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -3,6 +3,7 @@ package tern
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net"
 	"os"
@@ -2215,6 +2216,236 @@ func TestGRPCClient_ProcessPendingCancelAlreadyTerminalRemoteLeavesApplyCancelPe
 	assert.Equal(t, state.Apply.Running, apply.State)
 	cancelReq, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationCancel)
 	require.NoError(t, err)
+	assert.NotNil(t, cancelReq)
+}
+
+func TestGRPCClient_ProcessPendingCancelKeepsRequestWhenRemoteStopped(t *testing.T) {
+	// A stopped remote is terminal but remains cancellable, so a cancel
+	// rejection with the remote stopped is not an already-consumed cancel.
+	// The durable cancel request must stay pending for the next drive to
+	// deliver — completing it here would let a pending start resume a schema
+	// change the user cancelled.
+	server := &capturingTernServer{
+		cancelErr:        status.Error(codes.Unavailable, "data plane restarting"),
+		progressState:    ternv1.State_STATE_STOPPED,
+		progressStateSet: true,
+		progressTables: []*ternv1.TableProgress{{
+			Namespace: "default",
+			TableName: "users",
+			Status:    state.Task.Stopped,
+		}},
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              7,
+		ApplyIdentifier: "apply-grpc-cancel",
+		ExternalID:      "remote-grpc-cancel",
+		PlanID:          99,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+		State:           state.Apply.Stopped,
+	}
+	controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationCancel,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "cli:alice",
+	}}}
+	storedApply := *apply
+	applyStore := &mockApplyStore{apply: &storedApply}
+	client.storage = &mockStorage{
+		applies:         applyStore,
+		tasks:           &mockTaskStore{},
+		logs:            &mockApplyLogStore{},
+		controlRequests: controlRequests,
+	}
+
+	handled, err := client.processPendingCancelControlRequest(t.Context(), apply, wholeApplyTaskScope())
+	require.Error(t, err)
+	assert.True(t, handled)
+	assert.Equal(t, state.Apply.Stopped, applyStore.apply.State)
+	cancelReq, getErr := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationCancel)
+	require.NoError(t, getErr)
+	assert.NotNil(t, cancelReq)
+}
+
+func TestGRPCClient_ProcessPendingCancelReconcilesCompletedRemote(t *testing.T) {
+	// A cancel can lose the race against the remote finishing: the remote
+	// settles completed before the cancel lands, and the re-sent Cancel is
+	// rejected as already terminal. The reconcile must adopt the remote's
+	// actual outcome — completed, not cancelled — and record which remote
+	// terminal state settled the request so operators reading the apply log
+	// are not misled into thinking the cancel won.
+	server := &capturingTernServer{
+		cancelErr:        status.Error(codes.Internal, "apply remote-grpc-cancel is already terminal (state: completed)"),
+		progressState:    ternv1.State_STATE_COMPLETED,
+		progressStateSet: true,
+		progressTables: []*ternv1.TableProgress{{
+			Namespace: "default",
+			TableName: "users",
+			Status:    state.Task.Completed,
+		}},
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              7,
+		ApplyIdentifier: "apply-grpc-cancel",
+		ExternalID:      "remote-grpc-cancel",
+		PlanID:          99,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+		State:           state.Apply.Running,
+	}
+	task := &storage.Task{
+		ID:             11,
+		TaskIdentifier: "task-users",
+		ApplyID:        apply.ID,
+		Namespace:      "default",
+		TableName:      "users",
+		State:          state.Task.Running,
+	}
+	controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationCancel,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "cli:alice",
+	}}}
+	storedApply := *apply
+	applyStore := &mockApplyStore{apply: &storedApply}
+	logs := &mockApplyLogStore{}
+	client.storage = &mockStorage{
+		applies:         applyStore,
+		tasks:           &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:            logs,
+		controlRequests: controlRequests,
+	}
+
+	handled, err := client.processPendingCancelControlRequest(t.Context(), apply, wholeApplyTaskScope())
+	require.NoError(t, err)
+	assert.True(t, handled)
+	assert.Equal(t, state.Apply.Completed, applyStore.apply.State)
+	cancelReq, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationCancel)
+	require.NoError(t, err)
+	assert.Nil(t, cancelReq)
+	var eventMessage string
+	for _, log := range logs.logs {
+		if log.EventType == storage.LogEventCancelRequested {
+			eventMessage = log.Message
+		}
+	}
+	assert.Contains(t, eventMessage, fmt.Sprintf("remote state: %s", state.Apply.Completed))
+}
+
+func TestGRPCClient_ProcessPendingCancelReconcilesFailedRemoteWithErrorMessage(t *testing.T) {
+	// A remote that failed before the cancel landed settles the apply failed;
+	// the reconcile must carry the remote's error message onto the stored
+	// apply so the failure is triageable from the apply row alone.
+	server := &capturingTernServer{
+		cancelErr:        status.Error(codes.Internal, "apply remote-grpc-cancel is already terminal (state: failed)"),
+		progressState:    ternv1.State_STATE_FAILED,
+		progressStateSet: true,
+		progressError:    "copy row chunk: disk full",
+		progressTables: []*ternv1.TableProgress{{
+			Namespace: "default",
+			TableName: "users",
+			Status:    state.Task.Failed,
+		}},
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              7,
+		ApplyIdentifier: "apply-grpc-cancel",
+		ExternalID:      "remote-grpc-cancel",
+		PlanID:          99,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+		State:           state.Apply.Running,
+	}
+	task := &storage.Task{
+		ID:             11,
+		TaskIdentifier: "task-users",
+		ApplyID:        apply.ID,
+		Namespace:      "default",
+		TableName:      "users",
+		State:          state.Task.Running,
+	}
+	controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationCancel,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "cli:alice",
+	}}}
+	storedApply := *apply
+	applyStore := &mockApplyStore{apply: &storedApply}
+	client.storage = &mockStorage{
+		applies:         applyStore,
+		tasks:           &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:            &mockApplyLogStore{},
+		controlRequests: controlRequests,
+	}
+
+	handled, err := client.processPendingCancelControlRequest(t.Context(), apply, wholeApplyTaskScope())
+	require.NoError(t, err)
+	assert.True(t, handled)
+	assert.Equal(t, state.Apply.Failed, applyStore.apply.State)
+	assert.Equal(t, "copy row chunk: disk full", applyStore.apply.ErrorMessage)
+	cancelReq, err := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationCancel)
+	require.NoError(t, err)
+	assert.Nil(t, cancelReq)
+}
+
+func TestGRPCClient_ProcessPendingCancelProgressFailureKeepsRequestPending(t *testing.T) {
+	// When the Progress read used to reconcile a failed cancel also fails,
+	// the drive knows nothing about the remote's actual state. It must fall
+	// through to the original cancel failure and keep the durable request
+	// pending, never guess a terminal outcome.
+	server := &capturingTernServer{
+		cancelErr:   status.Error(codes.Unavailable, "data plane restarting"),
+		progressErr: status.Error(codes.Unavailable, "data plane restarting"),
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              7,
+		ApplyIdentifier: "apply-grpc-cancel",
+		ExternalID:      "remote-grpc-cancel",
+		PlanID:          99,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+		State:           state.Apply.Running,
+	}
+	controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationCancel,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "cli:alice",
+	}}}
+	storedApply := *apply
+	applyStore := &mockApplyStore{apply: &storedApply}
+	client.storage = &mockStorage{
+		applies:         applyStore,
+		tasks:           &mockTaskStore{},
+		logs:            &mockApplyLogStore{},
+		controlRequests: controlRequests,
+	}
+
+	handled, err := client.processPendingCancelControlRequest(t.Context(), apply, wholeApplyTaskScope())
+	require.Error(t, err)
+	assert.True(t, handled)
+	assert.Equal(t, state.Apply.Running, applyStore.apply.State)
+	cancelReq, getErr := controlRequests.GetPending(t.Context(), apply.ID, storage.ControlOperationCancel)
+	require.NoError(t, getErr)
 	assert.NotNil(t, cancelReq)
 }
 


### PR DESCRIPTION
## Why this matters

Cancelling a remote apply is not idempotent today. If the data plane consumes a cancel but the driver loses its lease (pod restart, handover) before persisting the terminal state, every subsequent drive claim re-sends `Cancel`, gets the remote's correct "already terminal (state: cancelled)" rejection, and treats it as a fatal resume error. The stored apply stays active and claimable forever: the lease ping-pongs between drivers, no terminal summary ever posts, and the database lock is never released — a permanently wedged apply that blocks all subsequent schema changes on that database until an operator hand-edits storage.

The two sibling control operations already handle this: cutover preflights remote progress and reconciles an already-terminal remote (`triggerRemoteOperationCutover`), and stop falls back to `completeRemoteStopFromTerminalProgress` when the Stop RPC fails. Cancel was the one control operation missing the idempotency branch.

## What it does

When the remote `Cancel` RPC fails, the drive now checks remote progress before failing the resume:

```
Cancel RPC error
      │
      ▼
 Progress preflight ──── remote terminal? ──── yes ──► reconcile stored apply/tasks
      │                                                complete durable cancel request
      no / unreachable                                 (operation drives leave the shared
      │                                                 parent request for siblings)
      ▼
 durable cancel request stays pending; the error surfaces for the next drive to retry

```

`completeRemoteCancelFromTerminalProgress` mirrors the stop fallback exactly, including operation-drive ownership: an operation-scoped drive reconciles only its own tasks and leaves the shared apply-level cancel request pending for sibling deployments.

Tests cover the already-terminal reconcile (whole apply), the fail-closed path when the remote is still active, and the multi-operation ownership boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)