### PR TITLE
feat(github): make check_run.rerequested durable

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -874,6 +874,7 @@ var knownWebhookActions = map[string]bool{
 	"ready_for_review":       true,
 	"reopened":               true,
 	"requested":              true,
+	"rerequested":            true,
 	"review_request_removed": true,
 	"review_requested":       true,
 	"submitted":              true,

--- a/pkg/webhook/check_run.go
+++ b/pkg/webhook/check_run.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+
+	"github.com/block/schemabot/pkg/metrics"
 )
 
 type checkRunPayload struct {
@@ -26,7 +28,7 @@ type checkRunPayload struct {
 	} `json:"installation"`
 }
 
-func (h *Handler) handleCheckRun(ctx context.Context, w http.ResponseWriter, body []byte) {
+func (h *Handler) handleCheckRun(ctx context.Context, metricApp string, w http.ResponseWriter, body []byte, deliveryID string) {
 	var payload checkRunPayload
 	if err := json.Unmarshal(body, &payload); err != nil {
 		h.writeError(w, http.StatusBadRequest, "invalid check_run payload")
@@ -35,7 +37,7 @@ func (h *Handler) handleCheckRun(ctx context.Context, w http.ResponseWriter, bod
 
 	switch payload.Action {
 	case "rerequested":
-		h.handleCheckRunRerequest(ctx, w, payload)
+		h.handleCheckRunRerequest(ctx, metricApp, w, payload, body, deliveryID)
 	case "completed":
 		h.handleParticipantCheckCompleted(ctx, w, payload)
 	default:
@@ -121,7 +123,7 @@ func (h *Handler) handleParticipantCheckCompleted(ctx context.Context, w http.Re
 	h.writeJSON(w, http.StatusOK, map[string]string{"message": "aggregate re-folded on participant check completion"})
 }
 
-func (h *Handler) handleCheckRunRerequest(ctx context.Context, w http.ResponseWriter, payload checkRunPayload) {
+func (h *Handler) handleCheckRunRerequest(ctx context.Context, metricApp string, w http.ResponseWriter, payload checkRunPayload, body []byte, deliveryID string) {
 	installationID := h.effectiveInstallationID(ctx, payload.Installation.ID)
 	if installationID == 0 {
 		h.writeError(w, http.StatusBadRequest, "missing installation ID in webhook payload")
@@ -135,7 +137,8 @@ func (h *Handler) handleCheckRunRerequest(ctx context.Context, w http.ResponseWr
 			"repo", repo,
 			"check_run_id", payload.CheckRun.ID,
 			"check_name", payload.CheckRun.Name,
-			"head_sha", payload.CheckRun.HeadSHA)
+			"head_sha", payload.CheckRun.HeadSHA,
+			"delivery_id", deliveryID)
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "check_run rerequest ignored without pull request"})
 		return
 	}
@@ -148,7 +151,8 @@ func (h *Handler) handleCheckRunRerequest(ctx context.Context, w http.ResponseWr
 			"pr", pr,
 			"installation_id", installationID,
 			"check_run_id", payload.CheckRun.ID,
-			"check_name", payload.CheckRun.Name)
+			"check_name", payload.CheckRun.Name,
+			"delivery_id", deliveryID)
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "repository not registered"})
 		return
 	}
