### PR TITLE
refactor(webhook): extract error-returning aggregate fold core

### DIFF
--- a/pkg/webhook/aggregate_fold_core_test.go
+++ b/pkg/webhook/aggregate_fold_core_test.go
@@ -59,7 +59,11 @@ func (s *foldStorage) Checks() storage.CheckStore {
 func newFoldHandler(t *testing.T, cfg *api.ServerConfig, checks storage.CheckStore) (*Handler, *http.ServeMux, *ghclient.InstallationClient) {
 	t.Helper()
 	client, mux := setupGitHubServer(t)
-	installClient := ghclient.NewInstallationClient(client, testLogger())
+	// Resolve the App slug so a participant Check Run read that finds no run
+	// classifies as a clean "not reported" (retriable, no error) rather than an
+	// ownership-unverifiable read error — letting a test exercise the genuine
+	// pending-convergence path distinctly from a participant read failure.
+	installClient := ghclient.NewInstallationClientWithSlug(client, testLogger(), "schemabot")
 	h := &Handler{
 		service:   api.New(&foldStorage{checks: checks}, cfg, nil, testLogger()),
 		ghClients: ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: installClient}),
@@ -77,6 +81,32 @@ func serveHeadSHA(t *testing.T, mux *http.ServeMux, sha string) {
 			"head": map[string]any{"sha": sha, "ref": "feature-branch"},
 			"base": map[string]any{"sha": "def456", "ref": "main"},
 			"user": map[string]any{"login": "testuser"},
+		}))
+	})
+}
+
+// serveLeaderPRFiles registers the changed-files lookup the aggregate leader
+// performs to resolve which participants a PR requires, reporting the given path
+// as modified so the participant covering it becomes expected.
+func serveLeaderPRFiles(t *testing.T, mux *http.ServeMux, path string) {
+	t.Helper()
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode([]map[string]string{{
+			"filename": path,
+			"status":   "modified",
+		}}))
+	})
+}
+
+// serveParticipantCheckRunsEmpty registers the commit check-runs lookup
+// FindCheckRunByName performs, reporting no runs on the commit so an expected
+// participant reads as not-yet-reported (a retriable, still-pending outcome).
+func serveParticipantCheckRunsEmpty(t *testing.T, mux *http.ServeMux, sha string) {
+	t.Helper()
+	mux.HandleFunc("GET /repos/octocat/hello-world/commits/"+sha+"/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"total_count": 0,
+			"check_runs":  []any{},
 		}))
 	})
 }
