### PR TITLE
fix(github): reject apply commands on closed PRs

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -5507,6 +5507,22 @@ Reopen this PR, or open a new PR with the schema change, and apply from there.
 </details>
 
 <details>
+<summary><a name="apply-blocked-pr-merged"></a><strong>Apply Blocked: PR Merged</strong></summary>
+
+
+## ⛔ Apply Blocked: PR Is Merged — Staging
+
+
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+This PR is already merged, so applies can no longer run from it. SchemaBot only applies schema changes from open PRs.
+
+If the schema change still needs to be applied, open a new PR with it and apply from there.
+
+
+</details>
+
+<details>
 <summary><a name="no-lock-found"></a><strong>No Lock Found</strong></summary>
 
 

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -5491,6 +5491,22 @@ Wait for it to complete or stop it first.
 </details>
 
 <details>
+<summary><a name="apply-blocked-pr-closed"></a><strong>Apply Blocked: PR Closed</strong></summary>
+
+
+## ⛔ Apply Blocked: PR Is Closed — Staging
+
+
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+This PR is closed, so its schema changes can never merge. SchemaBot only applies schema changes from open PRs.
+
+Reopen this PR, or open a new PR with the schema change, and apply from there.
+
+
+</details>
+
+<details>
 <summary><a name="no-lock-found"></a><strong>No Lock Found</strong></summary>
 
 

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -120,6 +120,7 @@ func previewApplyCommandAllOutput() {
 		{"APPLY BLOCKED BY OTHER PR", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByOtherPR()) }},
 		{"APPLY BLOCKED BY CLI", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByCLI()) }},
 		{"APPLY ALREADY IN PROGRESS", func() { fmt.Print(webhooktemplates.PreviewCommentApplyInProgress()) }},
+		{"APPLY BLOCKED: PR CLOSED", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedClosedPR()) }},
 		{"NO LOCK FOUND", func() { fmt.Print(webhooktemplates.PreviewCommentApplyConfirmNoLock()) }},
 		{"BASE SCHEMA CHANGED SINCE PR DIVERGED", func() { fmt.Print(webhooktemplates.PreviewCommentBaseSchemaFreshnessRejected()) }},
 		{"BLOCKED BY PRIOR ENV (PENDING)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByPriorEnv()) }},

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -121,6 +121,7 @@ func previewApplyCommandAllOutput() {
 		{"APPLY BLOCKED BY CLI", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByCLI()) }},
 		{"APPLY ALREADY IN PROGRESS", func() { fmt.Print(webhooktemplates.PreviewCommentApplyInProgress()) }},
 		{"APPLY BLOCKED: PR CLOSED", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedClosedPR()) }},
+		{"APPLY BLOCKED: PR MERGED", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedMergedPR()) }},
 		{"NO LOCK FOUND", func() { fmt.Print(webhooktemplates.PreviewCommentApplyConfirmNoLock()) }},
 		{"BASE SCHEMA CHANGED SINCE PR DIVERGED", func() { fmt.Print(webhooktemplates.PreviewCommentBaseSchemaFreshnessRejected()) }},
 		{"BLOCKED BY PRIOR ENV (PENDING)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByPriorEnv()) }},

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -756,6 +756,10 @@ type PullRequestInfo struct {
 	// State is the PR's lifecycle state as GitHub reports it: "open" or
 	// "closed" (a merged PR reads as closed).
 	State string
+	// Merged reports whether the PR was merged. GitHub folds merged PRs into
+	// State "closed", so callers that message operators differently for a
+	// merged PR versus an abandoned one must consult this alongside IsClosed.
+	Merged bool
 }
 
 // OpenPullRequest holds the PR metadata needed for operator scans.
@@ -920,6 +924,7 @@ func (ic *InstallationClient) fetchPullRequest(ctx context.Context, repo string,
 		BaseRef: ghPR.GetBase().GetRef(),
 		User:    ghPR.GetUser().GetLogin(),
 		State:   ghPR.GetState(),
+		Merged:  ghPR.GetMerged(),
 	}, nil
 }
 

