### PR TITLE
fix(github): make lint and apply-blocked template previews realistic and discoverable

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -43,8 +43,8 @@ ALTER TABLE `products` ADD INDEX `idx_category_price`(`category`, `price`);
 ```
 
 ⚠️ **Lint Warnings**:
-- [orders] New column uses floating-point data type
-- [users] Column added without DEFAULT value
+- [users] Column "created_at" uses TIMESTAMP which overflows on 2038-01-19. Consider using DATETIME instead.
+- [products] Index 'idx_category' on columns (category) is redundant - covered by index 'idx_category_price' on columns (category, price)
 
 📋 **Plan**: **2** tables to create, **1** table to alter
 
@@ -670,8 +670,8 @@ ALTER TABLE `products` ADD INDEX `idx_category_price`(`category`, `price`);
 </details>
 
 ⚠️ **Lint Warnings**:
-- [orders] Primary key uses signed integer type (should be UNSIGNED)
-- [users] Column uses utf8 charset (should be utf8mb4)
+- [users] Column "created_at" uses TIMESTAMP which overflows on 2038-01-19. Consider using DATETIME instead.
+- [products] Index 'idx_category' on columns (category) is redundant - covered by index 'idx_category_price' on columns (category, price)
 
 📋 **Plan**: **2** tables to create, **1** table to alter
 
@@ -745,6 +745,37 @@ ALTER TABLE `customers` DROP INDEX `idx_customers_email`;
 **Destructive drop guidance:**
 
 Before dropping an index in MySQL, first make the dropped index invisible and verify application queries no longer rely on it for safe performance.
+
+**🚨 To proceed with these destructive changes, re-run with `--allow-unsafe`:**
+```
+schemabot apply -e staging --allow-unsafe
+```
+
+</details>
+
+<details>
+<summary><a name="schema-lint-errors-blocked"></a><strong>Schema Lint Errors Blocked</strong></summary>
+
+
+## Schema Change Plan — Staging
+
+**Database**: `testapp` | **Type**: `MySQL` | **Schema Name**: `testapp`
+
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
+
+```sql
+ALTER TABLE `orders` MODIFY COLUMN `id` int NOT NULL AUTO_INCREMENT;
+
+ALTER TABLE `users` RENAME COLUMN `email` TO `email_address`;
+```
+
+📋 **Plan**: **2** tables to alter
+
+---
+
+**⛔ 2 Unsafe Changes Detected:**
+- `orders`: Primary key column "id" has type "int"
+- `users`: Column rename detected in table "users": "email" to "email_address". Renaming a column cannot be done atomically across application pods, and ORMs that generate column names at compile time (e.g. jOOQ) will break until code is recompiled
 
 **🚨 To proceed with these destructive changes, re-run with `--allow-unsafe`:**
 ```
@@ -1309,47 +1340,6 @@ Apply in progress
 ### PR Comments
 
 <details>
