### PR TITLE
feat(webhook): route merge_group, push, and PR-close through the durable inbox

### DIFF
--- a/pkg/webhook/check_cleanup_integration_test.go
+++ b/pkg/webhook/check_cleanup_integration_test.go
@@ -89,10 +89,10 @@ func TestE2EPRCloseCleanup(t *testing.T) {
 
 	h := NewHandler(svc, nil, nil, slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})))
 
-	// Close the PR while the apply is running. The handler is invoked directly
-	// (not through the async webhook goroutine) so the retention assertions
-	// below observe a finished cleanup pass.
-	h.handlePRClosed("octocat/hello-world", 1, 12345, false)
+	// Close the PR while the apply is running. Cleanup is invoked directly (not
+	// through the async webhook goroutine) so the retention assertions below
+	// observe a finished cleanup pass.
+	require.NoError(t, h.runPRCloseCleanup(t.Context(), "octocat/hello-world", 1, false))
 
 	lock, err := svc.Storage().Locks().Get(t.Context(), dbName, "mysql")
 	require.NoError(t, err)

--- a/pkg/webhook/durable_dispatch.go
+++ b/pkg/webhook/durable_dispatch.go
@@ -414,6 +414,10 @@ func (h *Handler) processDurableWebhookEvent(ctx context.Context, event *storage
 		return h.processDurablePullRequest(ctx, event)
 	case "check_run":
 		return h.processDurableCheckRun(ctx, event)
+	case "merge_group":
+		return h.processDurableMergeGroup(ctx, event)
+	case "push":
+		return h.processDurablePush(ctx, event)
 	default:
 		h.logger.Info("durable webhook delivery ignored because event type is unsupported",
 			"delivery_id", event.DeliveryID, "event", event.Event, "action", event.Action,
@@ -422,48 +426,54 @@ func (h *Handler) processDurableWebhookEvent(ctx context.Context, event *storage
 	}
 }
 
-// processDurablePullRequest drives the auto-plan flow for a claimed
-// pull_request delivery. The durability contract of this slice covers config
-// discovery and plan dispatch: per-database plan execution still runs in
-// detached goroutines (handleMultiEnvPlan via goSafe), exactly as on the
-// request path, and its durability is owned by the applies/tasks layer once
-// plans are created.
+// processDurablePullRequest decodes a claimed pull_request delivery and routes
+// it to the processor for its action. It re-validates the action fail-closed —
+// rows can arrive via replay or a future producer — so a replayed action can
+// never reach the wrong flow.
 func (h *Handler) processDurablePullRequest(ctx context.Context, event *storage.WebhookEvent) (retry bool, err error) {
 	var payload pullRequestPayload
 	if err := json.Unmarshal(event.Payload, &payload); err != nil {
 		return false, fmt.Errorf("decode durable pull_request delivery %s: %w", event.DeliveryID, err)
 	}
 
-	// The HTTP handler only enqueues auto-plannable actions, but rows can also
-	// come from replay or future producers; re-validate so a replayed "closed"
-	// action can never trigger an auto-plan.
-	if !isAutoPlannablePullRequestAction(payload.Action) {
-		h.logger.Info("durable pull_request delivery ignored because action is not auto-plannable",
+	switch {
+	case isAutoPlannablePullRequestAction(payload.Action):
+		return h.processDurablePullRequestAutoPlan(ctx, event, payload)
+	case payload.Action == "closed":
+		return h.processDurablePullRequestClosed(ctx, event, payload)
+	default:
+		h.logger.Info("durable pull_request delivery ignored because action needs no work",
 			"delivery_id", event.DeliveryID, "action", payload.Action,
 			"repo", event.Repository, "pr", event.PullRequest)
 		return false, nil
 	}
+}
 
-	installationID, parseErr := strconv.ParseInt(event.TenantID, 10, 64)
-	if parseErr != nil {
-		// A non-numeric TenantID is a corrupted/enqueue-side bug, distinct from a
-		// legitimately empty tenant; surface it rather than silently folding it
-		// into the payload fallback below.
-		h.logger.Warn("durable pull_request delivery has an unparseable tenant ID; falling back to the payload installation",
-			"delivery_id", event.DeliveryID, "tenant_id", event.TenantID,
-			"repo", event.Repository, "pr", event.PullRequest, "error", parseErr)
+// processDurablePullRequestClosed runs PR-close cleanup for a claimed closed
+// delivery under the delivery lease. runPRCloseCleanup is idempotent, so a
+// retry after a partial cleanup reconciles rather than double-acts.
+func (h *Handler) processDurablePullRequestClosed(ctx context.Context, event *storage.WebhookEvent, payload pullRequestPayload) (retry bool, err error) {
+	repo := payload.Repository.FullName
+	pr := payload.PullRequest.Number
+	if repo == "" || pr == 0 {
+		return false, fmt.Errorf("durable pull_request closed delivery %s missing repo or PR", event.DeliveryID)
 	}
-	if parseErr != nil || installationID == 0 {
-		// Fallback for rows without a stored tenant. Today the only producer
-		// (enqueueDurablePullRequest) always stores a resolved non-zero
-		// installation ID, so this only matters for replay or future producers.
-		// The payload carries an installation ID only for org/user App installs;
-		// repo-level deliveries have none, so a future producer that synthesizes
-		// such rows (WH-6b) must persist a resolved installation ID in TenantID
-		// rather than relying on this fallback, or repo-level deliveries will
-		// terminally fail here.
-		installationID = h.effectiveInstallationID(ctx, payload.Installation.ID)
+	if err := h.runPRCloseCleanup(ctx, repo, pr, payload.PullRequest.Merged); err != nil {
+		return true, fmt.Errorf("pr close cleanup for durable delivery %s (%s#%d): %w", event.DeliveryID, repo, pr, err)
 	}
+	h.logger.Info("durable pull_request close cleanup completed",
+		"delivery_id", event.DeliveryID, "repo", repo, "pr", pr, "merged", payload.PullRequest.Merged)
+	return false, nil
+}
+
+// processDurablePullRequestAutoPlan drives the auto-plan flow for a claimed
+// pull_request delivery. The durability contract of this slice covers config
+// discovery and plan dispatch: per-database plan execution still runs in
+// detached goroutines (handleMultiEnvPlan via goSafe), exactly as on the
+// request path, and its durability is owned by the applies/tasks layer once
+// plans are created.
+func (h *Handler) processDurablePullRequestAutoPlan(ctx context.Context, event *storage.WebhookEvent, payload pullRequestPayload) (retry bool, err error) {
+	installationID := h.durableInstallationID(ctx, event, payload.Installation.ID)
 	if installationID == 0 {
 		return false, fmt.Errorf("durable pull_request delivery %s missing installation ID", event.DeliveryID)
 	}
@@ -671,9 +681,19 @@ func (h *Handler) enqueueDurableCheckRun(ctx context.Context, payload checkRunPa
 	})
 }
 
-// enqueueDurableWebhookEvent persists a delivery into the durable inbox. The
-// enqueue is the durability boundary: once the row is inserted, the durable
-// driver owns the delivery. On graceful shutdown the request ctx is
+// enqueueDurableWebhookEvent persists a delivery into the durable inbox and
+// wakes the driver pool. It is the shared fast-ACK path behind every durable
+// event type: the caller builds a fully-populated WebhookEvent (Provider,
+// DeliveryID, Event, and the raw Payload the driver re-decodes), and this
+// helper enforces the invariants every producer shares — storage must be
+// available and the GitHub delivery GUID (the dedup key) must be present —
+// before Create. It returns inserted=false when the delivery GUID already
+// exists so callers can treat a redelivery as an idempotent no-op, and only
+// wakes the pool on a genuine insert so a duplicate does not spin a driver
+// for a row that is already queued or terminal.
+//
+// The enqueue is the durability boundary: once the row is inserted, the
+// durable driver owns the delivery. On graceful shutdown the request ctx is
 // cancelled, which would abort the INSERT and 500 the delivery — and GitHub
 // does not auto-retry failed webhook deliveries, so the work would be lost
 // until an operator manually redelivers it. Detach from request cancellation
@@ -697,6 +717,31 @@ func (h *Handler) enqueueDurableWebhookEvent(ctx context.Context, event *storage
 		h.wakeDurableWebhookDispatch()
 	}
 	return inserted, nil
+}
+
+// durableInstallationID resolves the installation ID for a claimed delivery.
+// It prefers the resolved ID persisted in TenantID at enqueue (every producer
+// today stores a resolved non-zero ID there) and falls back to the payload
+// installation ID for replayed or future-producer rows that lack one. Driver
+// work runs outside an HTTP request, so the context carries no repo-level
+// resolved installation; the payload carries an ID only for org/user App
+// installs. A future producer that synthesizes rows for repo-level deliveries
+// (which have no payload installation) must persist a resolved installation ID
+// in TenantID rather than relying on this fallback, or those rows fail here.
+func (h *Handler) durableInstallationID(ctx context.Context, event *storage.WebhookEvent, payloadID int64) int64 {
+	installationID, parseErr := strconv.ParseInt(event.TenantID, 10, 64)
+	if parseErr != nil {
+		// A non-numeric TenantID is a corrupted/enqueue-side bug, distinct from a
+		// legitimately empty tenant; surface it rather than silently folding it
+		// into the payload fallback below.
+		h.logger.Warn("durable webhook delivery has an unparseable tenant ID; falling back to the payload installation",
+			"delivery_id", event.DeliveryID, "tenant_id", event.TenantID, "event", event.Event,
+			"repo", event.Repository, "pr", event.PullRequest, "error", parseErr)
+	}
+	if parseErr != nil || installationID == 0 {
+		installationID = h.effectiveInstallationID(ctx, payloadID)
+	}
+	return installationID
 }
 
 func (h *Handler) webhookEventStore() storage.WebhookEventStore {

--- a/pkg/webhook/durable_dispatch_test.go
+++ b/pkg/webhook/durable_dispatch_test.go
@@ -570,7 +570,7 @@ func TestDurableWebhookDispatchLifecycleDrainsQueuedEvent(t *testing.T) {
 		Provider:   storage.WebhookProviderGitHub,
 		DeliveryID: "delivery-lifecycle",
 		Event:      "push",
-		Payload:    []byte(`{}`),
+		Payload:    []byte(`{"ref": "refs/heads/feature", "after": "abc123def456", "repository": {"full_name": "octocat/hello-world", "default_branch": "main"}}`),
 	})
 	h := newDurableDriverHandler(t, store, nil, nil)
 	h.durableWebhookPollInterval = 10 * time.Millisecond

--- a/pkg/webhook/durable_dispatch_test.go
+++ b/pkg/webhook/durable_dispatch_test.go
@@ -299,7 +299,7 @@ func TestDurableWebhookDriverCompletesUnsupportedEvent(t *testing.T) {
 	store := newScriptedWebhookEventStore(&storage.WebhookEvent{
 		Provider:   storage.WebhookProviderGitHub,
 		DeliveryID: "delivery-unsupported",
-		Event:      "push",
+		Event:      "issue_comment",
 		Payload:    []byte(`{}`),
 	})
 	h := newDurableDriverHandler(t, store, nil, nil)
@@ -440,9 +440,9 @@ func TestDurableWebhookDriverStopsRetryingAtAttemptCap(t *testing.T) {
 // a burst of queued deliveries is worked down without waiting for the next tick.
 func TestDurableWebhookDrainProcessesBacklogInOnePass(t *testing.T) {
 	store := newScriptedWebhookEventStore(
-		&storage.WebhookEvent{Provider: storage.WebhookProviderGitHub, DeliveryID: "d1", Event: "push", Payload: []byte(`{}`)},
-		&storage.WebhookEvent{Provider: storage.WebhookProviderGitHub, DeliveryID: "d2", Event: "push", Payload: []byte(`{}`)},
-		&storage.WebhookEvent{Provider: storage.WebhookProviderGitHub, DeliveryID: "d3", Event: "push", Payload: []byte(`{}`)},
+		&storage.WebhookEvent{Provider: storage.WebhookProviderGitHub, DeliveryID: "d1", Event: "issue_comment", Payload: []byte(`{}`)},
+		&storage.WebhookEvent{Provider: storage.WebhookProviderGitHub, DeliveryID: "d2", Event: "issue_comment", Payload: []byte(`{}`)},
+		&storage.WebhookEvent{Provider: storage.WebhookProviderGitHub, DeliveryID: "d3", Event: "issue_comment", Payload: []byte(`{}`)},
 	)
 	h := newDurableDriverHandler(t, store, nil, nil)
 

--- a/pkg/webhook/durable_merge_group_test.go
+++ b/pkg/webhook/durable_merge_group_test.go
@@ -1,0 +1,214 @@
+package webhook
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/api"
+	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+func durableMergeGroupEvent() *storage.WebhookEvent {
+	payload := []byte(`{
+		"action": "checks_requested",
+		"merge_group": {"head_sha": "mergesha123"},
+		"repository": {"full_name": "octocat/hello-world"},
+		"installation": {"id": 12345}
+	}`)
+	return &storage.WebhookEvent{
+		Provider:   storage.WebhookProviderGitHub,
+		DeliveryID: "delivery-mg-1",
+		Event:      "merge_group",
+		Action:     "checks_requested",
+		Repository: "octocat/hello-world",
+		HeadSHA:    "mergesha123",
+		TenantID:   "12345",
+		Payload:    payload,
+	}
+}
+
+// With durable dispatch enabled, a merge_group delivery is persisted and ACKed
+// fast: no GitHub client is created on the request path, and a leased driver
+// posts the check later. This closes the window where a restart mid-post drops
+// a merge-queue check and wedges the queue.
+func TestDurableMergeGroupWebhookQueuesAndAcks(t *testing.T) {
+	events := newRecordingWebhookEventStore()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	service := api.New(&durableWebhookTestStorage{webhookEvents: events}, &api.ServerConfig{
+		Repos: map[string]api.RepoConfig{"octocat/hello-world": {}},
+	}, nil, logger)
+	clientFactory := &fakeClientFactory{forInstallationStarted: make(chan struct{})}
+	h := NewHandler(service, clientFactory, nil, logger, WithDurableWebhookDispatch())
+
+	req := buildMergeGroupWebhookRequest(t, "checks_requested", "mergesha123", nil)
+	req.Header.Set(headerDeliveryID, "delivery-mg-1")
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.JSONEq(t, `{"message":"merge_group check queued"}`, rr.Body.String())
+
+	event, err := events.GetByDeliveryID(t.Context(), storage.WebhookProviderGitHub, "delivery-mg-1")
+	require.NoError(t, err)
+	require.NotNil(t, event)
+	require.Equal(t, "merge_group", event.Event)
+	require.Equal(t, "checks_requested", event.Action)
+	require.Equal(t, "octocat/hello-world", event.Repository)
+	require.Equal(t, "mergesha123", event.HeadSHA)
+	require.Equal(t, "12345", event.TenantID)
+	require.NotEmpty(t, event.Payload)
+
+	select {
+	case <-clientFactory.forInstallationStarted:
+		t.Fatal("durable request path should not create a GitHub client")
+	default:
+	}
+}
+
+// A webhook redelivery reuses the delivery GUID, so the inbox deduplicates it to
+// a single row rather than queuing the same merge-group check twice.
+func TestDurableMergeGroupWebhookDeduplicatesDelivery(t *testing.T) {
+	events := newRecordingWebhookEventStore()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	service := api.New(&durableWebhookTestStorage{webhookEvents: events}, &api.ServerConfig{
+		Repos: map[string]api.RepoConfig{"octocat/hello-world": {}},
+	}, nil, logger)
+	h := NewHandler(service, &fakeClientFactory{}, nil, logger, WithDurableWebhookDispatch())
+
+	for range 2 {
+		req := buildMergeGroupWebhookRequest(t, "checks_requested", "mergesha123", nil)
+		req.Header.Set(headerDeliveryID, "delivery-mg-1")
+		rr := httptest.NewRecorder()
+
+		h.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+	}
+
+	events.mu.Lock()
+	defer events.mu.Unlock()
+	require.Len(t, events.events, 1)
+}
+
+// The driver posts the passing aggregate check on the merge-group head for each
+// gated environment, then marks the delivery completed.
+func TestDurableMergeGroupDriverPostsChecks(t *testing.T) {
+	client, mux := setupGitHubServer(t)
+	created := make(chan createdCheckRun, 10)
+	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		var c createdCheckRun
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&c))
+		created <- c
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 555})
+	})
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+
+	store := newScriptedWebhookEventStore(durableMergeGroupEvent())
+	config := &api.ServerConfig{
+		AllowedEnvironments: []string{"production"},
+		Repos:               map[string]api.RepoConfig{"octocat/hello-world": {}},
+	}
+	h := newDurableDriverHandler(t, store, config, &fakeClientFactory{client: installClient})
+
+	h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
+
+	select {
+	case c := <-created:
+		assert.Equal(t, "SchemaBot (production)", c.Name)
+		assert.Equal(t, "mergesha123", c.HeadSHA)
+		assert.Equal(t, "success", c.Conclusion)
+	case <-time.After(durableWebhookTestDeadline):
+		t.Fatal("expected the driver to post a merge_group check")
+	}
+	select {
+	case <-store.completed:
+	case <-time.After(durableWebhookTestDeadline):
+		t.Fatal("expected the delivery to be marked completed")
+	}
+	require.Empty(t, store.failed)
+}
+
+// A merge_group delivery for a repo this deployment does not manage completes as
+// a no-op — its check is not required there — without creating a GitHub client.
+func TestDurableMergeGroupDriverCompletesUnregisteredRepo(t *testing.T) {
+	store := newScriptedWebhookEventStore(durableMergeGroupEvent())
+	config := &api.ServerConfig{Repos: map[string]api.RepoConfig{"other/repo": {}}}
+	factory := &fakeClientFactory{forInstallationStarted: make(chan struct{})}
+	h := newDurableDriverHandler(t, store, config, factory)
+
+	h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
+
+	select {
+	case <-store.completed:
+	default:
+		t.Fatal("expected unregistered-repo merge_group delivery to be marked completed")
+	}
+	require.Empty(t, store.failed)
+	select {
+	case <-factory.forInstallationStarted:
+		t.Fatal("unregistered repo must not create a GitHub client")
+	default:
+	}
+}
+
+// An aggregate participant stays silent on merge-group commits — the leader
+// posts the required check — so the driver completes the delivery as a no-op.
+func TestDurableMergeGroupDriverParticipantStaysSilent(t *testing.T) {
+	store := newScriptedWebhookEventStore(durableMergeGroupEvent())
+	config := &api.ServerConfig{
+		AllowedEnvironments: []string{"production"},
+		Repos: map[string]api.RepoConfig{"octocat/hello-world": {
+			Aggregate: &api.AggregateConfig{Role: api.AggregateRoleParticipant},
+		}},
+	}
+	factory := &fakeClientFactory{forInstallationStarted: make(chan struct{})}
+	h := newDurableDriverHandler(t, store, config, factory)
+
+	h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
+
+	select {
+	case <-store.completed:
+	default:
+		t.Fatal("expected participant merge_group delivery to be marked completed")
+	}
+	require.Empty(t, store.failed)
+	select {
+	case <-factory.forInstallationStarted:
+		t.Fatal("participant must not create a GitHub client for a merge_group check")
+	default:
+	}
+}
+
+// A GitHub client failure while posting the check is retryable: the merge queue
+// blocks until the check lands, so the delivery must be retried, not dropped.
+func TestDurableMergeGroupDriverRetriesClientFailure(t *testing.T) {
+	store := newScriptedWebhookEventStore(durableMergeGroupEvent())
+	config := &api.ServerConfig{Repos: map[string]api.RepoConfig{"octocat/hello-world": {}}}
+	factory := &fakeClientFactory{forInstallationErr: errors.New("installation token unavailable")}
+	h := newDurableDriverHandler(t, store, config, factory)
+
+	before := time.Now()
+	h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
+
+	select {
+	case failure := <-store.failed:
+		require.NotNil(t, failure.retryAfter, "client failure must stay retryable")
+		require.True(t, failure.retryAfter.After(before), "retry must be scheduled in the future")
+		require.Contains(t, failure.errMsg, "installation token unavailable")
+	default:
+		t.Fatal("expected client failure to be marked failed")
+	}
+	require.Empty(t, store.completed)
+}