--- a/pkg/webhook/apply_gating.go
+++ b/pkg/webhook/apply_gating.go
@@ -18,12 +18,19 @@ import (
 // on closed PRs: they are the recovery paths for an apply that ran while the
 // PR was open. A PR fetch failure blocks the command (fail closed) because
 // the PR state cannot be verified.
+//
+// This is a safety re-check, so it bypasses the request-scoped PR-info cache:
+// discovery earlier in the same delivery may have cached the PR as open, and a
+// close landing between discovery and this gate must still block the apply.
 func (h *Handler) enforceOpenPR(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, installationID int64, commandName, environment, requestedBy string) (blocked bool) {
-	prInfo, err := client.FetchPullRequest(ctx, repo, pr)
+	prInfo, err := client.FetchPullRequestNoCache(ctx, repo, pr)
 	if err != nil {
 		h.logger.Error("failed to fetch PR state for the closed-PR apply gate; blocking the command",
 			"repo", repo, "pr", pr, "environment", environment, "command", commandName, "error", err)
-		h.postCommandError(repo, pr, installationID, commandName, environment, requestedBy, "Failed to fetch PR info: "+err.Error())
+		// The raw error can carry internal detail (hosts, headers, newlines)
+		// that must not render in PR markdown; operators triage from the log
+		// line above.
+		h.postCommandError(repo, pr, installationID, commandName, environment, requestedBy, "Could not verify the pull request state, so the command was blocked. Retry, and see server logs if it persists.")
 		return true
 	}
 	if !prInfo.IsClosed() {

--- a/pkg/webhook/apply_gating.go
+++ b/pkg/webhook/apply_gating.go
@@ -10,6 +10,31 @@ import (
 	"github.com/block/schemabot/pkg/webhook/templates"
 )
 
+// enforceOpenPR rejects apply-family commands on closed PRs. A closed PR's
+// schema changes can never merge, so applying them would push schema to the
+// target database from code with no path to the base branch — and the PR's
+// close-time lock cleanup has already run, so a lock acquired by the apply
+// would be orphaned until a manual unlock. Rollback and unlock stay available
+// on closed PRs: they are the recovery paths for an apply that ran while the
+// PR was open. A PR fetch failure blocks the command (fail closed) because
+// the PR state cannot be verified.
+func (h *Handler) enforceOpenPR(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, installationID int64, commandName, environment, requestedBy string) (blocked bool) {
+	prInfo, err := client.FetchPullRequest(ctx, repo, pr)
+	if err != nil {
+		h.logger.Error("failed to fetch PR state for the closed-PR apply gate; blocking the command",
+			"repo", repo, "pr", pr, "environment", environment, "command", commandName, "error", err)
+		h.postCommandError(repo, pr, installationID, commandName, environment, requestedBy, "Failed to fetch PR info: "+err.Error())
+		return true
+	}
+	if !prInfo.IsClosed() {
+		return false
+	}
+	h.logger.Info("apply command rejected: PR is closed",
+		"repo", repo, "pr", pr, "environment", environment, "command", commandName, "requested_by", requestedBy)
+	h.postComment(repo, pr, installationID, templates.RenderApplyBlockedClosedPR(environment, requestedBy))
+	return true
+}
+
 // isAggregateCheckName reports whether a check name matches this deployment's
 // configured aggregate Check Run name: the base name itself or the
 // environment-scoped form "base (<env>)". Aggregate identity is decided by

--- a/pkg/webhook/apply_gating.go
+++ b/pkg/webhook/apply_gating.go
@@ -10,14 +10,17 @@ import (
 	"github.com/block/schemabot/pkg/webhook/templates"
 )
 
-// enforceOpenPR rejects apply-family commands on closed PRs. A closed PR's
-// schema changes can never merge, so applying them would push schema to the
-// target database from code with no path to the base branch — and the PR's
-// close-time lock cleanup has already run, so a lock acquired by the apply
-// would be orphaned until a manual unlock. Rollback and unlock stay available
-// on closed PRs: they are the recovery paths for an apply that ran while the
-// PR was open. A PR fetch failure blocks the command (fail closed) because
-// the PR state cannot be verified.
+// enforceOpenPR rejects apply-family commands on closed PRs, merged or not.
+// An abandoned PR's schema changes can never merge, so applying them would
+// push schema to the target database from code with no path to the base
+// branch; a merged PR's timeline is no longer the driving surface for new
+// applies. In both cases the PR's close-time lock cleanup has already run, so
+// a lock acquired by the apply would be orphaned until a manual unlock. The
+// rejection copy distinguishes the two so the operator gets recovery guidance
+// that is actually possible (a merged PR cannot be reopened). Rollback and
+// unlock stay available on closed PRs: they are the recovery paths for an
+// apply that ran while the PR was open. A PR fetch failure blocks the command
+// (fail closed) because the PR state cannot be verified.
 //
 // This is a safety re-check, so it bypasses the request-scoped PR-info cache:
 // discovery earlier in the same delivery may have cached the PR as open, and a
@@ -37,8 +40,8 @@ func (h *Handler) enforceOpenPR(ctx context.Context, client *ghclient.Installati
 		return false
 	}
 	h.logger.Info("apply command rejected: PR is closed",
-		"repo", repo, "pr", pr, "environment", environment, "command", commandName, "requested_by", requestedBy)
-	h.postComment(repo, pr, installationID, templates.RenderApplyBlockedClosedPR(environment, requestedBy))
+		"repo", repo, "pr", pr, "environment", environment, "command", commandName, "requested_by", requestedBy, "merged", prInfo.Merged)
+	h.postComment(repo, pr, installationID, templates.RenderApplyBlockedClosedPR(environment, requestedBy, prInfo.Merged))
 	return true
 }
 

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -55,6 +55,10 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		h.acknowledgeCommandActPoint(repo, pr, installationID, result)
 	}
 
