### PR TITLE
fix(github): derive cutover readiness in ApplyStatusFromProgress

### DIFF
--- a/pkg/webhook/apply.go
+++ b/pkg/webhook/apply.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/block/schemabot/pkg/apitypes"
-	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/schemabot/pkg/tern"
 	"github.com/block/schemabot/pkg/webhook/templates"
@@ -134,21 +133,12 @@ func tableProgressFromTasks(databaseFallback string, tasks []*storage.Task, shar
 			ChecksumRowsChecked: t.ChecksumRowsChecked,
 			ChecksumRowsTotal:   t.ChecksumRowsTotal,
 			IsInstant:           t.IsInstant,
-			ReadyToComplete:     taskReadyForCutover(t),
+			ReadyToComplete:     templates.TaskStatusReadyForCutover(string(t.State)),
 			ErrorMessage:        t.ErrorMessage,
 			Shards:              shardProgressForTable(shardsByTable, t.ApplyOperationID, t.Namespace, t.TableName),
 		})
 	}
 	return out
-}
-
-// taskReadyForCutover reports whether a table's task is ready for the operator
-// to cut over. A task parked at the cutover barrier has finished its copy and
-// verification phases — the remaining binlog catch-up happens under cutover
-// itself — so the barrier state is what makes the table ready. Engines report
-// no separate per-task readiness signal.
-func taskReadyForCutover(t *storage.Task) bool {
-	return state.IsState(t.State, state.Task.WaitingForCutover)
 }
 
 // shardProgressForTable returns the per-shard summary rows for a table, sorted by