@@ -173,6 +203,40 @@ func TestUpdateAggregateCheckOnceFollowUpContract(t *testing.T) {
 
 		assert.Equal(t, aggregateFoldScheduleParticipantRefold, followUp)
 		assert.Error(t, err)
+	})
+
+	t.Run("participant that has not reported schedules a participant re-fold with no error", func(t *testing.T) {
+		h, mux, client := newFoldHandler(t, aggregateLeaderConfig(), &foldCheckStore{})
+		serveHeadSHA(t, mux, "abc123")
+		serveLeaderPRFiles(t, mux, "tenant-b/schema/orders.sql")
+		serveParticipantCheckRunsEmpty(t, mux, "abc123")
+		serveCheckRunCreate(t, mux)
+
+		followUp, err := h.updateAggregateCheckOnce(t.Context(), client, "octocat/hello-world", 1, "abc123")
+
+		assert.Equal(t, aggregateFoldScheduleParticipantRefold, followUp)
+		assert.NoError(t, err)
+	})
+
+	t.Run("participant check read failure schedules a participant re-fold with no error", func(t *testing.T) {
+		// A failed participant Check Run read is deliberately conveyed only
+		// through the retriable disposition, not the error return: participant
+		// convergence is owned by the re-fold budget, so folding the read error
+		// in would make a retry-owning caller and the re-fold timer double-retry
+		// the same condition. The fold reports the aggregate as
+		// published-but-unconverged with a nil error.
+		h, mux, client := newFoldHandler(t, aggregateLeaderConfig(), &foldCheckStore{})
+		serveHeadSHA(t, mux, "abc123")
+		serveLeaderPRFiles(t, mux, "tenant-b/schema/orders.sql")
+		mux.HandleFunc("GET /repos/octocat/hello-world/commits/abc123/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "boom", http.StatusInternalServerError)
+		})
+		serveCheckRunCreate(t, mux)
+
+		followUp, err := h.updateAggregateCheckOnce(t.Context(), client, "octocat/hello-world", 1, "abc123")
+
+		assert.Equal(t, aggregateFoldScheduleParticipantRefold, followUp)
+		assert.NoError(t, err)
 	})
 
 	t.Run("successful fold clears the participant re-fold budget with no error", func(t *testing.T) {

--- a/pkg/webhook/aggregate_fold_core_test.go
+++ b/pkg/webhook/aggregate_fold_core_test.go
@@ -1,0 +1,217 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/api"
+	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// foldCheckStore is a configurable CheckStore for exercising the follow-up /
+// error contract of updateAggregateCheckOnce in isolation. Each hook controls
+// exactly one branch the fold core takes, and upsertCalls records how many
+// per-environment writes were attempted so a test can prove later environments
+// are still attempted after an earlier write fails.
+type foldCheckStore struct {
+	storage.CheckStore
+	byPR        []*storage.Check
+	byPRErr     error
+	get         *storage.Check
+	getErr      error
+	upsertErr   error
+	upsertCalls int
+}
+
+func (s *foldCheckStore) GetByPR(_ context.Context, _ string, _ int) ([]*storage.Check, error) {
+	return s.byPR, s.byPRErr
+}
+
+func (s *foldCheckStore) Get(_ context.Context, _ string, _ int, _, _, _ string) (*storage.Check, error) {
+	return s.get, s.getErr
+}
+
+func (s *foldCheckStore) Upsert(_ context.Context, _ *storage.Check) error {
+	s.upsertCalls++
+	return s.upsertErr
+}
+
+// foldStorage wires a foldCheckStore into the empty storage used elsewhere in
+// the package so only the check store's behavior varies per test.
+type foldStorage struct {
+	emptyStorage
+	checks storage.CheckStore
+}
+
+func (s *foldStorage) Checks() storage.CheckStore {
+	return s.checks
+}
+
+// newFoldHandler builds a handler backed by the given config and check store
+// and a fake GitHub server, returning the handler, the GitHub mux for route
+// registration, and the installation client to pass to updateAggregateCheckOnce.
+func newFoldHandler(t *testing.T, cfg *api.ServerConfig, checks storage.CheckStore) (*Handler, *http.ServeMux, *ghclient.InstallationClient) {
+	t.Helper()
+	client, mux := setupGitHubServer(t)
+	installClient := ghclient.NewInstallationClient(client, testLogger())
+	h := &Handler{
+		service:   api.New(&foldStorage{checks: checks}, cfg, nil, testLogger()),
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{client: installClient}),
+		logger:    testLogger(),
+	}
+	return h, mux, installClient
+}
+
+// serveHeadSHA registers the PR lookup FetchPullRequest performs, reporting the
+// given commit as the PR's current head.
+func serveHeadSHA(t *testing.T, mux *http.ServeMux, sha string) {
+	t.Helper()
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"head": map[string]any{"sha": sha, "ref": "feature-branch"},
+			"base": map[string]any{"sha": "def456", "ref": "main"},
+			"user": map[string]any{"login": "testuser"},
+		}))
+	})
+}
+
+// serveCheckRunCreate registers the check-run create endpoint so the fold's
+// upsert reaches the storage write.
+func serveCheckRunCreate(t *testing.T, mux *http.ServeMux) {
+	t.Helper()
+	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 555}))
+	})
+}
+
+// TestUpdateAggregateCheckOnceFollowUpContract pins the follow-up disposition
+// and error semantics of the one-shot fold core so the durable dispatch path
+// (which acts on both) can rely on them. The legacy fire-and-forget wrapper
+// discards the error but applies the same follow-up, so these mappings also
+// characterize its unchanged behavior.
+func TestUpdateAggregateCheckOnceFollowUpContract(t *testing.T) {
+	t.Run("checks disabled yields no follow-up and no error", func(t *testing.T) {
+		checksOff := false
+		cfg := &api.ServerConfig{Repos: map[string]api.RepoConfig{
+			"octocat/hello-world": {EnableChecks: &checksOff},
+		}}
+		h, _, client := newFoldHandler(t, cfg, &foldCheckStore{})
+
+		followUp, err := h.updateAggregateCheckOnce(t.Context(), client, "octocat/hello-world", 1, "abc123")
+
+		assert.Equal(t, aggregateFoldNoFollowUp, followUp)
+		assert.NoError(t, err)
+	})
+
+	t.Run("empty head SHA schedules a leader re-fold and returns an error", func(t *testing.T) {
+		h, _, client := newFoldHandler(t, nonAggregateConfig(), &foldCheckStore{})
+
+		followUp, err := h.updateAggregateCheckOnce(t.Context(), client, "octocat/hello-world", 1, "")
+
+		assert.Equal(t, aggregateFoldScheduleLeaderRefold, followUp)
+		assert.Error(t, err)
+	})
+
+	t.Run("superseded head schedules a leader re-fold with no error", func(t *testing.T) {
+		h, mux, client := newFoldHandler(t, nonAggregateConfig(), &foldCheckStore{})
+		serveHeadSHA(t, mux, "current999")
+
+		followUp, err := h.updateAggregateCheckOnce(t.Context(), client, "octocat/hello-world", 1, "stale111")
+
+		assert.Equal(t, aggregateFoldScheduleLeaderRefold, followUp)
+		assert.NoError(t, err, "a genuinely newer head is not an operational failure")
+	})
+
+	t.Run("PR fetch failure schedules a leader re-fold and returns an error", func(t *testing.T) {
+		h, mux, client := newFoldHandler(t, nonAggregateConfig(), &foldCheckStore{})
+		mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "boom", http.StatusInternalServerError)
+		})
+
+		followUp, err := h.updateAggregateCheckOnce(t.Context(), client, "octocat/hello-world", 1, "abc123")
+
+		assert.Equal(t, aggregateFoldScheduleLeaderRefold, followUp)
+		assert.Error(t, err)
+	})
+
+	t.Run("GetByPR failure schedules a leader re-fold and returns an error", func(t *testing.T) {
+		store := &foldCheckStore{byPRErr: assert.AnError}
+		h, mux, client := newFoldHandler(t, nonAggregateConfig(), store)
+		serveHeadSHA(t, mux, "abc123")
+
+		followUp, err := h.updateAggregateCheckOnce(t.Context(), client, "octocat/hello-world", 1, "abc123")
+
+		assert.Equal(t, aggregateFoldScheduleLeaderRefold, followUp)
+		assert.Error(t, err)
+	})
+
+	t.Run("no checks and no participants yields no follow-up and no error", func(t *testing.T) {
+		h, mux, client := newFoldHandler(t, nonAggregateConfig(), &foldCheckStore{})
+		serveHeadSHA(t, mux, "abc123")
+
+		followUp, err := h.updateAggregateCheckOnce(t.Context(), client, "octocat/hello-world", 1, "abc123")
+
+		assert.Equal(t, aggregateFoldNoFollowUp, followUp)
+		assert.NoError(t, err)
+	})
+
+	t.Run("leader that cannot fetch PR files schedules a participant re-fold and returns an error", func(t *testing.T) {
+		h, mux, client := newFoldHandler(t, aggregateLeaderConfig(), &foldCheckStore{})
+		serveHeadSHA(t, mux, "abc123")
+		mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "boom", http.StatusInternalServerError)
+		})
+
+		followUp, err := h.updateAggregateCheckOnce(t.Context(), client, "octocat/hello-world", 1, "abc123")
+
+		assert.Equal(t, aggregateFoldScheduleParticipantRefold, followUp)
+		assert.Error(t, err)
+	})
+
+	t.Run("successful fold clears the participant re-fold budget with no error", func(t *testing.T) {
+		store := &foldCheckStore{byPR: []*storage.Check{{
+			Repository: "octocat/hello-world", PullRequest: 1, HeadSHA: "abc123",
+			Environment: "staging", DatabaseType: "mysql", DatabaseName: "orders",
+			Status: "completed", Conclusion: "success",
+		}}}
+		h, mux, client := newFoldHandler(t, nonAggregateConfig(), store)
+		serveHeadSHA(t, mux, "abc123")
+		serveCheckRunCreate(t, mux)
+
+		followUp, err := h.updateAggregateCheckOnce(t.Context(), client, "octocat/hello-world", 1, "abc123")
+
+		assert.Equal(t, aggregateFoldClearParticipantRefoldBudget, followUp)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, store.upsertCalls)
+	})
+
+	t.Run("a per-environment upsert failure still attempts every environment and joins the errors", func(t *testing.T) {
+		cfg := &api.ServerConfig{
+			AllowedEnvironments: []string{"staging", "production"},
+			Repos:               map[string]api.RepoConfig{"octocat/hello-world": {}},
+		}
+		store := &foldCheckStore{
+			byPR: []*storage.Check{
+				{Repository: "octocat/hello-world", PullRequest: 1, HeadSHA: "abc123", Environment: "staging", DatabaseType: "mysql", DatabaseName: "orders", Status: "completed", Conclusion: "success"},
+				{Repository: "octocat/hello-world", PullRequest: 1, HeadSHA: "abc123", Environment: "production", DatabaseType: "mysql", DatabaseName: "orders", Status: "completed", Conclusion: "success"},
+			},
+			upsertErr: assert.AnError,
+		}
+		h, mux, client := newFoldHandler(t, cfg, store)
+		serveHeadSHA(t, mux, "abc123")
+		serveCheckRunCreate(t, mux)
+
+		followUp, err := h.updateAggregateCheckOnce(t.Context(), client, "octocat/hello-world", 1, "abc123")
+
+		assert.Equal(t, aggregateFoldClearParticipantRefoldBudget, followUp)
+		assert.Error(t, err)
+		assert.Equal(t, 2, store.upsertCalls, "a failed environment write must not skip the remaining environments")
+	})
+}

