### PR TITLE
fix(github): stop stamping a neutral check run on unlock

### DIFF
--- a/pkg/webhook/apply_check_records.go
+++ b/pkg/webhook/apply_check_records.go
@@ -154,37 +154,3 @@ func (h *Handler) updateCheckRecordForApplyStart(ctx context.Context, client *gh
 	h.updateAggregateCheck(ctx, client, repo, pr, check.HeadSHA)
 	return nil
 }
-
-// updateCheckRunAfterUnlock updates a check run to neutral after lock release.
-func (h *Handler) updateCheckRunAfterUnlock(ctx context.Context, repo string, pr int, lock *storage.Lock, installationID int64) {
-	client, err := h.clientForRepo(repo, installationID)
-	if err != nil {
-		h.logger.Error("failed to create GitHub client for check run update",
-			"repo", repo, "pr", pr, "database", lock.DatabaseName, "database_type", lock.DatabaseType, "error", err)
-		return
-	}
-
-	prInfo, err := client.FetchPullRequest(ctx, repo, pr)
-	if err != nil {
-		h.logger.Error("failed to fetch PR for check run update",
-			"repo", repo, "pr", pr, "database", lock.DatabaseName, "database_type", lock.DatabaseType, "error", err)
-		return
-	}
-
-	checkName := fmt.Sprintf("SchemaBot Apply: /%s/%s", lock.DatabaseType, lock.DatabaseName)
-
-	opts := ghclient.CheckRunOptions{
-		Name:       checkName,
-		Status:     checkStatusCompleted,
-		Conclusion: checkConclusionNeutral,
-		Output: &ghclient.CheckRunOutput{
-			Title:   "Lock released",
-			Summary: "Schema change cancelled. Lock has been released.",
-		},
-	}
-
-	if _, err := client.CreateCheckRun(ctx, repo, prInfo.HeadSHA, opts); err != nil {
-		h.logger.Error("failed to update check run after unlock",
-			"repo", repo, "pr", pr, "database", lock.DatabaseName, "database_type", lock.DatabaseType, "head_sha", prInfo.HeadSHA, "error", err)
-	}
-}

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -543,12 +543,6 @@ func (h *Handler) handleUnlockCommand(repo string, pr int, installationID int64,
 
 		h.postComment(repo, pr, installationID, templates.RenderUnlockSuccess(
 			lock.DatabaseName, "", requestedBy))
-
-		// Update check run to neutral for PR-owned locks. CLI-owned locks have no
-		// associated PR check record to update.
-		if lock.Repository != "" && lock.PullRequest != 0 {
-			h.updateCheckRunAfterUnlock(ctx, repo, pr, lock, installationID)
-		}
 	}
 }
 

--- a/pkg/webhook/apply_integration_test.go
+++ b/pkg/webhook/apply_integration_test.go
@@ -432,24 +432,8 @@ func TestE2EUnlock(t *testing.T) {
 	client := gh.NewClient(nil)
 	client.BaseURL, _ = url.Parse(server.URL + "/")
 
-	// For unlock, we still need PR info for the check run
-	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(gh.PullRequest{
-			Head: &gh.PullRequestBranch{
-				Ref: new("feature-branch"),
-				SHA: new("abc123"),
-			},
-			Base: &gh.PullRequestBranch{
-				Ref: new("main"),
-				SHA: new("def456"),
-			},
-			User: &gh.User{Login: new("testuser")},
-		})
-	})
-
 	comments := make(chan string, 10)
 	reactions := make(chan string, 10)
-	checkRuns := make(chan checkRunCapture, 10)
 
 	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
 		var body struct {
@@ -466,13 +450,6 @@ func TestE2EUnlock(t *testing.T) {
 		}
 		_ = json.NewDecoder(r.Body).Decode(&body)
 		reactions <- body.Content
-		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
-	})
-	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
-		var body checkRunCapture
-		_ = json.NewDecoder(r.Body).Decode(&body)
-		checkRuns <- body
 		w.WriteHeader(http.StatusCreated)
 		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
 	})
