### PR TITLE
fix(github): minimize stale plan comments when auto-plan finds no changes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -814,6 +814,11 @@ for the same set of environments. A same-commit comment covering different
 environments is kept expanded — it may be the only visible plan for those
 environments.
 
+A plan outcome can also supersede without posting: when an auto-plan resolves
+to no changes, no new comment appears (the check run alone reports the green
+state), but plan comments from prior commits still collapse — the pending DDL
+and apply prompt they show no longer match the branch.
+
 One safety hold: a plan comment whose commit produced an apply is never
 minimized, even after new pushes. That comment is the record of what actually
 ran against the database, and it stays visible until an operator reconciles

--- a/pkg/webhook/auto_plan_integration_test.go
+++ b/pkg/webhook/auto_plan_integration_test.go
@@ -462,6 +462,12 @@ func TestE2EAutoPlanWithLintViolations(t *testing.T) {
 	}
 }
 
+// TestE2EAutoPlanNoChangesSkipsComment exercises the up-to-date-PR UX through
+// the full webhook path: a synchronize delivery whose auto-plan resolves to no
+// changes posts no plan comment (the check run alone reports the green state),
+// and the outcome supersedes the slot's plan comments from prior heads — their
+// pending DDL and apply prompt no longer match the branch, so they collapse
+// even though no new comment replaces them.
 func TestE2EAutoPlanNoChangesSkipsComment(t *testing.T) {
 	dbName := "webhook_autoplan_nochange"
 	svc := setupE2EService(t, dbName)
@@ -489,6 +495,26 @@ func TestE2EAutoPlanNoChangesSkipsComment(t *testing.T) {
 
 	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
 
+	// A plan comment from a prior head is still expanded on the PR; the
+	// no-changes outcome must collapse it.
+	insertPlanCommentRow(t, svc.Storage(), "octocat/hello-world", 1, dbName, "staging", "priorsha", 9001, "IC_stale_prior")
+
+	minimized := make(chan string, 4)
+	mux.HandleFunc("POST /graphql", func(w http.ResponseWriter, r *http.Request) {
+		var gql struct {
+			Variables map[string]string `json:"variables"`
+		}
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&gql))
+		minimized <- gql.Variables["id"]
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"minimizeComment": map[string]any{
+					"minimizedComment": map[string]any{"isMinimized": true},
+				},
+			},
+		})
+	})
+
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	installClient := ghclient.NewInstallationClient(client, logger)
 	factory := &fakeClientFactory{client: installClient}
@@ -515,6 +541,18 @@ func TestE2EAutoPlanNoChangesSkipsComment(t *testing.T) {
 	case <-time.After(30 * time.Second):
 		t.Fatal("timed out waiting for check run")
 	}
+
+	// The prior head's plan comment collapses even though no new comment is
+	// posted: the no-changes outcome supersedes it.
+	select {
+	case node := <-minimized:
+		assert.Equal(t, "IC_stale_prior", node)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for the prior head's plan comment to be minimized")
+	}
+	require.Eventually(t, func() bool {
+		return len(unminimizedHeads(t, svc.Storage(), "octocat/hello-world", 1, dbName, "mysql")) == 0
+	}, 10*time.Second, 100*time.Millisecond, "the minimized plan comment must be recorded in storage")
 
 	// No comment should be posted — give it a moment to confirm nothing arrives
 	select {

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -458,7 +458,14 @@ func (h *Handler) handleMultiEnvPlan(repo string, pr int, databaseName, tenant s
 			}
 		}
 		if !anyChanges && !hasErrors {
-			h.logger.Info("auto-plan: no changes detected, skipping comment", "repo", repo, "pr", pr)
+			// The no-changes outcome supersedes older plan comments just as a
+			// new plan comment would: a prior head's comment still advertises
+			// pending DDL and an apply prompt that no longer match the branch.
+			h.logger.Info("auto-plan: no changes detected; skipping comment and minimizing plan comments from prior heads",
+				"repo", repo, "pr", pr, "database", multiEnvData.Database,
+				"database_type", multiEnvData.DatabaseType, "head_sha", multiEnvData.HeadSHA)
+			h.minimizeStalePlanComments(ctx, client, repo, pr,
+				multiEnvData.Database, multiEnvData.DatabaseType, multiEnvData.HeadSHA)
 			return
 		}
 	}