--- a/pkg/webhook/durable_pr_closed_test.go
+++ b/pkg/webhook/durable_pr_closed_test.go
@@ -1,0 +1,138 @@
+package webhook
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/api"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// durableClosedTestStorage provides the webhook inbox plus the lock/apply/check
+// stores runPRCloseCleanup reads, so the driver can drive a claimed close
+// delivery end to end.
+type durableClosedTestStorage struct {
+	emptyStorage
+	webhookEvents storage.WebhookEventStore
+	locks         *prClosedLockStore
+	applies       storage.ApplyStore
+	checks        *prClosedCheckStore
+}
+
+func (s *durableClosedTestStorage) WebhookEvents() storage.WebhookEventStore { return s.webhookEvents }
+func (s *durableClosedTestStorage) Locks() storage.LockStore                 { return s.locks }
+func (s *durableClosedTestStorage) Applies() storage.ApplyStore              { return s.applies }
+func (s *durableClosedTestStorage) Checks() storage.CheckStore               { return s.checks }
+
+func durableClosedEvent() *storage.WebhookEvent {
+	payload := []byte(`{
+		"action": "closed",
+		"pull_request": {"number": 1, "merged": true, "head": {"sha": "head-sha", "ref": "feature"}},
+		"repository": {"full_name": "octocat/hello-world"},
+		"installation": {"id": 12345}
+	}`)
+	return &storage.WebhookEvent{
+		Provider:    storage.WebhookProviderGitHub,
+		DeliveryID:  "delivery-closed-1",
+		Event:       "pull_request",
+		Action:      "closed",
+		Repository:  "octocat/hello-world",
+		PullRequest: 1,
+		HeadSHA:     "head-sha",
+		TenantID:    "12345",
+		Payload:     payload,
+	}
+}
+
+// With durable dispatch enabled, a PR-close delivery is persisted and ACKed
+// fast: a leased driver runs the lock/check cleanup later, so a restart mid
+// cleanup cannot drop the delivery and leave a lock held or stale check state.
+func TestDurablePRClosedWebhookQueuesAndAcks(t *testing.T) {
+	events := newRecordingWebhookEventStore()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	service := api.New(&durableWebhookTestStorage{webhookEvents: events}, &api.ServerConfig{
+		Repos: map[string]api.RepoConfig{"octocat/hello-world": {}},
+	}, nil, logger)
+	h := NewHandler(service, &fakeClientFactory{}, nil, logger, WithDurableWebhookDispatch())
+
+	req := buildPRWebhookRequest(t, prWebhookPayloadOpts{action: "closed", merged: true}, nil)
+	req.Header.Set(headerDeliveryID, "delivery-closed-1")
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.JSONEq(t, `{"message":"PR close cleanup queued"}`, rr.Body.String())
+
+	event, err := events.GetByDeliveryID(t.Context(), storage.WebhookProviderGitHub, "delivery-closed-1")
+	require.NoError(t, err)
+	require.NotNil(t, event)
+	require.Equal(t, "pull_request", event.Event)
+	require.Equal(t, "closed", event.Action)
+	require.Equal(t, 1, event.PullRequest)
+}
+
+// The driver runs PR-close cleanup for a claimed delivery: with all applies
+// terminal it releases the locks, deletes stored check state, and completes.
+func TestDurablePRClosedDriverRunsCleanup(t *testing.T) {
+	lockStore := &prClosedLockStore{locks: []*storage.Lock{prClosedLock("orders")}}
+	checkStore := &prClosedCheckStore{}
+	scripted := newScriptedWebhookEventStore(durableClosedEvent())
+	st := &durableClosedTestStorage{
+		webhookEvents: scripted,
+		locks:         lockStore,
+		applies:       &prClosedApplyStore{applies: []*storage.Apply{prClosedApply("orders", state.Apply.Completed)}},
+		checks:        checkStore,
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	service := api.New(st, &api.ServerConfig{}, nil, logger)
+	h := NewHandler(service, &fakeClientFactory{}, nil, logger, WithDurableWebhookDispatch())
+
+	h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
+
+	require.Equal(t, []string{"orders"}, lockStore.released, "the driver must release locks for a merged closed PR")
+	require.Equal(t, 1, checkStore.deleteCalls, "the driver must delete stored check state")
+	require.Equal(t, []bool{true}, checkStore.deleteMerged, "the delete must run in merged mode")
+	select {
+	case <-scripted.completed:
+	default:
+		t.Fatal("expected the close delivery to be marked completed")
+	}
+	require.Empty(t, scripted.failed)
+}
+
+// A failed apply lookup fails closed — nothing is released or deleted — and the
+// delivery stays retryable so a transient storage blip does not permanently
+// skip cleanup and leave a lock stranded.
+func TestDurablePRClosedDriverRetriesOnApplyLookupFailure(t *testing.T) {
+	lockStore := &prClosedLockStore{locks: []*storage.Lock{prClosedLock("orders")}}
+	checkStore := &prClosedCheckStore{}
+	scripted := newScriptedWebhookEventStore(durableClosedEvent())
+	st := &durableClosedTestStorage{
+		webhookEvents: scripted,
+		locks:         lockStore,
+		applies:       &failingPRApplyLookupStore{},
+		checks:        checkStore,
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	service := api.New(st, &api.ServerConfig{}, nil, logger)
+	h := NewHandler(service, &fakeClientFactory{}, nil, logger, WithDurableWebhookDispatch())
+
+	h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
+
+	require.Empty(t, lockStore.released, "no lock is released when apply state is unknown")
+	require.Equal(t, 0, checkStore.deleteCalls, "no check state is deleted when apply state is unknown")
+	select {
+	case failure := <-scripted.failed:
+		require.NotNil(t, failure.retryAfter, "a failed apply lookup must stay retryable")
+	default:
+		t.Fatal("expected the close delivery to be marked failed and retryable")
+	}
+	require.Empty(t, scripted.completed)
+}

--- a/pkg/webhook/durable_push_test.go
+++ b/pkg/webhook/durable_push_test.go
@@ -158,32 +158,67 @@ func TestDurablePushDriverCompletesUnregisteredRepo(t *testing.T) {
 	}
 }
 
-// A non-deletion push row with an empty head SHA is a corrupted/replayed row,
-// not the all-zeros deletion sentinel, so the driver fails it terminally rather
-// than silently completing it as a no-op and never refreshing the check source.
-func TestDurablePushDriverFailsEmptyHeadSHATerminally(t *testing.T) {
-	event := durablePushEvent()
-	event.Payload = []byte(`{
-		"ref": "refs/heads/main",
-		"after": "",
-		"deleted": false,
-		"repository": {"full_name": "octocat/hello-world", "default_branch": "main"},
-		"installation": {"id": 12345}
-	}`)
-	store := newScriptedWebhookEventStore(event)
-	config := &api.ServerConfig{Repos: map[string]api.RepoConfig{"octocat/hello-world": {}}}
-	h := newDurableDriverHandler(t, store, config, &fakeClientFactory{})
-
-	h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
-
-	select {
-	case failure := <-store.failed:
-		require.Nil(t, failure.retryAfter, "an empty head SHA is malformed and must not be retried")
-		require.Contains(t, failure.errMsg, "missing head SHA")
-	default:
-		t.Fatal("expected empty-head-SHA push delivery to be marked failed")
+// A push row with an empty repo or an empty head SHA is a corrupted/replayed
+// row (the deletion sentinel is an all-zeros SHA, not an empty one), so the
+// driver fails it terminally — even when the corruption also blanks the fields
+// a routine skip would match, such as the ref and default branch — rather than
+// silently completing it as a non-default-branch or unregistered-repo skip.
+func TestDurablePushDriverFailsMalformedRowTerminally(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{
+			name: "empty head SHA",
+			payload: `{
+				"ref": "refs/heads/main",
+				"after": "",
+				"deleted": false,
+				"repository": {"full_name": "octocat/hello-world", "default_branch": "main"},
+				"installation": {"id": 12345}
+			}`,
+		},
+		{
+			name: "empty head SHA with empty ref and default branch",
+			payload: `{
+				"ref": "",
+				"after": "",
+				"deleted": false,
+				"repository": {"full_name": "octocat/hello-world", "default_branch": ""},
+				"installation": {"id": 12345}
+			}`,
+		},
+		{
+			name: "empty repo",
+			payload: `{
+				"ref": "refs/heads/main",
+				"after": "abc123def456",
+				"deleted": false,
+				"repository": {"full_name": "", "default_branch": "main"},
+				"installation": {"id": 12345}
+			}`,
+		},
 	}
-	require.Empty(t, store.completed)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := durablePushEvent()
+			event.Payload = []byte(tt.payload)
+			store := newScriptedWebhookEventStore(event)
+			config := &api.ServerConfig{Repos: map[string]api.RepoConfig{"octocat/hello-world": {}}}
+			h := newDurableDriverHandler(t, store, config, &fakeClientFactory{})
+
+			h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
+
+			select {
+			case failure := <-store.failed:
+				require.Nil(t, failure.retryAfter, "a malformed push row must not be retried")
+				require.Contains(t, failure.errMsg, "missing repo or head SHA")
+			default:
+				t.Fatal("expected malformed push delivery to be marked failed")
+			}
+			require.Empty(t, store.completed)
+		})
+	}
 }
 
 // A GitHub client failure while posting the check is retryable so the ruleset