-<summary><a name="apply-blocked-by-other-pr"></a><strong>Apply Blocked By Other PR</strong></summary>
-
-
-## 🔒 Apply Blocked — Staging
-
-**Database**: `testapp`
-
-*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
-
-Another PR currently holds the lock for this database.
-
-**Locked by**: [block/myapp#42](https://github.com/block/myapp/pull/42)
-**Since**: 2026-03-15 12:30:00 UTC
-
-Wait for the other PR to complete or ask the lock holder to run `schemabot unlock`.
-
-</details>
-
-<details>
-<summary><a name="apply-blocked-by-cli"></a><strong>Apply Blocked By CLI</strong></summary>
-
-
-## 🔒 Apply Blocked — Staging
-
-**Database**: `testapp`
-
-*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
-
-A CLI session currently holds the lock for this database.
-
-**Locked by**: `cli:jackjackbits@macbook.local`
-**Since**: 2026-03-15 14:00:00 UTC
-
-Ask the lock holder to run `schemabot unlock` from their CLI, or force-unlock with:
-```
-schemabot unlock -d testapp --force
-```
-
-</details>
-
-<details>
 <summary><a name="unlock-success"></a><strong>Unlock Success</strong></summary>
 
 
@@ -1360,22 +1350,6 @@ schemabot unlock -d testapp --force
 *Released by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 The database is now available for schema changes.
-
-</details>
-
-<details>
-<summary><a name="apply-already-in-progress"></a><strong>Apply Already In Progress</strong></summary>
-
-
-## ⚠️ Apply Already In Progress — Staging
-
-**Database**: `testapp`
-
-*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
-
-An apply is already running for this PR (apply ID: `apply-a1b2c3d4e5f6`, state: `running`).
-
-Wait for it to complete or stop it first.
 
 </details>
 
@@ -1392,93 +1366,6 @@ No apply lock is held for this database. Run `apply` first to generate a plan an
 ```
 schemabot apply -e staging
 ```
-
-</details>
-
-<details>
-<summary><a name="blocked-by-prior-env-pending"></a><strong>Blocked By Prior Env (Pending)</strong></summary>
-
-
-## ❌ Apply Blocked — Production
-
-**Database**: `testapp`
-
-Staging has pending changes. Apply staging first before applying to production.
-
-```
-schemabot apply -e staging
-```
-
-</details>
-
-<details>
-<summary><a name="blocked-by-prior-env-failed"></a><strong>Blocked By Prior Env (Failed)</strong></summary>
-
-
-## ❌ Apply Blocked — Production
-
-**Database**: `testapp`
-
-Staging failed. Fix the issue and re-apply staging before applying to production.
-
-```
-schemabot apply -e staging
-```
-
-</details>
-
-<details>
-<summary><a name="blocked-by-prior-env-in-progress"></a><strong>Blocked By Prior Env (In Progress)</strong></summary>
-
-
-## ⏳ Apply Blocked — Production
-
-**Database**: `testapp`
-
-Staging is currently in progress. Wait for it to complete before applying to production.
-
-Once staging completes, retry:
-```
-schemabot apply -e production
-```
-
-</details>
-
-<details>
-<summary><a name="review-required"></a><strong>Review Required</strong></summary>
-
-
-## Review Required
-
-**Database**: `testapp` | **Environment**: `staging`
-
-*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
-
-Schema changes require approval from an authorized reviewer before applying.
-
-**Authorized reviewers**:
-- @acme/schema-reviewers
-- @jdoe
-
-### Next steps
-1. Request a review from an authorized reviewer above
-2. Once approved, run `schemabot apply -e staging` again
-
-</details>
-
-<details>
-<summary><a name="review-gate-error-failclosed"></a><strong>Review Gate Error (Fail-closed)</strong></summary>
-
-
-## ❌ Apply Failed
-
-**Environment**: `staging`
-
-*Requested by @jackjackbits at  UTC*
-
-### Error
-
-> Review gate check failed: expand team @acme/schema-reviewers: team membership cannot be read. If approval is granted through a GitHub team, verify the GitHub App can read organization members and team membership.
 </details>
 
 ### CLI Output
@@ -1879,6 +1766,401 @@ CREATE TABLE `addresses` (
 *Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
 
 Schema changes are being applied. This comment will be updated with progress.
+
+</details>
+
+<details>
+<summary><a name="apply-blocked-by-other-pr"></a><strong>Apply Blocked By Other PR</strong></summary>
+
+
+## 🔒 Apply Blocked — Staging
+
+**Database**: `testapp`
+
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+Another PR currently holds the lock for this database.
+
+**Locked by**: [block/myapp#42](https://github.com/block/myapp/pull/42)
+**Since**: 2026-03-15 12:30:00 UTC
+
+Wait for the other PR to complete or ask the lock holder to run `schemabot unlock`.
+
+</details>
+
+<details>
+<summary><a name="apply-blocked-by-cli"></a><strong>Apply Blocked By CLI</strong></summary>
+
+
+## 🔒 Apply Blocked — Staging
+
+**Database**: `testapp`
+
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+A CLI session currently holds the lock for this database.
+
+**Locked by**: `cli:jackjackbits@macbook.local`
+**Since**: 2026-03-15 14:00:00 UTC
+
+Ask the lock holder to run `schemabot unlock` from their CLI, or force-unlock with:
+```
+schemabot unlock -d testapp --force
+```
+
+</details>
+
+<details>
+<summary><a name="apply-blocked-already-in-progress"></a><strong>Apply Blocked: Already In Progress</strong></summary>
+
+
+## ⚠️ Apply Already In Progress — Staging
+
+**Database**: `testapp`
+
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+An apply is already running for this PR (apply ID: `apply-a1b2c3d4e5f6`, state: `running`).
+
+Wait for it to complete or stop it first.
+
+</details>
+
+<details>
+<summary><a name="apply-blocked-pr-closed"></a><strong>Apply Blocked: PR Closed</strong></summary>
+
+
+## ⛔ Apply Blocked: PR Is Closed — Staging
+
+
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+This PR is closed, so its schema changes can never merge. SchemaBot only applies schema changes from open PRs.
+
+Reopen this PR, or open a new PR with the schema change, and apply from there.
+
+</details>
+
+<details>
+<summary><a name="apply-blocked-pr-merged"></a><strong>Apply Blocked: PR Merged</strong></summary>
+
+
+## ⛔ Apply Blocked: PR Is Merged — Staging
+
+
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+This PR is already merged, so applies can no longer run from it. SchemaBot only applies schema changes from open PRs.
+
+If the schema change still needs to be applied, open a new PR with it and apply from there.
+
+</details>
+
+<details>
+<summary><a name="apply-blocked-base-schema-changed-since-pr-diverged"></a><strong>Apply Blocked: Base Schema Changed Since PR Diverged</strong></summary>
+
+
+## ⚠️ Apply rejected — base schema is newer — Production
+
+**Database**: `testapp`
+
+The base branch contains newer changes to the schema directory `schema/testapp` that are not included in this PR. Applying this branch could revert those changes.
+
+Merge or rebase the current base branch into this PR, review the updated plan, then run `apply` again.
+
+_Requested by @jackjackbits_
+
+</details>
+
+<details>
+<summary><a name="apply-blocked-schema-stale-new-commits"></a><strong>Apply Blocked: Schema Stale (New Commits)</strong></summary>
+
+
+## ⚠️ Rejected — new commits since discovery — Staging
+
+**Database**: `testapp`
+
+Schema files were loaded at `0123456789abcdef0123456789abcdef01234567`, but the current PR HEAD is `abcdef1234567890abcdef1234567890abcdef12`. These files no longer match what is on the branch.
+
+Re-run the command to use the current HEAD:
+
+```
+schemabot apply -e staging
+```
+
+_Requested by @jackjackbits_
+
+</details>
+
+<details>
+<summary><a name="apply-blocked-confirmed-plan-stale"></a><strong>Apply Blocked: Confirmed Plan Stale</strong></summary>
+
+
+## ⚠️ Rejected — the plan you confirmed is stale — Staging
+
+**Database**: `testapp`
+
+The confirmation plan was rendered at `0123456789abcdef0123456789abcdef01234567`, but the current PR HEAD is `abcdef1234567890abcdef1234567890abcdef12`. New commits have landed since the plan was posted, so the DDL you reviewed no longer matches what is on the branch.
+
+Re-run `apply` to generate a fresh plan against the current HEAD:
+
+```
+schemabot apply -e staging
+```
+
+_Requested by @jackjackbits_
+
+</details>
+
+<details>
+<summary><a name="apply-blocked-by-prior-env-pending"></a><strong>Apply Blocked By Prior Env (Pending)</strong></summary>
+
+
+## ❌ Apply Blocked — Production
+
+**Database**: `testapp`
+
+Staging has pending changes. Apply staging first before applying to production.
+
+```
+schemabot apply -e staging
+```
+
+</details>
+
+<details>
+<summary><a name="apply-blocked-by-prior-env-failed"></a><strong>Apply Blocked By Prior Env (Failed)</strong></summary>
+
+
+## ❌ Apply Blocked — Production
+
+**Database**: `testapp`
+
+Staging failed. Fix the issue and re-apply staging before applying to production.
+
+```
+schemabot apply -e staging
+```
+
+</details>
+
+<details>
+<summary><a name="apply-blocked-by-prior-env-in-progress"></a><strong>Apply Blocked By Prior Env (In Progress)</strong></summary>
+
+
+## ⏳ Apply Blocked — Production
+
+**Database**: `testapp`
+
+Staging is currently in progress. Wait for it to complete before applying to production.
+
+Once staging completes, retry:
+```
+schemabot apply -e production
+```
+
+</details>
+
+<details>
+<summary><a name="apply-blocked-prior-env-check-missing"></a><strong>Apply Blocked: Prior Env Check Missing</strong></summary>
+
+
+## ❌ Apply Blocked
+
+SchemaBot could not find a completed `staging` check for this PR.
+
+SchemaBot must verify `staging` before applying a later environment. Create the missing `staging` status with:
+```
+schemabot plan -e staging
+```
+
+If the plan finds changes, apply `staging` and wait for the SchemaBot check to succeed. Then retry this apply.
+
+</details>
+
+<details>
+<summary><a name="apply-blocked-prior-env-check-read-error"></a><strong>Apply Blocked: Prior Env Check Read Error</strong></summary>
+
+
+## ❌ Apply Blocked
+
+Could not verify staging status: failed to query check runs. Retry the apply command.
+
+_Error: list check runs for ref: 502 Bad Gateway_
+</details>
+
+<details>
+<summary><a name="apply-blocked-prior-env-check-untrusted"></a><strong>Apply Blocked: Prior Env Check Untrusted</strong></summary>
+
+
+## ❌ Apply Blocked
+
+A `staging` check named `SchemaBot (staging)` exists on this PR, but it was created by a GitHub App this SchemaBot deployment does not trust:
+
+- `acme-automation`
+
+SchemaBot only verifies `staging` through check runs created by trusted SchemaBot deployment Apps.
+
+### Next steps
+- If the App above is the SchemaBot deployment that owns `staging`, an operator must add its slug to `github.trusted-check-app-slugs` in this deployment's server config.
+- If you do not recognize the App, do not trust it — the check may be impersonating SchemaBot.
+
+Re-running `schemabot plan -e staging` will not resolve this.
+
+</details>
+
+<details>
+<summary><a name="apply-blocked-environment-not-in-promotion-order"></a><strong>Apply Blocked: Environment Not In Promotion Order</strong></summary>
+
+
+## ❌ Apply Blocked — Development
+
+`development` is not in the configured promotion order, so SchemaBot cannot determine which environments must be applied before it and cannot enforce staging-first ordering.
+
+Configured promotion order: `staging` → `production`
+
+Add `development` to `environment_order` so SchemaBot knows where it sits in the promotion sequence, then retry the apply.
+
+</details>
+
+<details>
+<summary><a name="apply-blocked-review-required"></a><strong>Apply Blocked: Review Required</strong></summary>
+
+
+## Review Required
+
+**Database**: `testapp` | **Environment**: `staging`
+
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
+
+Schema changes require approval from an authorized reviewer before applying.
+
+**Authorized reviewers**:
+- @acme/schema-reviewers
+- @jdoe
+
+### Next steps
+1. Request a review from an authorized reviewer above
+2. Once approved, run `schemabot apply -e staging` again
+
+</details>
+
+<details>
+<summary><a name="apply-blocked-review-gate-error-failclosed"></a><strong>Apply Blocked: Review Gate Error (Fail-closed)</strong></summary>
+
+
+## ❌ Apply Failed
+
+**Environment**: `staging`
+
+*Requested by @jackjackbits at  UTC*
+
+### Error
+
+> Review gate check failed: expand team @acme/schema-reviewers: team membership cannot be read. If approval is granted through a GitHub team, verify the GitHub App can read organization members and team membership.
+</details>
+
+<details>
+<summary><a name="apply-blocked-checks-not-passing"></a><strong>Apply Blocked: Checks Not Passing</strong></summary>
+
+
+## ❌ Apply Blocked — Staging
+
+Cannot apply while PR checks are not passing:
+
+| Check | Status |
+|-------|--------|
+| `CI / unit-tests` | failure |
+| `CI / lint` | timed_out |
+
+Get the checks passing — fix failures and re-run cancelled or stale checks — then retry:
+```
+schemabot apply -e staging
+```
+
+</details>
+
+<details>
+<summary><a name="apply-blocked-checks-in-progress"></a><strong>Apply Blocked: Checks In Progress</strong></summary>
+
+
+## ⏳ Apply Blocked — Staging
+
+Cannot apply while PR checks are still running:
+
+| Check | Status |
+|-------|--------|
+| `CI / unit-tests` | in_progress |
+| `CI / integration-tests` | queued |
+
+Wait for checks to complete and retry:
+```
+schemabot apply -e staging
+```
+
+</details>
+
+<details>
+<summary><a name="apply-blocked-check-status-read-error"></a><strong>Apply Blocked: Check Status Read Error</strong></summary>
+
+
+## ❌ Apply Blocked — Staging
+
+The SchemaBot GitHub App `schemabot-app` cannot read PR check statuses for this repository.
+
+The diagnostic REST probes indicate the installation is missing or has not accepted:
+- **Checks: Read**
+- **Commit statuses: Read**
+
+Grant or accept those permissions, then retry:
+```
+schemabot apply -e staging
+```
+
+</details>
+
+<details>
+<summary><a name="apply-blocked-actor-not-authorized"></a><strong>Apply Blocked: Actor Not Authorized</strong></summary>
+
+
+## SchemaBot Command Not Authorized
+
+**Database**: `orders` | **Environment**: `staging`
+
+@mona is not authorized to run `schemabot apply` for this database.
+
+A configured SchemaBot admin/database operator must run this command.
+
+</details>
+
+<details>
+<summary><a name="actor-authorization-unavailable"></a><strong>Actor Authorization: Unavailable</strong></summary>
+
+
+## SchemaBot Authorization Check Failed
+
+**Database**: `orders` | **Environment**: `production`
+**Requested by**: @mona
+
+SchemaBot could not verify authorization for `schemabot apply-confirm`. No schema change was started.
+
+If access is granted through a GitHub team, verify the GitHub App can read organization members and team membership.
+
+A configured SchemaBot admin/database operator should inspect SchemaBot authorization logs before retrying.
+
+</details>
+
+<details>
+<summary><a name="actor-authorization-database-not-configured"></a><strong>Actor Authorization: Database Not Configured</strong></summary>
+
+
+## SchemaBot Command Not Authorized
+
+**Database**: `payments`
+
+`schemabot unlock` cannot run because database `payments` is not configured on this SchemaBot instance.
+
+Verify the database name, or run the command against the SchemaBot instance that manages this database.
 
 </details>
 
@@ -5436,844 +5718,6 @@ No schema changes found for database 'new-db'
 ```
 </details>
 
-
-## Apply Gates
-
-### PR Comments
-
-<details>
-<summary><a name="apply-gate-schema-change-apply-automatic"></a><strong>Apply Gate: Schema Change Apply (Automatic)</strong></summary>
-
-
-## Schema Change Apply — Staging
-
-**Database**: `testapp` | **Type**: `MySQL` | **Schema Name**: `testapp`
-
-*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
-
-🔒 **Lock acquired by** `acme/myapp#42` at 2026-03-14 10:30:00 UTC
-
-```sql
-CREATE TABLE `users` (
-    `id` bigint unsigned NOT NULL AUTO_INCREMENT,
-    `email` varchar(255) NOT NULL,
-    `created_at` timestamp DEFAULT current_timestamp(),
-    PRIMARY KEY(`id`),
-    INDEX `idx_email`(`email`)
-) ENGINE InnoDB,
-  CHARSET utf8mb4,
-  COLLATE utf8mb4_0900_ai_ci;
-
-CREATE TABLE `orders` (
-    `id` bigint unsigned NOT NULL AUTO_INCREMENT,
-    `user_id` bigint NOT NULL,
-    `total_cents` bigint NOT NULL,
-    `status` varchar(50) NOT NULL DEFAULT 'pending',
-    PRIMARY KEY(`id`),
-    INDEX `idx_user_id`(`user_id`)
-) ENGINE InnoDB,
-  CHARSET utf8mb4,
-  COLLATE utf8mb4_0900_ai_ci;
-
-ALTER TABLE `products` ADD INDEX `idx_category_price`(`category`, `price`);
-```
-
-📋 **Plan**: **2** tables to create, **1** table to alter
-
-
----
-
-**Applying automatically**
-
-
-</details>
-
-<details>
-<summary><a name="apply-gate-schema-change-apply-with-options"></a><strong>Apply Gate: Schema Change Apply (With Options)</strong></summary>
-
-
-## Schema Change Apply — Staging
-
-**Database**: `testapp` | **Type**: `MySQL` | **Schema Name**: `testapp`
-
-*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
-
-🔒 **Lock acquired by** `acme/myapp#42` at 2026-03-14 10:30:00 UTC
-
-```sql
-CREATE TABLE `users` (
-    `id` bigint unsigned NOT NULL AUTO_INCREMENT,
-    `email` varchar(255) NOT NULL,
-    `created_at` timestamp DEFAULT current_timestamp(),
-    PRIMARY KEY(`id`),
-    INDEX `idx_email`(`email`)
-) ENGINE InnoDB,
-  CHARSET utf8mb4,
-  COLLATE utf8mb4_0900_ai_ci;
-
-CREATE TABLE `orders` (
-    `id` bigint unsigned NOT NULL AUTO_INCREMENT,
-    `user_id` bigint NOT NULL,
-    `total_cents` bigint NOT NULL,
-    `status` varchar(50) NOT NULL DEFAULT 'pending',
-    PRIMARY KEY(`id`),
-    INDEX `idx_user_id`(`user_id`)
-) ENGINE InnoDB,
-  CHARSET utf8mb4,
-  COLLATE utf8mb4_0900_ai_ci;
-
-ALTER TABLE `products` ADD INDEX `idx_category_price`(`category`, `price`);
-```
-
-📋 **Plan**: **2** tables to create, **1** table to alter
-
-
-**Options**: ⏸️ Defer Cutover | ⏩ Skip Revert
-
----
-
-**Applying automatically**
-
-
-</details>
-
-<details>
-<summary><a name="apply-gate-schema-change-apply-downgraded"></a><strong>Apply Gate: Schema Change Apply (Downgraded)</strong></summary>
-
-
-## Schema Change Apply — Staging
-
-**Database**: `testapp` | **Type**: `MySQL` | **Schema Name**: `testapp`
-
-*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
-
-🔒 **Lock acquired by** `acme/myapp#42` at 2026-03-14 10:30:00 UTC
-
-```sql
-CREATE TABLE `users` (
-    `id` bigint unsigned NOT NULL AUTO_INCREMENT,
-    `email` varchar(255) NOT NULL,
-    `created_at` timestamp DEFAULT current_timestamp(),
-    PRIMARY KEY(`id`),
-    INDEX `idx_email`(`email`)
-) ENGINE InnoDB,
-  CHARSET utf8mb4,
-  COLLATE utf8mb4_0900_ai_ci;
-
-CREATE TABLE `orders` (
-    `id` bigint unsigned NOT NULL AUTO_INCREMENT,
-    `user_id` bigint NOT NULL,
-    `total_cents` bigint NOT NULL,
-    `status` varchar(50) NOT NULL DEFAULT 'pending',
-    PRIMARY KEY(`id`),
-    INDEX `idx_user_id`(`user_id`)
-) ENGINE InnoDB,
-  CHARSET utf8mb4,
-  COLLATE utf8mb4_0900_ai_ci;
-
-ALTER TABLE `products` ADD INDEX `idx_category_price`(`category`, `price`);
-```
-
-📋 **Plan**: **2** tables to create, **1** table to alter
-
-
----
-
-⚠️ **Automatic apply paused**: Schema changes differ from auto-plan — review and confirm manually
-
-Review the plan above, then confirm manually:
-```
-schemabot apply-confirm -e staging
-```
-
-🔓 To discard this plan and unlock, comment:
-```
-schemabot unlock
-```
-
-
-</details>
-
-<details>
-<summary><a name="apply-started"></a><strong>Apply Started</strong></summary>
-
-
-## Schema Change Status — Staging
-
-**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
-
-*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
-
-Schema changes are being applied. This comment will be updated with progress.
-
-
-</details>
-
-<details>
-<summary><a name="unlock-success"></a><strong>Unlock Success</strong></summary>
-
-
-## 🔓 Lock Released — Staging
-
-**Database**: `testapp`
-
-*Released by @jackjackbits at 2026-01-01 00:00:00 UTC*
-
-The database is now available for schema changes.
-
-
-</details>
-
-<details>
-<summary><a name="apply-blocked-by-other-pr"></a><strong>Apply Blocked By Other PR</strong></summary>
-
-
-## 🔒 Apply Blocked — Staging
-
-**Database**: `testapp`
-
-*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
-
-Another PR currently holds the lock for this database.
-
-**Locked by**: [block/myapp#42](https://github.com/block/myapp/pull/42)
-**Since**: 2026-03-15 12:30:00 UTC
-
-Wait for the other PR to complete or ask the lock holder to run `schemabot unlock`.
-
-
-</details>
-
-<details>
-<summary><a name="apply-blocked-by-cli"></a><strong>Apply Blocked By CLI</strong></summary>
-
-
-## 🔒 Apply Blocked — Staging
-
-**Database**: `testapp`
-
-*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
-
-A CLI session currently holds the lock for this database.
-
-**Locked by**: `cli:jackjackbits@macbook.local`
-**Since**: 2026-03-15 14:00:00 UTC
-
-Ask the lock holder to run `schemabot unlock` from their CLI, or force-unlock with:
-```
-schemabot unlock -d testapp --force
-```
-
-
-</details>
-
-<details>
-<summary><a name="apply-already-in-progress"></a><strong>Apply Already In Progress</strong></summary>
-
-
-## ⚠️ Apply Already In Progress — Staging
-
-**Database**: `testapp`
-
-*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
-
-An apply is already running for this PR (apply ID: `apply-a1b2c3d4e5f6`, state: `running`).
-
-Wait for it to complete or stop it first.
-
-
-</details>
-
-<details>
-<summary><a name="apply-blocked-pr-closed"></a><strong>Apply Blocked: PR Closed</strong></summary>
-
-
-## ⛔ Apply Blocked: PR Is Closed — Staging
-
-
-*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
-
-This PR is closed, so its schema changes can never merge. SchemaBot only applies schema changes from open PRs.
-
-Reopen this PR, or open a new PR with the schema change, and apply from there.
-
-
-</details>
-
-<details>
-<summary><a name="apply-blocked-pr-merged"></a><strong>Apply Blocked: PR Merged</strong></summary>
-
-
-## ⛔ Apply Blocked: PR Is Merged — Staging
-
-
-*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
-
-This PR is already merged, so applies can no longer run from it. SchemaBot only applies schema changes from open PRs.
-
-If the schema change still needs to be applied, open a new PR with it and apply from there.
-
-
-</details>
-
-<details>
-<summary><a name="no-lock-found"></a><strong>No Lock Found</strong></summary>
-
-
-## 🔒 No Lock Found — Staging
-
-**Database**: `testapp`
-
-No apply lock is held for this database. Run `apply` first to generate a plan and acquire the lock.
-
-```
-schemabot apply -e staging
-```
-
-
-</details>
-
-<details>
-<summary><a name="base-schema-changed-since-pr-diverged"></a><strong>Base Schema Changed Since PR Diverged</strong></summary>
-
-
-## ⚠️ Apply rejected — base schema is newer — Production
-
-**Database**: `testapp`
-
-The base branch contains newer changes to the schema directory `schema/testapp` that are not included in this PR. Applying this branch could revert those changes.
-
-Merge or rebase the current base branch into this PR, review the updated plan, then run `apply` again.
-
-_Requested by @jackjackbits_
-
-
-</details>
-
-<details>
-<summary><a name="blocked-by-prior-env-pending"></a><strong>Blocked By Prior Env (Pending)</strong></summary>
-
-
-## ❌ Apply Blocked — Production
-
-**Database**: `testapp`
-
-Staging has pending changes. Apply staging first before applying to production.
-
-```
-schemabot apply -e staging
-```
-
-
-</details>
-
-<details>
-<summary><a name="blocked-by-prior-env-failed"></a><strong>Blocked By Prior Env (Failed)</strong></summary>
-
-
-## ❌ Apply Blocked — Production
-
-**Database**: `testapp`
-
-Staging failed. Fix the issue and re-apply staging before applying to production.
-
-```
-schemabot apply -e staging
-```
-
-
-</details>
-
-<details>
-<summary><a name="blocked-by-prior-env-in-progress"></a><strong>Blocked By Prior Env (In Progress)</strong></summary>
-
-
-## ⏳ Apply Blocked — Production
-
-**Database**: `testapp`
-
-Staging is currently in progress. Wait for it to complete before applying to production.
-
-Once staging completes, retry:
-```
-schemabot apply -e production
-```
-
-
-</details>
-
-<details>
-<summary><a name="review-required"></a><strong>Review Required</strong></summary>
-
-
-## Review Required
-
-**Database**: `testapp` | **Environment**: `staging`
-
-*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC*
-
-Schema changes require approval from an authorized reviewer before applying.
-
-**Authorized reviewers**:
-- @acme/schema-reviewers
-- @jdoe
-
-### Next steps
-1. Request a review from an authorized reviewer above
-2. Once approved, run `schemabot apply -e staging` again
-
-
-</details>
-
-<details>
-<summary><a name="review-gate-error-failclosed"></a><strong>Review Gate Error (Fail-closed)</strong></summary>
-
-
-## ❌ Apply Failed
-
-**Environment**: `staging`
-
-*Requested by @jackjackbits at  UTC*
-
-### Error
-
-> Review gate check failed: expand team @acme/schema-reviewers: team membership cannot be read. If approval is granted through a GitHub team, verify the GitHub App can read organization members and team membership.
-
-</details>
-
-<details>
-<summary><a name="actor-authorization-not-authorized"></a><strong>Actor Authorization: Not Authorized</strong></summary>
-
-
-## SchemaBot Command Not Authorized
-
-**Database**: `orders` | **Environment**: `staging`
-
-@mona is not authorized to run `schemabot apply` for this database.
-
-A configured SchemaBot admin/database operator must run this command.
-
-
-</details>
-
-<details>
-<summary><a name="actor-authorization-unavailable"></a><strong>Actor Authorization: Unavailable</strong></summary>
-
-
-## SchemaBot Authorization Check Failed
-
-**Database**: `orders` | **Environment**: `production`
-**Requested by**: @mona
-
-SchemaBot could not verify authorization for `schemabot apply-confirm`. No schema change was started.
-
-If access is granted through a GitHub team, verify the GitHub App can read organization members and team membership.
-
-A configured SchemaBot admin/database operator should inspect SchemaBot authorization logs before retrying.
-
-
-</details>
-
-<details>
-<summary><a name="actor-authorization-database-not-configured"></a><strong>Actor Authorization: Database Not Configured</strong></summary>
-
-
-## SchemaBot Command Not Authorized
-
-**Database**: `payments`
-
-`schemabot unlock` cannot run because database `payments` is not configured on this SchemaBot instance.
-
-Verify the database name, or run the command against the SchemaBot instance that manages this database.
-
-
-</details>
-
-<details>
-<summary><a name="start-command-accepted"></a><strong>Start Command Accepted</strong></summary>
-
-
-## Start Request Accepted
-
-**Apply**: `apply-a1b2c3d4e5f67890`
-**Environment**: `staging`
-**Requested by**: @alice
-
-Start request accepted. SchemaBot will resume this schema change; status remains available from the PR progress comment or CLI.
-
-**Tasks selected for start**: 1 started, 0 skipped.
-
-
-</details>
-
-<details>
-<summary><a name="start-command-already-pending"></a><strong>Start Command Already Pending</strong></summary>
-
-
-## Start Request Accepted
-
-**Apply**: `apply-a1b2c3d4e5f67890`
-**Environment**: `staging`
-**Requested by**: @alice
-
-Start was already requested. SchemaBot will keep the existing start request pending until the operator owner finishes it.
-
-**Tasks selected for start**: 1 started, 0 skipped.
-
-
-</details>
-
-<details>
-<summary><a name="cutover-command-accepted"></a><strong>Cutover Command Accepted</strong></summary>
-
-
-## Cutover Request Accepted
-
-**Apply**: `apply-a1b2c3d4e5f67890`
-**Environment**: `staging`
-**Requested by**: @alice
-
-Cutover request accepted. SchemaBot will complete this schema change; status remains available from the PR progress comment or CLI.
-
-
-</details>
-
-<details>
-<summary><a name="cutover-command-already-in-progress"></a><strong>Cutover Command Already In Progress</strong></summary>
-
-
-## Cutover Request Accepted
-
-**Apply**: `apply-a1b2c3d4e5f67890`
-**Environment**: `staging`
-**Requested by**: @alice
-
-Cutover is already in progress. SchemaBot will keep reporting progress from the existing apply.
-
-
-</details>
-
-<details>
-<summary><a name="volume-command-accepted"></a><strong>Volume Command Accepted</strong></summary>
-
-
-## Volume Request Accepted
-
-**Apply**: `apply-a1b2c3d4e5f67890`
-**Environment**: `staging`
-**Requested by**: @alice
-
-Volume change to 8 requested. SchemaBot will adjust the speed of this schema change shortly; once the new level takes effect, a fresh progress comment will track the schema change at the new volume.
-
-
-</details>
-
-<details>
-<summary><a name="volume-command-invalid-level"></a><strong>Volume Command Invalid Level</strong></summary>
-
-
-## Missing or Invalid Volume Level
-
-Usage: `schemabot volume <apply-id> -e <environment> -v <level>`
-
-The `-v` flag is required and must be a number between 1 (slowest) and 11 (fastest).
-
-</details>
-
-<details>
-<summary><a name="volume-command-missing-apply-id"></a><strong>Volume Command Missing Apply ID</strong></summary>
-
-
-## Missing Apply ID
-
-Usage: `schemabot volume <apply-id> -e <environment> -v <1-11>`
-
-Use `schemabot status -e <environment>` to find the apply ID.
-
-</details>
-
-<details>
-<summary><a name="volume-changed-superseded-progress-comment"></a><strong>Volume Changed: Superseded Progress Comment</strong></summary>
-
-
-⏩ Volume changed to **8/11** — progress continues in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
-
-<details>
-<summary>Progress before the volume change</summary>
-
-## Schema Change Status — Staging
-
-**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
-
-*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
-
-**Status**: In Progress | Volume: 3/11
-
-**`users`**: 🟦🟦🟦🟦🟦🟦⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ 32%
-
-```sql
-ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
-```
-Rows: 2,300,000 / 7,200,000 · ETA: 13m 0s
-
-
----
-
-To stop this schema change:
-```
-schemabot stop apply-a1b2c3d4e5f6 -e staging
-```
-
-_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
-
-
-</details>
-
-
-</details>
-
-<details>
-<summary><a name="resumed-superseded-progress-comment"></a><strong>Resumed: Superseded Progress Comment</strong></summary>
-
-
-▶️ Schema change resumed — progress continues in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
-
-<details>
-<summary>Progress before the stop</summary>
-
-## Schema Change Status — Staging
-
-**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
-
-*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
-
-**Status**: Stopped
-
-**`users`**: 🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 32%
-
-```sql
-ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
-```
-Rows: 2,300,000 / 7,200,000
-
-
----
-
-Paused — to resume from where it stopped:
-```
-schemabot start apply-a1b2c3d4e5f6 -e staging
-```
-
-
-</details>
-
-
-</details>
-
-<details>
-<summary><a name="revert-superseded-progress-comment"></a><strong>Revert: Superseded Progress Comment</strong></summary>
-
-
-Schema change reverting — the revert is tracked in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
-
-<details>
-<summary>Progress before the revert</summary>
-
-## Schema Change Status — Staging
-
-**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
-
-*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
-
-**Status**: Revert Window
-
-**`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Complete (revert window open)
-
-```sql
-ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
-```
-
-
----
-
-To skip revert and keep changes:
-```
-schemabot skip-revert apply-a1b2c3d4e5f6 -e staging
-```
-
-To revert:
-```
-schemabot revert apply-a1b2c3d4e5f6 -e staging
-```
-
-_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
-
-
-</details>
-
-
-</details>
-
-<details>
-<summary><a name="skip-revert-superseded-progress-comment"></a><strong>Skip Revert: Superseded Progress Comment</strong></summary>
-
-
-Revert skipped — the schema change is finalizing in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
-
-<details>
-<summary>Progress before the revert was skipped</summary>
-
-## Schema Change Status — Staging
-
-**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
-
-*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
-
-**Status**: Revert Window
-
-**`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Complete (revert window open)
-
-```sql
-ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
-```
-
-
----
-
-To skip revert and keep changes:
-```
-schemabot skip-revert apply-a1b2c3d4e5f6 -e staging
-```
-
-To revert:
-```
-schemabot revert apply-a1b2c3d4e5f6 -e staging
-```
-
-_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
-
-
-</details>
-
-
-</details>
-
-<details>
-<summary><a name="cutover-complete-superseded-cutover-prompt"></a><strong>Cutover Complete: Superseded Cutover Prompt</strong></summary>
-
-
-Cutover complete — progress continues in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
-
-<details>
-<summary>Cutover prompt</summary>
-
-## Schema Change Status — Staging
-
-**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
-
-*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
-
-**Status**: Waiting for Cutover
-
-**0/1** table(s) ready for cutover — waiting on 1
-
-**`users`**: 🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨🟨 Waiting for cutover
-
-```sql
-ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
-```
-
-
----
-
-SchemaBot triggers cutover automatically — no action needed.
-
-_Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:00 UTC</relative-time> (2026-01-01 00:00:00 UTC)_
-
-
-</details>
-
-
-</details>
-
-<details>
-<summary><a name="retry-superseded-progress-comment-generic"></a><strong>Retry: Superseded Progress Comment (Generic)</strong></summary>
-
-
-⏭️ Progress comment superseded — progress continues in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
-
-<details>
-<summary>Earlier progress</summary>
-
-## Schema Change Status — Staging
-
-**Database**: `testapp` | **Apply ID**: `apply-a1b2c3d4e5f6`
-
-*Applied by @jackjackbits at 2026-01-01 00:00:00 UTC*
-
-**Status**: Stopped
-
-**`users`**: 🟧🟧🟧🟧🟧🟧⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜ ⏹️ Stopped at 32%
-
-```sql
-ALTER TABLE `users` ADD INDEX `idx_email_created`(`email`, `created_at`);
-```
-Rows: 2,300,000 / 7,200,000
-
-
----
-
-Paused — to resume from where it stopped:
-```
-schemabot start apply-a1b2c3d4e5f6 -e staging
-```
-
-
-</details>
-
-
-</details>
-
-<details>
-<summary><a name="checks-gate-not-passing"></a><strong>Checks Gate: Not Passing</strong></summary>
-
-
-## ❌ Apply Blocked — Staging
-
-Cannot apply while PR checks are not passing:
-
-| Check | Status |
-|-------|--------|
-| `CI / unit-tests` | failure |
-| `CI / lint` | timed_out |
-
-Get the checks passing — fix failures and re-run cancelled or stale checks — then retry:
-```
-schemabot apply -e staging
-```
-
-
-</details>
-
-<details>
-<summary><a name="checks-gate-in-progress"></a><strong>Checks Gate: In Progress</strong></summary>
-
-
-## ⏳ Apply Blocked — Staging
-
-Cannot apply while PR checks are still running:
-
-| Check | Status |
-|-------|--------|
-| `CI / unit-tests` | in_progress |
-| `CI / integration-tests` | queued |
-
-Wait for checks to complete and retry:
-```
-schemabot apply -e staging
-```
-
-</details>
 
 ## Multi-Deployment Apply
 

--- a/pkg/cmd/commands/preview.go
+++ b/pkg/cmd/commands/preview.go
@@ -110,7 +110,6 @@ func (cmd *PreviewCmd) Run(g *Globals) error {
 		templates.PreviewCommentApplyBlocked, templates.PreviewCommentApplyBlockedCLI,
 		templates.PreviewCommentApplyActive,
 		templates.PreviewCommentApplyNoLock, templates.PreviewCommentBaseSchemaStale,
-		templates.PreviewCommentApplyAllType,
 		templates.PreviewCommentChecksGateNotPassing, templates.PreviewCommentChecksGateInProgress,
 		templates.PreviewCommentActorNotAuthorized, templates.PreviewCommentActorAuthUnavailable,
 		templates.PreviewCommentDatabaseNotConfigured,
@@ -307,7 +306,6 @@ Apply Command Comments (GitHub PR apply commands):
   comment_cutover_active        Cutover already in progress
   comment_volume_accepted       Volume request accepted
   comment_volume_invalid        Volume command with a missing or invalid level
-  comment_apply_all             Show all apply command previews
 
 Aggregate Types (grouped PR + CLI pairs):
   comment_plan_all              PR plan & status comments

--- a/pkg/cmd/commands/preview.go
+++ b/pkg/cmd/commands/preview.go
@@ -82,6 +82,7 @@ func (cmd *PreviewCmd) Run(g *Globals) error {
 		templates.PreviewCommentHelp, templates.PreviewCommentSupportChannel,
 		templates.PreviewCommentErrors, templates.PreviewCommentUnsafeBlocked,
 		templates.PreviewCommentDropColumnBlocked, templates.PreviewCommentDropIndexBlocked,
+		templates.PreviewCommentLintErrorsBlocked,
 		templates.PreviewCommentApplyPlan, templates.PreviewCommentApplyPlanOptions,
 		templates.PreviewCommentApplyPlanUnsafe,
 		templates.PreviewCommentApplyProgress, templates.PreviewCommentApplyCompleted,
@@ -254,6 +255,7 @@ Comment Templates (GitHub PR comments):
   comment_unsafe_blocked        Unsafe changes blocked (no --allow-unsafe)
   comment_drop_column_blocked   Drop column blocked with destructive-drop guidance
   comment_drop_index_blocked    Drop index blocked with destructive-drop guidance
+  comment_lint_errors_blocked   Error-severity schema lint violations block apply
   comment_single_progress       Single table: running (most common case)
   comment_single_complete       Single table: completed
   comment_single_failed         Single table: failed

--- a/pkg/cmd/internal/templates/preview.go
+++ b/pkg/cmd/internal/templates/preview.go
@@ -129,6 +129,7 @@ const (
 	PreviewCommentUnsafeBlocked                PreviewType = "comment_unsafe_blocked"                  // Unsafe changes blocked (no --allow-unsafe)
 	PreviewCommentDropColumnBlocked            PreviewType = "comment_drop_column_blocked"             // Drop column blocked with destructive-drop guidance
 	PreviewCommentDropIndexBlocked             PreviewType = "comment_drop_index_blocked"              // Drop index blocked with destructive-drop guidance
+	PreviewCommentLintErrorsBlocked            PreviewType = "comment_lint_errors_blocked"             // Error-severity schema lint violations block apply
 	PreviewCommentApplyPlan                    PreviewType = "comment_apply_plan"                      // Locked apply-plan comment
 	PreviewCommentApplyPlanOptions             PreviewType = "comment_apply_plan_options"              // Locked apply-plan with options
 	PreviewCommentApplyPlanUnsafe              PreviewType = "comment_apply_plan_unsafe"               // Locked apply-plan with unsafe warning
@@ -196,5 +197,4 @@ const (
 	PreviewCommentCutoverActive         PreviewType = "comment_cutover_active"               // Cutover command when cutover is already in progress
 	PreviewCommentVolumeAccepted        PreviewType = "comment_volume_accepted"              // Volume command accepted
 	PreviewCommentVolumeInvalid         PreviewType = "comment_volume_invalid"               // Volume command with a missing or invalid level
-	PreviewCommentApplyAllType          PreviewType = "comment_apply_all"                    // Show all apply comment previews
 )

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -27,7 +27,7 @@ func previewCommentErrorsOutput() {
 		if i > 0 {
 			fmt.Println()
 		}
-		fmt.Println("---", s.name, strings.Repeat("-", 50-len(s.name)))
+		fmt.Println("---", s.name, strings.Repeat("-", max(50-len(s.name), 3)))
 		fmt.Println()
 		fmt.Print(s.fn())
 		fmt.Println()
@@ -55,6 +55,7 @@ func previewCommentAllOutput() {
 		{"UNSAFE CHANGES BLOCKED", func() { fmt.Print(webhooktemplates.PreviewCommentUnsafeBlocked()) }},
 		{"DROP COLUMN BLOCKED", func() { fmt.Print(webhooktemplates.PreviewCommentDropColumnBlocked()) }},
 		{"DROP INDEX BLOCKED", func() { fmt.Print(webhooktemplates.PreviewCommentDropIndexBlocked()) }},
+		{"SCHEMA LINT ERRORS BLOCKED", func() { fmt.Print(webhooktemplates.PreviewCommentLintErrorsBlocked()) }},
 		{"MULTI-ENV PLAN (IDENTICAL)", func() { fmt.Print(webhooktemplates.PreviewCommentMultiEnvPlan()) }},
 		{"MULTI-ENV PLAN (DIFFERENT)", func() { fmt.Print(webhooktemplates.PreviewCommentMultiEnvPlanDiff()) }},
 		{"MULTI-ENV PLAN (ERROR)", func() { fmt.Print(webhooktemplates.PreviewCommentMultiEnvPlanError()) }},
@@ -107,70 +108,7 @@ func previewCommentAllOutput() {
 		if i > 0 {
 			fmt.Println()
 		}
-		fmt.Println("---", s.name, strings.Repeat("-", 50-len(s.name)))
-		fmt.Println()
-		s.fn()
-		fmt.Println()
-	}
-}
-
-func previewApplyCommandAllOutput() {
-	sections := []struct {
-		name string
-		fn   func()
-	}{
-		{"APPLY GATE: SCHEMA CHANGE APPLY (AUTOMATIC)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlan()) }},
-		{"APPLY GATE: SCHEMA CHANGE APPLY (WITH OPTIONS)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlanOptions()) }},
-		{"APPLY GATE: SCHEMA CHANGE APPLY (DOWNGRADED)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlanDowngraded()) }},
-		{"APPLY STARTED", func() { fmt.Print(webhooktemplates.PreviewCommentApplyStarted()) }},
-		{"UNLOCK SUCCESS", func() { fmt.Print(webhooktemplates.PreviewCommentUnlockSuccess()) }},
-		{"APPLY BLOCKED BY OTHER PR", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByOtherPR()) }},
-		{"APPLY BLOCKED BY CLI", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByCLI()) }},
-		{"APPLY ALREADY IN PROGRESS", func() { fmt.Print(webhooktemplates.PreviewCommentApplyInProgress()) }},
-		{"APPLY BLOCKED: PR CLOSED", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedClosedPR()) }},
-		{"APPLY BLOCKED: PR MERGED", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedMergedPR()) }},
-		{"NO LOCK FOUND", func() { fmt.Print(webhooktemplates.PreviewCommentApplyConfirmNoLock()) }},
-		{"BASE SCHEMA CHANGED SINCE PR DIVERGED", func() { fmt.Print(webhooktemplates.PreviewCommentBaseSchemaFreshnessRejected()) }},
-		{"BLOCKED BY PRIOR ENV (PENDING)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByPriorEnv()) }},
-		{"BLOCKED BY PRIOR ENV (FAILED)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByPriorEnvFailed()) }},
-		{"BLOCKED BY PRIOR ENV (IN PROGRESS)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByPriorEnvInProgress()) }},
-		{"REVIEW REQUIRED", func() { fmt.Print(webhooktemplates.PreviewCommentReviewRequired()) }},
-		{"REVIEW GATE ERROR (FAIL-CLOSED)", func() { fmt.Print(webhooktemplates.PreviewCommentReviewGateError()) }},
-		{"ACTOR AUTHORIZATION: NOT AUTHORIZED", func() { fmt.Print(webhooktemplates.PreviewCommentPRCommandNotAuthorized()) }},
-		{"ACTOR AUTHORIZATION: UNAVAILABLE", func() { fmt.Print(webhooktemplates.PreviewCommentPRCommandAuthorizationUnavailable()) }},
-		{"ACTOR AUTHORIZATION: DATABASE NOT CONFIGURED", func() { fmt.Print(webhooktemplates.PreviewCommentPRCommandDatabaseNotConfigured()) }},
-		{"START COMMAND ACCEPTED", func() { fmt.Print(webhooktemplates.PreviewCommentStartCommandAccepted()) }},
-		{"START COMMAND ALREADY PENDING", func() { fmt.Print(webhooktemplates.PreviewCommentStartCommandAlreadyRequested()) }},
-		{"CUTOVER COMMAND ACCEPTED", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAccepted()) }},
-		{"CUTOVER COMMAND ALREADY IN PROGRESS", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverCommandAlreadyInProgress()) }},
-		{"VOLUME COMMAND ACCEPTED", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeCommandAccepted()) }},
-		{"VOLUME COMMAND INVALID LEVEL", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeInvalidLevel()) }},
-		{"VOLUME COMMAND MISSING APPLY ID", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeMissingApplyID()) }},
-		{"VOLUME CHANGED: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentVolumeSupersededProgress()) }},
-		{"RESUMED: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentResumeSupersededProgress()) }},
-		{"REVERT: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentRevertSupersededProgress()) }},
-		{"SKIP REVERT: SUPERSEDED PROGRESS COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentSkipRevertSupersededProgress()) }},
-		{"CUTOVER COMPLETE: SUPERSEDED CUTOVER PROMPT", func() { fmt.Print(webhooktemplates.PreviewCommentCutoverSuperseded()) }},
-		{"RETRY: SUPERSEDED PROGRESS COMMENT (GENERIC)", func() { fmt.Print(webhooktemplates.PreviewCommentSupersededProgress()) }},
-		{"CHECKS GATE: NOT PASSING", func() {
-			fmt.Print(webhooktemplates.RenderApplyBlockedByNonPassingChecks("staging", []webhooktemplates.BlockingCheck{
-				{Name: "CI / unit-tests", State: "failure"},
-				{Name: "CI / lint", State: "timed_out"},
-			}))
-		}},
-		{"CHECKS GATE: IN PROGRESS", func() {
-			fmt.Print(webhooktemplates.RenderApplyBlockedByInProgressChecks("staging", []webhooktemplates.BlockingCheck{
-				{Name: "CI / unit-tests", State: "in_progress"},
-				{Name: "CI / integration-tests", State: "queued"},
-			}, nil))
-		}},
-	}
-
-	for i, s := range sections {
-		if i > 0 {
-			fmt.Println()
-		}
-		fmt.Println("---", s.name, strings.Repeat("-", 50-len(s.name)))
+		fmt.Println("---", s.name, strings.Repeat("-", max(50-len(s.name), 3)))
 		fmt.Println()
 		s.fn()
 		fmt.Println()
@@ -205,6 +143,7 @@ func previewCommentPlanAllOutput() {
 		{"MULTI-ENV PLAN (LINT WARNINGS)", func() { fmt.Print(webhooktemplates.PreviewCommentMultiEnvPlanLint()) }},
 		{"DROP COLUMN BLOCKED", func() { fmt.Print(webhooktemplates.PreviewCommentDropColumnBlocked()) }},
 		{"DROP INDEX BLOCKED", func() { fmt.Print(webhooktemplates.PreviewCommentDropIndexBlocked()) }},
+		{"SCHEMA LINT ERRORS BLOCKED", func() { fmt.Print(webhooktemplates.PreviewCommentLintErrorsBlocked()) }},
 		{"HELP COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentHelp()) }},
 		{"SUPPORT CHANNEL FOOTER", func() { fmt.Print(webhooktemplates.PreviewCommentSupportChannel()) }},
 		{"NO CONFIG (NO -D FLAG)", func() { fmt.Print(webhooktemplates.PreviewCommentErrorNoConfig()) }},
@@ -225,16 +164,8 @@ func previewCommentLockingAllOutput() {
 		name string
 		fn   func()
 	}{
-		{"APPLY BLOCKED BY OTHER PR", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByOtherPR()) }},
-		{"APPLY BLOCKED BY CLI", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByCLI()) }},
 		{"UNLOCK SUCCESS", func() { fmt.Print(webhooktemplates.PreviewCommentUnlockSuccess()) }},
-		{"APPLY ALREADY IN PROGRESS", func() { fmt.Print(webhooktemplates.PreviewCommentApplyInProgress()) }},
 		{"NO LOCK FOUND", func() { fmt.Print(webhooktemplates.PreviewCommentApplyConfirmNoLock()) }},
-		{"BLOCKED BY PRIOR ENV (PENDING)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByPriorEnv()) }},
-		{"BLOCKED BY PRIOR ENV (FAILED)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByPriorEnvFailed()) }},
-		{"BLOCKED BY PRIOR ENV (IN PROGRESS)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByPriorEnvInProgress()) }},
-		{"REVIEW REQUIRED", func() { fmt.Print(webhooktemplates.PreviewCommentReviewRequired()) }},
-		{"REVIEW GATE ERROR (FAIL-CLOSED)", func() { fmt.Print(webhooktemplates.PreviewCommentReviewGateError()) }},
 	}
 	printSections(sections)
 }
@@ -249,6 +180,40 @@ func previewCommentApplyFlowAllOutput() {
 		{"SCHEMA CHANGE APPLY (DOWNGRADED)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyPlanDowngraded()) }},
 		{"SCHEMA CHANGE APPLY (VITESS + OPTIONS)", func() { fmt.Print(webhooktemplates.PreviewCommentVitessApplyPlan()) }},
 		{"APPLY STARTED", func() { fmt.Print(webhooktemplates.PreviewCommentApplyStarted()) }},
+		// Blocked applies: the apply command was rejected before starting
+		{"APPLY BLOCKED BY OTHER PR", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByOtherPR()) }},
+		{"APPLY BLOCKED BY CLI", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByCLI()) }},
+		{"APPLY BLOCKED: ALREADY IN PROGRESS", func() { fmt.Print(webhooktemplates.PreviewCommentApplyInProgress()) }},
+		{"APPLY BLOCKED: PR CLOSED", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedClosedPR()) }},
+		{"APPLY BLOCKED: PR MERGED", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedMergedPR()) }},
+		{"APPLY BLOCKED: BASE SCHEMA CHANGED SINCE PR DIVERGED", func() { fmt.Print(webhooktemplates.PreviewCommentBaseSchemaFreshnessRejected()) }},
+		{"APPLY BLOCKED: SCHEMA STALE (NEW COMMITS)", func() { fmt.Print(webhooktemplates.PreviewCommentStaleSchemaRejected()) }},
+		{"APPLY BLOCKED: CONFIRMED PLAN STALE", func() { fmt.Print(webhooktemplates.PreviewCommentStalePlanRejected()) }},
+		{"APPLY BLOCKED BY PRIOR ENV (PENDING)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByPriorEnv()) }},
+		{"APPLY BLOCKED BY PRIOR ENV (FAILED)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByPriorEnvFailed()) }},
+		{"APPLY BLOCKED BY PRIOR ENV (IN PROGRESS)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByPriorEnvInProgress()) }},
+		{"APPLY BLOCKED: PRIOR ENV CHECK MISSING", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByMissingPriorEnvCheck()) }},
+		{"APPLY BLOCKED: PRIOR ENV CHECK READ ERROR", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByPriorEnvCheckError()) }},
+		{"APPLY BLOCKED: PRIOR ENV CHECK UNTRUSTED", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByUntrustedPriorEnvCheck()) }},
+		{"APPLY BLOCKED: ENVIRONMENT NOT IN PROMOTION ORDER", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByUnlistedEnvironment()) }},
+		{"APPLY BLOCKED: REVIEW REQUIRED", func() { fmt.Print(webhooktemplates.PreviewCommentReviewRequired()) }},
+		{"APPLY BLOCKED: REVIEW GATE ERROR (FAIL-CLOSED)", func() { fmt.Print(webhooktemplates.PreviewCommentReviewGateError()) }},
+		{"APPLY BLOCKED: CHECKS NOT PASSING", func() {
+			fmt.Print(webhooktemplates.RenderApplyBlockedByNonPassingChecks("staging", []webhooktemplates.BlockingCheck{
+				{Name: "CI / unit-tests", State: "failure"},
+				{Name: "CI / lint", State: "timed_out"},
+			}))
+		}},
+		{"APPLY BLOCKED: CHECKS IN PROGRESS", func() {
+			fmt.Print(webhooktemplates.RenderApplyBlockedByInProgressChecks("staging", []webhooktemplates.BlockingCheck{
+				{Name: "CI / unit-tests", State: "in_progress"},
+				{Name: "CI / integration-tests", State: "queued"},
+			}, nil))
+		}},
+		{"APPLY BLOCKED: CHECK STATUS READ ERROR", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedByCheckStatusError()) }},
+		{"APPLY BLOCKED: ACTOR NOT AUTHORIZED", func() { fmt.Print(webhooktemplates.PreviewCommentPRCommandNotAuthorized()) }},
+		{"ACTOR AUTHORIZATION: UNAVAILABLE", func() { fmt.Print(webhooktemplates.PreviewCommentPRCommandAuthorizationUnavailable()) }},
+		{"ACTOR AUTHORIZATION: DATABASE NOT CONFIGURED", func() { fmt.Print(webhooktemplates.PreviewCommentPRCommandDatabaseNotConfigured()) }},
 		// Single-table (most common case)
 		{"SINGLE TABLE: RUNNING", func() { fmt.Print(webhooktemplates.PreviewCommentApplySingleProgress()) }},
 		{"SINGLE TABLE: RUNNING (VOLUME TUNED)", func() { fmt.Print(webhooktemplates.PreviewCommentApplySingleProgressVolume()) }},