--- a/pkg/webhook/check_publisher.go
+++ b/pkg/webhook/check_publisher.go
@@ -81,8 +81,19 @@ func (h *Handler) verifyHeadSHACurrency(ctx context.Context, client *ghclient.In
 // timer or mutates the re-fold budget itself, so the owner of retries (the
 // updateAggregateCheck wrapper today; the durable dispatch path later) decides
 // how to act on the disposition. A ScheduleParticipantRefold follow-up with a
-// nil error is a successful fold whose participant convergence is still pending
-// — distinct from a failed fold, which also returns a non-nil error.
+// nil error means the aggregate was published but at least one expected
+// participant has not yet converged (not reported, not terminal, or its Check
+// Run read failed).
+//
+// Participant Check Run *read* failures are deliberately conveyed only through
+// this retriable disposition, not the error return: participant convergence is
+// owned by the re-fold budget, and folding those reads into the error would make
+// a retry-owning caller (the durable path) and the re-fold timer double-retry
+// the same condition. So a nil error here does NOT assert that no operational
+// GitHub read failed during the fold — only that the fold itself completed and
+// the aggregate was written. Operational failures the caller must react to (head
+// verification, PR-files fetch, per-environment upserts) do return a non-nil
+// error alongside their disposition.
 type aggregateFoldFollowUp uint8
 
 const (
@@ -106,6 +117,13 @@ func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.Ins
 		h.scheduleLeaderRefoldIfConfigured(ctx, repo, pr, client.InstallationID())
 	case aggregateFoldScheduleParticipantRefold:
 		h.scheduleParticipantRefold(ctx, repo, pr, client.InstallationID())
+	default:
+		// A follow-up the fold core returns but the wrapper doesn't apply would
+		// silently drop the post-fold side effect (a re-fold that never gets
+		// scheduled, a budget that never clears). Fail loud so a new disposition
+		// can't no-op here unnoticed.
+		h.logger.Error("unhandled aggregate fold follow-up, post-fold side effect dropped",
+			"repo", repo, "pr", pr, "head_sha", headSHA, "follow_up", followUp)
 	}
 }
 