--- a/pkg/webhook/durable_push_test.go
+++ b/pkg/webhook/durable_push_test.go
@@ -1,0 +1,181 @@
+package webhook
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/api"
+	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+func durablePushEvent() *storage.WebhookEvent {
+	payload := []byte(`{
+		"ref": "refs/heads/main",
+		"after": "pushsha123",
+		"deleted": false,
+		"repository": {"full_name": "octocat/hello-world", "default_branch": "main"},
+		"installation": {"id": 12345}
+	}`)
+	return &storage.WebhookEvent{
+		Provider:   storage.WebhookProviderGitHub,
+		DeliveryID: "delivery-push-1",
+		Event:      "push",
+		Repository: "octocat/hello-world",
+		HeadSHA:    "pushsha123",
+		TenantID:   "12345",
+		Payload:    payload,
+	}
+}
+
+// With durable dispatch enabled, a default-branch push is persisted and ACKed
+// fast: no GitHub client is created on the request path, and a leased driver
+// posts the ruleset-source check later, surviving a restart mid-post.
+func TestDurablePushWebhookQueuesAndAcks(t *testing.T) {
+	events := newRecordingWebhookEventStore()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	service := api.New(&durableWebhookTestStorage{webhookEvents: events}, &api.ServerConfig{
+		Repos: map[string]api.RepoConfig{"octocat/hello-world": {}},
+	}, nil, logger)
+	clientFactory := &fakeClientFactory{forInstallationStarted: make(chan struct{})}
+	h := NewHandler(service, clientFactory, nil, logger, WithDurableWebhookDispatch())
+
+	req := buildPushWebhookRequest(t, "refs/heads/main", "pushsha123", false)
+	req.Header.Set(headerDeliveryID, "delivery-push-1")
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.JSONEq(t, `{"message":"default-branch check queued"}`, rr.Body.String())
+
+	event, err := events.GetByDeliveryID(t.Context(), storage.WebhookProviderGitHub, "delivery-push-1")
+	require.NoError(t, err)
+	require.NotNil(t, event)
+	require.Equal(t, "push", event.Event)
+	require.Equal(t, "octocat/hello-world", event.Repository)
+	require.Equal(t, "pushsha123", event.HeadSHA)
+	require.Equal(t, "12345", event.TenantID)
+	require.NotEmpty(t, event.Payload)
+
+	select {
+	case <-clientFactory.forInstallationStarted:
+		t.Fatal("durable request path should not create a GitHub client")
+	default:
+	}
+}
+
+// A non-default-branch push is filtered before enqueue, so no inbox row is
+// created — only default-branch commits keep the ruleset check source current.
+func TestDurablePushWebhookIgnoresFeatureBranch(t *testing.T) {
+	events := newRecordingWebhookEventStore()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	service := api.New(&durableWebhookTestStorage{webhookEvents: events}, &api.ServerConfig{
+		Repos: map[string]api.RepoConfig{"octocat/hello-world": {}},
+	}, nil, logger)
+	h := NewHandler(service, &fakeClientFactory{}, nil, logger, WithDurableWebhookDispatch())
+
+	req := buildPushWebhookRequest(t, "refs/heads/feature-branch", "pushsha123", false)
+	req.Header.Set(headerDeliveryID, "delivery-push-1")
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	events.mu.Lock()
+	defer events.mu.Unlock()
+	require.Empty(t, events.events, "a feature-branch push must not be enqueued")
+}
+
+// The driver posts the passing default-branch check on the pushed commit for
+// each gated environment, then marks the delivery completed.
+func TestDurablePushDriverPostsChecks(t *testing.T) {
+	client, mux := setupGitHubServer(t)
+	created := make(chan createdCheckRun, 10)
+	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		var c createdCheckRun
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&c))
+		created <- c
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 555})
+	})
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+
+	store := newScriptedWebhookEventStore(durablePushEvent())
+	config := &api.ServerConfig{
+		AllowedEnvironments: []string{"production"},
+		Repos:               map[string]api.RepoConfig{"octocat/hello-world": {}},
+	}
+	h := newDurableDriverHandler(t, store, config, &fakeClientFactory{client: installClient})
+
+	h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
+
+	select {
+	case c := <-created:
+		assert.Equal(t, "SchemaBot (production)", c.Name)
+		assert.Equal(t, "pushsha123", c.HeadSHA)
+		assert.Equal(t, "success", c.Conclusion)
+	case <-time.After(durableWebhookTestDeadline):
+		t.Fatal("expected the driver to post a default-branch check")
+	}
+	select {
+	case <-store.completed:
+	case <-time.After(durableWebhookTestDeadline):
+		t.Fatal("expected the delivery to be marked completed")
+	}
+	require.Empty(t, store.failed)
+}
+
+// A push delivery for a repo this deployment does not manage completes as a
+// no-op — there is no check source to maintain — without creating a client.
+func TestDurablePushDriverCompletesUnregisteredRepo(t *testing.T) {
+	store := newScriptedWebhookEventStore(durablePushEvent())
+	config := &api.ServerConfig{Repos: map[string]api.RepoConfig{"other/repo": {}}}
+	factory := &fakeClientFactory{forInstallationStarted: make(chan struct{})}
+	h := newDurableDriverHandler(t, store, config, factory)
+
+	h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
+
+	select {
+	case <-store.completed:
+	default:
+		t.Fatal("expected unregistered-repo push delivery to be marked completed")
+	}
+	require.Empty(t, store.failed)
+	select {
+	case <-factory.forInstallationStarted:
+		t.Fatal("unregistered repo must not create a GitHub client")
+	default:
+	}
+}
+
+// A GitHub client failure while posting the check is retryable so the ruleset
+// check source is refreshed rather than left to age until the next push.
+func TestDurablePushDriverRetriesClientFailure(t *testing.T) {
+	store := newScriptedWebhookEventStore(durablePushEvent())
+	config := &api.ServerConfig{Repos: map[string]api.RepoConfig{"octocat/hello-world": {}}}
+	factory := &fakeClientFactory{forInstallationErr: errors.New("installation token unavailable")}
+	h := newDurableDriverHandler(t, store, config, factory)
+
+	before := time.Now()
+	h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
+
+	select {
+	case failure := <-store.failed:
+		require.NotNil(t, failure.retryAfter, "client failure must stay retryable")
+		require.True(t, failure.retryAfter.After(before), "retry must be scheduled in the future")
+		require.Contains(t, failure.errMsg, "installation token unavailable")
+	default:
+		t.Fatal("expected client failure to be marked failed")
+	}
+	require.Empty(t, store.completed)
+}