--- a/pkg/webhook/apply.go
+++ b/pkg/webhook/apply.go
@@ -133,7 +133,7 @@ func tableProgressFromTasks(databaseFallback string, tasks []*storage.Task, shar
 			ChecksumRowsChecked: t.ChecksumRowsChecked,
 			ChecksumRowsTotal:   t.ChecksumRowsTotal,
 			IsInstant:           t.IsInstant,
-			ReadyToComplete:     templates.TaskStatusReadyForCutover(string(t.State)),
+			ReadyToComplete:     templates.TaskStatusReadyForCutover(t.State),
 			ErrorMessage:        t.ErrorMessage,
 			Shards:              shardProgressForTable(shardsByTable, t.ApplyOperationID, t.Namespace, t.TableName),
 		})

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -50,10 +50,11 @@ type TableProgressData struct {
 // ready for the operator to cut over. A task parked at the cutover barrier has
 // finished its copy and verification phases — the remaining binlog catch-up
 // happens under cutover itself — so the barrier state is what makes the table
-// ready. Engines report no separate per-task readiness signal, so this is the
-// single predicate every TableProgressData producer derives ReadyToComplete
-// from. Accepts raw engine statuses (Spirit "waitingOnSentinelTable", Vitess
-// "ready_to_complete") as well as canonical task states.
+// ready. Engines fold any internal readiness signal into the task status they
+// report, so this is the single predicate every TableProgressData producer
+// derives ReadyToComplete from. Accepts raw engine statuses (Spirit
+// "waitingOnSentinelTable", Vitess "ready_to_complete") as well as canonical
+// task states.
 func TaskStatusReadyForCutover(status string) bool {
 	return state.NormalizeTaskStatus(status) == state.Task.WaitingForCutover
 }

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -52,9 +52,10 @@ type TableProgressData struct {
 // happens under cutover itself — so the barrier state is what makes the table
 // ready. Engines report no separate per-task readiness signal, so this is the
 // single predicate every TableProgressData producer derives ReadyToComplete
-// from.
+// from. Accepts raw engine statuses (Spirit "waitingOnSentinelTable", Vitess
+// "ready_to_complete") as well as canonical task states.
 func TaskStatusReadyForCutover(status string) bool {
-	return state.IsState(status, state.Task.WaitingForCutover)
+	return state.NormalizeTaskStatus(status) == state.Task.WaitingForCutover
 }
 
 // ShardProgressData is the high-level status of one shard, for the compact

--- a/pkg/webhook/templates/apply.go
+++ b/pkg/webhook/templates/apply.go
@@ -30,7 +30,10 @@ type TableProgressData struct {
 	ChecksumRowsChecked int64
 	ChecksumRowsTotal   int64
 	IsInstant           bool
-	ReadyToComplete     bool
+	// ReadyToComplete marks the table as ready for the operator to cut over.
+	// Producers must derive it with TaskStatusReadyForCutover so every render
+	// path agrees on what "ready" means.
+	ReadyToComplete bool
 
 	// ErrorMessage is the task's last error. Rendered for states where the
 	// per-table error explains what the user is seeing (e.g. a retrying task).
@@ -41,6 +44,17 @@ type TableProgressData struct {
 	// while the table is in flight (see renderShardSummary); detailed per-shard
 	// row counts/ETAs stay in the CLI, not the PR comment.
 	Shards []ShardProgressData
+}
+
+// TaskStatusReadyForCutover reports whether a table's task status marks it as
+// ready for the operator to cut over. A task parked at the cutover barrier has
+// finished its copy and verification phases — the remaining binlog catch-up
+// happens under cutover itself — so the barrier state is what makes the table
+// ready. Engines report no separate per-task readiness signal, so this is the
+// single predicate every TableProgressData producer derives ReadyToComplete
+// from.
+func TaskStatusReadyForCutover(status string) bool {
+	return state.IsState(status, state.Task.WaitingForCutover)
 }
 
 // ShardProgressData is the high-level status of one shard, for the compact
@@ -1475,6 +1489,7 @@ func ApplyStatusFromProgress(resp *apitypes.ProgressResponse, requestedBy string
 			PercentComplete: int(t.PercentComplete),
 			ETASeconds:      t.ETASeconds,
 			IsInstant:       t.IsInstant,
+			ReadyToComplete: TaskStatusReadyForCutover(t.Status),
 		})
 	}
 

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -1211,6 +1211,25 @@ func TestRenderPRCommandAuthorizationUnavailable(t *testing.T) {
 	assert.Contains(t, result, "inspect SchemaBot authorization logs")
 }
 
+func TestTaskStatusReadyForCutover(t *testing.T) {
+	tests := []struct {
+		status string
+		ready  bool
+	}{
+		{state.Task.WaitingForCutover, true},
+		{"WAITING_FOR_CUTOVER", true},
+		{"waitingOnSentinelTable", true}, // raw Spirit status
+		{"ready_to_complete", true},      // raw Vitess status
+		{state.Task.Running, false},
+		{"copyRows", false}, // raw Spirit status
+		{state.Task.Completed, false},
+		{state.Task.Stopped, false},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.ready, TaskStatusReadyForCutover(tt.status), "status %q", tt.status)
+	}
+}
+
 func TestApplyStatusFromProgress(t *testing.T) {
 	resp := &apitypes.ProgressResponse{
 		State:       "running",

--- a/pkg/webhook/templates/apply_test.go
+++ b/pkg/webhook/templates/apply_test.go
@@ -1229,6 +1229,14 @@ func TestApplyStatusFromProgress(t *testing.T) {
 				ETASeconds:      120,
 			},
 			{
+				TableName:       "orders",
+				DDL:             "ALTER TABLE `orders` ADD INDEX `idx_status` (`status`)",
+				Status:          state.Task.WaitingForCutover,
+				RowsCopied:      10000,
+				RowsTotal:       10000,
+				PercentComplete: 100,
+			},
+			{
 				TableName: "", // empty table name should be filtered
 			},
 		},
@@ -1242,10 +1250,13 @@ func TestApplyStatusFromProgress(t *testing.T) {
 	assert.Equal(t, "running", data.State)
 	assert.Equal(t, "Spirit", data.Engine)
 	assert.Equal(t, "apply_abc123", data.ApplyID)
-	require.Len(t, data.Tables, 1) // empty table name filtered
+	require.Len(t, data.Tables, 2) // empty table name filtered
 	assert.Equal(t, "users", data.Tables[0].TableName)
 	assert.Equal(t, int64(5000), data.Tables[0].RowsCopied)
 	assert.Equal(t, 50, data.Tables[0].PercentComplete)
+	assert.False(t, data.Tables[0].ReadyToComplete, "a copying table is not ready for cutover")
+	assert.Equal(t, "orders", data.Tables[1].TableName)
+	assert.True(t, data.Tables[1].ReadyToComplete, "a table parked at the cutover barrier renders as ready")
 }
 
 func TestPreviewCommentApplyProgress(t *testing.T) {

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -1137,7 +1137,7 @@ func PreviewCommentApplyWaitingForCutover() string {
 	tables := sampleApplyTables()
 	for i := range tables {
 		tables[i].Status = state.Task.WaitingForCutover
-		tables[i].ReadyToComplete = true
+		tables[i].ReadyToComplete = TaskStatusReadyForCutover(tables[i].Status)
 	}
 	return RenderApplyStatusComment(sampleApplyData(state.Apply.WaitingForCutover, tables))
 }
@@ -1231,7 +1231,7 @@ func PreviewCommentMultiDeploymentApplyInProgress() string {
 	euTables := sampleApplyTables()
 	for i := range euTables {
 		euTables[i].Status = state.Task.WaitingForCutover
-		euTables[i].ReadyToComplete = true
+		euTables[i].ReadyToComplete = TaskStatusReadyForCutover(euTables[i].Status)
 	}
 
 	usTables := sampleApplyTables()


### PR DESCRIPTION
## Summary
`ApplyStatusFromProgress` builds table rows for apply status comments but never set `ReadyToComplete`, while the storage-backed producer derives it from the cutover-barrier state. Any future caller wiring `ApplyStatusFromProgress` into a render path would silently reintroduce the "0/N tables ready" contradiction in cutover comments.

## What
- Extract the readiness rule into a single exported predicate, `templates.TaskStatusReadyForCutover`, and derive `ReadyToComplete` from it in both `TableProgressData` producers.
- Delete the private `taskReadyForCutover` wrapper in `pkg/webhook`; the shared predicate is called directly.

## Why
Both producers must agree on what "ready for cutover" means. With one predicate next to the field it governs, the producers cannot drift apart again.

Before:
```
tableProgressFromTasks ──▶ taskReadyForCutover ──▶ ReadyToComplete
ApplyStatusFromProgress ──▶ (never set)         ──▶ always false
```
After:
```
tableProgressFromTasks  ──┐
├─▶ TaskStatusReadyForCutover ──▶ ReadyToComplete
ApplyStatusFromProgress ──┘
```