@@ -448,8 +413,9 @@ func printSections(sections []struct {
 		}
 		// Clamp the trailing rule so a section name longer than the target width
 		// doesn't pass a negative count to strings.Repeat (which panics and would
-		// abort the whole TEMPLATES.md regeneration).
-		dashes := max(50-len(s.name), 0)
+		// abort the whole TEMPLATES.md regeneration). Keep at least a few dashes
+		// so the section-marker line still matches the wrapper's pattern.
+		dashes := max(50-len(s.name), 3)
 		fmt.Println("---", s.name, strings.Repeat("-", dashes))
 		fmt.Println()
 		s.fn()

--- a/pkg/cmd/internal/templates/preview_defer.go
+++ b/pkg/cmd/internal/templates/preview_defer.go
@@ -247,7 +247,7 @@ func previewDeferAllOutput() {
 		if i > 0 {
 			fmt.Println()
 		}
-		fmt.Println("---", s.name, strings.Repeat("-", 50-len(s.name)))
+		fmt.Println("---", s.name, strings.Repeat("-", max(50-len(s.name), 3)))
 		fmt.Println()
 		s.fn()
 	}

--- a/pkg/cmd/internal/templates/preview_dispatch.go
+++ b/pkg/cmd/internal/templates/preview_dispatch.go
@@ -152,6 +152,8 @@ func PreviewCLIOutput(previewType PreviewType) {
 		fmt.Print(webhooktemplates.PreviewCommentDropColumnBlocked())
 	case PreviewCommentDropIndexBlocked:
 		fmt.Print(webhooktemplates.PreviewCommentDropIndexBlocked())
+	case PreviewCommentLintErrorsBlocked:
+		fmt.Print(webhooktemplates.PreviewCommentLintErrorsBlocked())
 	case PreviewCommentApplyPlan:
 		fmt.Print(webhooktemplates.PreviewCommentApplyPlan())
 	case PreviewCommentApplyPlanOptions:
@@ -281,8 +283,6 @@ func PreviewCLIOutput(previewType PreviewType) {
 		fmt.Print(webhooktemplates.PreviewCommentVolumeCommandAccepted())
 	case PreviewCommentVolumeInvalid:
 		fmt.Print(webhooktemplates.PreviewCommentVolumeInvalidLevel())
-	case PreviewCommentApplyAllType:
-		previewApplyCommandAllOutput()
 	// Paired aggregate previews (PR + CLI subsections)
 	case PreviewCommentPlanAll:
 		previewCommentPlanAllOutput()

--- a/pkg/cmd/internal/templates/preview_lint.go
+++ b/pkg/cmd/internal/templates/preview_lint.go
@@ -55,7 +55,7 @@ func previewLintAllOutput() {
 		if i > 0 {
 			fmt.Println()
 		}
-		fmt.Println("---", s.name, strings.Repeat("-", 50-len(s.name)))
+		fmt.Println("---", s.name, strings.Repeat("-", max(50-len(s.name), 3)))
 		fmt.Println()
 		s.fn()
 	}

--- a/pkg/cmd/internal/templates/preview_sequential.go
+++ b/pkg/cmd/internal/templates/preview_sequential.go
@@ -228,7 +228,7 @@ func previewSequentialAllOutput() {
 		if i > 0 {
 			fmt.Println()
 		}
-		fmt.Println("---", s.name, strings.Repeat("-", 50-len(s.name)))
+		fmt.Println("---", s.name, strings.Repeat("-", max(50-len(s.name), 3)))
 		fmt.Println()
 		s.fn()
 	}

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -17,6 +17,7 @@ const (
 	PreviewErrorMiddleFailed = "lock wait timeout exceeded; try restarting transaction"
 	previewRepository        = "block/schemabot"
 	previewHeadSHA           = "abcdef1234567890abcdef1234567890abcdef12"
+	previewStaleSHA          = "0123456789abcdef0123456789abcdef01234567"
 	previewRequestedBy       = "jackjackbits"
 )
 
@@ -47,10 +48,7 @@ func PreviewCommentPlan() string {
 				},
 			},
 		},
-		LintViolations: []LintViolationData{
-			{Message: "New column uses floating-point data type", Table: "orders", LinterName: "has_float"},
-			{Message: "Column added without DEFAULT value", Table: "users", LinterName: "no_default"},
-		},
+		LintViolations: sampleLintWarnings(),
 	})
 }
 