--- a/pkg/webhook/check_publisher.go
+++ b/pkg/webhook/check_publisher.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/block/schemabot/pkg/api"
@@ -28,6 +29,18 @@ func (h *Handler) shouldPublishChecks(ctx context.Context, repo string, operatio
 // SHA. It records a metric and logs the reason before every false return so
 // callers can stop without adding duplicate log noise.
 func (h *Handler) verifyHeadSHAStillCurrentForPR(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA, operation string) bool {
+	current, _ := h.verifyHeadSHACurrency(ctx, client, repo, pr, headSHA, operation)
+	return current
+}
+
+// verifyHeadSHACurrency is the lossless form of verifyHeadSHAStillCurrentForPR:
+// it returns the same current bool plus the underlying error so a caller with a
+// retry mechanism can tell a transient failure (empty head SHA or a PR-fetch
+// error, both non-nil) apart from a genuinely superseded head (current=false,
+// err=nil), which must never be retried as if GitHub had failed. It records the
+// same metrics and logs as before. A superseded head is not an operational
+// failure, so it returns a nil error.
+func (h *Handler) verifyHeadSHACurrency(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA, operation string) (bool, error) {
 	if headSHA == "" {
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
 			Operation:  operation,
@@ -35,7 +48,7 @@ func (h *Handler) verifyHeadSHAStillCurrentForPR(ctx context.Context, client *gh
 			Status:     "error",
 		})
 		h.logger.Error("refusing to update status check without head SHA", "repo", repo, "pr", pr, "operation", operation)
-		return false
+		return false, fmt.Errorf("verify head SHA for %s#%d (%s): missing head SHA", repo, pr, operation)
 	}
 
 	prInfo, err := client.FetchPullRequest(ctx, repo, pr)
@@ -47,7 +60,7 @@ func (h *Handler) verifyHeadSHAStillCurrentForPR(ctx context.Context, client *gh
 		})
 		h.logger.Error("failed to verify status check head SHA before update",
 			"repo", repo, "pr", pr, "head_sha", headSHA, "operation", operation, "error", err)