@@ -159,13 +163,60 @@ func (h *Handler) handleCheckRunRerequest(ctx context.Context, w http.ResponseWr
 			"pr", pr,
 			"check_run_id", payload.CheckRun.ID,
 			"check_name", payload.CheckRun.Name,
-			"head_sha", payload.CheckRun.HeadSHA)
+			"head_sha", payload.CheckRun.HeadSHA,
+			"delivery_id", deliveryID)
 		h.writeJSON(w, http.StatusOK, map[string]string{"message": "check_run rerequest ignored for non-SchemaBot check"})
 		return
 	}
 
 	if payload.CheckRun.HeadSHA == "" {
 		h.writeError(w, http.StatusBadRequest, "missing check_run head SHA")
+		return
+	}
+
+	if h.durableWebhookDispatch {
+		// Enqueue failure is a deliberate 500 with no in-process fallback: it
+		// fails loudly (metric below + a red delivery in GitHub's webhook UI)
+		// rather than silently, but GitHub never auto-retries a check_run
+		// rerequest, so the delivery stays lost until an operator hits
+		// "Redeliver" (which re-creates the row, or reopens it if a terminal
+		// row exists) or re-triggers the check.
+		inserted, err := h.enqueueDurableCheckRun(ctx, payload, body, deliveryID, pr, installationID)
+		if err != nil {
+			h.logger.Error("failed to enqueue durable check_run rerequest",
+				"repo", repo,
+				"pr", pr,
+				"head_sha", payload.CheckRun.HeadSHA,
+				"installation_id", installationID,
+				"check_run_id", payload.CheckRun.ID,
+				"check_name", payload.CheckRun.Name,
+				"delivery_id", deliveryID,
+				"error", err)
+			metrics.RecordWebhookEvent(ctx, metricApp, "check_run", payload.Action, repo, "durable_enqueue_failed")
+			h.writeError(w, http.StatusInternalServerError, "failed to enqueue webhook delivery")
+			return
+		}
+		if !inserted {
+			h.logger.Info("durable check_run rerequest already queued",
+				"repo", repo,
+				"pr", pr,
+				"head_sha", payload.CheckRun.HeadSHA,
+				"installation_id", installationID,
+				"check_run_id", payload.CheckRun.ID,
+				"check_name", payload.CheckRun.Name,
+				"delivery_id", deliveryID)
+			h.writeJSON(w, http.StatusOK, map[string]string{"message": "check_run rerequest already queued"})
+			return
+		}
+		h.logger.Info("durable check_run rerequest queued",
+			"repo", repo,
+			"pr", pr,
+			"head_sha", payload.CheckRun.HeadSHA,
+			"installation_id", installationID,
+			"check_run_id", payload.CheckRun.ID,
+			"check_name", payload.CheckRun.Name,
+			"delivery_id", deliveryID)
+		h.writeJSON(w, http.StatusOK, map[string]string{"message": "check_run rerequest queued"})
 		return
 	}
 