@@ -396,6 +394,68 @@ func PreviewCommentApplyBlockedByPriorEnvInProgress() string {
 	return RenderApplyBlockedByPriorEnvInProgress("testapp", "production", "staging")
 }
 
+// PreviewCommentApplyBlockedByCheckStatusError renders a sample fail-closed
+// block for a check-status read that failed because the GitHub App
+// installation is missing permissions.
+func PreviewCommentApplyBlockedByCheckStatusError() string {
+	return RenderApplyBlockedByCheckStatusError("staging",
+		fmt.Errorf("list check runs for ref: Resource not accessible by integration"),
+		&CheckStatusAccessDetails{
+			GitHubApp:          "schemabot-app",
+			MissingPermissions: []string{"Checks: Read", "Commit statuses: Read"},
+		})
+}
+
+// PreviewCommentApplyBlockedByPriorEnvCheckError renders a sample fail-closed
+// block for a prior-environment check that could not be read.
+func PreviewCommentApplyBlockedByPriorEnvCheckError() string {
+	return RenderApplyBlockedByPriorEnvCheckError("staging", "query check runs",
+		fmt.Errorf("list check runs for ref: 502 Bad Gateway"))
+}
+
+// PreviewCommentApplyBlockedByMissingPriorEnvCheck renders a sample block for
+// a prior environment with no completed SchemaBot check on the PR.
+func PreviewCommentApplyBlockedByMissingPriorEnvCheck() string {
+	return RenderApplyBlockedByMissingPriorEnvCheck("staging")
+}
+
+// PreviewCommentApplyBlockedByUntrustedPriorEnvCheck renders a sample block
+// for a prior-environment check created only by untrusted GitHub Apps.
+func PreviewCommentApplyBlockedByUntrustedPriorEnvCheck() string {
+	return RenderApplyBlockedByUntrustedPriorEnvCheck("staging", "SchemaBot (staging)", []string{"acme-automation"})
+}
+
+// PreviewCommentApplyBlockedByUnlistedEnvironment renders a sample block for a
+// target environment missing from the configured promotion order.
+func PreviewCommentApplyBlockedByUnlistedEnvironment() string {
+	return RenderApplyBlockedByUnlistedEnvironment("development", []string{"staging", "production"})
+}
+
+// PreviewCommentStaleSchemaRejected renders a sample rejection for schema
+// files loaded at an older commit than the current PR HEAD.
+func PreviewCommentStaleSchemaRejected() string {
+	return RenderStaleSchemaRejection(StaleSchemaRejectionData{
+		RequestedBy:  previewRequestedBy,
+		Database:     "testapp",
+		Environment:  "staging",
+		DiscoverySHA: previewStaleSHA,
+		CurrentSHA:   previewHeadSHA,
+		Action:       "apply",
+	})
+}
+
+// PreviewCommentStalePlanRejected renders a sample rejection for a confirmed
+// plan rendered against a commit that is no longer the PR HEAD.
+func PreviewCommentStalePlanRejected() string {
+	return RenderStalePlanRejection(StalePlanRejectionData{
+		RequestedBy: previewRequestedBy,
+		Database:    "testapp",
+		Environment: "staging",
+		PlanSHA:     previewStaleSHA,
+		CurrentSHA:  previewHeadSHA,
+	})
+}
+
 // sampleTime returns a fixed time for preview rendering consistency.
 func sampleTime() time.Time {
 	return time.Date(2026, 3, 15, 14, 30, 0, 0, time.UTC)
@@ -412,6 +472,15 @@ func samplePlanChanges() []KeyspaceChangeData {
 				"ALTER TABLE `products` ADD INDEX `idx_category_price` (`category`, `price`);",
 			},
 		},