+	if blocked := h.enforceOpenPR(ctx, client, repo, pr, installationID, action.Apply, environment, requestedBy); blocked {
+		return
+	}
+
 	if blocked := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, schemaResult.Database, schemaResult.Type, environment, action.Apply); blocked {
 		return
 	}
@@ -314,6 +318,10 @@ func (h *Handler) handleApplyConfirmCommand(repo string, pr int, environment, da
 	}
 	if err := h.attachServerEnvironments(schemaResult, environment); err != nil {
 		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.ApplyConfirm, err)
+		return
+	}
+
+	if blocked := h.enforceOpenPR(ctx, client, repo, pr, installationID, action.ApplyConfirm, environment, requestedBy); blocked {
 		return
 	}
 

--- a/pkg/webhook/apply_integration_test.go
+++ b/pkg/webhook/apply_integration_test.go
@@ -92,6 +92,113 @@ func TestE2EApplyWithChanges(t *testing.T) {
 	}
 }
 
+// TestE2EApplyRejectedOnClosedPR verifies the closed-PR apply gate: an apply
+// command on a closed PR must be rejected with an explicit comment before any
+// plan, lock, or execution work happens. A closed PR's schema changes have no
+// path to the base branch, and its close-time lock cleanup has already run, so
+// an apply from it would push unmergeable schema and orphan the database lock.
+func TestE2EApplyRejectedOnClosedPR(t *testing.T) {
+	dbName := "webhook_apply_closed_pr"
+	svc := setupE2EService(t, dbName)
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+
+	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
+	closedState := "closed"
+	result.PRState.Store(&closedState)
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	installClient := ghclient.NewInstallationClient(client, logger)
+	factory := &fakeClientFactory{client: installClient}
+
+	h := NewHandler(svc, factory, nil, logger)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot apply -e staging",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "PR Is Closed")
+		assert.Contains(t, body, "open PRs")
+		assert.NotContains(t, body, "Applying automatically")
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for closed-PR rejection comment")
+	}
+
+	// The rejected apply must not have acquired the database lock.
+	lock, err := svc.Storage().Locks().Get(t.Context(), dbName, "mysql")
+	require.NoError(t, err)
+	assert.Nil(t, lock)
+}
+
+// TestE2EApplyConfirmRejectedOnClosedPR verifies the closed-PR gate also
+// covers the manual confirmation path: apply-confirm on a closed PR is
+// rejected before any lock or freshness handling, so a confirmation comment
+// cannot execute a pending apply after the PR closes.
+func TestE2EApplyConfirmRejectedOnClosedPR(t *testing.T) {
+	dbName := "webhook_applyconfirm_closed_pr"
+	svc := setupE2EService(t, dbName)
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+
+	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
+	closedState := "closed"
+	result.PRState.Store(&closedState)
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	installClient := ghclient.NewInstallationClient(client, logger)
+	factory := &fakeClientFactory{client: installClient}
+
+	h := NewHandler(svc, factory, nil, logger)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot apply-confirm -e staging",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "PR Is Closed")
+		assert.Contains(t, body, "open PRs")
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for closed-PR rejection comment")
+	}
+
+	lock, err := svc.Storage().Locks().Get(t.Context(), dbName, "mysql")
+	require.NoError(t, err)
+	assert.Nil(t, lock)
+}
+
 func TestE2EApplyNoChanges(t *testing.T) {
 	dbName := "webhook_apply_nochanges"
 	svc := setupE2EService(t, dbName)

--- a/pkg/webhook/apply_integration_test.go
+++ b/pkg/webhook/apply_integration_test.go
@@ -199,6 +199,62 @@ func TestE2EApplyConfirmRejectedOnClosedPR(t *testing.T) {
 	assert.Nil(t, lock)
 }
 
+// TestE2EApplyRejectedOnMergedPR verifies the closed-PR gate's merged flavor:
+// GitHub reports a merged PR as closed, so the gate still blocks the apply,
+// but the rejection copy must not tell the operator to reopen the PR (a
+// merged PR cannot be reopened) or claim its changes can never merge (they
+// did). The operator instead gets pointed at opening a new PR.
+func TestE2EApplyRejectedOnMergedPR(t *testing.T) {
+	dbName := "webhook_apply_merged_pr"
+	svc := setupE2EService(t, dbName)
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+
+	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
+	closedState := "closed"
+	result.PRState.Store(&closedState)
+	result.PRMerged.Store(true)
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	installClient := ghclient.NewInstallationClient(client, logger)
+	factory := &fakeClientFactory{client: installClient}
+
+	h := NewHandler(svc, factory, nil, logger)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot apply -e staging",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "PR Is Merged")
+		assert.Contains(t, body, "open PRs")
+		assert.NotContains(t, body, "Reopen this PR")
+		assert.NotContains(t, body, "can never merge")
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for merged-PR rejection comment")
+	}
+
+	lock, err := svc.Storage().Locks().Get(t.Context(), dbName, "mysql")
+	require.NoError(t, err)
+	assert.Nil(t, lock)
+}
+
 func TestE2EApplyNoChanges(t *testing.T) {
 	dbName := "webhook_apply_nochanges"
 	svc := setupE2EService(t, dbName)

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -251,9 +251,19 @@ func RenderApplyInProgress(data ApplyLockConflictData) string {
 }
 
 // RenderApplyBlockedClosedPR renders a rejection when an apply command targets
-// a closed PR.
-func RenderApplyBlockedClosedPR(environment, requestedBy string) string {
+// a closed PR. merged selects the copy: a merged PR cannot be reopened and its
+// schema changes did merge, so the abandoned-PR guidance ("reopen this PR" /
+// "can never merge") would mislead the operator.
+func RenderApplyBlockedClosedPR(environment, requestedBy string, merged bool) string {
 	var sb strings.Builder
+
+	if merged {
+		writeEnvironmentTitle(&sb, "⛔ Apply Blocked: PR Is Merged", environment)
+		writeRequesterOrTimestamp(&sb, requestedBy)
+		sb.WriteString("\nThis PR is already merged, so applies can no longer run from it. SchemaBot only applies schema changes from open PRs.\n\n")
+		sb.WriteString("If the schema change still needs to be applied, open a new PR with it and apply from there.\n")
+		return sb.String()
+	}
 
 	writeEnvironmentTitle(&sb, "⛔ Apply Blocked: PR Is Closed", environment)
 	writeRequesterOrTimestamp(&sb, requestedBy)

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -250,6 +250,19 @@ func RenderApplyInProgress(data ApplyLockConflictData) string {
 	return sb.String()
 }
 
+// RenderApplyBlockedClosedPR renders a rejection when an apply command targets
+// a closed PR.
+func RenderApplyBlockedClosedPR(environment, requestedBy string) string {
+	var sb strings.Builder
+
+	writeEnvironmentTitle(&sb, "⛔ Apply Blocked: PR Is Closed", environment)
+	writeRequesterOrTimestamp(&sb, requestedBy)
+	sb.WriteString("\nThis PR is closed, so its schema changes can never merge. SchemaBot only applies schema changes from open PRs.\n\n")
+	sb.WriteString("Reopen this PR, or open a new PR with the schema change, and apply from there.\n")
+
+	return sb.String()
+}
+
 // RenderNoLocksFound renders a comment when unlock finds no locks for this PR.
 func RenderNoLocksFound() string {
 	var sb strings.Builder

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -300,6 +300,11 @@ func PreviewCommentApplyInProgress() string {
 	})
 }
 
+// PreviewCommentApplyBlockedClosedPR renders a sample closed-PR apply rejection.
+func PreviewCommentApplyBlockedClosedPR() string {
+	return RenderApplyBlockedClosedPR("staging", previewRequestedBy)
+}
+
 // PreviewCommentApplyConfirmNoLock renders a sample "no lock found" comment.
 func PreviewCommentApplyConfirmNoLock() string {
 	return RenderApplyConfirmNoLock("testapp", "staging")

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -300,9 +300,16 @@ func PreviewCommentApplyInProgress() string {
 	})
 }
 
-// PreviewCommentApplyBlockedClosedPR renders a sample closed-PR apply rejection.
+// PreviewCommentApplyBlockedClosedPR renders a sample apply rejection for a
+// closed-but-unmerged PR.
 func PreviewCommentApplyBlockedClosedPR() string {
-	return RenderApplyBlockedClosedPR("staging", previewRequestedBy)
+	return RenderApplyBlockedClosedPR("staging", previewRequestedBy, false)
+}
+
+// PreviewCommentApplyBlockedMergedPR renders a sample apply rejection for a
+// merged PR.
+func PreviewCommentApplyBlockedMergedPR() string {
+	return RenderApplyBlockedClosedPR("staging", previewRequestedBy, true)
 }
 
 // PreviewCommentApplyConfirmNoLock renders a sample "no lock found" comment.

--- a/pkg/webhook/webhook_integration_test.go
+++ b/pkg/webhook/webhook_integration_test.go
@@ -303,6 +303,11 @@ type planFlowResult struct {
 	// "closed" before issuing the webhook request.
 	PRState atomic.Pointer[string]
 
+	// PRMerged marks the PR served by /pulls/1 as merged. GitHub reports a
+	// merged PR with state "closed" and merged true, so tests exercising the
+	// merged-PR rejection copy set this together with PRState "closed".
+	PRMerged atomic.Bool
+
 	// CheckStatusNodes optionally overrides the default passing-checks REST
 	// responses installed by setupFakeGitHubForPlan. Tests that need to drive
 	// different check-gate responses across consecutive calls (e.g. PASS at the
@@ -385,8 +390,10 @@ func setupFakeGitHubForPlanWithPRFiles(t *testing.T, mux *http.ServeMux, schemaS
 		if override := result.PRState.Load(); override != nil {
 			prState = *override
 		}
+		merged := result.PRMerged.Load()
 		_ = json.NewEncoder(w).Encode(gh.PullRequest{
-			State: &prState,
+			State:  &prState,
+			Merged: &merged,
 			Head: &gh.PullRequestBranch{
 				Ref: new("feature-branch"),
 				SHA: &sha,

--- a/pkg/webhook/webhook_integration_test.go
+++ b/pkg/webhook/webhook_integration_test.go
@@ -298,6 +298,11 @@ type planFlowResult struct {
 	HeadSHAs    []string
 	headSHACall atomic.Int64
 
+	// PRState overrides the lifecycle state served by /pulls/1. Empty (the
+	// default) serves "open"; tests exercising the closed-PR command gate set
+	// "closed" before issuing the webhook request.
+	PRState atomic.Pointer[string]
+
 	// CheckStatusNodes optionally overrides the default passing-checks REST
 	// responses installed by setupFakeGitHubForPlan. Tests that need to drive
 	// different check-gate responses across consecutive calls (e.g. PASS at the
@@ -376,7 +381,12 @@ func setupFakeGitHubForPlanWithPRFiles(t *testing.T, mux *http.ServeMux, schemaS
 	// preserves the historical "abc123" for every existing test).
 	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, r *http.Request) {
 		sha := result.nextHeadSHA()
+		prState := "open"
+		if override := result.PRState.Load(); override != nil {
+			prState = *override
+		}
 		_ = json.NewEncoder(w).Encode(gh.PullRequest{
+			State: &prState,
 			Head: &gh.PullRequestBranch{
 				Ref: new("feature-branch"),
 				SHA: &sha,


### PR DESCRIPTION
## Why this matters

Commenting `schemabot apply` (or `apply-confirm`) on a **closed** PR ran the apply to completion. The closed-PR guard lived only in the plan/converge path (`convergeAggregatesForNoManagedSchemaChanges`); the apply command path never checked PR state. That fails open twice:

- Schema lands on the target database from code that has no path to the base branch — anyone can push schema from closed/rejected PRs, and the freshness gate's intent is bypassed since a closed PR never updates against base.
- The database lock acquired by the apply is orphaned: close-time lock cleanup already fired when the PR closed, so nothing ever releases it, and every later PR is blocked until a manual `unlock` on the closed PR.

## What it does

Adds an open-PR gate (`enforceOpenPR`) to `handleApplyCommand` and `handleApplyConfirmCommand`, placed after ownership discovery — so on aggregate fan-out repos only the owning deployment posts the rejection, preserving the unowned-silence contract — and before any check reconciliation, gating, or lock work. The gate fails closed when the PR state cannot be fetched.

A closed PR gets an explicit rejection comment instead of an apply, and the copy distinguishes why the PR is closed: GitHub reports merged PRs as closed too, so a merged PR gets its own variant ("Apply Blocked: PR Is Merged") pointing at opening a new PR — the abandoned-PR guidance ("reopen this PR" / "can never merge") is impossible or false for a merged one. Rollback and unlock intentionally stay available on closed PRs: they are the recovery paths for an apply that ran while the PR was open.

Webhook integration tests cover both commands and both closed flavors: rejection comment posted, no apply plan comment, and no database lock acquired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
