### PR TITLE
fix(github): resolve unscoped commands deterministically on multi-database PRs

### DIFF
--- a/pkg/github/config.go
+++ b/pkg/github/config.go
@@ -426,94 +426,36 @@ func (ic *InstallationClient) FindConfigByDatabaseNameInRepo(ctx context.Context
 	return config, configDir, nil
 }
 
-// FindConfigForPR finds the schemabot.yaml config by searching changed config files and directories of changed schema files.
+// FindConfigForPR resolves the single schemabot.yaml config that manages the
+// PR's changed files, using the same discovery as auto-plan: changed config
+// files plus the nearest config above each changed schema file. A PR whose
+// changes resolve to more than one config is ambiguous for single-database
+// callers and returns ErrMultipleConfigs naming every candidate — the caller
+// must scope the command with -d.
 func (ic *InstallationClient) FindConfigForPR(ctx context.Context, repo string, pr int) (*SchemabotConfig, string, error) {
-	prInfo, err := ic.FetchPullRequest(ctx, repo, pr)
-	if err != nil {
-		return nil, "", fmt.Errorf("fetch PR info: %w", err)
-	}
-
-	configs, err := ic.findConfigsChangedInPR(ctx, repo, pr, prInfo.HeadSHA)
+	configs, err := ic.FindAllConfigsForPR(ctx, repo, pr)
 	if err != nil {
 		return nil, "", err
 	}
-	if len(configs) == 1 {
+	return SingleDiscoveredConfig(configs)
+}
+
+// SingleDiscoveredConfig reduces a discovery result to the one config a
+// single-database code path can act on: ErrNoConfig when nothing was
+// discovered, the config itself when exactly one was, and ErrMultipleConfigs
+// naming every candidate database when the changed files span several configs.
+func SingleDiscoveredConfig(configs []DiscoveredConfig) (*SchemabotConfig, string, error) {
+	switch len(configs) {
+	case 0:
+		return nil, "", ErrNoConfig
+	case 1:
 		return configs[0].Config, configs[0].SchemaDir, nil
 	}
-	if len(configs) > 1 {
-		var databases []string
-		for _, dc := range configs {
-			databases = append(databases, fmt.Sprintf("`%s` (%s)", dc.Config.Database, dc.SchemaDir))
-		}
-		return nil, "", fmt.Errorf("%w: %s", ErrMultipleConfigs, strings.Join(databases, ", "))
+	var databases []string
+	for _, dc := range configs {
+		databases = append(databases, fmt.Sprintf("`%s` (%s)", dc.Config.Database, dc.SchemaDir))
 	}
-
-	files, err := ic.FetchPRFiles(ctx, repo, pr)
-	if err != nil {
-		return nil, "", fmt.Errorf("fetch PR files: %w", err)
-	}
-
-	var schemaFiles []string
-	for _, file := range files {
-		if IsSchemaFile(file.Filename) {
-			schemaFiles = append(schemaFiles, file.Filename)
-		}
-	}
-
-	if len(schemaFiles) == 0 {
-		return nil, "", ErrNoConfig
-	}
-
-	// Collect all unique directories to search for config
-	dirsToSearch := make(map[string]bool)
-	for _, file := range schemaFiles {
-		dir := path.Dir(file)
-		for dir != "." && dir != "" {
-			dirsToSearch[dir] = true
-			dir = path.Dir(dir)
-		}
-		dirsToSearch["."] = true
-	}
-
-	// Search for config starting from shallowest directory
-	var bestConfig *SchemabotConfig
-	var bestConfigDir string
-	bestDepth := -1
-
-	for dir := range dirsToSearch {
-		configPath := dir + "/" + ConfigFileName
-		if dir == "." {
-			configPath = ConfigFileName
-		}
-
-		config, err := ic.FetchConfig(ctx, repo, configPath, prInfo.HeadSHA)
-		if err != nil {
-			if errors.Is(err, ErrNoConfig) {
-				continue
-			}
-			// Config not found at this path is expected — the search
-			// walks up parent directories. Other errors (auth failures,
-			// rate limits, server errors) must propagate.
-			return nil, "", err
-		}
-
-		depth := strings.Count(dir, "/")
-		if dir == "." {
-			depth = 0
-		}
-
-		if bestConfig == nil || depth < bestDepth {
-			bestConfig = config
-			bestConfigDir = dir
-			bestDepth = depth
-		}
-	}
-
-	if bestConfig == nil {
-		return nil, "", ErrNoConfig
-	}
-
-	return bestConfig, bestConfigDir, nil
+	return nil, "", fmt.Errorf("%w: %s", ErrMultipleConfigs, strings.Join(databases, ", "))
 }
 
 // FindAllConfigsForPR finds ALL schemabot.yaml configs that apply to the changed files in a PR.
@@ -723,31 +665,6 @@ func newDiscoveredConfig(config *SchemabotConfig, dir string) DiscoveredConfig {
 		Path:      configPath,
 		SchemaDir: dir,
 	}
-}
-
-func (ic *InstallationClient) findConfigsChangedInPR(ctx context.Context, repo string, pr int, ref string) ([]DiscoveredConfig, error) {
-	files, err := ic.FetchPRFiles(ctx, repo, pr)
-	if err != nil {
-		return nil, fmt.Errorf("fetch PR files: %w", err)
-	}
-
-	configsByPath := make(map[string]DiscoveredConfig)
-	for _, file := range files {
-		if !isConfigFile(file.Filename) {
-			continue
-		}
-		if isRemovedPRFile(file.Status) {
-			continue
-		}
-		configDir := path.Dir(file.Filename)
-		config, err := ic.FetchConfig(ctx, repo, file.Filename, ref)
-		if err != nil {
-			return nil, fmt.Errorf("fetch changed config %s: %w", file.Filename, err)
-		}
-		configsByPath[configDir] = newDiscoveredConfig(config, configDir)
-	}
-
-	return sortedConfigs(configsByPath), nil
 }
 
 func selectConfigByDatabaseName(databaseName string, configs []DiscoveredConfig) (*SchemabotConfig, string, bool, error) {

--- a/pkg/github/config_test.go
+++ b/pkg/github/config_test.go
@@ -332,6 +332,47 @@ func TestFindConfigForPRDiscoversChangedConfigFile(t *testing.T) {
 	assert.Equal(t, "apps/widgets/schema", schemaDir)
 }
 
+func TestFindConfigForPRRejectsMultipleDiscoveredConfigs(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerPullRequest(t, mux, "abc123")
+	registerPullRequestFiles(t, mux, []*gh.CommitFile{
+		{
+			Filename: new("apps/widgets/schema/schemabot.yaml"),
+			Status:   new("added"),
+		},
+		{
+			Filename: new("apps/gadgets/schema/schemabot.yaml"),
+			Status:   new("added"),
+		},
+	})
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema/schemabot.yaml", "database: widgets\ntype: mysql\n")
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/apps/gadgets/schema/schemabot.yaml", "database: gadgets\ntype: mysql\n")
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	_, _, err := ic.FindConfigForPR(t.Context(), "octocat/hello-world", 1)
+
+	require.ErrorIs(t, err, ErrMultipleConfigs)
+	assert.Contains(t, err.Error(), "`widgets` (apps/widgets/schema)")
+	assert.Contains(t, err.Error(), "`gadgets` (apps/gadgets/schema)")
+}
+
+func TestFindConfigForPRDiscoversNearestConfigForChangedSchemaFile(t *testing.T) {
+	client, mux := setupConfigTestGitHubServer(t)
+	registerPullRequest(t, mux, "abc123")
+	registerPullRequestFiles(t, mux, []*gh.CommitFile{{
+		Filename: new("apps/widgets/schema/main/widgets.sql"),
+		Status:   new("modified"),
+	}})
+	registerFileContent(t, mux, "/repos/octocat/hello-world/contents/apps/widgets/schema/schemabot.yaml", "database: widgets\ntype: mysql\n")
+
+	ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	config, schemaDir, err := ic.FindConfigForPR(t.Context(), "octocat/hello-world", 1)
+
+	require.NoError(t, err)
+	assert.Equal(t, "widgets", config.Database)
+	assert.Equal(t, "apps/widgets/schema", schemaDir)
+}
+
 func TestFindConfigByDatabaseNameUsesChangedConfigFileBeforeRepoScan(t *testing.T) {
 	client, mux := setupConfigTestGitHubServer(t)
 	registerPullRequest(t, mux, "abc123")

--- a/pkg/github/schema.go
+++ b/pkg/github/schema.go
@@ -50,6 +50,14 @@ func (ic *InstallationClient) CreateSchemaRequestFromPR(ctx context.Context, rep
 	if err != nil {
 		return nil, err
 	}
+	return ic.CreateSchemaRequestForConfig(ctx, repo, pr, environment, config, configDir, validateEnvironment)
+}
+
+// CreateSchemaRequestForConfig fetches schema files and builds a plan request
+// for a config the caller has already discovered and selected — for example
+// after filtering a multi-config discovery result down to the one config this
+// deployment manages.
+func (ic *InstallationClient) CreateSchemaRequestForConfig(ctx context.Context, repo string, pr int, environment string, config *SchemabotConfig, configDir string, validateEnvironment EnvironmentValidator) (*SchemaRequestResult, error) {
 	if validateEnvironment != nil {
 		if err := validateEnvironment(config.Database, environment); err != nil {
 			return nil, err

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -592,10 +592,10 @@ func (h *Handler) inferUnlockDatabase(ctx context.Context, repo string, pr int, 
 
 	config, _, err := h.resolveUnscopedManagedConfig(ctx, client, repo, pr, action.Unlock)
 	if err != nil {
-		// A config this deployment does not manage means there is nothing for
-		// this deployment to unlock — same outcome as no config at all.
-		var notOwned *schemaConfigOutsideAllowedDirsError
-		if errors.As(err, &notOwned) {
+		// Schema another deployment owns — whether outside allowed_dirs or for
+		// a database not in this deployment's registry — means there is nothing
+		// for this deployment to unlock: same outcome as no config at all.
+		if isSchemaUnownedByDeploymentError(err) {
 			return "", ghclient.ErrNoConfig
 		}
 		if errors.Is(err, ghclient.ErrMultipleConfigs) {

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -590,18 +590,18 @@ func (h *Handler) inferUnlockDatabase(ctx context.Context, repo string, pr int, 
 		return "", err
 	}
 
-	config, configDir, err := client.FindConfigForPR(ctx, repo, pr)
-	if errors.Is(err, ghclient.ErrNoConfig) {
-		config, configDir, _, err = client.FindConfigInRepo(ctx, repo, pr)
-	}
+	config, _, err := h.resolveUnscopedManagedConfig(ctx, client, repo, pr, action.Unlock)
 	if err != nil {
+		// A config this deployment does not manage means there is nothing for
+		// this deployment to unlock — same outcome as no config at all.
+		var notOwned *schemaConfigOutsideAllowedDirsError
+		if errors.As(err, &notOwned) {
+			return "", ghclient.ErrNoConfig
+		}
 		if errors.Is(err, ghclient.ErrMultipleConfigs) {
 			return "", fmt.Errorf("multiple SchemaBot configs match this PR; retry with `schemabot unlock -d <database> --force`: %w", err)
 		}
 		return "", err
-	}
-	if !h.configPathManagedByRepo(ctx, repo, pr, "", config, configDir, action.Unlock) {
-		return "", ghclient.ErrNoConfig
 	}
 	if config == nil || config.Database == "" {
 		return "", fmt.Errorf("no database found in SchemaBot config")

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -251,13 +251,9 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName, tenant s
 		}
 		schemaDatabase = config.Database
 	} else {
-		config, configDir, findErr := client.FindConfigForPR(ctx, repo, pr)
+		config, _, findErr := h.resolveUnscopedManagedConfig(ctx, client, repo, pr, action.Plan)
 		if findErr != nil {
 			h.handleSchemaRequestError(repo, pr, installationID, "", databaseName, requestedBy, action.Plan, findErr)
-			return
-		}
-		if !h.configPathManagedByRepo(ctx, repo, pr, "", config, configDir, action.Plan) {
-			h.handleSchemaRequestError(repo, pr, installationID, "", databaseName, requestedBy, action.Plan, newSchemaConfigOutsideAllowedDirsError(config, configDir))
 			return
 		}
 		schemaDatabase = config.Database

--- a/pkg/webhook/plan_integration_test.go
+++ b/pkg/webhook/plan_integration_test.go
@@ -6,12 +6,15 @@ package webhook
 
 import (
 	"database/sql"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path"
 	"strings"
 	"testing"
 	"time"
@@ -125,6 +128,133 @@ func TestE2EPlanWithChanges(t *testing.T) {
 	assert.True(t, check.HasChanges, "check should indicate changes detected")
 	assert.Equal(t, "completed", check.Status)
 	assert.Equal(t, "action_required", check.Conclusion)
+}
+
+// TestE2EPlanUnscopedRejectsMultipleManagedDatabases verifies that an unscoped
+// plan command on a PR whose changes span two databases this deployment manages
+// is rejected with the "Multiple Databases Detected" comment instead of
+// arbitrarily picking one of the databases. One command drives one database, so
+// the user must disambiguate with -d.
+func TestE2EPlanUnscopedRejectsMultipleManagedDatabases(t *testing.T) {
+	dbName := "webhook_plan_multidb"
+	svc := setupE2EService(t, dbName)
+	dbConfig := svc.Config().Databases[dbName]
+	dbConfig.AllowedRepos = []string{"octocat/hello-world"}
+	dbConfig.AllowedDirs = []string{"schema", "schema2"}
+	svc.Config().Databases[dbName] = dbConfig
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+	prFiles := []*gh.CommitFile{
+		{Filename: new("schema/schemabot.yaml"), Status: new("modified")},
+		{Filename: new("schema2/schemabot.yaml"), Status: new("modified")},
+	}
+	result := setupFakeGitHubForPlanWithPRFiles(t, mux, schemaFiles, schemabotConfig, dbName, prFiles)
+	registerSecondSchemabotConfig(t, mux, "schema2/schemabot.yaml", "database: webhook_plan_multidb_other\ntype: mysql\n")
+
+	h := newE2EHandler(t, svc, client)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot plan -e staging",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "Multiple Databases Detected")
+		assert.Contains(t, body, dbName)
+		assert.Contains(t, body, "webhook_plan_multidb_other")
+	case <-time.After(webhookIntegrationPollDeadline):
+		t.Fatal("timed out waiting for multiple databases rejection comment")
+	}
+
+	plans, err := svc.Storage().Plans().GetByPR(t.Context(), "octocat/hello-world", 1)
+	require.NoError(t, err)
+	for _, plan := range plans {
+		assert.NotEqual(t, dbName, plan.Database, "ambiguous unscoped plan should not be stored")
+	}
+}
+
+// TestE2EPlanUnscopedPlansOwnedDatabaseWhenPRTouchesUnownedConfig verifies the
+// fan-out contract for unscoped commands on a PR spanning several databases:
+// discovered configs are narrowed to the ones this deployment manages before
+// deciding whether the command is ambiguous. A PR touching one config this
+// deployment owns and one it does not must plan the owned database rather than
+// reject with "Multiple Databases Detected" — the unowned config is another
+// deployment's to handle.
+func TestE2EPlanUnscopedPlansOwnedDatabaseWhenPRTouchesUnownedConfig(t *testing.T) {
+	dbName := "webhook_plan_fanout_owned"
+	svc := setupE2EService(t, dbName)
+	dbConfig := svc.Config().Databases[dbName]
+	dbConfig.AllowedRepos = []string{"octocat/hello-world"}
+	dbConfig.AllowedDirs = []string{"schema"}
+	svc.Config().Databases[dbName] = dbConfig
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+	prFiles := []*gh.CommitFile{
+		{Filename: new("schema/schemabot.yaml"), Status: new("modified")},
+		{Filename: new("unowned/schemabot.yaml"), Status: new("modified")},
+	}
+	result := setupFakeGitHubForPlanWithPRFiles(t, mux, schemaFiles, schemabotConfig, dbName, prFiles)
+	registerSecondSchemabotConfig(t, mux, "unowned/schemabot.yaml", "database: webhook_plan_fanout_unowned\ntype: mysql\n")
+
+	h := newE2EHandler(t, svc, client)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot plan -e staging",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "## Schema Change Plan")
+		assert.Contains(t, body, "CREATE TABLE")
+		assert.Contains(t, body, dbName)
+		assert.NotContains(t, body, "webhook_plan_fanout_unowned")
+	case <-time.After(webhookIntegrationPollDeadline):
+		t.Fatal("timed out waiting for plan comment for the owned database")
+	}
+}
+
+// registerSecondSchemabotConfig serves an additional schemabot.yaml at the
+// given repo path so a test PR can span more than one discovered config.
+func registerSecondSchemabotConfig(t *testing.T, mux *http.ServeMux, repoPath, content string) {
+	t.Helper()
+	mux.HandleFunc("GET /repos/octocat/hello-world/contents/"+repoPath, func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.RepositoryContent{
+			Name:     new(path.Base(repoPath)),
+			Path:     new(repoPath),
+			Content:  new(base64.StdEncoding.EncodeToString([]byte(content))),
+			Encoding: new("base64"),
+		}))
+	})
 }
 
 // TestE2EPlanSourcePolicyBlocksUnauthorizedRepo verifies the trusted GitHub

--- a/pkg/webhook/plan_integration_test.go
+++ b/pkg/webhook/plan_integration_test.go
@@ -140,8 +140,16 @@ func TestE2EPlanUnscopedRejectsMultipleManagedDatabases(t *testing.T) {
 	svc := setupE2EService(t, dbName)
 	dbConfig := svc.Config().Databases[dbName]
 	dbConfig.AllowedRepos = []string{"octocat/hello-world"}
-	dbConfig.AllowedDirs = []string{"schema", "schema2"}
+	dbConfig.AllowedDirs = []string{"schema"}
 	svc.Config().Databases[dbName] = dbConfig
+	// The second database is genuinely this deployment's: registered and with
+	// its own allowed dir, so the ambiguity is real rather than an ownership
+	// artifact.
+	svc.Config().Databases["webhook_plan_multidb_other"] = api.DatabaseConfig{
+		Type:         "mysql",
+		AllowedRepos: []string{"octocat/hello-world"},
+		AllowedDirs:  []string{"schema2"},
+	}
 
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
@@ -240,6 +248,60 @@ func TestE2EPlanUnscopedPlansOwnedDatabaseWhenPRTouchesUnownedConfig(t *testing.
 		assert.NotContains(t, body, "webhook_plan_fanout_unowned")
 	case <-time.After(webhookIntegrationPollDeadline):
 		t.Fatal("timed out waiting for plan comment for the owned database")
+	}
+}
+
+// TestE2EPlanUnscopedPlansRegisteredDatabaseWhenPRTouchesUnregisteredConfig
+// verifies the fan-out contract on repos partitioned by database registry
+// rather than allowed_dirs: with no directory allowlist configured, every
+// discovered config passes the directory filter, so multiplicity must be
+// decided over the configs whose database this deployment has registered. A PR
+// touching one registered database's config and one unregistered database's
+// config must plan the registered database instead of rejecting with
+// "Multiple Databases Detected" — the unregistered config belongs to whichever
+// deployment has that database in its registry.
+func TestE2EPlanUnscopedPlansRegisteredDatabaseWhenPRTouchesUnregisteredConfig(t *testing.T) {
+	dbName := "webhook_plan_registry_owned"
+	svc := setupE2EService(t, dbName)
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+	prFiles := []*gh.CommitFile{
+		{Filename: new("schema/schemabot.yaml"), Status: new("modified")},
+		{Filename: new("other/schemabot.yaml"), Status: new("modified")},
+	}
+	result := setupFakeGitHubForPlanWithPRFiles(t, mux, schemaFiles, schemabotConfig, dbName, prFiles)
+	registerSecondSchemabotConfig(t, mux, "other/schemabot.yaml", "database: webhook_plan_registry_unregistered\ntype: mysql\n")
+
+	h := newE2EHandler(t, svc, client)
+
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot plan -e staging",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "## Schema Change Plan")
+		assert.Contains(t, body, "CREATE TABLE")
+		assert.Contains(t, body, dbName)
+		assert.NotContains(t, body, "Multiple Databases Detected")
+		assert.NotContains(t, body, "webhook_plan_registry_unregistered")
+	case <-time.After(webhookIntegrationPollDeadline):
+		t.Fatal("timed out waiting for plan comment for the registered database")
 	}
 }
 

--- a/pkg/webhook/schema_source_policy.go
+++ b/pkg/webhook/schema_source_policy.go
@@ -90,10 +90,20 @@ func newSchemaConfigOutsideAllowedDirsError(config *ghclient.SchemabotConfig, sc
 }
 
 func (h *Handler) createManagedSchemaRequestFromPR(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, environment, databaseName, source string) (*ghclient.SchemaRequestResult, error) {
-	schemaResult, err := client.CreateSchemaRequestFromPR(ctx, repo, pr, environment, databaseName, h.validateRequestedDatabaseEnvironment)
+	var schemaResult *ghclient.SchemaRequestResult
+	var err error
+	if databaseName == "" {
+		schemaResult, err = h.createUnscopedSchemaRequestFromPR(ctx, client, repo, pr, environment, source)
+	} else {
+		schemaResult, err = client.CreateSchemaRequestFromPR(ctx, repo, pr, environment, databaseName, h.validateRequestedDatabaseEnvironment)
+	}
 	if err != nil {
 		return nil, err
 	}
+	// Re-check the resolved schema root: environment resolution can retarget it
+	// (for example through an environment symlink), so ownership must hold for
+	// the path the schema files were actually fetched from, not just the
+	// discovered config directory.
 	if !h.shouldProcessSchemaConfig(ctx, repo, pr, schemaResult.HeadSHA, schemaResult.Database, schemaResult.Type, schemaResult.SchemaPath, source) {
 		return nil, &schemaConfigOutsideAllowedDirsError{
 			Database:     schemaResult.Database,
@@ -102,6 +112,57 @@ func (h *Handler) createManagedSchemaRequestFromPR(ctx context.Context, client *
 		}
 	}
 	return schemaResult, nil
+}
+
+// createUnscopedSchemaRequestFromPR resolves which database an unscoped
+// command (no -d) targets and fetches that database's schema files.
+func (h *Handler) createUnscopedSchemaRequestFromPR(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, environment, source string) (*ghclient.SchemaRequestResult, error) {
+	config, configDir, err := h.resolveUnscopedManagedConfig(ctx, client, repo, pr, source)
+	if err != nil {
+		return nil, err
+	}
+	return client.CreateSchemaRequestForConfig(ctx, repo, pr, environment, config, configDir, h.validateRequestedDatabaseEnvironment)
+}
+
+// resolveUnscopedManagedConfig resolves which database an unscoped command
+// (no -d) targets. Discovery mirrors auto-plan — changed config files plus the
+// nearest config above each changed schema file — and the discovered configs
+// are filtered to the ones this deployment manages before deciding
+// multiplicity, so on fan-out repos each deployment decides from its own slice:
+//
+//   - no configs discovered at all: fall back to repo-wide single-config
+//     discovery (a changeless PR can still carry commands for its database)
+//   - none of the discovered configs managed here: an unowned-schema error,
+//     which unscoped fan-out handling downgrades to a silent skip
+//   - exactly one managed config: the command targets it, even when the PR
+//     also touches configs other deployments own
+//   - several managed configs: ErrMultipleConfigs — one apply drives one
+//     database, so the user must scope the command with -d
+func (h *Handler) resolveUnscopedManagedConfig(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, source string) (*ghclient.SchemabotConfig, string, error) {
+	configs, err := client.FindAllConfigsForPR(ctx, repo, pr)
+	if err != nil {
+		return nil, "", err
+	}
+	if len(configs) == 0 {
+		config, configDir, _, err := client.FindConfigInRepo(ctx, repo, pr)
+		if err != nil {
+			return nil, "", err
+		}
+		if !h.configPathManagedByRepo(ctx, repo, pr, "", config, configDir, source) {
+			return nil, "", newSchemaConfigOutsideAllowedDirsError(config, configDir)
+		}
+		return config, configDir, nil
+	}
+	// filterManagedDiscoveredConfigs filters in place, so give it a copy —
+	// callers may still need the full discovery result.
+	managed := h.filterManagedDiscoveredConfigs(ctx, repo, pr, "", source, slices.Clone(configs))
+	if len(managed) == 0 {
+		h.logger.Info("unscoped command discovered only schema configs this deployment does not manage",
+			"repo", repo, "pr", pr, "source", source,
+			"discovered_configs", len(configs))
+		return nil, "", newSchemaConfigOutsideAllowedDirsError(configs[0].Config, configs[0].SchemaDir)
+	}
+	return ghclient.SingleDiscoveredConfig(managed)
 }
 
 func (h *Handler) validateRequestedDatabaseEnvironment(database, environment string) error {

--- a/pkg/webhook/schema_source_policy.go
+++ b/pkg/webhook/schema_source_policy.go
@@ -162,7 +162,39 @@ func (h *Handler) resolveUnscopedManagedConfig(ctx context.Context, client *ghcl
 			"discovered_configs", len(configs))
 		return nil, "", newSchemaConfigOutsideAllowedDirsError(configs[0].Config, configs[0].SchemaDir)
 	}
-	return ghclient.SingleDiscoveredConfig(managed)
+	// The directory allowlist is only half the ownership contract: on repos
+	// partitioned by database registry rather than allowed_dirs, a config for
+	// another deployment's database passes the directory filter here. Narrow to
+	// the configs whose database this deployment has registered before deciding
+	// multiplicity, so a PR spanning several deployments' databases is not
+	// falsely ambiguous for the one that owns a single database in it.
+	registered := h.registeredDiscoveredConfigs(managed)
+	if len(registered) == 0 {
+		if len(managed) == 1 {
+			return managed[0].Config, managed[0].SchemaDir, nil
+		}
+		h.logger.Info("unscoped command discovered only schema configs for databases not registered on this deployment",
+			"repo", repo, "pr", pr, "source", source,
+			"discovered_configs", len(configs), "managed_configs", len(managed))
+		return nil, "", &api.DatabaseNotConfiguredError{Database: managed[0].Config.Database}
+	}
+	return ghclient.SingleDiscoveredConfig(registered)
+}
+
+// registeredDiscoveredConfigs narrows discovered configs to the ones whose
+// database has an entry in this deployment's databases registry.
+func (h *Handler) registeredDiscoveredConfigs(configs []ghclient.DiscoveredConfig) []ghclient.DiscoveredConfig {
+	config, ok := h.serverConfig()
+	if !ok {
+		return configs
+	}
+	var registered []ghclient.DiscoveredConfig
+	for _, cfg := range configs {
+		if config.Database(cfg.Config.Database) != nil {
+			registered = append(registered, cfg)
+		}
+	}
+	return registered
 }
 
 func (h *Handler) validateRequestedDatabaseEnvironment(database, environment string) error {


### PR DESCRIPTION
## Why this matters

An unscoped command (no `-d`) on a PR spanning several databases resolved its target through a legacy shallowest-directory search whose ties broke on Go map iteration order — the command could silently plan or apply an **arbitrary** database. The "Multiple Databases Detected" rejection only fired when several config files themselves changed; a PR touching schema files under two different configs never triggered it.

## What it does

- `FindConfigForPR` now reuses auto-plan's discovery (changed config files plus the nearest config above each changed schema file) and fails deterministically with `ErrMultipleConfigs` when more than one config is discovered, instead of picking one.
- The webhook layer filters discovered configs to the ones the deployment owns **before** deciding multiplicity. Ownership is both halves of the server config: the directory allowlist *and* the database registry, so repos partitioned by either mechanism keep the fan-out contract:

  ```
  discover configs on PR
        │
        ├─ none        → repo-wide single-config fallback (changeless PRs)
        │
        └─ filter to allowed_dirs-managed configs
              ├─ 0  → unowned-schema error (fan-out: silent skip)
              └─ narrow to registered databases
                    ├─ 1  → command targets it, even if the PR also
                    │       touches configs other deployments own
                    ├─ 2+ → Multiple Databases Detected → user retries with -d
                    └─ 0  → single managed config passes through;
                            several unregistered → database-not-configured
                            (fan-out: silent skip)
  ```

  On a repo where several deployments each own a slice of the schema, an unscoped command resolves each deployment's own database rather than rejecting because another deployment's config also changed.
- The plan identity lookup and the unscoped `unlock` database inference share the same resolution, so all unscoped command paths agree on the target.

Northstar: one command, one unambiguous database — SchemaBot never guesses which schema you meant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