--- a/pkg/webhook/plan_comment_minimize.go
+++ b/pkg/webhook/plan_comment_minimize.go
@@ -90,28 +90,58 @@ func (h *Handler) postTrackedPlanComment(repo string, pr int, installationID int
 }
 
 // minimizeSupersededPlanComments collapses the unminimized plan comments that
-// the newly posted comment supersedes. A comment whose plan became an apply
-// is kept expanded: the apply makes it the operational record of what ran,
-// and hiding it costs more than the noise it saves. Every failure keeps the
-// comment expanded and its row unminimized, so the next supersede retries it.
+// the newly posted comment supersedes, per planCommentSupersedes.
 func (h *Handler) minimizeSupersededPlanComments(ctx context.Context, client *ghclient.InstallationClient, posted *storage.PlanComment) {
+	h.minimizePlanCommentsForSlot(ctx, client,
+		posted.Repository, posted.PullRequest, posted.DatabaseName, posted.DatabaseType, posted.HeadSHA, posted)
+}
+
+// minimizeStalePlanComments collapses the slot's unminimized plan comments
+// rendered at a head other than the current one, for plan outcomes that
+// supersede prior comments without posting a new comment — an auto-plan
+// resolving to no changes still moves the head past every older comment,
+// whose pending DDL and apply prompt no longer match the branch. Same-head
+// comments stay expanded: one may be the only visible plan for its
+// environment scope.
+func (h *Handler) minimizeStalePlanComments(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, database, databaseType, headSHA string) {
+	if database == "" || headSHA == "" {
+		// Without a database and head there is no slot identity to sweep;
+		// treating the empty identity as a slot could collapse untracked
+		// error-only comments across databases.
+		h.logger.Info("skipping stale plan comment minimize because no database or head resolved to key the slot",
+			"repo", repo, "pr", pr, "database", database, "database_type", databaseType, "head_sha", headSHA)
+		return
+	}
+	h.minimizePlanCommentsForSlot(ctx, client, repo, pr, database, databaseType, headSHA, nil)
+}
+
+// minimizePlanCommentsForSlot sweeps the slot's unminimized plan comments and
+// collapses the superseded ones. posted is the newly posted comment when the
+// sweep follows a post: its own row is skipped and supersession follows
+// planCommentSupersedes. When posted is nil the sweep follows an outcome with
+// no new comment, and only comments from heads other than headSHA are
+// superseded. A comment whose plan became an apply is kept expanded: the
+// apply makes it the operational record of what ran, and hiding it costs more
+// than the noise it saves. Every failure keeps the comment expanded and its
+// row unminimized, so the next sweep retries it.
+func (h *Handler) minimizePlanCommentsForSlot(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, database, databaseType, headSHA string, posted *storage.PlanComment) {
 	slotAttrs := []any{
-		"repo", posted.Repository, "pr", posted.PullRequest,
-		"database", posted.DatabaseName, "database_type", posted.DatabaseType,
-		"head_sha", posted.HeadSHA,
+		"repo", repo, "pr", pr,
+		"database", database, "database_type", databaseType,
+		"head_sha", headSHA,
 	}
 
 	priors, err := h.service.Storage().PlanComments().ListUnminimizedForSlot(ctx,
-		posted.Repository, posted.PullRequest, posted.DatabaseName, posted.DatabaseType)
+		repo, pr, database, databaseType)
 	if err != nil {
-		h.logger.Error("failed to list prior plan comments; superseded plan comments stay expanded until the next plan comment posts",
+		h.logger.Error("failed to list prior plan comments; superseded plan comments stay expanded until the next supersede sweep",
 			append(slotAttrs, "error", err)...)
 		return
 	}
 
 	for _, prior := range priors {
 		// Skip the comment that was just posted (its row is in the list too).
-		if prior.ID == posted.ID || prior.GitHubCommentID == posted.GitHubCommentID {
+		if posted != nil && (prior.ID == posted.ID || prior.GitHubCommentID == posted.GitHubCommentID) {
 			continue
 		}
 		priorAttrs := []any{
@@ -120,8 +150,13 @@ func (h *Handler) minimizeSupersededPlanComments(ctx context.Context, client *gh
 			"environment_scope", prior.EnvironmentScope, "head_sha", prior.HeadSHA,
 			"comment_id", prior.GitHubCommentID,
 		}
-		if !planCommentSupersedes(posted, prior) {
-			h.logger.Debug("keeping plan comment expanded: not superseded (same head, different environment scope)", priorAttrs...)
+		if posted != nil {
+			if !planCommentSupersedes(posted, prior) {
+				h.logger.Debug("keeping plan comment expanded: not superseded (same head, different environment scope)", priorAttrs...)
+				continue
+			}
+		} else if prior.HeadSHA == headSHA {
+			h.logger.Debug("keeping plan comment expanded: it renders the current head", priorAttrs...)
 			continue
 		}
 
@@ -140,7 +175,7 @@ func (h *Handler) minimizeSupersededPlanComments(ctx context.Context, client *gh
 		}
 
 		if err := client.MinimizeComment(ctx, prior.Repository, prior.GitHubNodeID); err != nil {
-			h.logger.Error("failed to minimize superseded plan comment; it stays expanded and is retried on the next plan comment",
+			h.logger.Error("failed to minimize superseded plan comment; it stays expanded and is retried on the next supersede sweep",
 				append(priorAttrs, "error", err)...)
 			metrics.RecordPlanCommentMinimize(ctx, prior.Repository, "minimize_error")
 			continue

--- a/pkg/webhook/plan_comment_minimize.go
+++ b/pkg/webhook/plan_comment_minimize.go
@@ -112,6 +112,28 @@ func (h *Handler) minimizeStalePlanComments(ctx context.Context, client *ghclien
 			"repo", repo, "pr", pr, "database", database, "database_type", databaseType, "head_sha", headSHA)
 		return
 	}
+
+	// With no newly posted comment anchoring the sweep, headSHA must be the
+	// PR's current head before anything is hidden. The sweep's head comes from
+	// the delivery's cached PR fetch, so a concurrent push can make it stale:
+	// sweeping on the old head would collapse the newer head's live comment
+	// with nothing replacing it, and no un-minimize path exists. Verify
+	// against a fresh fetch and leave the slot alone when the branch has
+	// moved on — the newer head's own plan outcome sweeps the slot instead.
+	freshPR, err := client.FetchPullRequestNoCache(ctx, repo, pr)
+	if err != nil {
+		h.logger.Error("failed to verify PR head for stale plan comment sweep; prior plan comments stay expanded until the next supersede sweep",
+			"repo", repo, "pr", pr, "database", database, "database_type", databaseType,
+			"head_sha", headSHA, "error", err)
+		return
+	}
+	if freshPR.HeadSHA != headSHA {
+		h.logger.Info("skipping stale plan comment sweep because the PR head moved past this plan outcome; the current head's own plan outcome sweeps the slot",
+			"repo", repo, "pr", pr, "database", database, "database_type", databaseType,
+			"head_sha", headSHA, "current_head_sha", freshPR.HeadSHA)
+		return
+	}
+
 	h.minimizePlanCommentsForSlot(ctx, client, repo, pr, database, databaseType, headSHA, nil)
 }
 

--- a/pkg/webhook/plan_comment_minimize_integration_test.go
+++ b/pkg/webhook/plan_comment_minimize_integration_test.go
@@ -333,3 +333,105 @@ func TestPlanCommentMinimizeFailureRetriesOnNextSupersede(t *testing.T) {
 	assert.ElementsMatch(t, []string{"IC_node1001", "IC_node1002"}, fake.minimizedNodes())
 	assert.Equal(t, []string{"shaC"}, unminimizedHeads(t, st, repo, 42, "orders", "mysql"))
 }
+
+// insertPlanCommentRow records an already-posted plan comment directly in
+// storage, so a test can lay out a slot's history without the supersede pass
+// that posting through the handler would run.
+func insertPlanCommentRow(t *testing.T, st storage.Storage, repo string, pr int, database, scope, headSHA string, commentID int64, nodeID string) {
+	t.Helper()
+	require.NoError(t, st.PlanComments().Insert(t.Context(), &storage.PlanComment{
+		Repository:       repo,
+		PullRequest:      pr,
+		DatabaseName:     database,
+		DatabaseType:     "mysql",
+		EnvironmentScope: scope,
+		HeadSHA:          headSHA,
+		GitHubCommentID:  commentID,
+		GitHubNodeID:     nodeID,
+	}))
+}
+
+// TestStalePlanCommentsMinimizedWithoutNewComment exercises the up-to-date-PR
+// UX: when the current head's plan outcome supersedes prior comments without
+// posting a new comment — an auto-plan that resolves to no changes — plan
+// comments rendered at older heads collapse, since the pending DDL and apply
+// prompt they advertise no longer match the branch. A comment already
+// rendered at the current head stays expanded (it may be the only visible
+// plan for its environment scope), other databases' slots are untouched, and
+// the sweep never posts a comment of its own.
+func TestStalePlanCommentsMinimizedWithoutNewComment(t *testing.T) {
+	const repo = "org/plan-min-stale-sweep"
+	h, st, fake := setupPlanCommentHandler(t, repo)
+
+	insertPlanCommentRow(t, st, repo, 42, "orders", "production,staging", "shaA", 9001, "IC_stale_shaA")
+	insertPlanCommentRow(t, st, repo, 42, "orders", "staging", "shaB", 9002, "IC_current_shaB")
+	insertPlanCommentRow(t, st, repo, 42, "billing", "production,staging", "shaA", 9003, "IC_billing_shaA")
+
+	client, err := h.clientForRepo(repo, 12345)
+	require.NoError(t, err)
+	h.minimizeStalePlanComments(t.Context(), client, repo, 42, "orders", "mysql", "shaB")
+
+	assert.Equal(t, []string{"IC_stale_shaA"}, fake.minimizedNodes(),
+		"only the prior-head orders comment is minimized")
+	assert.Equal(t, []string{"shaB"}, unminimizedHeads(t, st, repo, 42, "orders", "mysql"),
+		"the current-head comment stays expanded and the stale row is recorded minimized")
+	assert.Equal(t, []string{"shaA"}, unminimizedHeads(t, st, repo, 42, "billing", "mysql"),
+		"another database's slot is untouched")
+	assert.Equal(t, 0, fake.createCount(), "the sweep posts no comment")
+}
+
+// TestStalePlanCommentSweepKeepsApplyOwnedHeadExpanded covers the safety hold
+// on the no-new-comment sweep: once an apply exists for the head a plan
+// comment was rendered at, that comment is the operational record of what ran.
+// A later head resolving to no changes — for example after the applied change
+// lands and the schema converges — must not hide it.
+func TestStalePlanCommentSweepKeepsApplyOwnedHeadExpanded(t *testing.T) {
+	const repo = "org/plan-min-stale-apply-owned"
+	h, st, fake := setupPlanCommentHandler(t, repo)
+	ctx := t.Context()
+
+	insertPlanCommentRow(t, st, repo, 42, "inventory", "staging", "shaA", 9001, "IC_owned_shaA")
+
+	// The shaA plan becomes an apply before the next push.
+	planID, err := st.Plans().Create(ctx, &storage.Plan{
+		PlanIdentifier: "plan_stale_owned_shaA",
+		Database:       "inventory",
+		DatabaseType:   "mysql",
+		Repository:     repo,
+		PullRequest:    42,
+		Environment:    "staging",
+		HeadSHA:        "shaA",
+		CreatedAt:      time.Now(),
+	})
+	require.NoError(t, err)
+	lock := &storage.Lock{
+		DatabaseName: "inventory",
+		DatabaseType: "mysql",
+		Repository:   repo,
+		PullRequest:  42,
+		Owner:        fmt.Sprintf("%s#42", repo),
+	}
+	require.NoError(t, st.Locks().Acquire(ctx, lock))
+	lock, err = st.Locks().Get(ctx, "inventory", "mysql")
+	require.NoError(t, err)
+	_, err = st.Applies().Create(ctx, &storage.Apply{
+		ApplyIdentifier: "apply_stale_owned_shaA",
+		LockID:          lock.ID,
+		PlanID:          planID,
+		Database:        "inventory",
+		DatabaseType:    "mysql",
+		Repository:      repo,
+		PullRequest:     42,
+		Environment:     "staging",
+		Engine:          "spirit",
+		State:           state.Apply.Running,
+	})
+	require.NoError(t, err)
+
+	client, err := h.clientForRepo(repo, 12345)
+	require.NoError(t, err)
+	h.minimizeStalePlanComments(t.Context(), client, repo, 42, "inventory", "mysql", "shaB")
+
+	assert.Empty(t, fake.minimizedNodes(), "the apply-owned shaA comment must stay expanded")
+	assert.Equal(t, []string{"shaA"}, unminimizedHeads(t, st, repo, 42, "inventory", "mysql"))
+}

--- a/pkg/webhook/plan_comment_minimize_integration_test.go
+++ b/pkg/webhook/plan_comment_minimize_integration_test.go
@@ -29,13 +29,15 @@ import (
 
 // planCommentFakeGitHub captures comment creates (returning REST id and
 // GraphQL node id) and minimizeComment mutations, with per-node failure
-// injection for the retry scenarios.
+// injection for the retry scenarios. It also serves the PR fetch with a
+// configurable current head so sweeps can verify head freshness.
 type planCommentFakeGitHub struct {
 	mu        sync.Mutex
 	nextID    int64
 	created   []int64
 	minimized []string
 	failNodes map[string]bool
+	headSHA   string
 }
 
 func (f *planCommentFakeGitHub) createComment() (int64, string) {
@@ -78,6 +80,18 @@ func (f *planCommentFakeGitHub) createCount() int {
 	return len(f.created)
 }
 
+func (f *planCommentFakeGitHub) setCurrentHead(sha string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.headSHA = sha
+}
+
+func (f *planCommentFakeGitHub) currentHead() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.headSHA
+}
+
 // setupFakeGitHubForPlanComments serves the comment-create REST endpoint and
 // the GraphQL minimizeComment mutation against any repo/PR.
 func setupFakeGitHubForPlanComments(t *testing.T) (*ghclient.InstallationClient, *planCommentFakeGitHub) {
@@ -92,6 +106,23 @@ func setupFakeGitHubForPlanComments(t *testing.T) (*ghclient.InstallationClient,
 		id, nodeID := fake.createComment()
 		w.WriteHeader(http.StatusCreated)
 		_ = json.NewEncoder(w).Encode(map[string]any{"id": id, "node_id": nodeID})
+	})
+
+	// PR fetch: serves the fake's configured current head so sweeps that
+	// verify head freshness see the branch state the test laid out.
+	mux.HandleFunc("GET /repos/", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(gh.PullRequest{
+			State: new("open"),
+			Head: &gh.PullRequestBranch{
+				Ref: new("feature-branch"),
+				SHA: new(fake.currentHead()),
+			},
+			Base: &gh.PullRequestBranch{
+				Ref: new("main"),
+				SHA: new("basesha"),
+			},
+			User: &gh.User{Login: new("testuser")},
+		})
 	})
 
 	mux.HandleFunc("POST /graphql", func(w http.ResponseWriter, r *http.Request) {
@@ -366,6 +397,7 @@ func TestStalePlanCommentsMinimizedWithoutNewComment(t *testing.T) {
 	insertPlanCommentRow(t, st, repo, 42, "orders", "production,staging", "shaA", 9001, "IC_stale_shaA")
 	insertPlanCommentRow(t, st, repo, 42, "orders", "staging", "shaB", 9002, "IC_current_shaB")
 	insertPlanCommentRow(t, st, repo, 42, "billing", "production,staging", "shaA", 9003, "IC_billing_shaA")
+	fake.setCurrentHead("shaB")
 
 	client, err := h.clientForRepo(repo, 12345)
 	require.NoError(t, err)
@@ -380,6 +412,30 @@ func TestStalePlanCommentsMinimizedWithoutNewComment(t *testing.T) {
 	assert.Equal(t, 0, fake.createCount(), "the sweep posts no comment")
 }
 
+// TestStalePlanCommentSweepSkipsWhenHeadMoved covers the concurrent-push
+// safety of the no-new-comment sweep: a plan outcome computed for an older
+// head must never hide the current head's live plan comment, because nothing
+// would replace it and minimized comments are never automatically restored.
+// When the PR head has moved past the sweep's head, the sweep leaves every
+// comment expanded — the current head's own plan outcome supersedes the slot.
+func TestStalePlanCommentSweepSkipsWhenHeadMoved(t *testing.T) {
+	const repo = "org/plan-min-stale-head-moved"
+	h, st, fake := setupPlanCommentHandler(t, repo)
+
+	insertPlanCommentRow(t, st, repo, 42, "orders", "staging", "shaA", 9001, "IC_old_shaA")
+	insertPlanCommentRow(t, st, repo, 42, "orders", "staging", "shaC", 9002, "IC_live_shaC")
+	fake.setCurrentHead("shaC")
+
+	client, err := h.clientForRepo(repo, 12345)
+	require.NoError(t, err)
+	h.minimizeStalePlanComments(t.Context(), client, repo, 42, "orders", "mysql", "shaB")
+
+	assert.Empty(t, fake.minimizedNodes(),
+		"a sweep for a superseded head must not touch the slot")
+	assert.ElementsMatch(t, []string{"shaA", "shaC"}, unminimizedHeads(t, st, repo, 42, "orders", "mysql"),
+		"every comment stays expanded until the current head's own sweep")
+}
+
 // TestStalePlanCommentSweepKeepsApplyOwnedHeadExpanded covers the safety hold
 // on the no-new-comment sweep: once an apply exists for the head a plan
 // comment was rendered at, that comment is the operational record of what ran.
@@ -391,6 +447,10 @@ func TestStalePlanCommentSweepKeepsApplyOwnedHeadExpanded(t *testing.T) {
 	ctx := t.Context()
 
 	insertPlanCommentRow(t, st, repo, 42, "inventory", "staging", "shaA", 9001, "IC_owned_shaA")
+	// A second stale comment with no apply proves the sweep ran and the
+	// shaA comment survived the hold specifically, not a sweep-wide skip.
+	insertPlanCommentRow(t, st, repo, 42, "inventory", "staging", "shaZ", 9002, "IC_unowned_shaZ")
+	fake.setCurrentHead("shaB")
 
 	// The shaA plan becomes an apply before the next push.
 	planID, err := st.Plans().Create(ctx, &storage.Plan{
@@ -432,6 +492,7 @@ func TestStalePlanCommentSweepKeepsApplyOwnedHeadExpanded(t *testing.T) {
 	require.NoError(t, err)
 	h.minimizeStalePlanComments(t.Context(), client, repo, 42, "inventory", "mysql", "shaB")
 
-	assert.Empty(t, fake.minimizedNodes(), "the apply-owned shaA comment must stay expanded")
+	assert.Equal(t, []string{"IC_unowned_shaZ"}, fake.minimizedNodes(),
+		"the sweep minimizes the unowned stale comment but the apply-owned shaA comment stays expanded")
 	assert.Equal(t, []string{"shaA"}, unminimizedHeads(t, st, repo, 42, "inventory", "mysql"))
 }


### PR DESCRIPTION
## Why this matters

Plan comments were only minimized when a newer plan comment posted. An auto-plan that resolves to no changes posts nothing (by design, to reduce PR noise) — so when a later commit makes the schema up to date, the previous head's plan comment stayed expanded, advertising pending DDL and a live apply prompt that no longer match the branch. Someone had to hide it manually. Staleness is a property of the head moving on, not of a new comment posting: an up-to-date outcome supersedes prior plan comments just as much as a new plan does.

## What it does

- The no-changes auto-plan outcome now runs the supersede-minimize sweep for the database slot before returning: prior unminimized plan comments rendered at other heads collapse, without posting any new comment.
- Before minimizing anything, the sweep verifies the delivery's head is still the PR's current head with a fresh (uncached) PR fetch. A sweep computed for an older head skips entirely — otherwise a slow no-changes plan racing a newer push could hide the newer head's live comment with nothing replacing it, and minimized comments are never automatically restored.
- Extracts the sweep into `minimizePlanCommentsForSlot`, shared by the posted-comment path (unchanged supersession via `planCommentSupersedes`) and the new head-based `minimizeStalePlanComments` variant.
- Safety semantics are unchanged: apply-owned comments stay expanded as the operational record, same-head comments stay expanded (they may be the only visible plan for their environment scope), and every failure keeps the comment expanded for retry on the next sweep.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)