--- a/pkg/webhook/durable_push_test.go
+++ b/pkg/webhook/durable_push_test.go
@@ -158,6 +158,34 @@ func TestDurablePushDriverCompletesUnregisteredRepo(t *testing.T) {
 	}
 }
 
+// A non-deletion push row with an empty head SHA is a corrupted/replayed row,
+// not the all-zeros deletion sentinel, so the driver fails it terminally rather
+// than silently completing it as a no-op and never refreshing the check source.
+func TestDurablePushDriverFailsEmptyHeadSHATerminally(t *testing.T) {
+	event := durablePushEvent()
+	event.Payload = []byte(`{
+		"ref": "refs/heads/main",
+		"after": "",
+		"deleted": false,
+		"repository": {"full_name": "octocat/hello-world", "default_branch": "main"},
+		"installation": {"id": 12345}
+	}`)
+	store := newScriptedWebhookEventStore(event)
+	config := &api.ServerConfig{Repos: map[string]api.RepoConfig{"octocat/hello-world": {}}}
+	h := newDurableDriverHandler(t, store, config, &fakeClientFactory{})
+
+	h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
+
+	select {
+	case failure := <-store.failed:
+		require.Nil(t, failure.retryAfter, "an empty head SHA is malformed and must not be retried")
+		require.Contains(t, failure.errMsg, "missing head SHA")
+	default:
+		t.Fatal("expected empty-head-SHA push delivery to be marked failed")
+	}
+	require.Empty(t, store.completed)
+}
+
 // A GitHub client failure while posting the check is retryable so the ruleset
 // check source is refreshed rather than left to age until the next push.
 func TestDurablePushDriverRetriesClientFailure(t *testing.T) {

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -715,10 +715,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.handlePullRequest(ctx, metricApp, sw, body, r.Header.Get(headerDeliveryID))
 		recordProcessed()
 	case "merge_group":
-		h.handleMergeGroup(ctx, metricApp, sw, body)
+		h.handleMergeGroup(ctx, metricApp, sw, body, r.Header.Get(headerDeliveryID))
 		recordProcessed()
 	case "push":
-		h.handlePush(ctx, metricApp, sw, body)
+		h.handlePush(ctx, metricApp, sw, body, r.Header.Get(headerDeliveryID))
 		recordProcessed()
 	default:
 		h.logger.Info("webhook ignored",

--- a/pkg/webhook/merge_group.go
+++ b/pkg/webhook/merge_group.go
@@ -243,6 +243,13 @@ func (h *Handler) processDurableMergeGroup(ctx context.Context, event *storage.W
 		return false, nil
 	}
 
+	// Bound the GitHub work so a stalled API call cannot be kept alive
+	// indefinitely by the lease heartbeat and monopolize a driver. Matches the
+	// request path's post budget and the durable auto-plan bootstrap. The driver
+	// context stays the parent, so shutdown or lease loss still cancels.
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	client, err := h.clientForRepo(repo, installationID)
 	if err != nil {
 		return true, fmt.Errorf("create GitHub client for durable merge_group %s@%s: %w", repo, headSHA, err)

--- a/pkg/webhook/merge_group.go
+++ b/pkg/webhook/merge_group.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/metrics"
+	"github.com/block/schemabot/pkg/storage"
 )
 
 // mergeGroupPayload is the subset of the GitHub merge_group webhook payload
@@ -42,7 +44,7 @@ type mergeGroupPayload struct {
 // before the PR could enter the queue. The merge group sits strictly downstream
 // of an already-completed, already-gated apply, so there is nothing left to
 // verify on the combined commit.
-func (h *Handler) handleMergeGroup(ctx context.Context, metricApp string, w http.ResponseWriter, body []byte) {
+func (h *Handler) handleMergeGroup(ctx context.Context, metricApp string, w http.ResponseWriter, body []byte, deliveryID string) {
 	var payload mergeGroupPayload
 	if err := json.Unmarshal(body, &payload); err != nil {
 		h.writeError(w, http.StatusBadRequest, "invalid merge_group payload")
@@ -104,6 +106,32 @@ func (h *Handler) handleMergeGroup(ctx context.Context, metricApp string, w http
 		return
 	}
 
+	if h.durableWebhookDispatch {
+		// Enqueue and ACK fast; a leased driver posts the check with retries so
+		// a process restart mid-post cannot drop the delivery. Enqueue failure
+		// is a deliberate 500 with no in-process fallback — it fails loudly (a
+		// red delivery in GitHub's webhook UI) so an operator can Redeliver.
+		inserted, err := h.enqueueDurableMergeGroup(ctx, payload, body, deliveryID, installationID)
+		if err != nil {
+			h.logger.Error("failed to enqueue durable merge_group check",
+				"repo", repo, "head_sha", headSHA, "installation_id", installationID,
+				"delivery_id", deliveryID, "error", err)
+			metrics.RecordWebhookEvent(ctx, metricApp, "merge_group", payload.Action, repo, "durable_enqueue_failed")
+			h.writeError(w, http.StatusInternalServerError, "failed to enqueue webhook delivery")
+			return
+		}
+		if !inserted {
+			h.logger.Info("durable merge_group delivery already queued",
+				"repo", repo, "head_sha", headSHA, "delivery_id", deliveryID)
+			h.writeJSON(w, http.StatusOK, map[string]string{"message": "merge_group check already queued"})
+			return
+		}
+		h.logger.Info("durable merge_group check queued",
+			"repo", repo, "head_sha", headSHA, "delivery_id", deliveryID)
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "merge_group check queued"})
+		return
+	}
+
 	postCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 	defer cancel()
 
@@ -115,12 +143,7 @@ func (h *Handler) handleMergeGroup(ctx context.Context, metricApp string, w http
 		return
 	}
 
-	if err := h.postPassingAggregateChecks(postCtx, client, repo, headSHA, passingAggregateCheckContent{
-		operation: "merge_group_check",
-		title:     "Schema changes verified before merge queue",
-		summary: "Schema changes in queued pull requests are applied and verified by SchemaBot before " +
-			"they enter the merge queue, so no additional verification is required for this merge group.",
-	}); err != nil {
+	if err := h.postPassingAggregateChecks(postCtx, client, repo, headSHA, mergeGroupCheckContent()); err != nil {
 		// Return 500 so the delivery is recorded as failed and shows up in the
 		// App's delivery log for redelivery. The merge queue blocks until the
 		// check is posted, so the failure must be visible for retry, not
@@ -137,6 +160,106 @@ func (h *Handler) handleMergeGroup(ctx context.Context, metricApp string, w http
 	}
 
 	h.writeJSON(w, http.StatusOK, map[string]string{"message": "merge_group checks posted"})
+}
+
+// mergeGroupCheckContent is the passing Check Run content published on a
+// merge-queue head. Both the request path and the durable driver use it so a
+// redelivery updates the same check with identical output.
+func mergeGroupCheckContent() passingAggregateCheckContent {
+	return passingAggregateCheckContent{
+		operation: "merge_group_check",
+		title:     "Schema changes verified before merge queue",
+		summary: "Schema changes in queued pull requests are applied and verified by SchemaBot before " +
+			"they enter the merge queue, so no additional verification is required for this merge group.",
+	}
+}
+
+// enqueueDurableMergeGroup persists a merge_group delivery in the inbox. The
+// stored TenantID is the resolved installation ID so the driver, which runs
+// outside any HTTP request, does not have to re-resolve a repo-level install.
+func (h *Handler) enqueueDurableMergeGroup(ctx context.Context, payload mergeGroupPayload, body []byte, deliveryID string, installationID int64) (bool, error) {
+	return h.enqueueDurableWebhookEvent(ctx, &storage.WebhookEvent{
+		Provider:   storage.WebhookProviderGitHub,
+		DeliveryID: deliveryID,
+		Event:      "merge_group",
+		Action:     payload.Action,
+		Repository: payload.Repository.FullName,
+		HeadSHA:    payload.MergeGroup.HeadSHA,
+		TenantID:   strconv.FormatInt(installationID, 10),
+		Payload:    body,
+	})
+}
+
+// processDurableMergeGroup posts the passing merge-queue check for a claimed
+// merge_group delivery. It re-validates every enqueue-time guard fail-closed —
+// config can change between enqueue and drive, and rows can arrive via replay —
+// so a now-ignored delivery completes as a no-op rather than posting a check
+// the current config would not. GitHub client and post failures are retryable;
+// posting is idempotent (the check is looked up by name and updated in place),
+// so a retry after a partial post reconciles rather than duplicates.
+func (h *Handler) processDurableMergeGroup(ctx context.Context, event *storage.WebhookEvent) (retry bool, err error) {
+	var payload mergeGroupPayload
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		return false, fmt.Errorf("decode durable merge_group delivery %s: %w", event.DeliveryID, err)
+	}
+
+	if payload.Action != "checks_requested" {
+		h.logger.Info("durable merge_group delivery ignored because action needs no check",
+			"delivery_id", event.DeliveryID, "action", payload.Action, "repo", event.Repository)
+		return false, nil
+	}
+
+	repo := payload.Repository.FullName
+	headSHA := payload.MergeGroup.HeadSHA
+	if repo == "" || headSHA == "" {
+		return false, fmt.Errorf("durable merge_group delivery %s missing repo or head SHA", event.DeliveryID)
+	}
+
+	installationID := h.durableInstallationID(ctx, event, payload.Installation.ID)
+	if installationID == 0 {
+		return false, fmt.Errorf("durable merge_group delivery %s missing installation ID", event.DeliveryID)
+	}
+
+	if h.service != nil && !h.service.Config().IsRepoAllowed(repo) {
+		h.logger.Warn("durable merge_group delivery from unregistered repository",
+			"delivery_id", event.DeliveryID, "repo", repo, "head_sha", headSHA, "installation_id", installationID)
+		metrics.RecordUnregisteredRepositoryWebhook(ctx, h.metricAppForRepo(repo), "merge_group", payload.Action, repo)
+		return false, nil
+	}
+
+	if h.isAggregateParticipant(repo) {
+		h.logger.Info("durable merge_group delivery skipped: aggregate participant stays silent; the leader posts the required checks",
+			"delivery_id", event.DeliveryID, "repo", repo, "head_sha", headSHA, "installation_id", installationID)
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:  "merge_group_check",
+			Repository: repo,
+			Status:     "skipped",
+		})
+		return false, nil
+	}
+
+	if !h.shouldPublishChecks(ctx, repo, "merge_group_check") {
+		// shouldPublishChecks logs and records the skip.
+		return false, nil
+	}
+
+	client, err := h.clientForRepo(repo, installationID)
+	if err != nil {
+		return true, fmt.Errorf("create GitHub client for durable merge_group %s@%s: %w", repo, headSHA, err)
+	}
+
+	if err := h.postPassingAggregateChecks(ctx, client, repo, headSHA, mergeGroupCheckContent()); err != nil {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:  "merge_group_check",
+			Repository: repo,
+			Status:     "error",
+		})
+		return true, fmt.Errorf("post durable merge_group checks for %s@%s: %w", repo, headSHA, err)
+	}
+
+	h.logger.Info("durable merge_group checks posted",
+		"delivery_id", event.DeliveryID, "repo", repo, "head_sha", headSHA)
+	return false, nil
 }
 
 // passingAggregateCheckContent carries the operation name and Check Run output