--- a/pkg/webhook/durable_check_run_test.go
+++ b/pkg/webhook/durable_check_run_test.go
@@ -1,0 +1,333 @@
+package webhook
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/api"
+	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// durableCheckRunRerequestEvent returns a claimable check_run rerequest inbox
+// row for the default SchemaBot aggregate check, mirroring what the HTTP path
+// enqueues.
+func durableCheckRunRerequestEvent(t *testing.T) *storage.WebhookEvent {
+	t.Helper()
+	payload := []byte(`{
+		"action": "rerequested",
+		"check_run": {"id": 123, "name": "SchemaBot", "head_sha": "head-sha", "pull_requests": [{"number": 7}]},
+		"repository": {"full_name": "octocat/hello-world"},
+		"installation": {"id": 12345}
+	}`)
+	return &storage.WebhookEvent{
+		Provider:    storage.WebhookProviderGitHub,
+		DeliveryID:  "delivery-check-run-1",
+		Event:       "check_run",
+		Action:      "rerequested",
+		Repository:  "octocat/hello-world",
+		PullRequest: 7,
+		HeadSHA:     "head-sha",
+		TenantID:    "12345",
+		Payload:     payload,
+	}
+}
+
+// With durable dispatch enabled, a check_run rerequest for a SchemaBot
+// aggregate check acks fast by persisting an inbox row rather than running
+// auto-plan synchronously on the request path, so a deploy mid-run cannot drop
+// the re-plan.
+func TestDurableCheckRunRerequestQueuesAndAcks(t *testing.T) {
+	events := newRecordingWebhookEventStore()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	service := api.New(&durableWebhookTestStorage{webhookEvents: events}, &api.ServerConfig{}, nil, logger)
+	clientFactory := &fakeClientFactory{forInstallationStarted: make(chan struct{})}
+	h := NewHandler(service, clientFactory, nil, logger, WithDurableWebhookDispatch())
+
+	req := buildCheckRunWebhookRequest(t, checkRunWebhookPayloadOpts{action: "rerequested", headSHA: "head-sha", pr: 7}, nil)
+	req.Header.Set(headerDeliveryID, "delivery-check-run-1")
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.JSONEq(t, `{"message":"check_run rerequest queued"}`, rr.Body.String())
+	event, err := events.GetByDeliveryID(t.Context(), storage.WebhookProviderGitHub, "delivery-check-run-1")
+	require.NoError(t, err)
+	require.NotNil(t, event)
+	require.Equal(t, "check_run", event.Event)
+	require.Equal(t, "rerequested", event.Action)
+	require.Equal(t, "octocat/hello-world", event.Repository)
+	require.Equal(t, 7, event.PullRequest)
+	require.Equal(t, "head-sha", event.HeadSHA)
+	require.Equal(t, "12345", event.TenantID)
+	require.NotEmpty(t, event.Payload)
+
+	select {
+	case <-clientFactory.forInstallationStarted:
+		t.Fatal("durable request path should not create a GitHub client")
+	default:
+	}
+}
+
+// A redelivered check_run rerequest (same delivery GUID) is deduplicated to a
+// single inbox row.
+func TestDurableCheckRunRerequestDeduplicatesDelivery(t *testing.T) {
+	events := newRecordingWebhookEventStore()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	service := api.New(&durableWebhookTestStorage{webhookEvents: events}, &api.ServerConfig{}, nil, logger)
+	h := NewHandler(service, &fakeClientFactory{}, nil, logger, WithDurableWebhookDispatch())
+
+	for range 2 {
+		req := buildCheckRunWebhookRequest(t, checkRunWebhookPayloadOpts{action: "rerequested"}, nil)
+		req.Header.Set(headerDeliveryID, "delivery-check-run-1")
+		rr := httptest.NewRecorder()
+
+		h.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+	}
+
+	events.mu.Lock()
+	defer events.mu.Unlock()
+	require.Len(t, events.events, 1)
+}
+
+// A rerequest for a check SchemaBot does not own is rejected before enqueue, so
+// no inbox row is created even with durable dispatch enabled.
+func TestDurableCheckRunRerequestSkipsNonSchemaBotCheck(t *testing.T) {
+	events := newRecordingWebhookEventStore()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	service := api.New(&durableWebhookTestStorage{webhookEvents: events}, &api.ServerConfig{}, nil, logger)
+	h := NewHandler(service, &fakeClientFactory{}, nil, logger, WithDurableWebhookDispatch())
+
+	req := buildCheckRunWebhookRequest(t, checkRunWebhookPayloadOpts{action: "rerequested", checkName: "Some Other Check"}, nil)
+	req.Header.Set(headerDeliveryID, "delivery-check-run-1")
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	events.mu.Lock()
+	defer events.mu.Unlock()
+	require.Empty(t, events.events, "a non-SchemaBot check rerequest must not be enqueued")
+}
+
+// A claimed check_run delivery whose action is not rerequested (only
+// rerequested is enqueued today) is ignored and completed rather than retried,
+// so a replayed or future-producer row cannot wedge the queue.
+func TestDurableCheckRunDriverCompletesUnsupportedAction(t *testing.T) {
+	store := newScriptedWebhookEventStore(&storage.WebhookEvent{
+		Provider:   storage.WebhookProviderGitHub,
+		DeliveryID: "delivery-check-run-completed",
+		Event:      "check_run",
+		Action:     "completed",
+		Payload:    []byte(`{"action":"completed"}`),
+	})
+	h := newDurableDriverHandler(t, store, nil, nil)
+
+	h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
+
+	select {
+	case outcome := <-store.completed:
+		require.Equal(t, int64(1), outcome.id)
+		require.Equal(t, "token-1", outcome.leaseToken)
+	default:
+		t.Fatal("expected unsupported check_run action to be marked completed")
+	}
+	require.Empty(t, store.failed)
+}
+
+// A malformed check_run payload cannot be decoded, so the driver fails it
+// terminally (no retry) rather than crash-looping the fleet on a poison row.
+func TestDurableCheckRunDriverFailsMalformedTerminally(t *testing.T) {
+	store := newScriptedWebhookEventStore(&storage.WebhookEvent{
+		Provider:   storage.WebhookProviderGitHub,
+		DeliveryID: "delivery-check-run-malformed",
+		Event:      "check_run",
+		Payload:    []byte(`{not json`),
+	})
+	h := newDurableDriverHandler(t, store, nil, nil)
+
+	h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
+
+	select {
+	case failure := <-store.failed:
+		require.Nil(t, failure.retryAfter, "malformed payload must not be retried")
+		require.Contains(t, failure.errMsg, "decode durable check_run delivery")
+	default:
+		t.Fatal("expected malformed check_run event to be marked failed")
+	}
+	require.Empty(t, store.completed)
+}
+
+// A check_run rerequest for a repo outside the allowlist is completed without
+// running auto-plan or creating a GitHub client.
+func TestDurableCheckRunDriverCompletesUnregisteredRepo(t *testing.T) {
+	store := newScriptedWebhookEventStore(durableCheckRunRerequestEvent(t))
+	config := &api.ServerConfig{Repos: map[string]api.RepoConfig{"other/repo": {}}}
+	factory := &fakeClientFactory{forInstallationStarted: make(chan struct{})}
+	h := newDurableDriverHandler(t, store, config, factory)
+
+	h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
+
+	select {
+	case <-store.completed:
+	default:
+		t.Fatal("expected unregistered-repo check_run event to be marked completed")
+	}
+	require.Empty(t, store.failed)
+	select {
+	case <-factory.forInstallationStarted:
+		t.Fatal("unregistered repo must not create a GitHub client")
+	default:
+	}
+}
+
+// A check_run rerequest for a check SchemaBot does not own is completed without
+// running auto-plan — the driver re-validates the same guard the request path
+// applies.
+func TestDurableCheckRunDriverCompletesNonSchemaBotCheck(t *testing.T) {
+	event := durableCheckRunRerequestEvent(t)
+	event.Payload = []byte(`{
+		"action": "rerequested",
+		"check_run": {"id": 123, "name": "Some Other Check", "head_sha": "head-sha", "pull_requests": [{"number": 7}]},
+		"repository": {"full_name": "octocat/hello-world"},
+		"installation": {"id": 12345}
+	}`)
+	store := newScriptedWebhookEventStore(event)
+	factory := &fakeClientFactory{forInstallationStarted: make(chan struct{})}
+	h := newDurableDriverHandler(t, store, nil, factory)
+
+	h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
+
+	select {
+	case <-store.completed:
+	default:
+		t.Fatal("expected non-SchemaBot check_run rerequest to be marked completed")
+	}
+	require.Empty(t, store.failed)
+	select {
+	case <-factory.forInstallationStarted:
+		t.Fatal("non-SchemaBot check must not create a GitHub client")
+	default:
+	}
+}
+
+// serveCheckRunPRHead registers the PR lookup the driver's pre-dispatch head
+// check performs, reporting currentHeadSHA as the PR's current head.
+func serveCheckRunPRHead(t *testing.T, mux *http.ServeMux, currentHeadSHA string) {
+	t.Helper()
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/7", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"head": map[string]any{"sha": currentHeadSHA, "ref": "feature-branch"},
+			"base": map[string]any{"sha": "def456", "ref": "main"},
+			"user": map[string]any{"login": "testuser"},
+		}))
+	})
+}
+
+// A durable rerequest whose head is no longer the PR's current head is completed
+// without running discovery: planning the stale head would list the current
+// PR's files against a stale config snapshot.
+func TestDurableCheckRunDriverCompletesStaleHead(t *testing.T) {
+	store := newScriptedWebhookEventStore(durableCheckRunRerequestEvent(t))
+	ghClient, mux := setupGitHubServer(t)
+	serveCheckRunPRHead(t, mux, "newer-sha-999")
+	var fileListCalls atomic.Int64
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/7/files", func(w http.ResponseWriter, _ *http.Request) {
+		fileListCalls.Add(1)
+		require.NoError(t, json.NewEncoder(w).Encode([]map[string]any{}))
+	})
+	factory := &fakeClientFactory{client: ghclient.NewInstallationClient(ghClient, testLogger())}
+	h := newDurableDriverHandler(t, store, nil, factory)
+
+	h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
+
+	select {
+	case <-store.completed:
+	default:
+		t.Fatal("expected a stale-head rerequest to be marked completed")
+	}
+	require.Empty(t, store.failed)
+	require.Equal(t, int64(0), fileListCalls.Load(), "a stale rerequest must stop before config discovery")
+}
+
+// A GitHub failure verifying the current head is uncertainty, not staleness, so
+// the delivery stays retryable rather than silently completing and dropping the
+// re-plan.
+func TestDurableCheckRunDriverRetriesHeadVerificationFailure(t *testing.T) {
+	store := newScriptedWebhookEventStore(durableCheckRunRerequestEvent(t))
+	ghClient, mux := setupGitHubServer(t)
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/7", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	factory := &fakeClientFactory{client: ghclient.NewInstallationClient(ghClient, testLogger())}
+	h := newDurableDriverHandler(t, store, nil, factory)
+
+	h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
+
+	select {
+	case failure := <-store.failed:
+		require.NotNil(t, failure.retryAfter, "head-verification failure must stay retryable")
+		require.Contains(t, failure.errMsg, "verify current head for durable check_run rerequest")
+	default:
+		t.Fatal("expected head-verification failure to be marked failed")
+	}
+	require.Empty(t, store.completed)
+}
+
+// A durable rerequest whose head is still current proceeds through discovery and
+// completes: a no-schema PR has nothing to plan, so the delivery is done once
+// auto-plan runs.
+func TestDurableCheckRunDriverReplansCurrentHead(t *testing.T) {
+	store := newScriptedWebhookEventStore(durableCheckRunRerequestEvent(t))
+	ghClient, mux := setupGitHubServer(t)
+	serveCheckRunPRHead(t, mux, "head-sha")
+	var fileListCalls atomic.Int64
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/7/files", func(w http.ResponseWriter, _ *http.Request) {
+		fileListCalls.Add(1)
+		require.NoError(t, json.NewEncoder(w).Encode([]map[string]any{
+			{"filename": "README.md", "status": "modified"},
+		}))
+	})
+	factory := &fakeClientFactory{client: ghclient.NewInstallationClient(ghClient, testLogger())}
+	h := newDurableDriverHandler(t, store, nil, factory)
+
+	h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
+
+	select {
+	case <-store.completed:
+	default:
+		t.Fatal("expected a current-head rerequest to be marked completed")
+	}
+	require.Empty(t, store.failed)
+	require.Equal(t, int64(1), fileListCalls.Load(), "a current rerequest must run config discovery")
+}
+
+// A bootstrap failure on a valid check_run rerequest stays retryable so a
+// transient installation-token outage does not drop the re-plan.
+func TestDurableCheckRunDriverRetriesBootstrapFailure(t *testing.T) {
+	store := newScriptedWebhookEventStore(durableCheckRunRerequestEvent(t))
+	factory := &fakeClientFactory{forInstallationErr: errors.New("installation token unavailable")}
+	h := newDurableDriverHandler(t, store, nil, factory)
+
+	h.driveNextDurableWebhook(t.Context(), 0, "test-host/1/webhook-driver-0")
+
+	select {
+	case failure := <-store.failed:
+		require.NotNil(t, failure.retryAfter, "bootstrap failure must stay retryable")
+		require.Contains(t, failure.errMsg, "installation token unavailable")
+	default:
+		t.Fatal("expected bootstrap failure to be marked failed")
+	}
+	require.Empty(t, store.completed)
+}