-		return false
+		return false, fmt.Errorf("verify head SHA for %s#%d (%s): %w", repo, pr, operation, err)
 	}
 	if prInfo.HeadSHA != headSHA {
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
@@ -58,13 +71,49 @@ func (h *Handler) verifyHeadSHAStillCurrentForPR(ctx context.Context, client *gh
 		h.logger.Info("skipping stale status check update because head SHA is no longer current for PR",
 			"repo", repo, "pr", pr, "operation", operation,
 			"stale_head_sha", headSHA, "current_head_sha", prInfo.HeadSHA)
-		return false
+		return false, nil
 	}
-	return true
+	return true, nil
 }
 
-// updateAggregateCheck recomputes and creates/updates aggregate check runs that roll
-// up per-database checks for a PR.
+// aggregateFoldFollowUp names the post-fold side effect a caller must apply
+// after updateAggregateCheckOnce returns. The one-shot fold never schedules a
+// timer or mutates the re-fold budget itself, so the owner of retries (the
+// updateAggregateCheck wrapper today; the durable dispatch path later) decides
+// how to act on the disposition. A ScheduleParticipantRefold follow-up with a
+// nil error is a successful fold whose participant convergence is still pending
+// — distinct from a failed fold, which also returns a non-nil error.
+type aggregateFoldFollowUp uint8
+
+const (
+	aggregateFoldNoFollowUp aggregateFoldFollowUp = iota
+	aggregateFoldClearParticipantRefoldBudget
+	aggregateFoldScheduleLeaderRefold
+	aggregateFoldScheduleParticipantRefold
+)
+
+// updateAggregateCheck is the fire-and-forget wrapper: it folds the aggregate
+// and applies the returned follow-up (timer scheduling / budget clearing) that
+// the callers with no way to react to a failed fold rely on. Callers that own a
+// retry mechanism call updateAggregateCheckOnce directly and act on its error.
+func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA string) {
+	followUp, _ := h.updateAggregateCheckOnce(ctx, client, repo, pr, headSHA)
+	switch followUp {
+	case aggregateFoldNoFollowUp:
+	case aggregateFoldClearParticipantRefoldBudget:
+		h.clearParticipantRefoldBudget(repo, pr)
+	case aggregateFoldScheduleLeaderRefold:
+		h.scheduleLeaderRefoldIfConfigured(ctx, repo, pr, client.InstallationID())
+	case aggregateFoldScheduleParticipantRefold:
+		h.scheduleParticipantRefold(ctx, repo, pr, client.InstallationID())
+	}
+}
+
+// updateAggregateCheckOnce recomputes and creates/updates aggregate check runs
+// that roll up per-database checks for a PR. It does the fold exactly once and
+// returns the follow-up its caller must apply plus the underlying error, so a
+// caller with a retry mechanism can react to a failed fold. It never schedules a
+// timer or mutates the re-fold budget itself.
 //
 // When allowed_environments is configured, per-environment aggregates are created
 // (e.g., "SchemaBot (staging)") that only roll up checks for that environment.
