### PR TITLE
test(storage): enforce claimable-state completeness for apply recovery

### DIFF
--- a/pkg/storage/mysqlstore/claimable_states_test.go
+++ b/pkg/storage/mysqlstore/claimable_states_test.go
@@ -1,0 +1,89 @@
+package mysqlstore
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/block/schemabot/pkg/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClaimableApplyStates_CoverEveryRegisteredState enforces the recovery
+// invariant documented on claimableApplyStates: every canonical Apply state is
+// either terminal, stale-heartbeat claimable, or deliberately routed through
+// its own recovery path. The stale-heartbeat re-claim is the only way a dead
+// driver's apply gets picked back up, so a dwellable state missing from all
+// three buckets is orphaned by any pod restart — no operator action can ever
+// terminalize it. A new state added to pkg/state must fail here until its
+// recovery story is decided explicitly.
+func TestClaimableApplyStates_CoverEveryRegisteredState(t *testing.T) {
+	claimable := make(map[string]bool)
+	for _, s := range claimableApplyStates() {
+		claimable[s] = true
+	}
+
+	// Non-terminal states deliberately absent from the stale-heartbeat claim
+	// because a dedicated path owns their recovery. Each entry names that path;
+	// adding a state here requires such a path to exist.
+	recoveredElsewhere := map[string]string{
+		// FindNextApply's queue arm claims pending applies with no staleness
+		// requirement; persistApplyClaim transitions pending to running.
+		state.Apply.Pending: "queue claim path",
+		// Paused needs an explicit human decision: release resumes it, and the
+		// stop-reconciliation claim (FindNextApplyForStopReconciliation)
+		// terminalizes it when an operator stops the rollout instead.
+		state.Apply.Paused: "release / stop-reconciliation path",
+		// The retryable recovery claim re-drives it under its own attempt
+		// budget (maxRecoveryAttempts) and freshness window.
+		state.Apply.FailedRetryable: "retryable recovery claim path",
+	}
+
+	v := reflect.ValueOf(state.Apply)
+	for i := 0; i < v.NumField(); i++ {
+		fieldName := v.Type().Field(i).Name
+		stateValue := v.Field(i).String()
+		require.NotEmptyf(t, stateValue, "state.Apply.%s is empty", fieldName)
+
+		if state.IsTerminalApplyState(stateValue) {
+			assert.Falsef(t, claimable[stateValue],
+				"state.Apply.%s (%q) is terminal and must not be stale-claimable: re-claiming a finished apply would re-drive completed work",
+				fieldName, stateValue)
+			continue
+		}
+		if path, ok := recoveredElsewhere[stateValue]; ok {
+			assert.Falsef(t, claimable[stateValue],
+				"state.Apply.%s (%q) is owned by the %s and must not also be stale-claimable: two claim paths racing over one apply",
+				fieldName, stateValue, path)
+			continue
+		}
+		assert.Truef(t, claimable[stateValue],
+			"state.Apply.%s (%q) is a non-terminal dwell state with no recovery path: add it to claimableApplyStates() or give it a dedicated claim arm and allowlist it here, otherwise a driver death permanently orphans the apply",
+			fieldName, stateValue)
+	}
+}
+
+// TestClaimableApplyStates_AreRegisteredActiveStates checks the claim list
+// from the other direction: every entry must normalize to a canonical,
+// non-terminal Apply state. The claim query matches raw stored strings, so
+// legacy aliases (e.g. recovering_cutover) are allowed as long as
+// NormalizeState maps them onto a registered active state — an entry that
+// normalizes to nothing registered would silently never match a row, and a
+// terminal entry would let recovery re-claim finished applies.
+func TestClaimableApplyStates_AreRegisteredActiveStates(t *testing.T) {
+	registered := make(map[string]bool)
+	v := reflect.ValueOf(state.Apply)
+	for _, field := range v.Fields() {
+		registered[field.String()] = true
+	}
+
+	for _, s := range claimableApplyStates() {
+		canonical := state.NormalizeState(s)
+		assert.Truef(t, registered[canonical],
+			"claimable entry %q normalizes to %q, which is not a registered state.Apply value",
+			s, canonical)
+		assert.Falsef(t, state.IsTerminalApplyState(canonical),
+			"claimable entry %q normalizes to terminal state %q: recovery must never re-claim a finished apply",
+			s, canonical)
+	}
+}


### PR DESCRIPTION
## Why this matters

The stale-heartbeat re-claim is the only recovery path after a driver dies. A dwellable apply state missing from `claimableApplyStates()` is orphaned by any pod restart — non-terminal and unclaimable forever, with no operator action able to recover it. That gap is only discoverable today by hitting it in production.

## What it does

Adds a completeness test that enumerates every canonical `state.Apply` state via reflection and requires each to be terminal, stale-claimable, or on an explicit allowlist naming its dedicated recovery path (pending → queue claim, paused → release / stop-reconciliation, failed_retryable → retryable recovery claim). A new state added without a recovery story now fails the test with an actionable message instead of shipping an orphan. A reverse check validates every claim-list entry normalizes to a registered active state, so legacy aliases stay valid and terminal states can never be re-claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)