+	}
+}
+
+// sampleLintWarnings returns warning-severity lint findings that match the
+// statements in samplePlanChanges, in the message format Spirit's linters emit.
+func sampleLintWarnings() []LintViolationData {
+	return []LintViolationData{
+		{Message: `Column "created_at" uses TIMESTAMP which overflows on 2038-01-19. Consider using DATETIME instead.`, Table: "users", LinterName: "has_timestamp"},
+		{Message: `Index 'idx_category' on columns (category) is redundant - covered by index 'idx_category_price' on columns (category, price)`, Table: "products", LinterName: "redundant_indexes"},
 	}
 }
 
@@ -496,6 +565,35 @@ func PreviewCommentDropIndexBlocked() string {
 				Table:  "customers",
 				Reason: "Unsafe operation detected: DROP INDEX `idx_customers_email`",
 			},
+		},
+	})
+}
+
+// PreviewCommentLintErrorsBlocked renders a sample plan where error-severity
+// schema lint violations block the apply. The reasons carry the raw
+// "[ERROR] linter:" prefixes engines report; the renderer strips them.
+func PreviewCommentLintErrorsBlocked() string {
+	return RenderUnsafeChangesBlocked(PlanCommentData{
+		Database:    "testapp",
+		SchemaName:  "testapp",
+		Environment: "staging",
+		HeadSHA:     previewHeadSHA,
+		Repository:  previewRepository,
+		RequestedBy: previewRequestedBy,
+		IsMySQL:     true,
+		Changes: []KeyspaceChangeData{
+			{
+				Keyspace: "testapp",
+				Statements: []string{
+					"ALTER TABLE `orders` MODIFY COLUMN `id` int NOT NULL AUTO_INCREMENT;",
+					"ALTER TABLE `users` RENAME COLUMN `email` TO `email_address`;",
+				},
+			},
+		},
+		HasUnsafeChanges: true,
+		UnsafeChanges: []UnsafeChangeData{
+			{Table: "orders", Reason: `[ERROR] primary_key: Primary key column "id" has type "int"`},
+			{Table: "users", Reason: `[ERROR] rename_column: Column rename detected in table "users": "email" to "email_address". Renaming a column cannot be done atomically across application pods, and ORMs that generate column names at compile time (e.g. jOOQ) will break until code is recompiled`},
 		},
 	})
 }