@@ -80,19 +129,19 @@ func (h *Handler) verifyHeadSHAStillCurrentForPR(ctx context.Context, client *gh
 //   - ANY check "action_required" → aggregate "action_required"
 //   - ALL checks "success"        → aggregate "success"
 //   - NO per-database checks      → no aggregate (PR doesn't touch schema)
-func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA string) {
+func (h *Handler) updateAggregateCheckOnce(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, headSHA string) (aggregateFoldFollowUp, error) {
 	if !h.shouldPublishChecks(ctx, repo, "aggregate_check_sync") {
-		return
+		return aggregateFoldNoFollowUp, nil
 	}
 
-	if !h.verifyHeadSHAStillCurrentForPR(ctx, client, repo, pr, headSHA, "aggregate_check_sync") {
-		// False covers a transient PR-fetch failure as well as a genuinely
-		// newer head; either way a leader's next re-fold fetches the
-		// then-current head, so arming a bounded re-fold converges the
-		// aggregate instead of stranding one waiting on a participant re-read.
-		// verifyHeadSHAStillCurrentForPR already logged the reason.
-		h.scheduleLeaderRefoldIfConfigured(ctx, repo, pr, client.InstallationID())
-		return
+	current, err := h.verifyHeadSHACurrency(ctx, client, repo, pr, headSHA, "aggregate_check_sync")
+	if !current {
+		// A non-current head covers a transient PR-fetch failure (non-nil err)
+		// as well as a genuinely newer head (nil err); either way a leader's
+		// next re-fold fetches the then-current head, so arm a bounded re-fold
+		// instead of stranding an aggregate waiting on a participant re-read.
+		// verifyHeadSHACurrency already logged the reason.
+		return aggregateFoldScheduleLeaderRefold, err
 	}
 
 	checks, err := h.service.Storage().Checks().GetByPR(ctx, repo, pr)
@@ -106,8 +155,7 @@ func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.Ins
 		// A storage blip must not end a leader's retry chain while its
 		// aggregate renders unresolved participants as in_progress; the
 		// bounded re-fold retries the read.
-		h.scheduleLeaderRefoldIfConfigured(ctx, repo, pr, client.InstallationID())
-		return
+		return aggregateFoldScheduleLeaderRefold, fmt.Errorf("fetch checks for aggregate %s#%d: %w", repo, pr, err)
 	}
 
 	// Filter out aggregate checks — only per-database checks contribute
@@ -143,8 +191,7 @@ func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.Ins
 			})
 			h.logger.Error("aggregate leader cannot fetch PR files, not publishing aggregate",
 				"repo", repo, "pr", pr, "head_sha", headSHA, "error", err)
-			h.scheduleParticipantRefold(ctx, repo, pr, client.InstallationID())
-			return
+			return aggregateFoldScheduleParticipantRefold, fmt.Errorf("fetch PR files for aggregate leader %s#%d: %w", repo, pr, err)
 		}
 		expectedParticipants = config.ExpectedParticipantChecksForPR(repo, prFilePaths(files))
 	}
@@ -159,7 +206,7 @@ func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.Ins
 			Status:     "noop",
 		})
 		h.logger.Debug("no per-database checks or expected participants for aggregate", "repo", repo, "pr", pr)
-		return
+		return aggregateFoldNoFollowUp, nil
 	}
 
 	checkNameBase := h.aggregateCheckNameForRepo(repo)
@@ -174,6 +221,12 @@ func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.Ins
 	// applies.
 	participantsRetriable := false
 	retryPending := h.participantRefoldBudgetRemaining(repo, pr)
+
+	// Every configured environment is attempted even if an earlier upsert fails,
+	// and the failures are joined so the participant follow-up below is still
+	// decided from the full fold — a single environment's write failure must not
+	// skip the others or drop the re-fold decision.
+	var upsertErrs []error
 
 	if len(config.AllowedEnvironments) > 0 {
 		// Per-environment aggregates: create one aggregate per allowed environment.
@@ -190,7 +243,9 @@ func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.Ins
 				continue
 			}
 			checkName := aggregateCheckNameForEnv(checkNameBase, env)