--- a/pkg/webhook/pr_closed_test.go
+++ b/pkg/webhook/pr_closed_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // prClosedTestStorage serves a fixed set of locks and applies and records
-// which cleanup operations handlePRClosed performed, so tests can verify
+// which cleanup operations runPRCloseCleanup performed, so tests can verify
 // whether locks were released and check state was deleted.
 type prClosedTestStorage struct {
 	emptyStorage
@@ -120,7 +120,7 @@ func TestPRClosedRetainsLockAndChecksForInFlightApply(t *testing.T) {
 	}
 
 	h := prClosedTestHandler(t, st)
-	h.handlePRClosed("octocat/hello-world", 1, 12345, true)
+	assert.NoError(t, h.runPRCloseCleanup(t.Context(), "octocat/hello-world", 1, true))
 
 	assert.Empty(t, lockStore.released, "lock for a database with an in-flight apply must not be released on PR close")
 	assert.Equal(t, 0, checkStore.deleteCalls, "stored check state must not be deleted while an apply is in flight")
@@ -144,7 +144,7 @@ func TestPRClosedReleasesOnlyLocksWithoutInFlightApply(t *testing.T) {
 	}
 
 	h := prClosedTestHandler(t, st)
-	h.handlePRClosed("octocat/hello-world", 1, 12345, true)
+	assert.NoError(t, h.runPRCloseCleanup(t.Context(), "octocat/hello-world", 1, true))
 
 	assert.Equal(t, []string{"billing"}, lockStore.released, "only the lock without an in-flight apply is released")
 	assert.Equal(t, 0, checkStore.deleteCalls, "stored check state must not be deleted while any apply is in flight")
@@ -166,7 +166,7 @@ func TestPRClosedCleansUpWhenAllAppliesTerminal(t *testing.T) {
 	}
 
 	h := prClosedTestHandler(t, st)
-	h.handlePRClosed("octocat/hello-world", 1, 12345, true)
+	assert.NoError(t, h.runPRCloseCleanup(t.Context(), "octocat/hello-world", 1, true))
 
 	assert.Equal(t, []string{"orders", "billing"}, lockStore.released, "all locks are released when applies are terminal")
 	assert.Equal(t, 1, checkStore.deleteCalls, "stored check state is deleted when applies are terminal")
@@ -189,7 +189,7 @@ func TestPRClosedCleansUpWhenPRHasNoApplies(t *testing.T) {
 	}
 
 	h := prClosedTestHandler(t, st)
-	h.handlePRClosed("octocat/hello-world", 1, 12345, false)
+	assert.NoError(t, h.runPRCloseCleanup(t.Context(), "octocat/hello-world", 1, false))
 
 	assert.Equal(t, []string{"orders"}, lockStore.released, "locks are released when the PR has no applies")
 	assert.Equal(t, 1, checkStore.deleteCalls, "stored check state is deleted when the PR has no applies")
@@ -210,7 +210,8 @@ func TestPRClosedSkipsCleanupWhenApplyLookupFails(t *testing.T) {
 	}
 
 	h := prClosedTestHandler(t, st)
-	h.handlePRClosed("octocat/hello-world", 1, 12345, true)
+	assert.Error(t, h.runPRCloseCleanup(t.Context(), "octocat/hello-world", 1, true),
+		"a failed apply lookup must be returned so the durable driver retries")
 
 	assert.Empty(t, lockStore.released, "no lock is released when apply state is unknown")
 	assert.Equal(t, 0, checkStore.deleteCalls, "no check state is deleted when apply state is unknown")

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -96,6 +96,11 @@ func (h *Handler) handlePullRequest(ctx context.Context, metricApp string, w htt
 			return
 		}
 		h.goSafe(payload.Repository.FullName, payload.PullRequest.Number, installationID, func() {
+			// One-shot: a failure here (including a lock lookup/release error,
+			// which also skips the check-state delete) is logged and not
+			// retried. That direction is fail-closed — retained locks and
+			// check state block until an operator or a reopen reconciles;
+			// nothing is wrongly unblocked. The durable path retries instead.
 			if err := h.runPRCloseCleanup(context.Background(), payload.Repository.FullName, payload.PullRequest.Number, payload.PullRequest.Merged); err != nil {
 				h.logger.Error("PR close cleanup failed",
 					"repo", payload.Repository.FullName, "pr", payload.PullRequest.Number, "error", err)
@@ -575,9 +580,10 @@ func (h *Handler) aggregateMessagesForAllEnvironments(message string) map[string
 // It takes a context so the durable driver can bound it to the delivery lease
 // (shutdown or lease loss cancels it) while the legacy request path passes a
 // detached context. Every failure is returned so a caller with a retry
-// mechanism (the durable driver) can retry: each step — the applies read, lock
-// releases, and the check delete — is idempotent, so re-running the whole
-// cleanup after a partial failure reconciles rather than double-acts.
+// mechanism (the durable driver) can retry: each step — the applies read, the
+// list-then-release lock pass, and the check delete — is safe to re-run, so
+// re-running the whole cleanup after a partial failure reconciles rather than
+// double-acts.
 func (h *Handler) runPRCloseCleanup(ctx context.Context, repo string, pr int, merged bool) error {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
@@ -685,8 +691,14 @@ func (h *Handler) inFlightAppliesForClosedPR(ctx context.Context, repo string, p
 // releaseLocksForClosedPR releases the closed PR's locks, except locks on
 // databases that still have an in-flight apply. Every release is attempted even
 // if an earlier one fails, and the failures are joined and returned so a caller
-// with a retry mechanism re-attempts the still-held locks; Release is
-// idempotent, so re-releasing an already-released lock is a no-op.
+// with a retry mechanism re-attempts the still-held locks. Release itself is
+// not idempotent — a missing row returns storage.ErrLockNotFound and a
+// re-acquired lock returns storage.ErrLockNotOwned — so re-running converges
+// only because each attempt re-lists the PR's locks first and a released
+// lock's row is deleted, never reappearing in a later attempt. A concurrent
+// manual unlock between the list and the release surfaces as a spurious
+// ErrLockNotFound that fails that attempt; the next retry no longer sees the
+// row and converges.
 func (h *Handler) releaseLocksForClosedPR(ctx context.Context, repo string, pr int, inFlight map[closedPRDatabase]bool) error {
 	locks, err := h.service.Storage().Locks().GetByPR(ctx, repo, pr)
 	if err != nil {

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"slices"
@@ -70,8 +71,35 @@ func (h *Handler) handlePullRequest(ctx context.Context, metricApp string, w htt
 	case isAutoPlannablePullRequestAction(payload.Action):
 		// proceed to auto-plan below
 	case payload.Action == "closed":
+		if h.durableWebhookDispatch {
+			// Enqueue and ACK fast; a leased driver runs cleanup with retries so
+			// a process restart mid-cleanup cannot drop the delivery and leave a
+			// lock held or stale check state behind.
+			inserted, err := h.enqueueDurablePullRequest(ctx, payload, body, deliveryID, installationID)
+			if err != nil {
+				h.logger.Error("failed to enqueue durable PR close cleanup",
+					"repo", payload.Repository.FullName, "pr", payload.PullRequest.Number,
+					"delivery_id", deliveryID, "error", err)
+				metrics.RecordWebhookEvent(ctx, metricApp, "pull_request", payload.Action, payload.Repository.FullName, "durable_enqueue_failed")
+				h.writeError(w, http.StatusInternalServerError, "failed to enqueue webhook delivery")
+				return
+			}
+			if !inserted {
+				h.logger.Info("durable PR close cleanup already queued",
+					"repo", payload.Repository.FullName, "pr", payload.PullRequest.Number, "delivery_id", deliveryID)
+				h.writeJSON(w, http.StatusOK, map[string]string{"message": "PR close cleanup already queued"})
+				return
+			}
+			h.logger.Info("durable PR close cleanup queued",
+				"repo", payload.Repository.FullName, "pr", payload.PullRequest.Number, "delivery_id", deliveryID)
+			h.writeJSON(w, http.StatusOK, map[string]string{"message": "PR close cleanup queued"})
+			return
+		}
 		h.goSafe(payload.Repository.FullName, payload.PullRequest.Number, installationID, func() {
-			h.handlePRClosed(payload.Repository.FullName, payload.PullRequest.Number, installationID, payload.PullRequest.Merged)
+			if err := h.runPRCloseCleanup(context.Background(), payload.Repository.FullName, payload.PullRequest.Number, payload.PullRequest.Merged); err != nil {
+				h.logger.Error("PR close cleanup failed",
+					"repo", payload.Repository.FullName, "pr", payload.PullRequest.Number, "error", err)
+			}
 		})
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "PR close cleanup started"})
 		return
@@ -527,8 +555,9 @@ func (h *Handler) aggregateMessagesForAllEnvironments(message string) map[string
 	return messages
 }
 
-// handlePRClosed cleans up resources when a PR is closed (merged or unmerged):
-// it releases locks held by this PR and deletes its stored check state.
+// runPRCloseCleanup cleans up resources when a PR is closed (merged or
+// unmerged): it releases locks held by this PR and deletes its stored check
+// state.
 //
 // Cleanup only covers finished work. While any apply for the PR is
 // non-terminal, that apply's database lock is retained so another PR cannot
@@ -542,8 +571,15 @@ func (h *Handler) aggregateMessagesForAllEnvironments(message string) map[string
 // and only reopen-time cleanup can re-verify it against the PR contents. If
 // apply state cannot be read, cleanup fails closed and nothing is released
 // or deleted.
-func (h *Handler) handlePRClosed(repo string, pr int, _ int64, merged bool) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+//
+// It takes a context so the durable driver can bound it to the delivery lease
+// (shutdown or lease loss cancels it) while the legacy request path passes a
+// detached context. Every failure is returned so a caller with a retry
+// mechanism (the durable driver) can retry: each step — the applies read, lock
+// releases, and the check delete — is idempotent, so re-running the whole
+// cleanup after a partial failure reconciles rather than double-acts.
+func (h *Handler) runPRCloseCleanup(ctx context.Context, repo string, pr int, merged bool) error {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	// A closed PR gets no more scheduled re-folds; drop its budget entry so the
@@ -562,17 +598,19 @@ func (h *Handler) handlePRClosed(repo string, pr int, _ int64, merged bool) {
 		})
 		h.logger.Error("PR close cleanup skipped: cannot verify apply state; all locks and check state are retained",
 			"repo", repo, "pr", pr, "error", err)
-		return
+		return fmt.Errorf("read applies for closed PR %s#%d: %w", repo, pr, err)
 	}
 
 	inFlight := h.inFlightAppliesForClosedPR(ctx, repo, pr, applies)
 
-	h.releaseLocksForClosedPR(ctx, repo, pr, inFlight)
+	if err := h.releaseLocksForClosedPR(ctx, repo, pr, inFlight); err != nil {
+		return fmt.Errorf("release locks for closed PR %s#%d: %w", repo, pr, err)
+	}
 
 	if len(inFlight) > 0 {
 		h.logger.Info("check state retained for closed PR until all applies reach a terminal state",
 			"repo", repo, "pr", pr, "in_flight_databases", len(inFlight))
-		return
+		return nil
 	}
 
 	// Delete stored check state for this PR. Apply-owned rows that still block
@@ -591,20 +629,21 @@ func (h *Handler) handlePRClosed(repo string, pr int, _ int64, merged bool) {
 			Status:     "error",
 		})
 		h.logger.Error("failed to delete checks for closed PR", "repo", repo, "pr", pr, "merged", merged, "error", err)
-	} else {
-		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
-			Operation:  "pr_close_cleanup",
-			Repository: repo,
-			Status:     "success",
-		})
-		if merged {
-			h.logger.Info("deleted checks for merged PR; apply-owned rows that still block are retained",
-				"repo", repo, "pr", pr)
-		} else {
-			h.logger.Info("deleted plan-only checks for unmerged closed PR; all apply-owned rows are retained",
-				"repo", repo, "pr", pr)
-		}
+		return fmt.Errorf("delete checks for closed PR %s#%d (merged=%t): %w", repo, pr, merged, err)
 	}
+	metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+		Operation:  "pr_close_cleanup",
+		Repository: repo,
+		Status:     "success",
+	})
+	if merged {
+		h.logger.Info("deleted checks for merged PR; apply-owned rows that still block are retained",
+			"repo", repo, "pr", pr)
+	} else {
+		h.logger.Info("deleted plan-only checks for unmerged closed PR; all apply-owned rows are retained",
+			"repo", repo, "pr", pr)
+	}
+	return nil
 }
 
 // closedPRDatabase identifies the database lock an apply holds.
@@ -644,13 +683,17 @@ func (h *Handler) inFlightAppliesForClosedPR(ctx context.Context, repo string, p
 }
 
 // releaseLocksForClosedPR releases the closed PR's locks, except locks on
-// databases that still have an in-flight apply.
-func (h *Handler) releaseLocksForClosedPR(ctx context.Context, repo string, pr int, inFlight map[closedPRDatabase]bool) {
+// databases that still have an in-flight apply. Every release is attempted even
+// if an earlier one fails, and the failures are joined and returned so a caller
+// with a retry mechanism re-attempts the still-held locks; Release is
+// idempotent, so re-releasing an already-released lock is a no-op.
+func (h *Handler) releaseLocksForClosedPR(ctx context.Context, repo string, pr int, inFlight map[closedPRDatabase]bool) error {
 	locks, err := h.service.Storage().Locks().GetByPR(ctx, repo, pr)
 	if err != nil {
 		h.logger.Error("failed to look up locks for closed PR; no locks released", "repo", repo, "pr", pr, "error", err)
-		return
+		return fmt.Errorf("look up locks for closed PR %s#%d: %w", repo, pr, err)
 	}
+	var releaseErrs []error
 	for _, lock := range locks {
 		if inFlight[closedPRDatabase{database: lock.DatabaseName, databaseType: lock.DatabaseType}] {
 			h.logger.Info("lock retained on PR close because an apply is in flight",
@@ -660,11 +703,13 @@ func (h *Handler) releaseLocksForClosedPR(ctx context.Context, repo string, pr i
 		if err := h.service.Storage().Locks().Release(ctx, lock.DatabaseName, lock.DatabaseType, lock.Owner); err != nil {
 			h.logger.Error("failed to release lock on PR close",
 				"repo", repo, "pr", pr, "database", lock.DatabaseName, "database_type", lock.DatabaseType, "error", err)
-		} else {
-			h.logger.Info("released lock on PR close",
-				"repo", repo, "pr", pr, "database", lock.DatabaseName)
+			releaseErrs = append(releaseErrs, fmt.Errorf("release lock on %s (%s): %w", lock.DatabaseName, lock.DatabaseType, err))
+			continue
 		}
+		h.logger.Info("released lock on PR close",
+			"repo", repo, "pr", pr, "database", lock.DatabaseName)
 	}
+	return errors.Join(releaseErrs...)
 }
 
 // cleanupStaleChecks updates checks for databases no longer in the PR.

--- a/pkg/webhook/push.go
+++ b/pkg/webhook/push.go
@@ -221,7 +221,13 @@ func (h *Handler) processDurablePush(ctx context.Context, event *storage.Webhook
 		return false, nil
 	}
 
-	if payload.Deleted || headSHA == "" || strings.Trim(headSHA, "0") == "" {
+	if headSHA == "" {
+		// The deletion sentinel is an all-zeros SHA, not an empty one; a truly
+		// empty head SHA is a corrupted/replayed row. Fail terminally so it
+		// surfaces as malformed rather than silently completing as a no-op.
+		return false, fmt.Errorf("durable push delivery %s missing head SHA", event.DeliveryID)
+	}
+	if payload.Deleted || strings.Trim(headSHA, "0") == "" {
 		h.logger.Info("durable push delivery ignored because it is a branch deletion",
 			"delivery_id", event.DeliveryID, "repo", repo, "ref", payload.Ref)
 		return false, nil
@@ -254,6 +260,13 @@ func (h *Handler) processDurablePush(ctx context.Context, event *storage.Webhook
 		// shouldPublishChecks logs and records the skip.
 		return false, nil
 	}
+
+	// Bound the GitHub work so a stalled API call cannot be kept alive
+	// indefinitely by the lease heartbeat and monopolize a driver. Matches the
+	// request path's post budget and the durable auto-plan bootstrap. The driver
+	// context stays the parent, so shutdown or lease loss still cancels.
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
 
 	client, err := h.clientForRepo(repo, installationID)
 	if err != nil {

--- a/pkg/webhook/push.go
+++ b/pkg/webhook/push.go
@@ -3,11 +3,14 @@ package webhook
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/block/schemabot/pkg/metrics"
+	"github.com/block/schemabot/pkg/storage"
 )
 
 // pushPayload is the subset of the GitHub push webhook payload SchemaBot
@@ -43,7 +46,7 @@ type pushPayload struct {
 // default branch, so a commit already on the default branch has nothing left to
 // verify. Rulesets evaluate required checks on PR and merge-queue commits, never
 // on commits already landed, so this check can never satisfy a merge gate.
-func (h *Handler) handlePush(ctx context.Context, metricApp string, w http.ResponseWriter, body []byte) {
+func (h *Handler) handlePush(ctx context.Context, metricApp string, w http.ResponseWriter, body []byte, deliveryID string) {
 	var payload pushPayload
 	if err := json.Unmarshal(body, &payload); err != nil {
 		h.writeError(w, http.StatusBadRequest, "invalid push payload")
@@ -110,6 +113,32 @@ func (h *Handler) handlePush(ctx context.Context, metricApp string, w http.Respo
 		return
 	}
 
+	if h.durableWebhookDispatch {
+		// Enqueue and ACK fast; a leased driver posts the check with retries so
+		// a process restart mid-post cannot drop the delivery. Enqueue failure
+		// is a deliberate 500 with no in-process fallback — it fails loudly (a
+		// red delivery in GitHub's webhook UI) so an operator can Redeliver.
+		inserted, err := h.enqueueDurablePush(ctx, payload, body, deliveryID, installationID)
+		if err != nil {
+			h.logger.Error("failed to enqueue durable default-branch check",
+				"repo", repo, "head_sha", headSHA, "installation_id", installationID,
+				"delivery_id", deliveryID, "error", err)
+			metrics.RecordWebhookEvent(ctx, metricApp, "push", "", repo, "durable_enqueue_failed")
+			h.writeError(w, http.StatusInternalServerError, "failed to enqueue webhook delivery")
+			return
+		}
+		if !inserted {
+			h.logger.Info("durable push delivery already queued",
+				"repo", repo, "head_sha", headSHA, "delivery_id", deliveryID)
+			h.writeJSON(w, http.StatusOK, map[string]string{"message": "default-branch check already queued"})
+			return
+		}
+		h.logger.Info("durable default-branch check queued",
+			"repo", repo, "head_sha", headSHA, "delivery_id", deliveryID)
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "default-branch check queued"})
+		return
+	}
+
 	postCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 	defer cancel()
 
@@ -121,13 +150,7 @@ func (h *Handler) handlePush(ctx context.Context, metricApp string, w http.Respo
 		return
 	}
 
-	if err := h.postPassingAggregateChecks(postCtx, client, repo, headSHA, passingAggregateCheckContent{
-		operation: "default_branch_check",
-		title:     "Schema changes are verified before merge",
-		summary: "SchemaBot gates schema changes on pull requests before they reach the default branch, " +
-			"so commits on the default branch require no additional verification. " +
-			"This check also keeps SchemaBot selectable as a required-check source in branch rulesets.",
-	}); err != nil {
+	if err := h.postPassingAggregateChecks(postCtx, client, repo, headSHA, defaultBranchCheckContent()); err != nil {
 		// Return 500 so the delivery is recorded as failed and shows up in the
 		// App's delivery log for redelivery. A missed post only ages the
 		// ruleset source index — the next default-branch push refreshes it —
@@ -144,4 +167,109 @@ func (h *Handler) handlePush(ctx context.Context, metricApp string, w http.Respo
 	}
 
 	h.writeJSON(w, http.StatusOK, map[string]string{"message": "default-branch checks posted"})
+}
+
+// defaultBranchCheckContent is the passing Check Run content published on a
+// default-branch commit. Both the request path and the durable driver use it so
+// a redelivery updates the same check with identical output.
+func defaultBranchCheckContent() passingAggregateCheckContent {
+	return passingAggregateCheckContent{
+		operation: "default_branch_check",
+		title:     "Schema changes are verified before merge",
+		summary: "SchemaBot gates schema changes on pull requests before they reach the default branch, " +
+			"so commits on the default branch require no additional verification. " +
+			"This check also keeps SchemaBot selectable as a required-check source in branch rulesets.",
+	}
+}
+
+// enqueueDurablePush persists a default-branch push delivery in the inbox. The
+// stored TenantID is the resolved installation ID so the driver, which runs
+// outside any HTTP request, does not have to re-resolve a repo-level install.
+func (h *Handler) enqueueDurablePush(ctx context.Context, payload pushPayload, body []byte, deliveryID string, installationID int64) (bool, error) {
+	return h.enqueueDurableWebhookEvent(ctx, &storage.WebhookEvent{
+		Provider:   storage.WebhookProviderGitHub,
+		DeliveryID: deliveryID,
+		Event:      "push",
+		Repository: payload.Repository.FullName,
+		HeadSHA:    payload.After,
+		TenantID:   strconv.FormatInt(installationID, 10),
+		Payload:    body,
+	})
+}
+
+// processDurablePush posts the passing default-branch check for a claimed push
+// delivery. It re-validates every enqueue-time guard fail-closed — config can
+// change between enqueue and drive, and rows can arrive via replay — so a
+// delivery the current config would ignore (not the default branch, a deletion,
+// an unregistered repo, a participant, or publishing disabled) completes as a
+// no-op rather than posting. GitHub client and post failures are retryable;
+// posting is idempotent (the check is looked up by name and updated in place),
+// so a retry after a partial post reconciles rather than duplicates.
+func (h *Handler) processDurablePush(ctx context.Context, event *storage.WebhookEvent) (retry bool, err error) {
+	var payload pushPayload
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		return false, fmt.Errorf("decode durable push delivery %s: %w", event.DeliveryID, err)
+	}
+
+	repo := payload.Repository.FullName
+	headSHA := payload.After
+
+	if payload.Repository.DefaultBranch == "" || payload.Ref != "refs/heads/"+payload.Repository.DefaultBranch {
+		h.logger.Info("durable push delivery ignored because it is not the default branch",
+			"delivery_id", event.DeliveryID, "repo", repo, "ref", payload.Ref,
+			"default_branch", payload.Repository.DefaultBranch)
+		return false, nil
+	}
+
+	if payload.Deleted || headSHA == "" || strings.Trim(headSHA, "0") == "" {
+		h.logger.Info("durable push delivery ignored because it is a branch deletion",
+			"delivery_id", event.DeliveryID, "repo", repo, "ref", payload.Ref)
+		return false, nil
+	}
+
+	installationID := h.durableInstallationID(ctx, event, payload.Installation.ID)
+	if installationID == 0 {
+		return false, fmt.Errorf("durable push delivery %s missing installation ID", event.DeliveryID)
+	}
+
+	if h.service != nil && !h.service.Config().IsRepoAllowed(repo) {
+		h.logger.Warn("durable push delivery from unregistered repository",
+			"delivery_id", event.DeliveryID, "repo", repo, "head_sha", headSHA, "installation_id", installationID)
+		metrics.RecordUnregisteredRepositoryWebhook(ctx, h.metricAppForRepo(repo), "push", "", repo)
+		return false, nil
+	}
+
+	if h.isAggregateParticipant(repo) {
+		h.logger.Info("durable push delivery skipped: aggregate participant stays silent; the leader maintains the check source",
+			"delivery_id", event.DeliveryID, "repo", repo, "head_sha", headSHA, "installation_id", installationID)
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:  "default_branch_check",
+			Repository: repo,
+			Status:     "skipped",
+		})
+		return false, nil
+	}
+
+	if !h.shouldPublishChecks(ctx, repo, "default_branch_check") {
+		// shouldPublishChecks logs and records the skip.
+		return false, nil
+	}
+
+	client, err := h.clientForRepo(repo, installationID)
+	if err != nil {
+		return true, fmt.Errorf("create GitHub client for durable push %s@%s: %w", repo, headSHA, err)
+	}
+
+	if err := h.postPassingAggregateChecks(ctx, client, repo, headSHA, defaultBranchCheckContent()); err != nil {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:  "default_branch_check",
+			Repository: repo,
+			Status:     "error",
+		})
+		return true, fmt.Errorf("post durable default-branch checks for %s@%s: %w", repo, headSHA, err)
+	}
+
+	h.logger.Info("durable default-branch checks posted",
+		"delivery_id", event.DeliveryID, "repo", repo, "head_sha", headSHA)
+	return false, nil
 }

--- a/pkg/webhook/push.go
+++ b/pkg/webhook/push.go
@@ -214,6 +214,14 @@ func (h *Handler) processDurablePush(ctx context.Context, event *storage.Webhook
 	repo := payload.Repository.FullName
 	headSHA := payload.After
 
+	// The deletion sentinel is an all-zeros SHA, not an empty one; an empty
+	// repo or head SHA is a corrupted/replayed row. Fail terminally before the
+	// routine skips below so corruption surfaces as malformed rather than
+	// silently completing as a non-default-branch or unregistered-repo skip.
+	if repo == "" || headSHA == "" {
+		return false, fmt.Errorf("durable push delivery %s missing repo or head SHA", event.DeliveryID)
+	}
+
 	if payload.Repository.DefaultBranch == "" || payload.Ref != "refs/heads/"+payload.Repository.DefaultBranch {
 		h.logger.Info("durable push delivery ignored because it is not the default branch",
 			"delivery_id", event.DeliveryID, "repo", repo, "ref", payload.Ref,
@@ -221,12 +229,6 @@ func (h *Handler) processDurablePush(ctx context.Context, event *storage.Webhook
 		return false, nil
 	}
 
-	if headSHA == "" {
-		// The deletion sentinel is an all-zeros SHA, not an empty one; a truly
-		// empty head SHA is a corrupted/replayed row. Fail terminally so it
-		// surfaces as malformed rather than silently completing as a no-op.
-		return false, fmt.Errorf("durable push delivery %s missing head SHA", event.DeliveryID)
-	}
 	if payload.Deleted || strings.Trim(headSHA, "0") == "" {
 		h.logger.Info("durable push delivery ignored because it is a branch deletion",
 			"delivery_id", event.DeliveryID, "repo", repo, "ref", payload.Ref)


### PR DESCRIPTION
## Summary
WH-9b converts the remaining non-`pull_request` webhook events off best-effort in-process goroutines onto the durable inbox (fast ack + leased-driver retries), reaching parity with the auto-plan path. `pull_request.closed` is the only true ack-then-drop loss window of this batch; `merge_group` and `push` already ack after synchronous work, so they gain restart-safe check posting rather than a loss fix.

## What
- Add a shared `enqueueDurableWebhook` + `durableInstallationID` helper behind every durable producer.
- Route `merge_group`, `push`, and `pull_request.closed` through the inbox: enqueue, fast-ack, then a leased driver drives the work with retries.
- Every durable processor re-validates its enqueue-time guards fail-closed at drive time (config can change between enqueue and drive; rows can arrive via replay), and every action is idempotent so a retry after a partial run reconciles instead of double-acting.
- Refactor `handlePRClosed` into a context-aware, error-returning `runPRCloseCleanup` / `releaseLocksForClosedPR`; all lock releases are attempted and joined, and every failure propagates so the driver retries under the delivery lease.
- Enqueue failure is a deliberate 500 (no in-process fallback) so it surfaces as a red delivery for operator redelivery.
- `check_run` is carved into a WH-9d follow-up (synchronous today, not a loss window; its `completed` action needs an error-contract rework across ~15 tier-0 callers). Participant nudges stay out of the delivery inbox — delayed timers with no delivery GUID need a scheduled-work row, not a delivery row.

## Why
A deploy landing mid-cleanup on a `pull_request.closed` delivery could drop the detached goroutine and leave a database lock held or stale check state behind, with no retry. Moving it under the durable lease closes that window; folding `merge_group`/`push` in at the same time keeps one enqueue/drive contract for all check-posting events.

## Before / after
Before (pull_request.closed)
```
webhook ──▶ 200 ack ──▶ goSafe{ cleanup }   ── deploy ──▶ goroutine dropped
lock still held
```

After (all three events)
```
webhook ──▶ enqueue row ──▶ 200 ack
│
▼
leased driver ──▶ run work ──(fail)──▶ retry under lease
│                                  (idempotent)
└──(restart)──▶ lease expires ──▶ reclaimed + resumed
```