@@ -741,10 +839,7 @@ func PreviewCommentMultiEnvPlan() string {
 // with lint violations included in each environment's plan.
 func PreviewCommentMultiEnvPlanLint() string {
 	changes := samplePlanChanges()
-	lintViolations := []LintViolationData{
-		{Message: "Primary key uses signed integer type (should be UNSIGNED)", Table: "orders", LinterName: "primary_key"},
-		{Message: "Column uses utf8 charset (should be utf8mb4)", Table: "users", LinterName: "allow_charset"},
-	}
+	lintViolations := sampleLintWarnings()
 	return RenderMultiEnvPlanComment(MultiEnvPlanCommentData{
 		Database:     "testapp",
 		SchemaName:   "testapp",

--- a/scripts/update-templates.sh
+++ b/scripts/update-templates.sh
@@ -167,15 +167,6 @@ render_paired_section "Apply Flow"     "comment_apply_flow_all" "cli_apply_all"
 # === PR-only sections ===
 {
     echo ""
-    echo "## Apply Gates"
-    echo ""
-    echo "### PR Comments"
-    echo ""
-    "$BINARY" preview "comment_apply_all" 2>&1 | wrap_sections
-} >> "$SNAPSHOT"
-
-{
-    echo ""
     echo "## Multi-Deployment Apply"
     echo ""
     echo "### PR Comments"


### PR DESCRIPTION
## Why this matters

TEMPLATES.md is how operators and reviewers discover what SchemaBot will actually say on a PR. The lint previews showed invented warning strings that don't match what Spirit's linters emit, there was no scenario showing error-severity lint findings blocking an apply, and the apply-blocked comments were scattered — split between the Locking section and a separate Apply Gates section far from Apply Flow — while seven live apply-blocked/rejection templates had no preview at all and never appeared in TEMPLATES.md.

## What it does

- Replaces the sample lint warnings in the plan previews with warning-severity findings in the exact message format Spirit's linters emit (`has_timestamp`, `redundant_indexes`), matched to the sample DDL.
- Adds a **Schema Lint Errors Blocked** scenario showing error-severity lint violations (primary key type, column rename) blocking an apply through the unsafe-changes renderer, including the `--allow-unsafe` guidance.
- Merges the Apply Gates section into Apply Flow so the PR apply lifecycle reads as one section: gate prompts → apply started → every **Apply Blocked** scenario as one contiguous cluster → actor authorization → progress states → control commands → summaries. The Locking section keeps lock lifecycle scenarios only, and the now-redundant `comment_apply_all` preview type is removed.
- Adds previews for seven blocked/rejection templates that previously had none: check-status read error, prior-env check read error / missing / untrusted, environment not in promotion order, stale schema (new commits since discovery), and stale confirmed plan.
- Clamps the preview section rule padding so labels longer than the target width keep a minimal dash rule instead of panicking `strings.Repeat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)