-			h.upsertAggregateCheckRun(ctx, client, repo, pr, headSHA, envChecks, checkName, env)
+			if err := h.upsertAggregateCheckRunOnce(ctx, client, repo, pr, headSHA, envChecks, checkName, env); err != nil {
+				upsertErrs = append(upsertErrs, err)
+			}
 		}
 	} else {
 		// Single aggregate. Uses aggregateSentinel for the environment field
@@ -200,14 +255,15 @@ func (h *Handler) updateAggregateCheck(ctx context.Context, client *ghclient.Ins
 		aggChecks := make([]*storage.Check, 0, len(dbChecks)+len(participantChecks))
 		aggChecks = append(aggChecks, dbChecks...)
 		aggChecks = append(aggChecks, participantChecks...)
-		h.upsertAggregateCheckRun(ctx, client, repo, pr, headSHA, aggChecks, checkNameBase, aggregateSentinel)
+		if err := h.upsertAggregateCheckRunOnce(ctx, client, repo, pr, headSHA, aggChecks, checkNameBase, aggregateSentinel); err != nil {
+			upsertErrs = append(upsertErrs, err)
+		}
 	}
 
 	if participantsRetriable {
-		h.scheduleParticipantRefold(ctx, repo, pr, client.InstallationID())
-	} else {
-		h.clearParticipantRefoldBudget(repo, pr)
+		return aggregateFoldScheduleParticipantRefold, errors.Join(upsertErrs...)
 	}
+	return aggregateFoldClearParticipantRefoldBudget, errors.Join(upsertErrs...)
 }
 
 // prFilePaths extracts the changed-file paths from a PR file listing for
@@ -218,19 +274,6 @@ func prFilePaths(files []ghclient.PRFile) []string {
 		paths = append(paths, f.Filename)
 	}
 	return paths
-}
-
-// upsertAggregateCheckRun is the fire-and-forget wrapper used by the callers
-// that have no way to react to a failed aggregate write. It records the same
-// metrics and logs as upsertAggregateCheckRunOnce and discards the returned
-// error. Callers that own a retry mechanism (the durable dispatch path) call
-// upsertAggregateCheckRunOnce directly.
-func (h *Handler) upsertAggregateCheckRun(
-	ctx context.Context, client *ghclient.InstallationClient,
-	repo string, pr int, headSHA string,
-	dbChecks []*storage.Check, checkName string, environment string,
-) {
-	_ = h.upsertAggregateCheckRunOnce(ctx, client, repo, pr, headSHA, dbChecks, checkName, environment)
 }
 
 // upsertAggregateCheckRunOnce computes the aggregate conclusion from the given


### PR DESCRIPTION
## Summary

Extracts a one-shot aggregate-fold core that returns a typed follow-up disposition plus the underlying error, preparing the durable `check_run.completed` path to distinguish operational failures from pending participant convergence. Current fire-and-forget behavior is preserved.

## What

- Adds `updateAggregateCheckOnce(...) (aggregateFoldFollowUp, error)`.
- Keeps `updateAggregateCheck(...)` as a behavior-preserving wrapper that applies the returned follow-up and ignores the error (matching today's void semantics).
- Head-SHA verification now distinguishes a superseded head `(false, nil)` from an operational error `(false, err)`.
- Per-environment upserts attempt every configured environment and aggregate failures with `errors.Join`.
- Adds characterization tests for the follow-up/error contract.

## Why

The durable completed-event path must tell apart:

- successful fold, participant convergence pending → participant follow-up + nil error
- failed fold that should be retried → follow-up + non-nil error

The previous void-returning fold could not express that distinction. This slice makes the distinction available without changing runtime behavior yet.

## Before / after

```text
Before                              After
updateAggregateCheck (void)         updateAggregateCheck (wrapper)
 - folds aggregate                   - calls one-shot core
 - schedules follow-ups inline       - applies returned follow-up
                                     - preserves current behavior

                                    updateAggregateCheckOnce
                                     - returns follow-up + error
                                     - no timer/budget side effects
                                     - joins per-environment errors
```

## Testing / validation

- `go build ./...`
- `go vet ./pkg/webhook/`
- `go test -race ./pkg/webhook/ -count=1`
- `golangci-lint run --new-from-rev origin/main ./pkg/webhook/`

## Scope

The 1a aggregate-upsert error plumbing is now on `main` (#784). This PR contains only the behavior-preserving fold-core extraction. Durable `check_run.completed` dispatch wiring remains a separate WH-9d follow-up.
