### PR TITLE
fix(github): post the terminal summary after a stopped apply resumes and completes

### DIFF
--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -2008,10 +2008,12 @@ func (s *applyStore) GetByDatabase(ctx context.Context, database, dbType, enviro
 // terminal state recently but whose progress comment was never followed by a
 // summary comment. Used to post missing summaries after restart.
 //
-// Two forms of "missing" qualify: no summary marker at all (the publisher never
-// ran), and a summary claim sentinel (github_comment_id = 0) stale for longer
-// than storage.SummaryClaimStaleAfter (the publisher claimed, then crashed
-// before posting). A fresh sentinel is an in-flight publish and is left alone.
+// Three forms of "missing" qualify: no summary marker at all (the publisher
+// never ran); a superseded marker (a stop's summary consumed by a resume
+// rotation, so the summary for the current terminal state was never posted);
+// and a summary claim sentinel (github_comment_id = 0) stale for longer than
+// storage.SummaryClaimStaleAfter (the publisher claimed, then crashed before
+// posting). A fresh sentinel is an in-flight publish and is left alone.
 //
 // Recency is judged per state family: most terminal states stamp completed_at,
 // but a stopped apply is resumable and keeps completed_at NULL, so it qualifies
@@ -2031,6 +2033,7 @@ func (s *applyStore) FindMissingSummaryComment(ctx context.Context) ([]*storage.
 		  )
 		  AND (
 			acs.id IS NULL
+			OR acs.superseded_at IS NOT NULL
 			OR (acs.github_comment_id = 0 AND acs.updated_at < `+s.dialect.RelativeTime(TimestampPrecisionDefault, BeforeCurrentTime, ParameterIntervalAmount(), IntervalSecond)+`)
 		  )
 		ORDER BY a.updated_at DESC

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -3241,6 +3241,37 @@ func TestApplyStore_FindMissingSummaryComment_SummaryClaimSentinels(t *testing.T
 	assert.Equal(t, staleClaim.ApplyIdentifier, applies[0].ApplyIdentifier)
 }
 
+// TestApplyStore_FindMissingSummaryComment_SupersededSummaryMarker verifies a
+// superseded summary marker counts as missing: a stop's summary consumed by a
+// resume rotation belongs to an earlier terminal state, so once the apply
+// reaches its next terminal state, reconciliation must repair the summary
+// rather than treating the stale marker as posted.
+func TestApplyStore_FindMissingSummaryComment_SupersededSummaryMarker(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	superseded := seedApplyMissingSummary(t, store, "apply_summary_superseded", state.Apply.Completed, 720)
+	require.NoError(t, store.ApplyComments().Upsert(ctx, &storage.ApplyComment{
+		ApplyID:         superseded.ID,
+		CommentState:    state.Comment.Summary,
+		GitHubCommentID: 2003,
+	}))
+	require.NoError(t, store.ApplyComments().Supersede(ctx, superseded.ID, state.Comment.Summary))
+
+	live := seedApplyMissingSummary(t, store, "apply_summary_live", state.Apply.Completed, 721)
+	require.NoError(t, store.ApplyComments().Upsert(ctx, &storage.ApplyComment{
+		ApplyID:         live.ID,
+		CommentState:    state.Comment.Summary,
+		GitHubCommentID: 2004,
+	}))
+
+	applies, err := store.Applies().FindMissingSummaryComment(ctx)
+	require.NoError(t, err)
+	require.Len(t, applies, 1)
+	assert.Equal(t, superseded.ApplyIdentifier, applies[0].ApplyIdentifier)
+}
+
 func TestApplyStore_GetByPR(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/mysqlstore/apply_comments.go
+++ b/pkg/storage/mysqlstore/apply_comments.go
@@ -146,6 +146,13 @@ func (s *applyCommentStore) DeleteByApply(ctx context.Context, applyID int64) er
 // active comment for its state (so it is not edited again and does not re-trigger
 // resume detection). A missing or already-superseded row is not an error. A later
 // Upsert for the same state clears superseded_at, making the row active again.
+//
+// Superseding the summary marker also re-arms terminal-summary publishing:
+// ClaimSummaryComment treats a superseded posted marker as reclaimable, so any
+// caller that supersedes a summary row is signing up the next terminal publish
+// to post a fresh summary comment. Callers that merely observe a summary must
+// not supersede it, or the apply gains a duplicate summary at its next
+// terminal transition.
 func (s *applyCommentStore) Supersede(ctx context.Context, applyID int64, commentState string) error {
 	lease, hasLease, err := applyLeaseFromContext(ctx, applyID)
 	if err != nil {
@@ -225,15 +232,19 @@ func (s *applyCommentStore) ClearPendingFreeze(ctx context.Context, applyID int6
 // apply by inserting the summary marker as a claim sentinel
 // (github_comment_id = 0). The unique key on (apply_id, comment_state) makes
 // this a race-safe first-writer-wins: the insert that lands the row wins the
-// claim. When the row already exists but is superseded — a stop's summary
-// marker consumed by a resume rotation — that summary belongs to an earlier
-// terminal state, so the current terminal state's summary is still owed: the
-// conditional update converts the superseded row back into a claim sentinel,
-// and exactly one concurrent claimant sees the affected row. Losing both
-// paths means another writer already claimed or posted the summary for the
-// current terminal state. Deliberately lease-agnostic — the claim itself is
-// the exactly-once authority, so a publisher whose apply lease was re-claimed
-// can still win or lose cleanly.
+// claim. When the row already exists but is superseded — a stop's posted
+// summary marker consumed by a resume rotation — that summary belongs to an
+// earlier terminal state, so the current terminal state's summary is still
+// owed: the conditional update converts the superseded row back into a claim
+// sentinel, and exactly one concurrent claimant sees the affected row. Only a
+// row that records a posted comment is reclaimable this way — a superseded
+// claim sentinel belongs to a publish that is still in flight or crashed
+// mid-publish, and stealing it here would hand two writers the same claim;
+// abandoned sentinels are recovered by ReclaimStaleSummaryClaim instead.
+// Losing both paths means another writer already claimed or posted the
+// summary for the current terminal state. Deliberately lease-agnostic — the
+// claim itself is the exactly-once authority, so a publisher whose apply
+// lease was re-claimed can still win or lose cleanly.
 func (s *applyCommentStore) ClaimSummaryComment(ctx context.Context, applyID int64) (bool, error) {
 	result, err := s.db.ExecContext(ctx, `
 		INSERT IGNORE INTO apply_comments (apply_id, comment_state, github_comment_id)
@@ -254,6 +265,7 @@ func (s *applyCommentStore) ClaimSummaryComment(ctx context.Context, applyID int
 		UPDATE apply_comments
 		SET github_comment_id = 0, superseded_at = NULL
 		WHERE apply_id = ? AND comment_state = ? AND superseded_at IS NOT NULL
+		  AND github_comment_id != 0
 	`, applyID, state.Comment.Summary)
 	if err != nil {
 		return false, fmt.Errorf("reclaim superseded summary comment for apply %d: %w", applyID, err)

--- a/pkg/storage/mysqlstore/apply_comments.go
+++ b/pkg/storage/mysqlstore/apply_comments.go
@@ -225,10 +225,15 @@ func (s *applyCommentStore) ClearPendingFreeze(ctx context.Context, applyID int6
 // apply by inserting the summary marker as a claim sentinel
 // (github_comment_id = 0). The unique key on (apply_id, comment_state) makes
 // this a race-safe first-writer-wins: the insert that lands the row wins the
-// claim; a duplicate-key loss means another writer already claimed or posted
-// the summary. Deliberately lease-agnostic — the claim itself is the
-// exactly-once authority, so a publisher whose apply lease was re-claimed can
-// still win or lose cleanly.
+// claim. When the row already exists but is superseded — a stop's summary
+// marker consumed by a resume rotation — that summary belongs to an earlier
+// terminal state, so the current terminal state's summary is still owed: the
+// conditional update converts the superseded row back into a claim sentinel,
+// and exactly one concurrent claimant sees the affected row. Losing both
+// paths means another writer already claimed or posted the summary for the
+// current terminal state. Deliberately lease-agnostic — the claim itself is
+// the exactly-once authority, so a publisher whose apply lease was re-claimed
+// can still win or lose cleanly.
 func (s *applyCommentStore) ClaimSummaryComment(ctx context.Context, applyID int64) (bool, error) {
 	result, err := s.db.ExecContext(ctx, `
 		INSERT IGNORE INTO apply_comments (apply_id, comment_state, github_comment_id)
@@ -240,6 +245,22 @@ func (s *applyCommentStore) ClaimSummaryComment(ctx context.Context, applyID int
 	rows, err := result.RowsAffected()
 	if err != nil {
 		return false, fmt.Errorf("read summary claim rows affected for apply %d: %w", applyID, err)
+	}
+	if rows == 1 {
+		return true, nil
+	}
+
+	result, err = s.db.ExecContext(ctx, `
+		UPDATE apply_comments
+		SET github_comment_id = 0, superseded_at = NULL
+		WHERE apply_id = ? AND comment_state = ? AND superseded_at IS NOT NULL
+	`, applyID, state.Comment.Summary)
+	if err != nil {
+		return false, fmt.Errorf("reclaim superseded summary comment for apply %d: %w", applyID, err)
+	}
+	rows, err = result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("read superseded summary reclaim rows affected for apply %d: %w", applyID, err)
 	}
 	return rows == 1, nil
 }

--- a/pkg/storage/mysqlstore/apply_comments_test.go
+++ b/pkg/storage/mysqlstore/apply_comments_test.go
@@ -446,7 +446,10 @@ func TestApplyCommentStore_DeleteByApply_DBError(t *testing.T) {
 // claim is first-writer-wins: the first claim inserts the sentinel
 // (github_comment_id = 0) and wins, every later claim for the same apply loses,
 // and a summary marker that already records a real comment also blocks the
-// claim. Claims for different applies are independent.
+// claim. A superseded marker — a stop's summary consumed by a resume rotation —
+// does not block: it converts back into a claim sentinel exactly once, so the
+// apply's next terminal state still gets its summary. Claims for different
+// applies are independent.
 func TestApplyCommentStore_ClaimSummaryComment(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
@@ -482,6 +485,24 @@ func TestApplyCommentStore_ClaimSummaryComment(t *testing.T) {
 	won, err = store.ApplyComments().ClaimSummaryComment(ctx, apply.ID)
 	require.NoError(t, err)
 	assert.False(t, won, "a posted summary must block the claim")
+
+	// A superseded summary — a stop's summary marker consumed by a resume
+	// rotation — no longer describes the current terminal state, so it must not
+	// block the claim: the row converts back into a claim sentinel.
+	require.NoError(t, store.ApplyComments().Supersede(ctx, apply.ID, state.Comment.Summary))
+	won, err = store.ApplyComments().ClaimSummaryComment(ctx, apply.ID)
+	require.NoError(t, err)
+	assert.True(t, won, "a superseded summary marker must be reclaimable")
+
+	claimed, err = store.ApplyComments().Get(ctx, apply.ID, state.Comment.Summary)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, int64(0), claimed.GitHubCommentID, "reclaimed marker is the sentinel form")
+	assert.Nil(t, claimed.SupersededAt, "reclaimed marker is active again")
+
+	won, err = store.ApplyComments().ClaimSummaryComment(ctx, apply.ID)
+	require.NoError(t, err)
+	assert.False(t, won, "exactly one claimant reclaims a superseded summary")
 }
 
 // TestApplyCommentStore_ReclaimStaleSummaryClaim verifies crashed-publisher

--- a/pkg/storage/mysqlstore/apply_comments_test.go
+++ b/pkg/storage/mysqlstore/apply_comments_test.go
@@ -503,6 +503,15 @@ func TestApplyCommentStore_ClaimSummaryComment(t *testing.T) {
 	won, err = store.ApplyComments().ClaimSummaryComment(ctx, apply.ID)
 	require.NoError(t, err)
 	assert.False(t, won, "exactly one claimant reclaims a superseded summary")
+
+	// A superseded claim sentinel belongs to a publish that is still in flight
+	// or crashed mid-publish — converting it back into an active sentinel would
+	// hand two writers the same claim. It is recovered by the stale-claim
+	// machinery (ReclaimStaleSummaryClaim), never by a competing claim.
+	require.NoError(t, store.ApplyComments().Supersede(ctx, apply.ID, state.Comment.Summary))
+	won, err = store.ApplyComments().ClaimSummaryComment(ctx, apply.ID)
+	require.NoError(t, err)
+	assert.False(t, won, "a superseded claim sentinel is not reclaimable")
 }
 
 // TestApplyCommentStore_ReclaimStaleSummaryClaim verifies crashed-publisher

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -468,10 +468,12 @@ type ApplyStore interface {
 	// FindMissingSummaryComment returns GitHub-backed applies that recently
 	// reached a terminal state (including stopped, judged by updated_at since a
 	// resumable stop keeps completed_at NULL) but whose progress comment was
-	// never followed by a summary comment — either no summary marker exists, or
-	// only a claim sentinel stale for longer than SummaryClaimStaleAfter
-	// remains from a publisher that crashed before posting. Used by startup
-	// reconciliation to post missing summary comments after restarts.
+	// never followed by a summary comment — no summary marker exists, the
+	// marker is superseded (a stop's summary consumed by a resume rotation, so
+	// the current terminal state's summary was never posted), or only a claim
+	// sentinel stale for longer than SummaryClaimStaleAfter remains from a
+	// publisher that crashed before posting. Used by startup reconciliation to
+	// post missing summary comments after restarts.
 	FindMissingSummaryComment(ctx context.Context) ([]*Apply, error)
 
 	// GetByPR returns all applies for a PR.
@@ -619,7 +621,10 @@ type ApplyCommentStore interface {
 
 	// ClaimSummaryComment atomically claims the right to publish the terminal
 	// summary comment for an apply by inserting the summary marker as a claim
-	// sentinel (github_comment_id = 0). Exactly one caller wins per apply: the
+	// sentinel (github_comment_id = 0). A superseded marker — a stop's summary
+	// consumed by a resume rotation — does not block the claim: it is converted
+	// back into a claim sentinel, since the summary it recorded belongs to an
+	// earlier terminal state. Exactly one caller wins per terminal state: the
 	// winner posts the summary and records the real comment ID via Upsert; every
 	// loser skips. The claim — not the apply lease — is the exactly-once
 	// authority for the summary, so a writer whose lease was re-claimed (stop

--- a/pkg/webhook/apply_comment_integration_test.go
+++ b/pkg/webhook/apply_comment_integration_test.go
@@ -507,7 +507,7 @@ func TestE2EStopResumeCompleteStillPostsTerminalSummary(t *testing.T) {
 	select {
 	case created := <-capture.creates:
 		terminalSummaryID = created.ID
-		assert.Contains(t, created.Body, "✅ Schema Change Applied")
+		assert.Contains(t, created.Body, "Schema Change Applied")
 	case <-time.After(5 * time.Second):
 		t.Fatal("expected a terminal summary comment for the completed apply")
 	}

--- a/pkg/webhook/apply_comment_integration_test.go
+++ b/pkg/webhook/apply_comment_integration_test.go
@@ -448,6 +448,79 @@ func TestE2EResumeRotatesProgressComment(t *testing.T) {
 	}
 }
 
+// An apply that is stopped, resumed, and then driven to completion must still
+// get its terminal summary comment: the stop posts a summary, the resume
+// rotation consumes (supersedes) that summary marker, and completion claims
+// the summary again — the superseded marker converts back into a claim
+// sentinel instead of blocking the claim — so the operator sees the final
+// result at the bottom of the PR rather than the apply ending silently.
+func TestE2EStopResumeCompleteStillPostsTerminalSummary(t *testing.T) {
+	ctx := t.Context()
+
+	f := setupApplyCommentFixture(t, applyCommentFixtureParams{
+		repo:       "org/repo-stop-resume",
+		pr:         143,
+		database:   "e2e_stop_resume_db",
+		applyState: state.Apply.Resuming,
+	})
+	st, apply, task, capture := f.st, f.apply, f.task, f.capture
+
+	// Seed the comments the stop left behind: the progress comment frozen at
+	// "Stopped" and the stopped summary marker.
+	f.handler.postAndTrackComment(ctx, apply.Repository, apply.PullRequest, 12345, apply, state.Comment.Progress, "Stopped at 50%")
+	requireCommentCreate(t, capture)
+	f.handler.postAndTrackComment(ctx, apply.Repository, apply.PullRequest, 12345, apply, state.Comment.Summary, "Schema Change Stopped")
+	stoppedSummaryID := requireCommentCreate(t, capture)
+
+	fake := clock.NewFake(task.CreatedAt)
+	obs := f.newObserver(st, fake)
+
+	// The first progress tick after resume rotates the progress comment and
+	// consumes the stopped summary marker by superseding it.
+	obs.OnProgress(apply, []*storage.Task{task})
+	requireCommentCreate(t, capture)
+	select {
+	case <-capture.edits: // freeze of the superseded progress comment
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the superseded progress comment to be frozen")
+	}
+	summary, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Summary)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	require.NotNil(t, summary.SupersededAt, "resume rotation must supersede the stopped summary marker")
+
+	// The resumed copy finishes and the apply completes.
+	apply.State = state.Apply.Completed
+	task.State = state.Task.Completed
+	task.RowsCopied = 1000
+	task.ProgressPercent = 100
+	obs.OnTerminal(apply, []*storage.Task{task})
+
+	// The terminal publish edits the progress comment to its final rendering
+	// and posts a fresh terminal summary comment.
+	select {
+	case <-capture.edits:
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the progress comment to be edited to its final rendering")
+	}
+	var terminalSummaryID int64
+	select {
+	case created := <-capture.creates:
+		terminalSummaryID = created.ID
+		assert.Contains(t, created.Body, "✅ Schema Change Applied")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected a terminal summary comment for the completed apply")
+	}
+	assert.NotEqual(t, stoppedSummaryID, terminalSummaryID, "the terminal summary is a fresh comment, not the stop's")
+
+	// The summary marker now records the terminal summary and is active again.
+	summary, err = st.ApplyComments().Get(ctx, apply.ID, state.Comment.Summary)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.Equal(t, terminalSummaryID, summary.GitHubCommentID)
+	assert.Nil(t, summary.SupersededAt)
+}
+
 // Across repeated stop/start iterations, each resume folds the progress
 // comment it supersedes, so the PR timeline keeps exactly one live progress
 // comment. A resume rotation also reconciles a freeze that a prior drive owed

--- a/pkg/webhook/apply_comment_integration_test.go
+++ b/pkg/webhook/apply_comment_integration_test.go
@@ -448,6 +448,166 @@ func TestE2EResumeRotatesProgressComment(t *testing.T) {
 	}
 }
 
+// A resume rotation whose fresh comment lands but whose summary-marker
+// consumption fails must not leave the marker active for the rest of the
+// drive: the marker is the durable signal that the next terminal summary needs
+// posting fresh, and a rotated-away marker still recorded as active would cost
+// the apply its eventual terminal summary. Later ticks retry only the
+// supersede — never a second rotation — and once storage heals the marker is
+// consumed.
+func TestE2EResumeSummaryMarkerSupersedeRetriedUntilItLands(t *testing.T) {
+	ctx := t.Context()
+
+	f := setupApplyCommentFixture(t, applyCommentFixtureParams{
+		repo:       "org/repo-resume-marker-retry",
+		pr:         156,
+		database:   "e2e_resume_marker_retry_db",
+		applyState: state.Apply.Resuming,
+	})
+	st, apply, task, capture, h := f.st, f.apply, f.task, f.capture, f.handler
+
+	// Seed the pre-resume comments left by the stop: the progress comment frozen
+	// at "Stopped" and the stopped summary marker that signals a resume rotation
+	// is owed.
+	h.postAndTrackComment(ctx, "org/repo-resume-marker-retry", 156, 12345, apply, state.Comment.Progress, "Stopped at 21%")
+	stoppedProgressID := requireCommentCreate(t, capture)
+	h.postAndTrackComment(ctx, "org/repo-resume-marker-retry", 156, 12345, apply, state.Comment.Summary, "Schema Change Stopped")
+	requireCommentCreate(t, capture)
+
+	failingStorage := &failingCommentSupersedeStorage{Storage: st}
+	fake := clock.NewFake(task.CreatedAt)
+	obs := f.newObserver(failingStorage, fake)
+
+	// The first tick rotates: the fresh comment posts and the stopped one is
+	// frozen, but consuming the summary marker fails at storage.
+	obs.OnProgress(apply, []*storage.Task{task})
+
+	var newProgressID int64
+	select {
+	case created := <-capture.creates:
+		newProgressID = created.ID
+		assert.Contains(t, created.Body, "**Status**: Resuming")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the resume rotation to post a fresh progress comment")
+	}
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, stoppedProgressID, edited.CommentID, "the freeze edit lands on the superseded comment")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the superseded progress comment to be frozen")
+	}
+	summary, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Summary)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.Nil(t, summary.SupersededAt, "the storage outage leaves the marker recorded as active")
+
+	// While the outage lasts, later ticks retry only the supersede: progress
+	// edits land in place on the fresh comment and no duplicate rotation posts.
+	apply.State = state.Apply.Running
+	fake.Advance(activeInterval + time.Second)
+	task.RowsCopied = 700
+	task.ProgressPercent = 70
+	obs.OnProgress(apply, []*storage.Task{task})
+
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, newProgressID, edited.CommentID, "ticks during the outage keep editing the rotated comment")
+	case created := <-capture.creates:
+		t.Fatalf("the supersede retry must not rotate again; got another new comment %d", created.ID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected an in-place edit of the rotated comment during the outage")
+	}
+	summary, err = st.ApplyComments().Get(ctx, apply.ID, state.Comment.Summary)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.Nil(t, summary.SupersededAt, "the marker stays active until the supersede lands")
+
+	// Storage heals: the next tick's retry consumes the marker without touching
+	// the rotated comment beyond its normal in-place edit.
+	failingStorage.heal()
+	fake.Advance(activeInterval + time.Second)
+	task.RowsCopied = 800
+	task.ProgressPercent = 80
+	obs.OnProgress(apply, []*storage.Task{task})
+
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, newProgressID, edited.CommentID, "the healed tick still edits the rotated comment in place")
+	case created := <-capture.creates:
+		t.Fatalf("the healed retry must not rotate again; got another new comment %d", created.ID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected an in-place edit of the rotated comment after storage heals")
+	}
+	summary, err = st.ApplyComments().Get(ctx, apply.ID, state.Comment.Summary)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.NotNil(t, summary.SupersededAt, "the retried supersede consumes the marker once storage heals")
+}
+
+// While a terminal-summary publish is in flight — the summary marker exists
+// only as a claim sentinel that has not yet recorded its posted comment — a
+// resumed apply's ticks must not rotate: superseding the sentinel mid-publish
+// would transfer the claim and let a later writer post a duplicate summary.
+// The rotation waits until the marker records its posted comment, then rotates
+// on the next tick.
+func TestE2EResumeRotationWaitsForSummaryClaimSentinel(t *testing.T) {
+	ctx := t.Context()
+
+	f := setupApplyCommentFixture(t, applyCommentFixtureParams{
+		repo:       "org/repo-resume-sentinel",
+		pr:         157,
+		database:   "e2e_resume_sentinel_db",
+		applyState: state.Apply.Resuming,
+	})
+	st, apply, task, capture, h := f.st, f.apply, f.task, f.capture, f.handler
+
+	h.postAndTrackComment(ctx, "org/repo-resume-sentinel", 157, 12345, apply, state.Comment.Progress, "Stopped at 21%")
+	stoppedProgressID := requireCommentCreate(t, capture)
+
+	// A stop-side publisher has claimed the summary but not yet posted it: the
+	// marker row is a claim sentinel with no comment ID.
+	won, err := st.ApplyComments().ClaimSummaryComment(ctx, apply.ID)
+	require.NoError(t, err)
+	require.True(t, won, "the claim sentinel is created for the in-flight publish")
+
+	fake := clock.NewFake(task.CreatedAt)
+	obs := f.newObserver(st, fake)
+
+	// Ticks while the sentinel is live edit the tracked comment in place and do
+	// not rotate.
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case created := <-capture.creates:
+		t.Fatalf("rotation must wait for the in-flight summary publish; got new comment %d: %s", created.ID, created.Body)
+	case edited := <-capture.edits:
+		assert.Equal(t, stoppedProgressID, edited.CommentID, "ticks keep editing the tracked comment while the publish is in flight")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected an in-place edit of the tracked comment while the sentinel is live")
+	}
+
+	// The publisher finishes: the marker records its posted summary comment.
+	// The next tick sees an active posted marker and rotates.
+	require.NoError(t, st.ApplyComments().Upsert(ctx, &storage.ApplyComment{
+		ApplyID:         apply.ID,
+		CommentState:    state.Comment.Summary,
+		GitHubCommentID: 70001,
+	}))
+	fake.Advance(activeInterval + time.Second)
+	obs.OnProgress(apply, []*storage.Task{task})
+
+	select {
+	case created := <-capture.creates:
+		assert.Contains(t, created.Body, "**Status**: Resuming")
+		assert.NotEqual(t, stoppedProgressID, created.ID, "the rotation posts a new comment, not a reuse of the stopped one")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the rotation once the summary marker records its posted comment")
+	}
+	summary, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Summary)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.NotNil(t, summary.SupersededAt, "the rotation consumes the posted marker")
+}
+
 // An apply that is stopped, resumed, and then driven to completion must still
 // get its terminal summary comment: the stop posts a summary, the resume
 // rotation consumes (supersedes) that summary marker, and completion claims

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -64,6 +64,14 @@ type CommentObserver struct {
 	resumeRotated     bool
 	volumeRotatedTo   int
 
+	// resumeSupersedePending marks that this observer's resume rotation posted
+	// its fresh comment but failed to consume the summary marker. The marker is
+	// the durable "summary owed" signal: left active with a posted comment ID,
+	// the next terminal publish would lose both claim legs and the completion
+	// summary would never post. Later ticks retry only the supersede until it
+	// lands.
+	resumeSupersedePending bool
+
 	// rotatedPhases records the control phases this observer already rotated
 	// for (or confirmed the tracked comment postdates), keyed by phase name,
 	// so later ticks skip the storage re-read. Guarded by mu like the other
@@ -751,9 +759,13 @@ func (o *CommentObserver) rotateProgressCommentForResume(apply *storage.Apply, t
 	if o.resumeRotated {
 		// This observer already rotated for the current resume. Guard against
 		// re-rotating (and posting duplicate fresh comments) on later ticks if the
-		// summary-marker delete below failed to land. A fresh observer on a later
-		// drive claim starts with this unset and rotates once more, bounding any
-		// duplicate to one per drive rather than one per tick.
+		// summary-marker supersede failed to land — retry only the supersede so
+		// the marker cannot sit active for the rest of the drive. A fresh
+		// observer on a later drive claim starts with this unset and rotates once
+		// more, bounding any duplicate to one per drive rather than one per tick.
+		if o.resumeSupersedePending {
+			o.supersedeResumeSummaryMarker(apply)
+		}
 		return false
 	}
 
@@ -769,6 +781,15 @@ func (o *CommentObserver) rotateProgressCommentForResume(apply *storage.Apply, t
 		// No active summary comment — either the apply has not been stopped, or a
 		// prior resume already consumed the marker. Nothing to rotate. This is the
 		// common path on every progress tick.
+		return false
+	}
+	if summary.GitHubCommentID == 0 {
+		// The marker is a claim sentinel: a terminal-summary publish is in
+		// flight. Rotating now would supersede the sentinel mid-publish and
+		// transfer the claim, so wait for the marker to record its posted
+		// comment before rotating. A crashed publisher's abandoned sentinel is
+		// recovered by the stale-claim machinery, not by this rotation.
+		o.logInfo(apply, "observer: summary claim sentinel is live; deferring resume rotation until the summary posts")
 		return false
 	}
 
@@ -808,13 +829,28 @@ func (o *CommentObserver) rotateProgressCommentForResume(apply *storage.Apply, t
 	// live one, so it must not be folded; no freeze marker was recorded either,
 	// since the marker rides the tracking write.
 
-	if err := o.stor.ApplyComments().Supersede(o.contextWithApplyLease(ctx, apply), o.applyID, state.Comment.Summary); err != nil {
-		o.logError(apply, "observer: failed to consume summary marker after resume rotation", "error", err)
-		return true
-	}
+	o.supersedeResumeSummaryMarker(apply)
 	o.logger.Info("observer: posted fresh progress comment for resumed apply",
 		"apply_id", o.applyID, "repo", o.repo, "pr", o.pr, "state", apply.State)
 	return true
+}
+
+// supersedeResumeSummaryMarker consumes the summary marker after a resume
+// rotation under its own deadline: the rotation's GitHub round-trips can spend
+// most of the tick's context budget, and this write is the durable record that
+// the rotation happened — left unconsumed, the marker keeps advertising a
+// summary that was already rotated away, and the next terminal publish would
+// lose both claim legs and never post its summary. On failure the pending flag
+// keeps later ticks retrying just this write until it lands.
+func (o *CommentObserver) supersedeResumeSummaryMarker(apply *storage.Apply) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := o.stor.ApplyComments().Supersede(o.contextWithApplyLease(ctx, apply), o.applyID, state.Comment.Summary); err != nil {
+		o.resumeSupersedePending = true
+		o.logError(apply, "observer: failed to consume summary marker after resume rotation; retrying on the next tick", "error", err)
+		return
+	}
+	o.resumeSupersedePending = false
 }
 
 // Control-operation phases recorded on tracked progress comments


### PR DESCRIPTION
## Why this matters

An apply that is stopped, resumed, and then driven to completion ended silently: the PR never got its final ✅ summary comment. Operators watching the bottom of the PR timeline for the outcome saw nothing after the resume — the last summary on the PR was the earlier ⏹️ stop record.

## What it does

- A stop posts its terminal summary and records the summary marker; the resume rotation consumes that marker by superseding it. The completion path's summary claim (`ClaimSummaryComment`) used a bare first-writer-wins insert, so the leftover superseded row made every completion-time claimant lose and the final summary was never posted. The claim now converts a superseded summary marker back into a claim sentinel — it belongs to an earlier terminal state, so the current terminal state's summary is still owed. A conditional update keeps it first-writer-wins: exactly one concurrent claimant reclaims it.
- Startup reconciliation (`FindMissingSummaryComment`) applies the same rule: a superseded summary marker counts as missing, so an apply whose publisher died before claiming is repaired on the next restart instead of being treated as already summarized.

```
stop        → ⏹️ summary posted, marker live
resume      → rotation supersedes the marker (fresh progress comment)
complete    → claim reclaims the superseded marker → ✅ summary posted
```

Covered by storage tests for the reclaim and outbox-query semantics, plus a webhook integration test driving the full stop → resume → complete lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)