### PR TITLE
feat(inventory): per-target schema_overrides mapping canonical namespace to physical schema

### DIFF
--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -13,6 +13,8 @@
 - [`$ENV` Substitution in Namespace Names](#env-substitution-in-namespace-names)
   - [Example](#example)
   - [Rules](#rules)
+- [Per-Target Schema Overrides](#per-target-schema-overrides)
+  - [Rules](#rules-1)
 - [Summary](#summary)
 - [How Namespaces Flow Through the System](#how-namespaces-flow-through-the-system)
 
@@ -161,6 +163,33 @@ schemabot plan -s myapp/schema -e production
 - You can mix `$ENV` directories with regular directories in the subdirectory layout.
 - When creating the directory from a shell, quote the name to prevent shell expansion: `mkdir 'bikeshare_$ENV'`
 
+## Per-Target Schema Overrides
+
+`$ENV` substitution handles physical schema names that vary by *environment*. When names vary by *deployment within one environment* — several regional clusters in the same environment naming the schema `bikeshare_qa`, `bikeshare_eu_qa`, and `bikeshare_us_qa` — one schema directory cannot express the variance, and copying the directory per region would triple the source of truth.
+
+Instead, keep one canonical directory (`bikeshare/`) and map the canonical namespace to each deployment's physical schema on the data-plane target:
+
+```yaml
+target_resolver:
+  targets:
+    eu-bikeshare-qa:
+      type: mysql
+      schema_overrides:
+        bikeshare: bikeshare_eu_qa
+      dsn_from:
+        # namespace-free endpoint/credentials
+```
+
+The canonical namespace stays the name everywhere SchemaBot stores or shows it — requests, plans, tasks, drift comparison, pull responses. The physical name only enters the data plane where MySQL is actually addressed: the connection schema in the DSN and `information_schema` predicates.
+
+### Rules
+
+- MySQL only, and currently exactly one mapping per target.
+- The target DSN must be namespace-free; a DSN that already names a database is rejected at config load.
+- A non-empty map is a strict allowlist: a requested namespace without a mapping fails rather than falling back to the canonical name, so a misrouted request cannot land in the wrong physical schema.
+- An empty/omitted map preserves the default behavior: the requested namespace is the physical schema.
+- Schema names must be unquoted-identifier-safe (`[a-zA-Z0-9_$]`, at most 64 characters).
+
 ## Summary
 
 | Scenario | schemabot.yaml | Namespaces | Example |
@@ -170,6 +199,7 @@ schemabot plan -s myapp/schema -e production
 | MySQL, different databases | 1 per database | 1 each | separate directories |
 | Vitess, multiple keyspaces | 1 | many | `commerce/`, `commerce_sharded/` |
 | Environment-specific namespace | 1 | 1 per env | `bikeshare_$ENV/` |
+| Deployment-specific physical schema | 1 | 1 canonical | `bikeshare/` + per-target `schema_overrides` |
 
 ## How Namespaces Flow Through the System
 

--- a/pkg/ddl/validate.go
+++ b/pkg/ddl/validate.go
@@ -13,11 +13,31 @@ import (
 // These checks run after parsing but before diffing, providing clear error
 // messages at plan time rather than failing during schema change execution.
 func ValidateCreateTable(ct *statement.CreateTable) error {
+	if err := ValidateUnqualifiedTableName(ct); err != nil {
+		return err
+	}
 	if err := ValidateDuplicateColumns(ct); err != nil {
 		return err
 	}
 	if err := ValidateIndexColumns(ct); err != nil {
 		return err
+	}
+	return nil
+}
+
+// ValidateUnqualifiedTableName rejects a CREATE TABLE statement whose table
+// name carries a schema qualifier (CREATE TABLE db.users ...). SchemaBot
+// selects the schema through the connection — the namespace on the request,
+// optionally remapped to a physical schema by per-target overrides — so a
+// desired statement is emitted verbatim for a new table and a qualifier would
+// silently address a different schema than the one the plan and apply run
+// against.
+func ValidateUnqualifiedTableName(ct *statement.CreateTable) error {
+	if ct.Raw == nil || ct.Raw.Table == nil {
+		return nil
+	}
+	if schemaName := ct.Raw.Table.Schema.String(); schemaName != "" {
+		return fmt.Errorf("table %q: schema-qualified table name %q.%q is not supported; the connection selects the schema, so remove the qualifier", ct.TableName, schemaName, ct.TableName)
 	}
 	return nil
 }

--- a/pkg/ddl/validate_test.go
+++ b/pkg/ddl/validate_test.go
@@ -139,4 +139,32 @@ func TestValidateCreateTable(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "duplicate column")
 	})
+
+	t.Run("rejects schema-qualified table name", func(t *testing.T) {
+		sql := "CREATE TABLE otherdb.users (id INT PRIMARY KEY)"
+		ct, err := statement.ParseCreateTable(sql)
+		require.NoError(t, err)
+
+		err = ValidateCreateTable(ct)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "schema-qualified table name")
+	})
+
+	t.Run("rejects backtick-quoted schema qualifier", func(t *testing.T) {
+		sql := "CREATE TABLE `otherdb`.`users` (id INT PRIMARY KEY)"
+		ct, err := statement.ParseCreateTable(sql)
+		require.NoError(t, err)
+
+		err = ValidateCreateTable(ct)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "schema-qualified table name")
+	})
+
+	t.Run("accepts unqualified table name", func(t *testing.T) {
+		sql := "CREATE TABLE users (id INT PRIMARY KEY)"
+		ct, err := statement.ParseCreateTable(sql)
+		require.NoError(t, err)
+
+		assert.NoError(t, ValidateCreateTable(ct))
+	})
 }

--- a/pkg/engine/spirit/control.go
+++ b/pkg/engine/spirit/control.go
@@ -279,8 +279,9 @@ func (e *Engine) Cutover(ctx context.Context, req *engine.ControlRequest) (*engi
 	}
 	e.mu.Unlock()
 
-	// Stateless cutover (no in-memory schema change, e.g. after a restart)
-	// addresses the schema the DSN connects to.
+	// Stateless cutover — no in-memory schema change, or one without a
+	// recorded database (e.g. after a restart) — addresses the schema the
+	// DSN connects to.
 	if database == "" {
 		var err error
 		database, err = statelessControlDatabase(req.Credentials.DSN, req.Database)

--- a/pkg/engine/spirit/control.go
+++ b/pkg/engine/spirit/control.go
@@ -236,6 +236,23 @@ func (e *Engine) Start(ctx context.Context, req *engine.ControlRequest) (*engine
 	}, nil
 }
 
+// statelessControlDatabase resolves the schema a stateless control operation
+// (cutover or sentinel lookup without an in-memory schema change) addresses.
+// The DSN's database wins: it carries the physical schema name, which can
+// differ from the request's logical database name when the target maps
+// namespaces to per-deployment physical schemas. The request database is only
+// a fallback for DSNs without a schema.
+func statelessControlDatabase(dsn, requestDatabase string) (string, error) {
+	cfg, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		return "", err
+	}
+	if cfg.DBName != "" {
+		return cfg.DBName, nil
+	}
+	return requestDatabase, nil
+}
+
 // Cutover triggers the final table swap.
 // When DeferCutOver was used, this triggers the deferred cutover by dropping
 // Spirit's sentinel table (_spirit_sentinel).
@@ -249,7 +266,7 @@ func (e *Engine) Cutover(ctx context.Context, req *engine.ControlRequest) (*engi
 
 	e.mu.Lock()
 	rm := e.runningSchemaChange
-	database := req.Database
+	database := ""
 	if rm != nil {
 		if !rm.deferCutover {
 			e.mu.Unlock()
@@ -258,18 +275,18 @@ func (e *Engine) Cutover(ctx context.Context, req *engine.ControlRequest) (*engi
 				Message:  "schema change was not started with defer_cutover",
 			}, nil
 		}
-		if rm.database != "" {
-			database = rm.database
-		}
+		database = rm.database
 	}
 	e.mu.Unlock()
 
+	// Stateless cutover (no in-memory schema change, e.g. after a restart)
+	// addresses the schema the DSN connects to.
 	if database == "" {
-		cfg, err := mysql.ParseDSN(req.Credentials.DSN)
+		var err error
+		database, err = statelessControlDatabase(req.Credentials.DSN, req.Database)
 		if err != nil {
 			return nil, fmt.Errorf("parse DSN for cutover database: %w", err)
 		}
-		database = cfg.DBName
 	}
 	if database == "" {
 		return nil, fmt.Errorf("database is required for cutover")
@@ -312,13 +329,10 @@ func (e *Engine) DeferredCutoverSignalExists(ctx context.Context, req *engine.De
 		return false, fmt.Errorf("DSN credentials required for deferred cutover signal lookup")
 	}
 
-	database := req.Database
-	if database == "" {
-		cfg, err := mysql.ParseDSN(req.Credentials.DSN)
-		if err != nil {
-			return false, fmt.Errorf("parse DSN for deferred cutover signal database: %w", err)
-		}
-		database = cfg.DBName
+	// The sentinel lives in the schema the DSN connects to.
+	database, err := statelessControlDatabase(req.Credentials.DSN, req.Database)
+	if err != nil {
+		return false, fmt.Errorf("parse DSN for deferred cutover signal database: %w", err)
 	}
 	if database == "" {
 		return false, fmt.Errorf("database is required for deferred cutover signal lookup")

--- a/pkg/engine/spirit/control_test.go
+++ b/pkg/engine/spirit/control_test.go
@@ -471,3 +471,33 @@ func TestVolumeConcurrentWithSettingsReads(t *testing.T) {
 	readers.Wait()
 	eng.Drain()
 }
+
+// Stateless control operations (cutover, deferred cutover sentinel lookup)
+// must address the schema the DSN connects to: under per-deployment schema
+// overrides the DSN carries the physical schema name while the request carries
+// the logical (canonical) database name. The request database is only a
+// fallback for DSNs without a schema.
+func TestStatelessControlDatabase(t *testing.T) {
+	t.Run("DSN database wins over request database", func(t *testing.T) {
+		got, err := statelessControlDatabase("root@tcp(localhost:3306)/bikeshare_eu_qa", "bikeshare")
+		require.NoError(t, err)
+		assert.Equal(t, "bikeshare_eu_qa", got)
+	})
+
+	t.Run("request database is the fallback for a namespace-free DSN", func(t *testing.T) {
+		got, err := statelessControlDatabase("root@tcp(localhost:3306)/", "bikeshare")
+		require.NoError(t, err)
+		assert.Equal(t, "bikeshare", got)
+	})
+
+	t.Run("empty when neither names a schema", func(t *testing.T) {
+		got, err := statelessControlDatabase("root@tcp(localhost:3306)/", "")
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("invalid DSN is an error", func(t *testing.T) {
+		_, err := statelessControlDatabase("not a dsn", "bikeshare")
+		require.Error(t, err)
+	})
+}

--- a/pkg/engine/spirit/spirit_integration_test.go
+++ b/pkg/engine/spirit/spirit_integration_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/block/schemabot/pkg/schema"
 	"github.com/block/schemabot/pkg/testutil"
 
-	_ "github.com/go-sql-driver/mysql"
+	drivermysql "github.com/go-sql-driver/mysql"
 )
 
 // Shared test infrastructure
@@ -2020,4 +2020,76 @@ func containsHelper(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+// Stateless control operations (cutover and deferred-cutover sentinel lookup
+// without an in-memory schema change) must address the schema the DSN connects
+// to, not the request's logical database name: under per-deployment schema
+// overrides the DSN carries the physical schema while the request carries the
+// canonical name. Addressing the request database instead would silently no-op
+// the sentinel drop (the cutover reports success while the sentinel survives)
+// and report the deferred-cutover signal as absent.
+func TestEngine_StatelessControlAddressesDSNSchema(t *testing.T) {
+	ctx := t.Context()
+	db, err := sql.Open("mysql", sharedDSN)
+	require.NoError(t, err, "open database")
+	defer utils.CloseAndLog(db)
+
+	const (
+		canonical      = "ctl_ovr_bikeshare"
+		physicalSchema = "ctl_ovr_bikeshare_region2_env1"
+	)
+
+	_, err = db.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS `"+physicalSchema+"`")
+	require.NoError(t, err, "create physical schema")
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(t.Context()), 30*time.Second)
+		defer cancel()
+		cleanupDB, cleanupErr := sql.Open("mysql", sharedDSN)
+		require.NoError(t, cleanupErr, "open database for stateless control cleanup")
+		defer utils.CloseAndLog(cleanupDB)
+		_, cleanupErr = cleanupDB.ExecContext(cleanupCtx, "DROP DATABASE IF EXISTS `"+physicalSchema+"`")
+		assert.NoError(t, cleanupErr, "drop physical schema")
+	})
+	_, err = db.ExecContext(ctx, "CREATE TABLE IF NOT EXISTS `"+physicalSchema+"`.`_spirit_sentinel` (`id` int NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB")
+	require.NoError(t, err, "create sentinel table in physical schema")
+
+	// The DSN names the physical schema; the request carries the canonical
+	// database name, which exists as no schema on this cluster.
+	cfg, err := drivermysql.ParseDSN(sharedDSN)
+	require.NoError(t, err, "parse shared DSN")
+	cfg.DBName = physicalSchema
+	creds := &engine.Credentials{DSN: cfg.FormatDSN()}
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	eng := New(Config{Logger: logger})
+
+	exists, err := eng.DeferredCutoverSignalExists(ctx, &engine.DeferredCutoverSignalRequest{
+		Database:    canonical,
+		Credentials: creds,
+	})
+	require.NoError(t, err, "deferred cutover signal lookup")
+	assert.True(t, exists, "sentinel in the DSN's physical schema is found despite the canonical request database")
+
+	result, err := eng.Cutover(ctx, &engine.ControlRequest{
+		Database:    canonical,
+		Credentials: creds,
+	})
+	require.NoError(t, err, "stateless cutover")
+	require.NotNil(t, result)
+	assert.True(t, result.Accepted, "stateless cutover is accepted")
+
+	var count int
+	require.NoError(t, db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = ? AND TABLE_NAME = '_spirit_sentinel'",
+		physicalSchema,
+	).Scan(&count), "count sentinel tables")
+	assert.Zero(t, count, "cutover drops the sentinel in the DSN's physical schema, not the canonical name")
+
+	exists, err = eng.DeferredCutoverSignalExists(ctx, &engine.DeferredCutoverSignalRequest{
+		Database:    canonical,
+		Credentials: creds,
+	})
+	require.NoError(t, err, "deferred cutover signal lookup after cutover")
+	assert.False(t, exists, "signal is reported absent after the sentinel drop")
 }

--- a/pkg/inventory/static.go
+++ b/pkg/inventory/static.go
@@ -43,6 +43,16 @@ type StaticTarget struct {
 	// availability risk are negligible. Prefer file: refs until that follow-up.
 	DSNFrom  *StaticDSNFromConfig `yaml:"dsn_from,omitempty"`
 	Metadata map[string]string    `yaml:"metadata,omitempty"`
+	// SchemaOverrides maps a requested (canonical) MySQL namespace to the
+	// physical schema name on this target, for targets whose physical schema
+	// names embed environment or region (e.g. bikeshare → bikeshare_eu_qa).
+	// The target DSN stays namespace-free; the mapped physical name is injected
+	// per operation instead of the requested namespace. When non-empty it is a
+	// strict allowlist: a requested namespace without a mapping fails rather
+	// than falling back to the canonical name, so a misrouted request cannot
+	// land in the wrong physical schema. MySQL only; currently limited to a
+	// single mapping per target.
+	SchemaOverrides map[string]string `yaml:"schema_overrides,omitempty"`
 }
 
 // StaticDSNFromConfig assembles a namespace-free MySQL DSN for a static target
@@ -88,6 +98,10 @@ type staticTargetEntry struct {
 	target       string
 	databaseType string
 	metadata     map[string]string
+	// schemaOverrides is the validated canonical→physical MySQL schema
+	// allowlist for this target; empty means the requested namespace is the
+	// physical schema.
+	schemaOverrides map[string]string
 	// dsn is set (non-nil) for entries resolved once at construction.
 	dsn *string
 	// dsnFrom is set for entries assembled fresh on every request.
@@ -138,10 +152,11 @@ func (r *StaticResolver) ResolveTarget(ctx context.Context, req Request) (*Targe
 		return nil, err
 	}
 	return &Target{
-		Target:       entry.target,
-		DatabaseType: entry.databaseType,
-		DSN:          dsn,
-		Metadata:     maps.Clone(entry.metadata),
+		Target:          entry.target,
+		DatabaseType:    entry.databaseType,
+		DSN:             dsn,
+		Metadata:        maps.Clone(entry.metadata),
+		SchemaOverrides: maps.Clone(entry.schemaOverrides),
 	}, nil
 }
 
@@ -161,10 +176,14 @@ func newStaticTargetEntry(target string, entry StaticTarget) (*staticTargetEntry
 	case !hasDSN && !hasDSNFrom:
 		return nil, fmt.Errorf("target %q missing dsn or dsn_from", target)
 	}
+	if err := ValidateSchemaOverrides(databaseType, entry.SchemaOverrides); err != nil {
+		return nil, fmt.Errorf("target %q: %w", target, err)
+	}
 	prepared := &staticTargetEntry{
-		target:       target,
-		databaseType: databaseType,
-		metadata:     maps.Clone(entry.Metadata),
+		target:          target,
+		databaseType:    databaseType,
+		metadata:        maps.Clone(entry.Metadata),
+		schemaOverrides: maps.Clone(entry.SchemaOverrides),
 	}
 	if hasDSNFrom {
 		if databaseType != "mysql" {
@@ -208,6 +227,56 @@ func (e staticTargetEntry) resolveDSN(ctx context.Context, req Request) (string,
 
 func canonicalDatabaseType(databaseType string) string {
 	return strings.ToLower(strings.TrimSpace(databaseType))
+}
+
+// ValidateSchemaOverrides checks a canonical→physical schema mapping. The
+// mapping is MySQL-only (it selects a MySQL schema; for Vitess the namespace
+// is a keyspace, a different concept) and is currently limited to a single
+// entry: SchemaBot's MySQL operations address one schema per target, and a
+// wider map would silently permit multi-schema routing this feature does not
+// support yet. It is exported so every consumer of a resolved target (not just
+// static inventory) enforces the same contract; a custom resolver cannot hand
+// an invalid mapping past it.
+func ValidateSchemaOverrides(databaseType string, overrides map[string]string) error {
+	if len(overrides) == 0 {
+		return nil
+	}
+	if databaseType != "mysql" {
+		return fmt.Errorf("schema_overrides is only supported for mysql, not %q", databaseType)
+	}
+	if len(overrides) > 1 {
+		return fmt.Errorf("schema_overrides supports exactly one mapping, got %d", len(overrides))
+	}
+	for canonical, physical := range overrides {
+		if err := validateSchemaIdentifier(canonical); err != nil {
+			return fmt.Errorf("schema_overrides key %q: %w", canonical, err)
+		}
+		if err := validateSchemaIdentifier(physical); err != nil {
+			return fmt.Errorf("schema_overrides value %q for key %q: %w", physical, canonical, err)
+		}
+	}
+	return nil
+}
+
+// validateSchemaIdentifier requires an unquoted-identifier-safe MySQL schema
+// name. Mapped names are injected into DSNs and SQL, so restrict them to the
+// character set that never needs quoting rather than supporting MySQL's full
+// quoted-identifier grammar.
+func validateSchemaIdentifier(name string) error {
+	if name == "" {
+		return fmt.Errorf("schema name must not be empty")
+	}
+	if len(name) > 64 {
+		return fmt.Errorf("schema name exceeds MySQL's 64-character identifier limit")
+	}
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '$':
+		default:
+			return fmt.Errorf("schema name contains unsupported character %q; only [a-zA-Z0-9_$] is allowed", r)
+		}
+	}
+	return nil
 }
 
 func validateResolvedStaticTargetDSN(target, databaseType, dsn string) error {

--- a/pkg/inventory/static_test.go
+++ b/pkg/inventory/static_test.go
@@ -2,6 +2,7 @@ package inventory
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/go-sql-driver/mysql"
@@ -396,6 +397,100 @@ func TestNewStaticResolverValidatesConfig(t *testing.T) {
 			name:    "missing dsn",
 			config:  StaticConfig{Targets: map[string]StaticTarget{"target-1": {DatabaseType: "mysql"}}},
 			wantErr: "target \"target-1\" missing dsn or dsn_from",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewStaticResolver(tt.config)
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestStaticResolverResolveTargetSchemaOverrides(t *testing.T) {
+	resolver, err := NewStaticResolver(StaticConfig{Targets: map[string]StaticTarget{
+		"eu-bikeshare-qa": {
+			DatabaseType:    "mysql",
+			DSN:             "root@tcp(localhost:3306)/",
+			SchemaOverrides: map[string]string{"bikeshare": "bikeshare_eu_qa"},
+		},
+	}})
+	require.NoError(t, err)
+
+	got, err := resolver.ResolveTarget(t.Context(), Request{Target: "eu-bikeshare-qa"})
+
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"bikeshare": "bikeshare_eu_qa"}, got.SchemaOverrides)
+}
+
+func TestStaticResolverResolveTargetClonesSchemaOverrides(t *testing.T) {
+	resolver, err := NewStaticResolver(StaticConfig{Targets: map[string]StaticTarget{
+		"target-1": {
+			DatabaseType:    "mysql",
+			DSN:             "root@tcp(localhost:3306)/",
+			SchemaOverrides: map[string]string{"bikeshare": "bikeshare_eu_qa"},
+		},
+	}})
+	require.NoError(t, err)
+
+	first, err := resolver.ResolveTarget(t.Context(), Request{Target: "target-1"})
+	require.NoError(t, err)
+	first.SchemaOverrides["bikeshare"] = "mutated"
+
+	second, err := resolver.ResolveTarget(t.Context(), Request{Target: "target-1"})
+	require.NoError(t, err)
+	assert.Equal(t, "bikeshare_eu_qa", second.SchemaOverrides["bikeshare"])
+}
+
+func TestNewStaticResolverValidatesSchemaOverrides(t *testing.T) {
+	target := func(overrides map[string]string, databaseType string) StaticConfig {
+		return StaticConfig{Targets: map[string]StaticTarget{
+			"target-1": {
+				DatabaseType:    databaseType,
+				DSN:             "root@tcp(localhost:3306)/",
+				SchemaOverrides: overrides,
+			},
+		}}
+	}
+
+	tests := []struct {
+		name    string
+		config  StaticConfig
+		wantErr string
+	}{
+		{
+			name:    "non-mysql target",
+			config:  target(map[string]string{"bikeshare": "bikeshare_eu_qa"}, "vitess"),
+			wantErr: "schema_overrides is only supported for mysql",
+		},
+		{
+			name: "more than one mapping",
+			config: target(map[string]string{
+				"bikeshare": "bikeshare_eu_qa",
+				"orders":    "orders_eu_qa",
+			}, "mysql"),
+			wantErr: "supports exactly one mapping",
+		},
+		{
+			name:    "empty canonical key",
+			config:  target(map[string]string{"": "bikeshare_eu_qa"}, "mysql"),
+			wantErr: "schema name must not be empty",
+		},
+		{
+			name:    "empty physical value",
+			config:  target(map[string]string{"bikeshare": ""}, "mysql"),
+			wantErr: "schema name must not be empty",
+		},
+		{
+			name:    "physical name with unsupported character",
+			config:  target(map[string]string{"bikeshare": "bikeshare-eu-qa"}, "mysql"),
+			wantErr: "unsupported character",
+		},
+		{
+			name:    "physical name over the MySQL identifier limit",
+			config:  target(map[string]string{"bikeshare": strings.Repeat("a", 65)}, "mysql"),
+			wantErr: "64-character identifier limit",
 		},
 	}
 

--- a/pkg/inventory/target.go
+++ b/pkg/inventory/target.go
@@ -19,6 +19,12 @@ type Target struct {
 	DatabaseType string
 	DSN          string
 	Metadata     map[string]string
+	// SchemaOverrides maps a requested (canonical) MySQL namespace to the
+	// physical schema name on this target. When non-empty it is a strict
+	// allowlist: a requested namespace without a mapping fails rather than
+	// falling back to the canonical name. Empty preserves the default
+	// behavior where the requested namespace is the physical schema.
+	SchemaOverrides map[string]string
 }
 
 // Resolver resolves opaque execution targets to inventory records.

--- a/pkg/tern/local_apply.go
+++ b/pkg/tern/local_apply.go
@@ -155,6 +155,12 @@ func (c *LocalClient) tryResolveStaleTask(ctx context.Context, t *storage.Task, 
 		return false
 	}
 
+	// The raw target credentials (no namespace mapping) are safe here only
+	// because Spirit's Progress is purely in-memory and never queries by
+	// request database or connection schema. An engine whose Progress inspects
+	// the database must resolve credentials per task (credentialsForTask)
+	// before this probe, or under schema overrides it would address the
+	// canonical name instead of the physical schema.
 	result, err := eng.Progress(ctx, &engine.ProgressRequest{
 		Database:    database,
 		Credentials: c.credentials(),

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -235,7 +235,7 @@ func NewLocalClient(cfg LocalConfig, stor storage.Storage, logger *slog.Logger) 
 	// client, and clone the map so the client's view cannot be mutated later.
 	if len(cfg.SchemaOverrides) > 0 {
 		if err := inventory.ValidateSchemaOverrides(cfg.Type, cfg.SchemaOverrides); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("local client for database %q: %w", cfg.Database, err)
 		}
 		hasDatabase, err := mysqlDSNHasDatabase(cfg.TargetDSN)
 		if err != nil {

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -92,6 +92,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -109,6 +110,7 @@ import (
 	"github.com/block/schemabot/pkg/engine"
 	"github.com/block/schemabot/pkg/engine/planetscale"
 	"github.com/block/schemabot/pkg/engine/spirit"
+	"github.com/block/schemabot/pkg/inventory"
 	"github.com/block/schemabot/pkg/metrics"
 	"github.com/block/schemabot/pkg/mysqlconn"
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
@@ -147,6 +149,16 @@ type LocalConfig struct {
 	// Keys used by Spirit: pending_drops ("false" disables the pending drops
 	// quarantine so DROP TABLE executes directly).
 	Metadata map[string]string
+
+	// SchemaOverrides maps a requested (canonical) MySQL namespace to the
+	// physical schema name on this target, for targets whose physical schema
+	// names embed environment or region. When non-empty it is a strict
+	// allowlist consulted wherever a namespace is turned into a connection
+	// schema: a requested namespace without a mapping fails rather than
+	// falling back to the canonical name. Empty preserves the default
+	// behavior where the requested namespace is the physical schema. MySQL
+	// only, and requires a namespace-free TargetDSN.
+	SchemaOverrides map[string]string
 
 	// WakeOperator notifies the owner loop after durable work is recorded — a
 	// queued apply from a dispatch, or an external control request. The callback
@@ -215,6 +227,26 @@ var _ Client = (*LocalClient)(nil)
 // NewLocalClient creates a new local Tern client that calls the Spirit engine directly.
 // The storage parameter should be SchemaBot's storage instance for plan/task management.
 func NewLocalClient(cfg LocalConfig, stor storage.Storage, logger *slog.Logger) (*LocalClient, error) {
+	// Schema overrides select a MySQL connection schema, so they only make
+	// sense for MySQL and only with a namespace-free target DSN (a DSN that
+	// already names a database would silently win over the mapping). Enforce
+	// the full mapping contract here as well as at inventory-config load so a
+	// custom resolver cannot hand an invalid combination straight to the
+	// client, and clone the map so the client's view cannot be mutated later.
+	if len(cfg.SchemaOverrides) > 0 {
+		if err := inventory.ValidateSchemaOverrides(cfg.Type, cfg.SchemaOverrides); err != nil {
+			return nil, err
+		}
+		hasDatabase, err := mysqlDSNHasDatabase(cfg.TargetDSN)
+		if err != nil {
+			return nil, fmt.Errorf("inspect MySQL target DSN for schema overrides: %w", err)
+		}
+		if hasDatabase {
+			return nil, fmt.Errorf("schema overrides require a namespace-free target DSN; the DSN already names a database")
+		}
+		cfg.SchemaOverrides = maps.Clone(cfg.SchemaOverrides)
+	}
+
 	// For Vitess databases, create a PlanetScale engine with a client factory
 	// that points at the API base URL from metadata (e.g., "http://localscale:8080").
 	// TargetDSN is the vtgate MySQL DSN for SHOW VITESS_MIGRATIONS.
@@ -371,6 +403,8 @@ func (c *LocalClient) credentialsForMySQLNamespace(namespace string) (*engine.Cr
 	// The data-plane model is a namespace-free DSN with the schema injected per
 	// operation (below); existing static/local configs still carry the database
 	// in the DSN, and those keep working until they migrate to namespace-free.
+	// (A DSN-with-database target cannot carry schema overrides; NewLocalClient
+	// rejects that combination.)
 	if hasDatabase {
 		return c.credentials(), nil
 	}
@@ -379,7 +413,11 @@ func (c *LocalClient) credentialsForMySQLNamespace(namespace string) (*engine.Cr
 	if namespace == "" {
 		return nil, fmt.Errorf("MySQL namespace is required for a namespace-free target DSN")
 	}
-	dsn, err := mysqlDSNWithDatabase(c.config.TargetDSN, namespace)
+	physical, err := c.physicalMySQLNamespace(namespace)
+	if err != nil {
+		return nil, err
+	}
+	dsn, err := mysqlDSNWithDatabase(c.config.TargetDSN, physical)
 	if err != nil {
 		return nil, err
 	}
@@ -387,6 +425,27 @@ func (c *LocalClient) credentialsForMySQLNamespace(namespace string) (*engine.Cr
 		DSN:      dsn,
 		Metadata: c.config.Metadata,
 	}, nil
+}
+
+// physicalMySQLNamespace resolves the physical schema name for a requested
+// (canonical) namespace. Without configured overrides the requested namespace
+// is the physical schema. With overrides the map is a strict allowlist: an
+// unmapped namespace fails rather than falling back to the canonical name, so
+// a request misrouted to this target cannot land in the wrong physical schema.
+func (c *LocalClient) physicalMySQLNamespace(namespace string) (string, error) {
+	if len(c.config.SchemaOverrides) == 0 {
+		return namespace, nil
+	}
+	physical, ok := c.config.SchemaOverrides[namespace]
+	if !ok {
+		return "", fmt.Errorf("target does not authorize MySQL namespace %q; configured schema overrides map only %v", namespace, slices.Sorted(maps.Keys(c.config.SchemaOverrides)))
+	}
+	c.logger.Debug("resolved schema override for namespace",
+		"database", c.config.Database,
+		"namespace", namespace,
+		"physical_schema", physical,
+	)
+	return physical, nil
 }
 
 func (c *LocalClient) credentialsForTask(task *storage.Task) (*engine.Credentials, error) {
@@ -443,7 +502,7 @@ func mysqlDSNDatabase(dsn string) (string, error) {
 	return cfg.DBName, nil
 }
 
-func (c *LocalClient) deferredCutoverSignalExists(ctx context.Context, apply *storage.Apply) (bool, bool, error) {
+func (c *LocalClient) deferredCutoverSignalExists(ctx context.Context, apply *storage.Apply, tasks []*storage.Task) (bool, bool, error) {
 	if apply == nil {
 		return false, false, fmt.Errorf("apply is required for deferred cutover signal lookup")
 	}
@@ -452,9 +511,24 @@ func (c *LocalClient) deferredCutoverSignalExists(ctx context.Context, apply *st
 	if !ok {
 		return false, false, nil
 	}
+	// Resolve credentials through the task namespace so the lookup addresses
+	// the schema the apply actually runs against: a namespace-free target DSN
+	// needs the namespace injected (and mapped, under schema overrides) or the
+	// signal query would silently run without a schema and miss the sentinel.
+	namespace := ""
+	for _, task := range tasks {
+		if task != nil && task.Namespace != "" {
+			namespace = task.Namespace
+			break
+		}
+	}
+	creds, err := c.credentialsForMySQLNamespace(namespace)
+	if err != nil {
+		return false, true, fmt.Errorf("resolve credentials for deferred cutover signal lookup for apply %s database %s: %w", apply.ApplyIdentifier, apply.Database, err)
+	}
 	exists, err := checker.DeferredCutoverSignalExists(ctx, &engine.DeferredCutoverSignalRequest{
 		Database:    apply.Database,
-		Credentials: c.credentials(),
+		Credentials: creds,
 	})
 	if err != nil {
 		return false, true, fmt.Errorf("check deferred cutover signal for apply %s database %s: %w", apply.ApplyIdentifier, apply.Database, err)
@@ -537,6 +611,16 @@ func (c *LocalClient) discoverPullNamespaces(ctx context.Context) ([]string, err
 		return []string{database}, nil
 	}
 
+	// A target with schema overrides serves exactly the mapped canonical
+	// namespaces. Return those keys rather than scanning the cluster, which
+	// would surface physical names (and unrelated databases) the requested
+	// canonical namespace model must not leak.
+	if len(c.config.SchemaOverrides) > 0 {
+		namespaces := slices.Sorted(maps.Keys(c.config.SchemaOverrides))
+		c.logger.Info("LocalClient.PullSchema: using schema-override namespaces", "database", c.config.Database, "namespace_count", len(namespaces))
+		return namespaces, nil
+	}
+
 	attrs := []any{"database", c.config.Database}
 	attrs = append(attrs, dsnLogAttrs(c.config.TargetDSN)...)
 	c.logger.Info("LocalClient.PullSchema: discovering live namespaces", attrs...)
@@ -579,8 +663,17 @@ func (c *LocalClient) pullSchemaNamespace(ctx context.Context, req *ternv1.PullS
 		return c.pullVitessSchemaNamespace(ctx, req, namespace)
 	}
 
+	// The physical schema is what MySQL is addressed by (connection schema and
+	// information_schema predicates); the requested canonical namespace stays
+	// the response key so callers never see physical names.
+	physical := namespace
 	targetDSN := c.config.TargetDSN
 	if c.config.Type == storage.DatabaseTypeMySQL {
+		var err error
+		physical, err = c.physicalMySQLNamespace(namespace)
+		if err != nil {
+			return nil, fmt.Errorf("resolve database %s namespace %s physical schema for schema pull: %w", c.config.Database, namespace, err)
+		}
 		creds, err := c.credentialsForMySQLPullNamespace(namespace)
 		if err != nil {
 			return nil, fmt.Errorf("resolve database %s namespace %s credentials for schema pull: %w", c.config.Database, namespace, err)
@@ -588,7 +681,7 @@ func (c *LocalClient) pullSchemaNamespace(ctx context.Context, req *ternv1.PullS
 		targetDSN = creds.DSN
 	}
 
-	attrs := []any{"database", c.config.Database, "namespace", namespace}
+	attrs := []any{"database", c.config.Database, "namespace", namespace, "physical_schema", physical}
 	attrs = append(attrs, dsnLogAttrs(targetDSN)...)
 	c.logger.Info("LocalClient.PullSchema: loading live schema", attrs...)
 
@@ -616,7 +709,7 @@ func (c *LocalClient) pullSchemaNamespace(ctx context.Context, req *ternv1.PullS
 		}
 		pulledTables[tbl.Name] = content
 	}
-	catalog, err := c.pullNamespaceCatalog(ctx, db, namespace, pulledTables, req.GetCatalogDetail())
+	catalog, err := c.pullNamespaceCatalog(ctx, db, namespace, physical, pulledTables, req.GetCatalogDetail())
 	if err != nil {
 		return nil, err
 	}
@@ -785,13 +878,15 @@ type pulledCatalog struct {
 	tables    map[string]*ternv1.TableCatalog
 }
 
-func (c *LocalClient) pullNamespaceCatalog(ctx context.Context, db *sql.DB, namespace string, pulledTables map[string]string, catalogDetail ternv1.PullCatalogDetail) (*pulledCatalog, error) {
+func (c *LocalClient) pullNamespaceCatalog(ctx context.Context, db *sql.DB, namespace, physical string, pulledTables map[string]string, catalogDetail ternv1.PullCatalogDetail) (*pulledCatalog, error) {
 	// BASIC pulls only canonical DDL and artifacts (the pre-catalog pull shape):
 	// no namespace or table catalog. The full structured catalog is built only
 	// at DETAILED detail.
 	if catalogDetail != ternv1.PullCatalogDetail_PULL_CATALOG_DETAIL_DETAILED {
 		return &pulledCatalog{}, nil
 	}
+	// The catalog is named by the requested canonical namespace; the live rows
+	// are read from the physical schema (they differ under schema overrides).
 	catalog := &pulledCatalog{
 		namespace: &ternv1.NamespaceCatalog{
 			Name:       namespace,
@@ -803,19 +898,19 @@ func (c *LocalClient) pullNamespaceCatalog(ctx context.Context, db *sql.DB, name
 	if len(pulledTables) == 0 {
 		return catalog, nil
 	}
-	if err := c.loadTableCatalog(ctx, db, namespace, pulledTables, catalog.tables); err != nil {
+	if err := c.loadTableCatalog(ctx, db, physical, pulledTables, catalog.tables); err != nil {
 		return nil, err
 	}
-	if err := c.loadColumnCatalog(ctx, db, namespace, pulledTables, catalog.tables); err != nil {
+	if err := c.loadColumnCatalog(ctx, db, physical, pulledTables, catalog.tables); err != nil {
 		return nil, err
 	}
-	if err := c.loadIndexCatalog(ctx, db, namespace, pulledTables, catalog.tables); err != nil {
+	if err := c.loadIndexCatalog(ctx, db, physical, pulledTables, catalog.tables); err != nil {
 		return nil, err
 	}
-	if err := c.loadForeignKeyCatalog(ctx, db, namespace, pulledTables, catalog.tables); err != nil {
+	if err := c.loadForeignKeyCatalog(ctx, db, physical, pulledTables, catalog.tables); err != nil {
 		return nil, err
 	}
-	if err := c.loadTableEstimates(ctx, db, namespace, pulledTables, catalog.tables); err != nil {
+	if err := c.loadTableEstimates(ctx, db, physical, pulledTables, catalog.tables); err != nil {
 		return nil, err
 	}
 	return catalog, nil
@@ -1080,7 +1175,11 @@ func (c *LocalClient) credentialsForMySQLPullNamespace(namespace string) (*engin
 	if namespace == "" {
 		return nil, fmt.Errorf("MySQL namespace is required for a namespace-free target DSN")
 	}
-	dsn, err := mysqlDSNWithDatabase(c.config.TargetDSN, namespace)
+	physical, err := c.physicalMySQLNamespace(namespace)
+	if err != nil {
+		return nil, err
+	}
+	dsn, err := mysqlDSNWithDatabase(c.config.TargetDSN, physical)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -494,6 +494,28 @@ func mysqlDSNHasDatabase(dsn string) (bool, error) {
 	return database != "", nil
 }
 
+// singleTaskNamespace returns the single non-empty namespace shared by the
+// tasks, or "" when no task carries one (a DSN-with-database target). Tasks
+// that drive one Spirit execution must agree on the namespace — it selects the
+// connection schema, so with mixed namespaces the schema addressed would
+// silently depend on task order. Fail loudly instead.
+func singleTaskNamespace(tasks []*storage.Task) (string, error) {
+	namespace := ""
+	for _, task := range tasks {
+		if task == nil || task.Namespace == "" {
+			continue
+		}
+		if namespace == "" {
+			namespace = task.Namespace
+			continue
+		}
+		if task.Namespace != namespace {
+			return "", fmt.Errorf("tasks span multiple namespaces (%q, %q)", namespace, task.Namespace)
+		}
+	}
+	return namespace, nil
+}
+
 func mysqlDSNDatabase(dsn string) (string, error) {
 	cfg, err := mysql.ParseDSN(dsn)
 	if err != nil {
@@ -522,18 +544,9 @@ func (c *LocalClient) deferredCutoverSignalExists(ctx context.Context, apply *st
 	// applies enforce this at credential resolution). Guard that invariant
 	// here: with mixed namespaces the lookup would silently depend on task
 	// order, so fail loudly instead.
-	namespace := ""
-	for _, task := range tasks {
-		if task == nil || task.Namespace == "" {
-			continue
-		}
-		if namespace == "" {
-			namespace = task.Namespace
-			continue
-		}
-		if task.Namespace != namespace {
-			return false, true, fmt.Errorf("deferred cutover signal lookup for apply %s database %s: tasks span multiple namespaces (%q, %q)", apply.ApplyIdentifier, apply.Database, namespace, task.Namespace)
-		}
+	namespace, err := singleTaskNamespace(tasks)
+	if err != nil {
+		return false, true, fmt.Errorf("deferred cutover signal lookup for apply %s database %s: %w", apply.ApplyIdentifier, apply.Database, err)
 	}
 	creds, err := c.credentialsForMySQLNamespace(namespace)
 	if err != nil {

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -512,14 +512,27 @@ func (c *LocalClient) deferredCutoverSignalExists(ctx context.Context, apply *st
 		return false, false, nil
 	}
 	// Resolve credentials through the task namespace so the lookup addresses
-	// the schema the apply actually runs against: a namespace-free target DSN
-	// needs the namespace injected (and mapped, under schema overrides) or the
-	// signal query would silently run without a schema and miss the sentinel.
+	// the schema the apply actually runs against. The engine's sentinel query
+	// is schema-qualified (DSN database first, request database as fallback),
+	// so without injecting the mapped task namespace it would address the
+	// canonical database name and miss a sentinel that lives in a different
+	// physical schema.
+	//
+	// A deferred-cutover apply's tasks share exactly one namespace (grouped
+	// applies enforce this at credential resolution). Guard that invariant
+	// here: with mixed namespaces the lookup would silently depend on task
+	// order, so fail loudly instead.
 	namespace := ""
 	for _, task := range tasks {
-		if task != nil && task.Namespace != "" {
+		if task == nil || task.Namespace == "" {
+			continue
+		}
+		if namespace == "" {
 			namespace = task.Namespace
-			break
+			continue
+		}
+		if task.Namespace != namespace {
+			return false, true, fmt.Errorf("deferred cutover signal lookup for apply %s database %s: tasks span multiple namespaces (%q, %q)", apply.ApplyIdentifier, apply.Database, namespace, task.Namespace)
 		}
 	}
 	creds, err := c.credentialsForMySQLNamespace(namespace)
@@ -669,15 +682,11 @@ func (c *LocalClient) pullSchemaNamespace(ctx context.Context, req *ternv1.PullS
 	physical := namespace
 	targetDSN := c.config.TargetDSN
 	if c.config.Type == storage.DatabaseTypeMySQL {
-		var err error
-		physical, err = c.physicalMySQLNamespace(namespace)
+		creds, resolvedPhysical, err := c.credentialsForMySQLPullNamespace(namespace)
 		if err != nil {
-			return nil, fmt.Errorf("resolve database %s namespace %s physical schema for schema pull: %w", c.config.Database, namespace, err)
+			return nil, fmt.Errorf("resolve database %s namespace %s target for schema pull: %w", c.config.Database, namespace, err)
 		}
-		creds, err := c.credentialsForMySQLPullNamespace(namespace)
-		if err != nil {
-			return nil, fmt.Errorf("resolve database %s namespace %s credentials for schema pull: %w", c.config.Database, namespace, err)
-		}
+		physical = resolvedPhysical
 		targetDSN = creds.DSN
 	}
 
@@ -916,21 +925,21 @@ func (c *LocalClient) pullNamespaceCatalog(ctx context.Context, db *sql.DB, name
 	return catalog, nil
 }
 
-func (c *LocalClient) loadTableCatalog(ctx context.Context, db *sql.DB, namespace string, pulledTables map[string]string, catalog map[string]*ternv1.TableCatalog) error {
+func (c *LocalClient) loadTableCatalog(ctx context.Context, db *sql.DB, physicalSchema string, pulledTables map[string]string, catalog map[string]*ternv1.TableCatalog) error {
 	rows, err := db.QueryContext(ctx, `
 		SELECT table_name, table_type, table_comment
 		FROM information_schema.tables
 		WHERE table_schema = ?
-		ORDER BY table_name`, namespace)
+		ORDER BY table_name`, physicalSchema)
 	if err != nil {
-		return fmt.Errorf("load table catalog for database %s namespace %s: %w", c.config.Database, namespace, err)
+		return fmt.Errorf("load table catalog for database %s physical schema %s: %w", c.config.Database, physicalSchema, err)
 	}
 	defer utils.CloseAndLog(rows)
 
 	for rows.Next() {
 		var tableName, tableType, tableComment string
 		if err := rows.Scan(&tableName, &tableType, &tableComment); err != nil {
-			return fmt.Errorf("scan table catalog for database %s namespace %s: %w", c.config.Database, namespace, err)
+			return fmt.Errorf("scan table catalog for database %s physical schema %s: %w", c.config.Database, physicalSchema, err)
 		}
 		if _, ok := pulledTables[tableName]; ok {
 			catalog[tableName] = &ternv1.TableCatalog{
@@ -941,7 +950,7 @@ func (c *LocalClient) loadTableCatalog(ctx context.Context, db *sql.DB, namespac
 		}
 	}
 	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterate table catalog for database %s namespace %s: %w", c.config.Database, namespace, err)
+		return fmt.Errorf("iterate table catalog for database %s physical schema %s: %w", c.config.Database, physicalSchema, err)
 	}
 	return nil
 }
@@ -950,14 +959,14 @@ func (c *LocalClient) loadTableCatalog(ctx context.Context, db *sql.DB, namespac
 // estimates from information_schema.tables. These are approximations (NULL for
 // views, stale until statistics are refreshed) and are only loaded at DETAILED
 // catalog detail.
-func (c *LocalClient) loadTableEstimates(ctx context.Context, db *sql.DB, namespace string, pulledTables map[string]string, catalog map[string]*ternv1.TableCatalog) error {
+func (c *LocalClient) loadTableEstimates(ctx context.Context, db *sql.DB, physicalSchema string, pulledTables map[string]string, catalog map[string]*ternv1.TableCatalog) error {
 	rows, err := db.QueryContext(ctx, `
 		SELECT table_name, table_rows, data_length, index_length
 		FROM information_schema.tables
 		WHERE table_schema = ?
-		ORDER BY table_name`, namespace)
+		ORDER BY table_name`, physicalSchema)
 	if err != nil {
-		return fmt.Errorf("load table estimates for database %s namespace %s: %w", c.config.Database, namespace, err)
+		return fmt.Errorf("load table estimates for database %s physical schema %s: %w", c.config.Database, physicalSchema, err)
 	}
 	defer utils.CloseAndLog(rows)
 
@@ -965,7 +974,7 @@ func (c *LocalClient) loadTableEstimates(ctx context.Context, db *sql.DB, namesp
 		var tableName string
 		var tableRows, dataLength, indexLength sql.NullInt64
 		if err := rows.Scan(&tableName, &tableRows, &dataLength, &indexLength); err != nil {
-			return fmt.Errorf("scan table estimates for database %s namespace %s: %w", c.config.Database, namespace, err)
+			return fmt.Errorf("scan table estimates for database %s physical schema %s: %w", c.config.Database, physicalSchema, err)
 		}
 		if _, ok := pulledTables[tableName]; ok {
 			tableCatalog := ensurePulledTableCatalog(catalog, tableName)
@@ -974,19 +983,19 @@ func (c *LocalClient) loadTableEstimates(ctx context.Context, db *sql.DB, namesp
 		}
 	}
 	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterate table estimates for database %s namespace %s: %w", c.config.Database, namespace, err)
+		return fmt.Errorf("iterate table estimates for database %s physical schema %s: %w", c.config.Database, physicalSchema, err)
 	}
 	return nil
 }
 
-func (c *LocalClient) loadColumnCatalog(ctx context.Context, db *sql.DB, namespace string, pulledTables map[string]string, catalog map[string]*ternv1.TableCatalog) error {
+func (c *LocalClient) loadColumnCatalog(ctx context.Context, db *sql.DB, physicalSchema string, pulledTables map[string]string, catalog map[string]*ternv1.TableCatalog) error {
 	rows, err := db.QueryContext(ctx, `
 		SELECT table_name, column_name, column_type, is_nullable, column_default, column_comment, extra
 		FROM information_schema.columns
 		WHERE table_schema = ?
-		ORDER BY table_name, ordinal_position`, namespace)
+		ORDER BY table_name, ordinal_position`, physicalSchema)
 	if err != nil {
-		return fmt.Errorf("load column catalog for database %s namespace %s: %w", c.config.Database, namespace, err)
+		return fmt.Errorf("load column catalog for database %s physical schema %s: %w", c.config.Database, physicalSchema, err)
 	}
 	defer utils.CloseAndLog(rows)
 
@@ -994,7 +1003,7 @@ func (c *LocalClient) loadColumnCatalog(ctx context.Context, db *sql.DB, namespa
 		var tableName, columnName, columnType, nullable, comment, extra string
 		var defaultValue sql.NullString
 		if err := rows.Scan(&tableName, &columnName, &columnType, &nullable, &defaultValue, &comment, &extra); err != nil {
-			return fmt.Errorf("scan column catalog for database %s namespace %s: %w", c.config.Database, namespace, err)
+			return fmt.Errorf("scan column catalog for database %s physical schema %s: %w", c.config.Database, physicalSchema, err)
 		}
 		if _, ok := pulledTables[tableName]; ok {
 			tableCatalog := ensurePulledTableCatalog(catalog, tableName)
@@ -1018,19 +1027,19 @@ func (c *LocalClient) loadColumnCatalog(ctx context.Context, db *sql.DB, namespa
 		}
 	}
 	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterate column catalog for database %s namespace %s: %w", c.config.Database, namespace, err)
+		return fmt.Errorf("iterate column catalog for database %s physical schema %s: %w", c.config.Database, physicalSchema, err)
 	}
 	return nil
 }
 
-func (c *LocalClient) loadIndexCatalog(ctx context.Context, db *sql.DB, namespace string, pulledTables map[string]string, catalog map[string]*ternv1.TableCatalog) error {
+func (c *LocalClient) loadIndexCatalog(ctx context.Context, db *sql.DB, physicalSchema string, pulledTables map[string]string, catalog map[string]*ternv1.TableCatalog) error {
 	rows, err := db.QueryContext(ctx, `
 		SELECT table_name, index_name, non_unique, column_name, expression
 		FROM information_schema.statistics
 		WHERE table_schema = ?
-		ORDER BY table_name, index_name, seq_in_index`, namespace)
+		ORDER BY table_name, index_name, seq_in_index`, physicalSchema)
 	if err != nil {
-		return fmt.Errorf("load index catalog for database %s namespace %s: %w", c.config.Database, namespace, err)
+		return fmt.Errorf("load index catalog for database %s physical schema %s: %w", c.config.Database, physicalSchema, err)
 	}
 	defer utils.CloseAndLog(rows)
 
@@ -1040,7 +1049,7 @@ func (c *LocalClient) loadIndexCatalog(ctx context.Context, db *sql.DB, namespac
 		var columnName, expression sql.NullString
 		var nonUnique int32
 		if err := rows.Scan(&tableName, &indexName, &nonUnique, &columnName, &expression); err != nil {
-			return fmt.Errorf("scan index catalog for database %s namespace %s: %w", c.config.Database, namespace, err)
+			return fmt.Errorf("scan index catalog for database %s physical schema %s: %w", c.config.Database, physicalSchema, err)
 		}
 		if _, ok := pulledTables[tableName]; ok {
 			indexedValue := ""
@@ -1050,7 +1059,7 @@ func (c *LocalClient) loadIndexCatalog(ctx context.Context, db *sql.DB, namespac
 			case expression.Valid:
 				indexedValue = expression.String
 			default:
-				c.logger.Warn("LocalClient.PullSchema: skipping index part without column or expression", "database", c.config.Database, "namespace", namespace, "table", tableName, "index", indexName)
+				c.logger.Warn("LocalClient.PullSchema: skipping index part without column or expression", "database", c.config.Database, "physical_schema", physicalSchema, "table", tableName, "index", indexName)
 				continue
 			}
 			tableCatalog := ensurePulledTableCatalog(catalog, tableName)
@@ -1071,7 +1080,7 @@ func (c *LocalClient) loadIndexCatalog(ctx context.Context, db *sql.DB, namespac
 		}
 	}
 	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterate index catalog for database %s namespace %s: %w", c.config.Database, namespace, err)
+		return fmt.Errorf("iterate index catalog for database %s physical schema %s: %w", c.config.Database, physicalSchema, err)
 	}
 	return nil
 }
@@ -1081,7 +1090,7 @@ func (c *LocalClient) loadIndexCatalog(ctx context.Context, db *sql.DB, namespac
 // per-constraint ON UPDATE / ON DELETE rules). referential_constraints
 // contains only foreign-key constraints, so the join naturally restricts to
 // them; primary-key and unique constraints are already represented as indexes.
-func (c *LocalClient) loadForeignKeyCatalog(ctx context.Context, db *sql.DB, namespace string, pulledTables map[string]string, catalog map[string]*ternv1.TableCatalog) error {
+func (c *LocalClient) loadForeignKeyCatalog(ctx context.Context, db *sql.DB, physicalSchema string, pulledTables map[string]string, catalog map[string]*ternv1.TableCatalog) error {
 	rows, err := db.QueryContext(ctx, `
 		SELECT kcu.table_name, kcu.constraint_name, kcu.column_name,
 		       kcu.referenced_table_name, kcu.referenced_column_name,
@@ -1091,9 +1100,9 @@ func (c *LocalClient) loadForeignKeyCatalog(ctx context.Context, db *sql.DB, nam
 		  ON rc.constraint_schema = kcu.constraint_schema
 		 AND rc.constraint_name = kcu.constraint_name
 		WHERE kcu.table_schema = ?
-		ORDER BY kcu.table_name, kcu.constraint_name, kcu.ordinal_position`, namespace)
+		ORDER BY kcu.table_name, kcu.constraint_name, kcu.ordinal_position`, physicalSchema)
 	if err != nil {
-		return fmt.Errorf("load foreign key catalog for database %s namespace %s: %w", c.config.Database, namespace, err)
+		return fmt.Errorf("load foreign key catalog for database %s physical schema %s: %w", c.config.Database, physicalSchema, err)
 	}
 	defer utils.CloseAndLog(rows)
 
@@ -1102,7 +1111,7 @@ func (c *LocalClient) loadForeignKeyCatalog(ctx context.Context, db *sql.DB, nam
 		var tableName, constraintName string
 		var columnName, referencedTable, referencedColumn, updateRule, deleteRule sql.NullString
 		if err := rows.Scan(&tableName, &constraintName, &columnName, &referencedTable, &referencedColumn, &updateRule, &deleteRule); err != nil {
-			return fmt.Errorf("scan foreign key catalog for database %s namespace %s: %w", c.config.Database, namespace, err)
+			return fmt.Errorf("scan foreign key catalog for database %s physical schema %s: %w", c.config.Database, physicalSchema, err)
 		}
 		if _, ok := pulledTables[tableName]; !ok {
 			continue
@@ -1126,7 +1135,7 @@ func (c *LocalClient) loadForeignKeyCatalog(ctx context.Context, db *sql.DB, nam
 		fk.ReferencedColumns = append(fk.ReferencedColumns, referencedColumn.String)
 	}
 	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterate foreign key catalog for database %s namespace %s: %w", c.config.Database, namespace, err)
+		return fmt.Errorf("iterate foreign key catalog for database %s physical schema %s: %w", c.config.Database, physicalSchema, err)
 	}
 	return nil
 }
@@ -1158,35 +1167,38 @@ func (c *LocalClient) pullResponseDatabase(req *ternv1.PullSchemaRequest) string
 	return c.config.Database
 }
 
-func (c *LocalClient) credentialsForMySQLPullNamespace(namespace string) (*engine.Credentials, error) {
+// credentialsForMySQLPullNamespace resolves the connection credentials and the
+// physical schema a pull for the requested canonical namespace reads, so the
+// pull path resolves the schema-override mapping exactly once.
+func (c *LocalClient) credentialsForMySQLPullNamespace(namespace string) (*engine.Credentials, string, error) {
 	if c.config.Type != storage.DatabaseTypeMySQL {
-		return c.credentials(), nil
+		return c.credentials(), namespace, nil
 	}
 	database, err := mysqlDSNDatabase(c.config.TargetDSN)
 	if err != nil {
-		return nil, fmt.Errorf("inspect MySQL target DSN for namespace injection: %w", err)
+		return nil, "", fmt.Errorf("inspect MySQL target DSN for namespace injection: %w", err)
 	}
 	if database != "" {
 		if database != namespace {
-			return nil, fmt.Errorf("target DSN database %q does not match requested namespace %q", database, namespace)
+			return nil, "", fmt.Errorf("target DSN database %q does not match requested namespace %q", database, namespace)
 		}
-		return c.credentials(), nil
+		return c.credentials(), namespace, nil
 	}
 	if namespace == "" {
-		return nil, fmt.Errorf("MySQL namespace is required for a namespace-free target DSN")
+		return nil, "", fmt.Errorf("MySQL namespace is required for a namespace-free target DSN")
 	}
 	physical, err := c.physicalMySQLNamespace(namespace)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	dsn, err := mysqlDSNWithDatabase(c.config.TargetDSN, physical)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	return &engine.Credentials{
 		DSN:      dsn,
 		Metadata: c.config.Metadata,
-	}, nil
+	}, physical, nil
 }
 
 func pulledSchemaFileContent(database string, tableName string, tableDDL string) (string, error) {

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -803,6 +803,118 @@ func dsnWithoutDatabase(t *testing.T, dsn string) string {
 	return cfg.FormatDSN()
 }
 
+// Under per-target schema overrides a pull requested by the canonical
+// namespace reads the physical schema end to end: response keys, pulled DDL,
+// and catalog names stay canonical while the tables, columns, indexes, and
+// size estimates come from the physical schema's live rows. A decoy schema
+// under the canonical name proves a wrong-schema read (canonical instead of
+// physical) would be caught.
+func TestLocalClient_PullSchemaOverridesReadPhysicalSchema(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	container, dsn := setupMySQLContainer(t)
+	_ = container // container is managed by TestMain
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err, "open database")
+	defer utils.CloseAndLog(db)
+
+	const (
+		canonical = "pull_ovr_bikeshare"
+		physical  = "pull_ovr_bikeshare_region2_env1"
+	)
+
+	for _, stmt := range []string{
+		"CREATE DATABASE IF NOT EXISTS `" + physical + "`",
+		// Decoy schema under the canonical name: reading the canonical name
+		// instead of the physical schema would surface `decoy` and miss
+		// `riders`.
+		"CREATE DATABASE IF NOT EXISTS `" + canonical + "`",
+		"CREATE TABLE IF NOT EXISTS `" + physical + "`.`riders` (`id` bigint unsigned NOT NULL AUTO_INCREMENT, `email` varchar(255) NOT NULL COMMENT 'login email', PRIMARY KEY (`id`), UNIQUE KEY `idx_email` (`email`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='riders table'",
+		"CREATE TABLE IF NOT EXISTS `" + canonical + "`.`decoy` (`id` bigint unsigned NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+	} {
+		_, err = db.ExecContext(t.Context(), stmt)
+		require.NoError(t, err, "prepare schema override pull schema")
+	}
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(t.Context()), 30*time.Second)
+		defer cancel()
+		cleanupDB, cleanupErr := sql.Open("mysql", dsn)
+		require.NoError(t, cleanupErr, "open database for schema override pull cleanup")
+		defer utils.CloseAndLog(cleanupDB)
+		for _, stmt := range []string{
+			"DROP DATABASE IF EXISTS `" + physical + "`",
+			"DROP DATABASE IF EXISTS `" + canonical + "`",
+		} {
+			_, cleanupErr = cleanupDB.ExecContext(cleanupCtx, stmt)
+			assert.NoError(t, cleanupErr, "cleanup schema override pull schema")
+		}
+	})
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	client, err := NewLocalClient(LocalConfig{
+		Database:        "logicaldb",
+		Type:            storage.DatabaseTypeMySQL,
+		TargetDSN:       dsnWithoutDatabase(t, dsn),
+		SchemaOverrides: map[string]string{canonical: physical},
+	}, nil, logger)
+	require.NoError(t, err, "create client")
+	defer utils.CloseAndLog(client)
+
+	resp, err := client.PullSchema(t.Context(), &ternv1.PullSchemaRequest{
+		Database:      "logicaldb",
+		Type:          storage.DatabaseTypeMySQL,
+		Environment:   localClientTestEnvironment,
+		Namespace:     canonical,
+		CatalogDetail: ternv1.PullCatalogDetail_PULL_CATALOG_DETAIL_DETAILED,
+	})
+	require.NoError(t, err, "pull canonical namespace")
+	require.Len(t, resp.Namespaces, 1, "pull returns exactly the requested canonical namespace")
+	require.Contains(t, resp.Namespaces, canonical, "response is keyed by the canonical namespace")
+	assert.NotContains(t, resp.Namespaces, physical, "physical schema name must not leak into response keys")
+
+	pulled := resp.Namespaces[canonical]
+	require.Contains(t, pulled.Tables, "riders", "DDL comes from the physical schema")
+	assert.Contains(t, pulled.Tables["riders"], "CREATE TABLE `riders`")
+	assert.NotContains(t, pulled.Tables, "decoy", "the canonical-name decoy schema must not be read")
+
+	require.NotNil(t, pulled.NamespaceCatalog)
+	assert.Equal(t, canonical, pulled.NamespaceCatalog.Name, "catalog is named by the canonical namespace")
+	require.Contains(t, pulled.TableCatalog, "riders", "catalog rows come from the physical schema")
+	assert.NotContains(t, pulled.TableCatalog, "decoy")
+	riders := pulled.TableCatalog["riders"]
+	assert.Equal(t, "riders table", riders.Comment)
+	require.Len(t, riders.Columns, 2, "column catalog reads the physical schema")
+	assert.Equal(t, "id", riders.Columns[0].Name)
+	assert.Equal(t, "email", riders.Columns[1].Name)
+	assert.Equal(t, "login email", riders.Columns[1].Comment)
+	require.Len(t, riders.Indexes, 2, "index catalog reads the physical schema")
+	assert.Positive(t, riders.DataSizeBytes, "size estimates read the physical schema")
+
+	// A pull without an explicit namespace serves exactly the canonical
+	// override keys — it never scans the cluster or surfaces physical names.
+	allResp, err := client.PullSchema(t.Context(), &ternv1.PullSchemaRequest{
+		Database:    "logicaldb",
+		Type:        storage.DatabaseTypeMySQL,
+		Environment: localClientTestEnvironment,
+	})
+	require.NoError(t, err, "pull all namespaces")
+	require.Len(t, allResp.Namespaces, 1, "pull-all serves exactly the mapped canonical namespaces")
+	assert.Contains(t, allResp.Namespaces, canonical)
+
+	// The override map is a strict allowlist: requesting the physical name
+	// directly fails closed.
+	_, err = client.PullSchema(t.Context(), &ternv1.PullSchemaRequest{
+		Database:    "logicaldb",
+		Type:        storage.DatabaseTypeMySQL,
+		Environment: localClientTestEnvironment,
+		Namespace:   physical,
+	})
+	require.Error(t, err, "pulling the physical schema name directly is rejected")
+	assert.Contains(t, err.Error(), "does not authorize MySQL namespace")
+}
+
 func TestLocalClient_Plan(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -915,6 +915,107 @@ func TestLocalClient_PullSchemaOverridesReadPhysicalSchema(t *testing.T) {
 	assert.Contains(t, err.Error(), "does not authorize MySQL namespace")
 }
 
+// A plan and apply for a canonical namespace with a schema override must run
+// entirely against the physical schema: the plan diffs the physical schema's
+// current state, and the apply lands the change there — never in a schema that
+// happens to carry the canonical name.
+func TestLocalClient_ApplySchemaOverridesTargetPhysicalSchema(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	container, dsn := setupMySQLContainer(t)
+	_ = container              // container is managed by TestMain
+	setupStorageSchema(t, dsn) // need storage tables
+
+	ctx := t.Context()
+
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err, "open database")
+	defer utils.CloseAndLog(db)
+
+	const (
+		canonical = "apply_ovr_bikeshare"
+		physical  = "apply_ovr_bikeshare_region2_env1"
+	)
+
+	for _, stmt := range []string{
+		"CREATE DATABASE IF NOT EXISTS `" + physical + "`",
+		// Decoy schema under the canonical name: an apply that addresses the
+		// canonical name instead of the physical schema would land here.
+		"CREATE DATABASE IF NOT EXISTS `" + canonical + "`",
+		"CREATE TABLE IF NOT EXISTS `" + physical + "`.`riders` (`id` bigint unsigned NOT NULL AUTO_INCREMENT, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+		"CREATE TABLE IF NOT EXISTS `" + canonical + "`.`riders` (`id` bigint unsigned NOT NULL AUTO_INCREMENT, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+	} {
+		_, err = db.ExecContext(ctx, stmt)
+		require.NoError(t, err, "prepare schema override apply schema")
+	}
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(t.Context()), 30*time.Second)
+		defer cancel()
+		cleanupDB, cleanupErr := sql.Open("mysql", dsn)
+		require.NoError(t, cleanupErr, "open database for schema override apply cleanup")
+		defer utils.CloseAndLog(cleanupDB)
+		for _, stmt := range []string{
+			"DROP DATABASE IF EXISTS `" + physical + "`",
+			"DROP DATABASE IF EXISTS `" + canonical + "`",
+		} {
+			_, cleanupErr = cleanupDB.ExecContext(cleanupCtx, stmt)
+			assert.NoError(t, cleanupErr, "cleanup schema override apply schema")
+		}
+	})
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	stor := createStorage(t, dsn)
+
+	client, err := NewLocalClient(LocalConfig{
+		Database:        "logicaldb",
+		Type:            storage.DatabaseTypeMySQL,
+		TargetDSN:       dsnWithoutDatabase(t, dsn),
+		SchemaOverrides: map[string]string{canonical: physical},
+	}, stor, logger)
+	require.NoError(t, err, "create client")
+	defer utils.CloseAndLog(client)
+	startTestOperator(t, stor, client)
+
+	// The plan diffs the physical schema, so the desired schema only needs the
+	// physical schema's tables — the decoy's identical table must not shadow it.
+	planResp, err := client.Plan(ctx, &ternv1.PlanRequest{
+		Type:     storage.DatabaseTypeMySQL,
+		Database: "logicaldb",
+		SchemaFiles: map[string]*ternv1.SchemaFiles{
+			canonical: {
+				Files: map[string]string{
+					"riders.sql": "CREATE TABLE riders (id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT, email VARCHAR(255), PRIMARY KEY (id))",
+				},
+			},
+		},
+	})
+	require.NoError(t, err, "Plan() returned error")
+	require.NotEmpty(t, planResp.PlanId, "expected plan_id")
+
+	applyResp, err := client.Apply(ctx, &ternv1.ApplyRequest{
+		PlanId:      planResp.PlanId,
+		Environment: localClientTestEnvironment,
+	})
+	require.NoError(t, err, "Apply() returned error")
+	require.True(t, applyResp.Accepted, "expected apply to be accepted, got error: %s", applyResp.ErrorMessage)
+
+	waitForApplyComplete(t, client, ctx, applyResp.ApplyId)
+
+	// The change landed in the physical schema.
+	var physicalCount int
+	err = db.QueryRowContext(ctx, "SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = ? AND TABLE_NAME = 'riders' AND COLUMN_NAME = 'email'", physical).Scan(&physicalCount)
+	require.NoError(t, err, "query physical schema columns")
+	assert.Equal(t, 1, physicalCount, "apply must add the column in the physical schema")
+
+	// The canonical-name decoy schema is untouched.
+	var canonicalCount int
+	err = db.QueryRowContext(ctx, "SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = ? AND TABLE_NAME = 'riders' AND COLUMN_NAME = 'email'", canonical).Scan(&canonicalCount)
+	require.NoError(t, err, "query canonical schema columns")
+	assert.Zero(t, canonicalCount, "apply must not touch the canonical-name decoy schema")
+}
+
 func TestLocalClient_Plan(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -3146,6 +3146,171 @@ func TestLocalClient_CredentialsNamespaceResolution(t *testing.T) {
 	})
 }
 
+// recordingSignalChecker records the deferred cutover signal request so tests
+// can assert the request database stays canonical while the credentials DSN
+// carries the physical schema.
+type recordingSignalChecker struct {
+	engine.Engine
+	req *engine.DeferredCutoverSignalRequest
+}
+
+func (e *recordingSignalChecker) DeferredCutoverSignalExists(_ context.Context, req *engine.DeferredCutoverSignalRequest) (bool, error) {
+	e.req = req
+	return true, nil
+}
+
+// Per-deployment schema overrides map a requested (canonical) MySQL namespace
+// to the physical schema name at the data-plane seam: the canonical name stays
+// in requests, plans, tasks, and pull responses; the physical name only enters
+// the connection schema. A non-empty map is a strict allowlist and requires a
+// namespace-free target DSN.
+func TestLocalClient_SchemaOverrides(t *testing.T) {
+	overrides := map[string]string{"bikeshare": "bikeshare_eu_qa"}
+	newClient := func() *LocalClient {
+		return &LocalClient{config: LocalConfig{
+			Type:            storage.DatabaseTypeMySQL,
+			TargetDSN:       "root@tcp(localhost:3306)/",
+			SchemaOverrides: overrides,
+		}, logger: slog.Default()}
+	}
+
+	t.Run("credentials inject the mapped physical schema", func(t *testing.T) {
+		creds, err := newClient().credentialsForMySQLNamespace("bikeshare")
+		require.NoError(t, err)
+		assert.Equal(t, "root@tcp(localhost:3306)/bikeshare_eu_qa", creds.DSN)
+	})
+
+	t.Run("unmapped canonical namespace fails closed", func(t *testing.T) {
+		_, err := newClient().credentialsForMySQLNamespace("orders")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not authorize MySQL namespace")
+	})
+
+	t.Run("pull credentials inject the mapped physical schema", func(t *testing.T) {
+		creds, err := newClient().credentialsForMySQLPullNamespace("bikeshare")
+		require.NoError(t, err)
+		assert.Equal(t, "root@tcp(localhost:3306)/bikeshare_eu_qa", creds.DSN)
+	})
+
+	t.Run("task credentials map the persisted canonical namespace", func(t *testing.T) {
+		creds, err := newClient().credentialsForTask(&storage.Task{Namespace: "bikeshare"})
+		require.NoError(t, err)
+		assert.Equal(t, "root@tcp(localhost:3306)/bikeshare_eu_qa", creds.DSN)
+	})
+
+	t.Run("grouped apply credentials map the plan namespace", func(t *testing.T) {
+		creds, err := newClient().credentialsForGroupedApply(&storage.Plan{
+			Namespaces: map[string]*storage.NamespacePlanData{"bikeshare": {}},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "root@tcp(localhost:3306)/bikeshare_eu_qa", creds.DSN)
+	})
+
+	t.Run("namespace discovery returns canonical keys, not physical names", func(t *testing.T) {
+		namespaces, err := newClient().discoverPullNamespaces(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, []string{"bikeshare"}, namespaces)
+	})
+
+	t.Run("no overrides preserves identity mapping", func(t *testing.T) {
+		c := &LocalClient{config: LocalConfig{
+			Type:      storage.DatabaseTypeMySQL,
+			TargetDSN: "root@tcp(localhost:3306)/",
+		}, logger: slog.Default()}
+
+		creds, err := c.credentialsForMySQLNamespace("bikeshare")
+		require.NoError(t, err)
+		assert.Equal(t, "root@tcp(localhost:3306)/bikeshare", creds.DSN)
+	})
+
+	t.Run("deferred cutover signal lookup sends physical DSN with canonical database", func(t *testing.T) {
+		checker := &recordingSignalChecker{}
+		c := &LocalClient{
+			config: LocalConfig{
+				Type:            storage.DatabaseTypeMySQL,
+				TargetDSN:       "root@tcp(localhost:3306)/",
+				SchemaOverrides: overrides,
+			},
+			spiritEngine: checker,
+			logger:       slog.Default(),
+		}
+
+		exists, supported, err := c.deferredCutoverSignalExists(t.Context(),
+			&storage.Apply{ApplyIdentifier: "apply-1", Database: "bikeshare"},
+			[]*storage.Task{{Namespace: "bikeshare"}},
+		)
+		require.NoError(t, err)
+		assert.True(t, supported)
+		assert.True(t, exists)
+		require.NotNil(t, checker.req)
+		assert.Equal(t, "bikeshare", checker.req.Database)
+		assert.Equal(t, "root@tcp(localhost:3306)/bikeshare_eu_qa", checker.req.Credentials.DSN)
+	})
+
+	t.Run("NewLocalClient rejects overrides for non-MySQL targets", func(t *testing.T) {
+		_, err := NewLocalClient(LocalConfig{
+			Database:        "bikeshare",
+			Type:            storage.DatabaseTypeVitess,
+			SchemaOverrides: overrides,
+		}, nil, slog.Default())
+		require.ErrorContains(t, err, "only supported for mysql")
+	})
+
+	t.Run("NewLocalClient rejects more than one mapping", func(t *testing.T) {
+		_, err := NewLocalClient(LocalConfig{
+			Database:  "bikeshare",
+			Type:      storage.DatabaseTypeMySQL,
+			TargetDSN: "root@tcp(localhost:3306)/",
+			SchemaOverrides: map[string]string{
+				"bikeshare": "bikeshare_eu_qa",
+				"orders":    "orders_eu_qa",
+			},
+		}, nil, slog.Default())
+		require.ErrorContains(t, err, "exactly one mapping")
+	})
+
+	t.Run("NewLocalClient rejects an empty physical schema name", func(t *testing.T) {
+		_, err := NewLocalClient(LocalConfig{
+			Database:        "bikeshare",
+			Type:            storage.DatabaseTypeMySQL,
+			TargetDSN:       "root@tcp(localhost:3306)/",
+			SchemaOverrides: map[string]string{"bikeshare": ""},
+		}, nil, slog.Default())
+		require.ErrorContains(t, err, "must not be empty")
+	})
+
+	t.Run("NewLocalClient rejects an unsafe physical schema name", func(t *testing.T) {
+		_, err := NewLocalClient(LocalConfig{
+			Database:        "bikeshare",
+			Type:            storage.DatabaseTypeMySQL,
+			TargetDSN:       "root@tcp(localhost:3306)/",
+			SchemaOverrides: map[string]string{"bikeshare": "bikeshare-eu-qa"},
+		}, nil, slog.Default())
+		require.ErrorContains(t, err, "unsupported character")
+	})
+
+	t.Run("NewLocalClient rejects overrides with a database-bearing DSN", func(t *testing.T) {
+		_, err := NewLocalClient(LocalConfig{
+			Database:        "bikeshare",
+			Type:            storage.DatabaseTypeMySQL,
+			TargetDSN:       "root@tcp(localhost:3306)/bikeshare_eu_qa",
+			SchemaOverrides: overrides,
+		}, nil, slog.Default())
+		require.ErrorContains(t, err, "namespace-free")
+	})
+
+	t.Run("NewLocalClient accepts overrides with a namespace-free DSN", func(t *testing.T) {
+		client, err := NewLocalClient(LocalConfig{
+			Database:        "bikeshare",
+			Type:            storage.DatabaseTypeMySQL,
+			TargetDSN:       "root@tcp(localhost:3306)/",
+			SchemaOverrides: overrides,
+		}, nil, slog.Default())
+		require.NoError(t, err)
+		require.NotNil(t, client)
+	})
+}
+
 func TestLocalClient_PlanNamespaceUsesConfiguredDatabase(t *testing.T) {
 	client := &LocalClient{config: LocalConfig{
 		Database: "testdb",

--- a/pkg/tern/local_client_test.go
+++ b/pkg/tern/local_client_test.go
@@ -3060,11 +3060,12 @@ func TestLocalClient_CredentialsNamespaceResolution(t *testing.T) {
 			TargetDSN: "root@tcp(localhost:3306)/orders_schema",
 		}, logger: slog.Default()}
 
-		creds, err := c.credentialsForMySQLPullNamespace("orders_schema")
+		creds, physical, err := c.credentialsForMySQLPullNamespace("orders_schema")
 		require.NoError(t, err)
 		assert.Equal(t, "root@tcp(localhost:3306)/orders_schema", creds.DSN)
+		assert.Equal(t, "orders_schema", physical)
 
-		_, err = c.credentialsForMySQLPullNamespace("audit_schema")
+		_, _, err = c.credentialsForMySQLPullNamespace("audit_schema")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "does not match requested namespace")
 	})
@@ -3075,9 +3076,10 @@ func TestLocalClient_CredentialsNamespaceResolution(t *testing.T) {
 			TargetDSN: "root@tcp(localhost:3306)/",
 		}, logger: slog.Default()}
 
-		creds, err := c.credentialsForMySQLPullNamespace("orders_schema")
+		creds, physical, err := c.credentialsForMySQLPullNamespace("orders_schema")
 		require.NoError(t, err)
 		assert.Equal(t, "root@tcp(localhost:3306)/orders_schema", creds.DSN)
+		assert.Equal(t, "orders_schema", physical)
 	})
 
 	t.Run("namespace-free DSN without a namespace is an error", func(t *testing.T) {
@@ -3187,9 +3189,10 @@ func TestLocalClient_SchemaOverrides(t *testing.T) {
 	})
 
 	t.Run("pull credentials inject the mapped physical schema", func(t *testing.T) {
-		creds, err := newClient().credentialsForMySQLPullNamespace("bikeshare")
+		creds, physical, err := newClient().credentialsForMySQLPullNamespace("bikeshare")
 		require.NoError(t, err)
 		assert.Equal(t, "root@tcp(localhost:3306)/bikeshare_eu_qa", creds.DSN)
+		assert.Equal(t, "bikeshare_eu_qa", physical)
 	})
 
 	t.Run("task credentials map the persisted canonical namespace", func(t *testing.T) {

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -182,6 +182,16 @@ func (c *LocalClient) startDeferredDeploy(ctx context.Context, apply *storage.Ap
 	if eng == nil {
 		return nil, fmt.Errorf("no engine configured for type: %s", c.config.Type)
 	}
+	// The deferred deploy resolves credentials from applyTasks[0] and drives
+	// every task with them, so all tasks must share one namespace: for MySQL it
+	// selects the connection schema (per-target overrides can remap it to a
+	// different physical schema), so with mixed namespaces every task would
+	// silently run against tasks[0]'s schema.
+	if c.config.Type == storage.DatabaseTypeMySQL {
+		if _, err := singleTaskNamespace(applyTasks); err != nil {
+			return nil, fmt.Errorf("deferred deploy for apply %s: %w", apply.ApplyIdentifier, err)
+		}
+	}
 	creds, err := c.credentialsForTask(applyTasks[0])
 	if err != nil {
 		return nil, fmt.Errorf("resolve credentials for deferred deploy task %s: %w", applyTasks[0].TaskIdentifier, err)

--- a/pkg/tern/local_control_resume.go
+++ b/pkg/tern/local_control_resume.go
@@ -1499,7 +1499,7 @@ func (c *LocalClient) resumeApplyWithTasks(ctx context.Context, apply *storage.A
 
 	deferredCutoverSignalAbsent := false
 	if shouldInspectCutoverSignalForResume(apply, forceCutoverResume) {
-		signalExists, signalSupported, err := c.deferredCutoverSignalExists(ctx, apply)
+		signalExists, signalSupported, err := c.deferredCutoverSignalExists(ctx, apply, tasks)
 		if err != nil {
 			c.logger.Warn("deferred cutover recovery could not verify engine cutover signal; operator will retry",
 				"apply_id", apply.ApplyIdentifier,

--- a/pkg/tern/target_router.go
+++ b/pkg/tern/target_router.go
@@ -522,10 +522,11 @@ func (r *TargetRouter) clientForTarget(ctx context.Context, target, databaseType
 	}
 
 	client, err := r.factory(LocalConfig{
-		Database:  namespace,
-		Type:      resolved.DatabaseType,
-		TargetDSN: resolved.DSN,
-		Metadata:  maps.Clone(resolved.Metadata),
+		Database:        namespace,
+		Type:            resolved.DatabaseType,
+		TargetDSN:       resolved.DSN,
+		Metadata:        maps.Clone(resolved.Metadata),
+		SchemaOverrides: maps.Clone(resolved.SchemaOverrides),
 	}, r.storage, r.logger)
 	if err != nil {
 		return nil, nil, fmt.Errorf("create local client for target %q database %q: %w", target, namespace, err)

--- a/pkg/tern/target_router_test.go
+++ b/pkg/tern/target_router_test.go
@@ -84,6 +84,7 @@ type targetRouterRecordingClient struct {
 	resumeApply        *storage.Apply
 	targetDSN          string
 	targetMetadata     map[string]string
+	schemaOverrides    map[string]string
 	pendingObserverSet bool
 	observerApplyID    int64
 	closed             bool
@@ -589,6 +590,33 @@ func TestTargetRouterCloseClosesCachedClients(t *testing.T) {
 	assert.True(t, created["orders"].closed)
 }
 
+// A resolved target's schema overrides must reach the LocalClient config so
+// the data-plane seam can map the canonical namespace to the physical schema.
+func TestTargetRouterPropagatesSchemaOverridesToLocalConfig(t *testing.T) {
+	resolver, err := inventory.NewStaticResolver(inventory.StaticConfig{Targets: map[string]inventory.StaticTarget{
+		"eu-bikeshare-qa": {
+			DatabaseType:    storage.DatabaseTypeMySQL,
+			DSN:             "root@tcp(localhost:3306)/",
+			SchemaOverrides: map[string]string{"bikeshare": "bikeshare_eu_qa"},
+		},
+	}})
+	require.NoError(t, err)
+	created := make(map[string]*targetRouterRecordingClient)
+	router := newTargetRouterForTest(t, resolver, nil, nil, created)
+
+	_, err = router.Plan(t.Context(), &ternv1.PlanRequest{
+		Database:    "bikeshare",
+		Type:        storage.DatabaseTypeMySQL,
+		Environment: "development",
+		Target:      "eu-bikeshare-qa",
+	})
+
+	require.NoError(t, err)
+	client := created["bikeshare"]
+	require.NotNil(t, client)
+	assert.Equal(t, map[string]string{"bikeshare": "bikeshare_eu_qa"}, client.schemaOverrides)
+}
+
 func newStaticResolver(t *testing.T) *inventory.StaticResolver {
 	t.Helper()
 	resolver, err := inventory.NewStaticResolver(inventory.StaticConfig{Targets: map[string]inventory.StaticTarget{
@@ -612,7 +640,7 @@ func newTargetRouterForTest(t *testing.T, resolver inventory.Resolver, applyStor
 		Storage:  targetRouterStorage{applies: applyStore, plans: planStore},
 		Logger:   slog.Default(),
 		LocalClientFactory: func(cfg LocalConfig, _ storage.Storage, _ *slog.Logger) (Client, error) {
-			client := &targetRouterRecordingClient{targetDSN: cfg.TargetDSN, targetMetadata: cfg.Metadata}
+			client := &targetRouterRecordingClient{targetDSN: cfg.TargetDSN, targetMetadata: cfg.Metadata, schemaOverrides: cfg.SchemaOverrides}
 			key := cfg.Database
 			if existing := created[key]; existing != nil {
 				key = fmt.Sprintf("%s#%d", cfg.Database, len(created)+1)


### PR DESCRIPTION
## Summary

One canonical schema directory can now serve deployments whose physical MySQL schema names embed region/environment (e.g. `bikeshare` → `bikeshare_region2_env1`). A `schema_overrides` map on the static inventory target translates the canonical namespace to the physical schema at the data-plane seam only; everything SchemaBot stores or shows stays canonical.

Closes #782

## What

- `schema_overrides` (canonical → physical) on static inventory targets, propagated through the target router into `LocalConfig`.
- The mapping is consulted wherever a namespace becomes a connection schema: DSN injection, `information_schema` predicates, pull/catalog queries, task/grouped-apply credentials, deferred-cutover sentinel lookup.
- Strict allowlist: with a non-empty map, an unmapped namespace fails closed. MySQL-only, one mapping per target initially, namespace-free target DSN required. Validation is centralized in exported `inventory.ValidateSchemaOverrides` and enforced again in `NewLocalClient` so custom resolvers can't bypass it.
- Spirit stateless cutover/sentinel controls now prefer the DSN's database (the physical schema) over the request's logical database, via a shared `statelessControlDatabase` helper.
- Docs: new "Per-Target Schema Overrides" section in `docs/namespaces.md`.

## Why

Region-infixed physical schema names previously forced one duplicated schema directory per deployment — hand-synced copies of every table file. `$ENV` substitution only handles per-environment variance, not per-deployment variance within one environment. Mapping at the data plane (rather than re-keying `SchemaFiles` at dispatch) keeps physical names out of stored plans/tasks and preserves cross-deployment plan equivalence.

## Before / after

### Before (identity):
```text
  request "bikeshare"
        |
        v
  plan / task / drift: "bikeshare"
        |
        v
  DSN schema / information_schema: bikeshare
```

### After (with schema_overrides):
```text
  request "bikeshare"
        |
        v
  plan / task / drift: "bikeshare"                        <- unchanged, canonical
        |
        v
  schema_overrides: bikeshare -> bikeshare_region2_env1   (strict allowlist)
        |
        v
  DSN schema / information_schema: bikeshare_region2_env1
```