@@ -508,15 +485,6 @@ func TestE2EUnlock(t *testing.T) {
 	lock, err := svc.Storage().Locks().Get(t.Context(), dbName, "mysql")
 	require.NoError(t, err)
 	assert.Nil(t, lock, "expected lock to be released")
-
-	// Verify check run updated to neutral
-	select {
-	case cr := <-checkRuns:
-		assert.Equal(t, "completed", cr.Status)
-		assert.Equal(t, "neutral", cr.Conclusion)
-	case <-time.After(10 * time.Second):
-		t.Fatal("timed out waiting for check run")
-	}
 }
 
 func TestE2EUnlockForceInfersDatabaseForCLILock(t *testing.T) {
@@ -664,21 +632,6 @@ func TestE2EUnlockDoesNotPassAggregateWithPendingChanges(t *testing.T) {
 	client := gh.NewClient(nil)
 	client.BaseURL, _ = url.Parse(server.URL + "/")
 
-	// The current PR commit is still the same commit that owns the pending plan.
-	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(gh.PullRequest{
-			Head: &gh.PullRequestBranch{
-				Ref: new("feature-branch"),
-				SHA: new("abc123"),
-			},
-			Base: &gh.PullRequestBranch{
-				Ref: new("main"),
-				SHA: new("def456"),
-			},
-			User: &gh.User{Login: new("testuser")},
-		})
-	})
-
 	comments := make(chan string, 10)
 	checkRuns := make(chan checkRunCapture, 10)
 
@@ -729,15 +682,14 @@ func TestE2EUnlockDoesNotPassAggregateWithPendingChanges(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, lock)
 
-	// Unlock updates the command-specific "SchemaBot Apply" check to neutral,
-	// but must not make the aggregate safety gate pass.
+	// Unlock never writes Check Runs: check state must keep reflecting stored
+	// apply outcomes only. The "Lock Released" comment is the final action in
+	// the release flow, so an empty channel here proves no check-run write
+	// happened.
 	select {
 	case cr := <-checkRuns:
-		assert.Contains(t, cr.Name, "SchemaBot Apply")
-		assert.Equal(t, checkStatusCompleted, cr.Status)
-		assert.Equal(t, checkConclusionNeutral, cr.Conclusion)
-	case <-time.After(webhookIntegrationCheckRunDeadline):
-		t.Fatal("timed out waiting for unlock check run")
+		t.Fatalf("unlock unexpectedly wrote a check run: %+v", cr)
+	default:
 	}
 
 	check, err := svc.Storage().Checks().Get(ctx, "octocat/hello-world", 1, "staging", "mysql", dbName)

--- a/pkg/webhook/prinfocache_dedup_integration_test.go
+++ b/pkg/webhook/prinfocache_dedup_integration_test.go
@@ -3,8 +3,6 @@
 package webhook
 
 import (
-	"context"
-	"encoding/json"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -19,7 +17,6 @@ import (
 
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/storage"
-	"github.com/block/schemabot/pkg/webhook/action"
 )
 
 // prFetchCountingTransport counts GET /repos/octocat/hello-world/pulls/1
@@ -36,77 +33,6 @@ func (t *prFetchCountingTransport) RoundTrip(req *http.Request) (*http.Response,
 		t.count.Add(1)
 	}
 	return t.base.RoundTrip(req)
-}
-
-// TestUnlockHandlerDedupesPRFetchAcrossLocks proves that a single
-// "schemabot unlock" invocation collapses every FetchPullRequest call
-// fanned out by updateCheckRunAfterUnlock — one per released lock — to a
-// single upstream GitHub call via the WithPRInfoCache wrap on the
-// handler's ctx. Without that wrap, every released lock would issue its
-// own /pulls fetch.
-func TestUnlockHandlerDedupesPRFetchAcrossLocks(t *testing.T) {
-	dbA := "webhook_unlock_dedup_a"
-	dbB := "webhook_unlock_dedup_b"
-	svc := setupE2EService(t, dbA)
-
-	for _, db := range []string{dbA, dbB} {
-		require.NoError(t, svc.Storage().Locks().Acquire(t.Context(), &storage.Lock{
-			DatabaseName: db,
-			DatabaseType: "mysql",
-			Repository:   "octocat/hello-world",
-			PullRequest:  1,
-			Owner:        "octocat/hello-world#1",
-		}))
-	}
-	t.Cleanup(func() {
-		for _, db := range []string{dbA, dbB} {
-			_ = svc.Storage().Locks().ForceRelease(context.WithoutCancel(t.Context()), db, "mysql")
-		}
-	})
-
-	var prFetchCalls atomic.Int32
-	mux := http.NewServeMux()
-	server := httptest.NewServer(mux)
-	t.Cleanup(server.Close)
-
-	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(gh.PullRequest{
-			Head: &gh.PullRequestBranch{Ref: new("feature-branch"), SHA: new("abc123")},
-			Base: &gh.PullRequestBranch{Ref: new("main"), SHA: new("def456")},
-			User: &gh.User{Login: new("testuser")},
-		})
-	})
-	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(map[string]any{"id": 99})
-	})
-	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
-	})
-
-	httpClient := &http.Client{Transport: &prFetchCountingTransport{base: http.DefaultTransport, count: &prFetchCalls}}
-	client := gh.NewClient(httpClient)
-	client.BaseURL, _ = url.Parse(server.URL + "/")
-
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
-	installClient := ghclient.NewInstallationClient(client, logger)
-	factory := &fakeClientFactory{client: installClient}
-	h := NewHandler(svc, factory, nil, logger)
-
-	// Call the handler entry point synchronously so every fan-out into
-	// updateCheckRunAfterUnlock resolves within the same WithPRInfoCache
-	// scope before the test asserts.
-	h.handleUnlockCommand("octocat/hello-world", 1, 12345, "testuser", CommandResult{Action: action.Unlock})
-
-	for _, db := range []string{dbA, dbB} {
-		l, err := svc.Storage().Locks().Get(t.Context(), db, "mysql")
-		require.NoError(t, err)
-		assert.Nil(t, l, "lock should be released for %s", db)
-	}
-
-	assert.Equal(t, int32(1), prFetchCalls.Load(),
-		"handleUnlockCommand must dedupe FetchPullRequest across all per-lock check-run cleanups within one invocation")
 }
 
 // TestRollbackConfirmHandlerDoesNotFetchPRForNoLock proves that