--- a/pkg/webhook/durable_dispatch.go
+++ b/pkg/webhook/durable_dispatch.go
@@ -679,7 +679,15 @@ func (h *Handler) enqueueDurableCheckRun(ctx context.Context, payload checkRunPa
 	if deliveryID == "" {
 		return false, fmt.Errorf("missing GitHub delivery ID")
 	}
-	inserted, err := store.Create(ctx, &storage.WebhookEvent{
+	// The enqueue is the durability boundary: once persisted, the durable driver
+	// owns delivery. On graceful shutdown the request ctx is cancelled, which
+	// would abort this INSERT and 500 — and GitHub never auto-retries a
+	// check_run rerequest, so the delivery would be lost. Detach from request
+	// cancellation (but keep a bounded deadline so a wedged DB can't stall
+	// shutdown) so the row still persists.
+	enqueueCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	inserted, err := store.Create(enqueueCtx, &storage.WebhookEvent{
 		Provider:    storage.WebhookProviderGitHub,
 		DeliveryID:  deliveryID,
 		Event:       "check_run",

--- a/pkg/webhook/durable_dispatch.go
+++ b/pkg/webhook/durable_dispatch.go
@@ -644,14 +644,7 @@ func (h *Handler) processDurableCheckRunRerequest(ctx context.Context, event *st
 }
 
 func (h *Handler) enqueueDurablePullRequest(ctx context.Context, payload pullRequestPayload, body []byte, deliveryID string, installationID int64) (bool, error) {
-	store := h.webhookEventStore()
-	if store == nil {
-		return false, fmt.Errorf("webhook event storage is unavailable")
-	}
-	if deliveryID == "" {
-		return false, fmt.Errorf("missing GitHub delivery ID")
-	}
-	inserted, err := store.Create(ctx, &storage.WebhookEvent{
+	return h.enqueueDurableWebhookEvent(ctx, &storage.WebhookEvent{
 		Provider:    storage.WebhookProviderGitHub,
 		DeliveryID:  deliveryID,
 		Event:       "pull_request",
@@ -662,32 +655,10 @@ func (h *Handler) enqueueDurablePullRequest(ctx context.Context, payload pullReq
 		TenantID:    strconv.FormatInt(installationID, 10),
 		Payload:     body,
 	})
-	if err != nil {
-		return false, fmt.Errorf("store durable pull_request delivery %s: %w", deliveryID, err)
-	}
-	if inserted {
-		h.wakeDurableWebhookDispatch()
-	}
-	return inserted, nil
 }
 
 func (h *Handler) enqueueDurableCheckRun(ctx context.Context, payload checkRunPayload, body []byte, deliveryID string, pr int, installationID int64) (bool, error) {
-	store := h.webhookEventStore()
-	if store == nil {
-		return false, fmt.Errorf("webhook event storage is unavailable")
-	}
-	if deliveryID == "" {
-		return false, fmt.Errorf("missing GitHub delivery ID")
-	}
-	// The enqueue is the durability boundary: once persisted, the durable driver
-	// owns delivery. On graceful shutdown the request ctx is cancelled, which
-	// would abort this INSERT and 500 — and GitHub never auto-retries a
-	// check_run rerequest, so the delivery would be lost. Detach from request
-	// cancellation (but keep a bounded deadline so a wedged DB can't stall
-	// shutdown) so the row still persists.
-	enqueueCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
-	defer cancel()
-	inserted, err := store.Create(enqueueCtx, &storage.WebhookEvent{
+	return h.enqueueDurableWebhookEvent(ctx, &storage.WebhookEvent{
 		Provider:    storage.WebhookProviderGitHub,
 		DeliveryID:  deliveryID,
 		Event:       "check_run",
@@ -698,8 +669,29 @@ func (h *Handler) enqueueDurableCheckRun(ctx context.Context, payload checkRunPa
 		TenantID:    strconv.FormatInt(installationID, 10),
 		Payload:     body,
 	})
+}
+
+// enqueueDurableWebhookEvent persists a delivery into the durable inbox. The
+// enqueue is the durability boundary: once the row is inserted, the durable
+// driver owns the delivery. On graceful shutdown the request ctx is
+// cancelled, which would abort the INSERT and 500 the delivery — and GitHub
+// does not auto-retry failed webhook deliveries, so the work would be lost
+// until an operator manually redelivers it. Detach from request cancellation
+// (but keep a bounded deadline so a wedged DB can't stall shutdown) so the
+// row still persists.
+func (h *Handler) enqueueDurableWebhookEvent(ctx context.Context, event *storage.WebhookEvent) (bool, error) {
+	store := h.webhookEventStore()
+	if store == nil {
+		return false, fmt.Errorf("webhook event storage is unavailable")
+	}
+	if event.DeliveryID == "" {
+		return false, fmt.Errorf("missing GitHub delivery ID")
+	}
+	enqueueCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	inserted, err := store.Create(enqueueCtx, event)
 	if err != nil {
-		return false, fmt.Errorf("store durable check_run delivery %s: %w", deliveryID, err)
+		return false, fmt.Errorf("store durable %s delivery %s: %w", event.Event, event.DeliveryID, err)
 	}
 	if inserted {
 		h.wakeDurableWebhookDispatch()

--- a/pkg/webhook/durable_dispatch.go
+++ b/pkg/webhook/durable_dispatch.go
@@ -412,6 +412,8 @@ func (h *Handler) processDurableWebhookEvent(ctx context.Context, event *storage
 	switch event.Event {
 	case "pull_request":
 		return h.processDurablePullRequest(ctx, event)
+	case "check_run":
+		return h.processDurableCheckRun(ctx, event)
 	default:
 		h.logger.Info("durable webhook delivery ignored because event type is unsupported",
 			"delivery_id", event.DeliveryID, "event", event.Event, "action", event.Action,
@@ -509,6 +511,138 @@ func (h *Handler) processDurablePullRequest(ctx context.Context, event *storage.
 	return false, nil
 }
 
+// processDurableCheckRun routes a claimed check_run delivery by action. Only
+// rerequested is enqueued today; a row with any other action is ignored rather
+// than retried so a replayed or future-producer row cannot wedge the queue.
+func (h *Handler) processDurableCheckRun(ctx context.Context, event *storage.WebhookEvent) (retry bool, err error) {
+	var payload checkRunPayload
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		return false, fmt.Errorf("decode durable check_run delivery %s: %w", event.DeliveryID, err)
+	}
+	switch payload.Action {
+	case "rerequested":
+		return h.processDurableCheckRunRerequest(ctx, event, payload)
+	default:
+		h.logger.Info("durable check_run delivery ignored because action is unsupported",
+			"delivery_id", event.DeliveryID, "action", payload.Action,
+			"repo", event.Repository, "pr", event.PullRequest)
+		return false, nil
+	}
+}
+
+// processDurableCheckRunRerequest re-runs auto-plan for a claimed check_run
+// rerequest. Config discovery and plan dispatch run under the delivery lease,
+// while per-database plan execution still runs in detached goroutines whose
+// durability is owned by the applies/tasks layer. Like the synchronous request
+// path it stops before discovery when the rerequested head is no longer the
+// PR's current head: planning a stale head would list the current PR's files
+// against a stale config snapshot, and a newer push already enqueued its own
+// delivery. A GitHub failure verifying the head keeps the delivery retryable
+// rather than completing it, so a transient outage cannot drop the re-plan.
+func (h *Handler) processDurableCheckRunRerequest(ctx context.Context, event *storage.WebhookEvent, payload checkRunPayload) (retry bool, err error) {
+	repo := payload.Repository.FullName
+	pr, ok := checkRunPullRequestNumber(payload)
+	if !ok {
+		h.logger.Info("durable check_run rerequest ignored without pull request",
+			"delivery_id", event.DeliveryID, "repo", repo,
+			"check_run_id", payload.CheckRun.ID, "check_name", payload.CheckRun.Name,
+			"head_sha", payload.CheckRun.HeadSHA)
+		return false, nil
+	}
+	if repo == "" || payload.CheckRun.HeadSHA == "" {
+		return false, fmt.Errorf("durable check_run rerequest %s missing repo or head SHA", event.DeliveryID)
+	}
+	if h.service != nil && !h.service.Config().IsRepoAllowed(repo) {
+		h.logger.Warn("durable check_run rerequest from unregistered repository",
+			"delivery_id", event.DeliveryID, "repo", repo, "pr", pr,
+			"check_run_id", payload.CheckRun.ID, "check_name", payload.CheckRun.Name,
+			"head_sha", payload.CheckRun.HeadSHA)
+		metrics.RecordUnregisteredRepositoryWebhook(ctx, h.metricAppForRepo(repo), "check_run", payload.Action, repo)
+		return false, nil
+	}
+	if !h.isSchemaBotAggregateCheckName(repo, payload.CheckRun.Name) {
+		h.logger.Info("durable check_run rerequest ignored for non-SchemaBot check",
+			"delivery_id", event.DeliveryID, "repo", repo, "pr", pr,
+			"check_run_id", payload.CheckRun.ID, "check_name", payload.CheckRun.Name,
+			"head_sha", payload.CheckRun.HeadSHA)
+		return false, nil
+	}
+
+	installationID, parseErr := strconv.ParseInt(event.TenantID, 10, 64)
+	if parseErr != nil {
+		// A non-numeric TenantID is a corrupted/enqueue-side bug, distinct from a
+		// legitimately empty tenant; surface it rather than silently folding it
+		// into the payload fallback below.
+		h.logger.Warn("durable check_run rerequest has an unparseable tenant ID; falling back to the payload installation",
+			"delivery_id", event.DeliveryID, "tenant_id", event.TenantID,
+			"repo", repo, "pr", pr, "head_sha", payload.CheckRun.HeadSHA, "error", parseErr)
+	}
+	if parseErr != nil || installationID == 0 {
+		// Fallback for rows without a stored tenant. The only producer today
+		// (enqueueDurableCheckRun) always stores a resolved non-zero
+		// installation ID; check_run payloads carry an installation ID only for
+		// org/user App installs, so a repo-level delivery relying on this
+		// fallback would fail below.
+		installationID = h.effectiveInstallationID(ctx, payload.Installation.ID)
+	}
+	if installationID == 0 {
+		return false, fmt.Errorf("durable check_run rerequest %s missing installation ID", event.DeliveryID)
+	}
+
+	// Keep the driver's run context: autoPlanBootstrap rebinds ctx to a
+	// timeout-bounded work context, and the post-run cancellation check below
+	// must distinguish "shutdown or lease loss" (runCtx) from "the work outran
+	// its own timeout after already succeeding" (ctx).
+	runCtx := ctx
+	ctx, cancel, client, err := h.autoPlanBootstrap(ctx, repo, installationID)
+	if err != nil {
+		metrics.RecordWebhookEvent(runCtx, h.metricAppForRepo(repo), "check_run", payload.Action, repo, "auto_plan_bootstrap_failed")
+		return true, fmt.Errorf("bootstrap durable check_run rerequest %s for %s#%d: %w", event.DeliveryID, repo, pr, err)
+	}
+	defer cancel()
+
+	// Verify the rerequested head is still the PR's current head before
+	// discovery. A GitHub failure here is uncertainty, not staleness: keep the
+	// delivery retryable so a transient outage cannot silently complete (and
+	// drop) the re-plan. A confirmed newer head means a later push already
+	// enqueued its own delivery, so complete this one without planning a stale
+	// snapshot.
+	prInfo, err := client.FetchPullRequest(ctx, repo, pr)
+	if err != nil {
+		metrics.RecordStatusCheckOperation(runCtx, metrics.StatusCheckOperation{
+			Operation:  "check_run_rerequest",
+			Repository: repo,
+			Status:     "error",
+		})
+		return true, fmt.Errorf("verify current head for durable check_run rerequest %s (%s#%d): %w", event.DeliveryID, repo, pr, err)
+	}
+	if prInfo.HeadSHA != payload.CheckRun.HeadSHA {
+		metrics.RecordStatusCheckOperation(runCtx, metrics.StatusCheckOperation{
+			Operation:  "check_run_rerequest",
+			Repository: repo,
+			Status:     "stale",
+		})
+		h.logger.Info("durable check_run rerequest ignored because head SHA is no longer current for PR",
+			"delivery_id", event.DeliveryID, "repo", repo, "pr", pr,
+			"stale_head_sha", payload.CheckRun.HeadSHA, "current_head_sha", prInfo.HeadSHA)
+		return false, nil
+	}
+
+	message, planErr := h.runAutoPlanForPR(ctx, client, repo, pr, payload.CheckRun.HeadSHA, installationID, "check_run.rerequested", "check_run.rerequested", "", event.DeliveryID)
+	if planErr != nil {
+		return true, fmt.Errorf("auto-plan for durable check_run rerequest %s (%s#%d): %w", event.DeliveryID, repo, pr, planErr)
+	}
+	if ctxErr := runCtx.Err(); ctxErr != nil {
+		// The run was cancelled (shutdown or lease loss) — the dispatch may be
+		// partial, so keep the delivery retryable instead of completing it.
+		return true, fmt.Errorf("durable check_run rerequest %s run cancelled during auto-plan dispatch: %w", event.DeliveryID, ctxErr)
+	}
+	h.logger.Info("durable check_run rerequest auto-plan dispatched",
+		"action", payload.Action, "repo", repo, "pr", pr, "head_sha", payload.CheckRun.HeadSHA,
+		"delivery_id", event.DeliveryID, "message", message)
+	return false, nil
+}
+
 func (h *Handler) enqueueDurablePullRequest(ctx context.Context, payload pullRequestPayload, body []byte, deliveryID string, installationID int64) (bool, error) {
 	store := h.webhookEventStore()
 	if store == nil {
@@ -530,6 +664,34 @@ func (h *Handler) enqueueDurablePullRequest(ctx context.Context, payload pullReq
 	})
 	if err != nil {
 		return false, fmt.Errorf("store durable pull_request delivery %s: %w", deliveryID, err)
+	}
+	if inserted {
+		h.wakeDurableWebhookDispatch()
+	}
+	return inserted, nil
+}
+
+func (h *Handler) enqueueDurableCheckRun(ctx context.Context, payload checkRunPayload, body []byte, deliveryID string, pr int, installationID int64) (bool, error) {
+	store := h.webhookEventStore()
+	if store == nil {
+		return false, fmt.Errorf("webhook event storage is unavailable")
+	}
+	if deliveryID == "" {
+		return false, fmt.Errorf("missing GitHub delivery ID")
+	}
+	inserted, err := store.Create(ctx, &storage.WebhookEvent{
+		Provider:    storage.WebhookProviderGitHub,
+		DeliveryID:  deliveryID,
+		Event:       "check_run",
+		Action:      payload.Action,
+		Repository:  payload.Repository.FullName,
+		PullRequest: pr,
+		HeadSHA:     payload.CheckRun.HeadSHA,
+		TenantID:    strconv.FormatInt(installationID, 10),
+		Payload:     body,
+	})
+	if err != nil {
+		return false, fmt.Errorf("store durable check_run delivery %s: %w", deliveryID, err)
 	}
 	if inserted {
 		h.wakeDurableWebhookDispatch()

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -709,7 +709,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.handleIssueComment(ctx, metricApp, sw, body)
 		recordProcessed()
 	case "check_run":
-		h.handleCheckRun(ctx, sw, body)
+		h.handleCheckRun(ctx, metricApp, sw, body, r.Header.Get(headerDeliveryID))
 		recordProcessed()
 	case "pull_request":
 		h.handlePullRequest(ctx, metricApp, sw, body, r.Header.Get(headerDeliveryID))


### PR DESCRIPTION
## Summary

Moves the `check_run.rerequested` auto-plan off the request goroutine and onto the durable webhook inbox, gated behind the existing durable-dispatch flag. A deploy/SIGTERM mid-run previously dropped the re-plan; now a fast ACK persists a leased-driver row with heartbeats, capped retries, and lease-expiry reclaim — full parity with the `pull_request` path. When the flag is off, the synchronous path is unchanged.

## What

- HTTP `handleCheckRunRerequest` enqueues a durable row (`enqueueDurableCheckRun`) and acks when durable dispatch is enabled.
- Driver routes `check_run` → `processDurableCheckRunRerequest`: re-validates guards, resolves the installation ID, verifies the head is still current, then runs auto-plan.
- Head verification is retry-aware: a GitHub failure keeps the delivery retryable (never silently dropped); a confirmed newer head completes without planning a stale snapshot.
- Adds `rerequested` to the webhook metrics action allowlist so it is no longer folded to `unknown`.

## Why

`check_run.rerequested` was the last synchronous auto-plan entry point with an ack-then-drop window on deploy. Making it durable closes that window. The change is additive and independent of the fold-core refactor stack (which covers the separate `check_run.completed` path).

## Before / after
```
Before                                  After (flag on)
handleCheckRunRerequest                 handleCheckRunRerequest
runAutoPlanForPR synchronously          enqueue row + fast ack
(deploy mid-run drops it)              leased driver:
verify head (retry on GH error,
complete on stale)
runAutoPlanForPR
```