--- a/pkg/webhook/unlock_test.go
+++ b/pkg/webhook/unlock_test.go
@@ -127,28 +127,12 @@ func TestUnlockRefusedWhenActiveApplyLookupFails(t *testing.T) {
 
 // TestUnlockReleasesLockWhenNoActiveApplies verifies the unlock happy path:
 // when the active-apply check confirms no non-terminal apply exists for the
-// locked database, the PR-owned lock is released, a success comment is
-// posted, and the apply check run is set to neutral.
+// locked database, the PR-owned lock is released and a success comment is
+// posted. Unlock never writes Check Runs: lock state is not check state, and
+// the aggregate check must keep reflecting the stored apply outcomes.
 func TestUnlockReleasesLockWhenNoActiveApplies(t *testing.T) {
 	client, mux := setupGitHubServer(t)
 	comments := recordComments(t, mux)
-	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
-		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
-			"head": map[string]any{"ref": "feature-branch", "sha": "abc123"},
-			"base": map[string]any{"ref": "main", "sha": "def456"},
-			"user": map[string]any{"login": "testuser"},
-		}))
-	})
-	checkRuns := make(chan string, 2)
-	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
-		var body struct {
-			Conclusion string `json:"conclusion"`
-		}
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		checkRuns <- body.Conclusion
-		w.WriteHeader(http.StatusCreated)
-		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 1}))
-	})
 
 	lockStore := &unlockTestLockStore{locks: []*storage.Lock{{
 		DatabaseName: "orders",
@@ -172,12 +156,5 @@ func TestUnlockReleasesLockWhenNoActiveApplies(t *testing.T) {
 		assert.Contains(t, body, "@testuser")
 	case <-time.After(2 * time.Second):
 		require.FailNow(t, "timed out waiting for unlock success comment")
-	}
-
-	select {
-	case conclusion := <-checkRuns:
-		assert.Equal(t, "neutral", conclusion)
-	case <-time.After(2 * time.Second):
-		require.FailNow(t, "timed out waiting for check run update after unlock")
 	}
 }


### PR DESCRIPTION
## Why this matters

`schemabot unlock` releases a database lock — it does not change any apply outcome. But the unlock handler stamped a completed-**neutral** Check Run ("Lock released / Schema change cancelled") on the PR head every time. The naming scheme it used exists nowhere else in the codebase, so each unlock spawned an orphan check object rather than updating real check state, with copy that is factually wrong whenever the database's latest apply had succeeded or failed rather than been cancelled. If branch protection ever matched that check name, a non-blocking `neutral` conclusion could visually launder a failed schema change.

## What it does

- Removes the per-database check write from the unlock path entirely. Unlock now releases the lock and posts the 🔓 comment; Check Runs are untouched, so the aggregate check keeps reflecting stored apply outcomes.
- Updates the unlock happy-path test to the new contract and removes the PR-fetch dedup test whose premise was the deleted per-lock check-run fanout.

The code predates the aggregate-check design. Lock state is not check state; nothing needs to be written for the checks to stay correct.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)