### PR TITLE
fix(github): post the deferred-cutover prompt from the parked gate state and finalize the progress comment at terminal

### DIFF
--- a/pkg/webhook/apply_comment_integration_test.go
+++ b/pkg/webhook/apply_comment_integration_test.go
@@ -550,13 +550,15 @@ func requireCommentCreate(t *testing.T, capture *commentCapture) int64 {
 }
 
 // applyCommentFixtureParams names the per-test identity of a comment-rotation
-// fixture. A zero volume seeds the apply without volume options.
+// fixture. A zero volume with deferCutover unset seeds the apply without
+// options.
 type applyCommentFixtureParams struct {
-	repo       string
-	pr         int
-	database   string
-	applyState string
-	volume     int
+	repo         string
+	pr           int
+	database     string
+	applyState   string
+	volume       int
+	deferCutover bool
 }
 
 // applyCommentFixture bundles the storage seeding and fake-GitHub plumbing the
@@ -619,8 +621,8 @@ func setupApplyCommentFixture(t *testing.T, p applyCommentFixtureParams) *applyC
 		Engine:          "spirit",
 		State:           p.applyState,
 	}
-	if p.volume != 0 {
-		apply.SetOptions(storage.ApplyOptions{Volume: p.volume})
+	if p.volume != 0 || p.deferCutover {
+		apply.SetOptions(storage.ApplyOptions{Volume: p.volume, DeferCutover: p.deferCutover})
 	}
 	applyID, err := st.Applies().Create(ctx, apply)
 	require.NoError(t, err)
@@ -1378,6 +1380,148 @@ func TestE2EDeferredCutoverPromptStaysMutedWithoutCutover(t *testing.T) {
 	assert.False(t, postCutoverPhase(trackedPhase(prog)), "no post-cutover phase is recorded without a cutover")
 }
 
+// A deferred-cutover apply parks at the gate in waiting_for_cutover until the
+// operator's cutover command arrives. The first observer tick that finds the
+// apply parked posts the cutover prompt — carrying the pasteable cutover
+// command — as a fresh comment at the bottom of the PR timeline rather than
+// an edit of the tracked progress comment, tracks it as the cutover comment,
+// and mutes progress edits behind it so later ticks at the gate change
+// nothing.
+func TestE2EDeferredCutoverParkedGatePostsPrompt(t *testing.T) {
+	ctx := t.Context()
+
+	f := setupApplyCommentFixture(t, applyCommentFixtureParams{
+		repo:         "org/repo-cutover-parked",
+		pr:           154,
+		database:     "e2e_cutover_parked_db",
+		applyState:   state.Apply.WaitingForCutover,
+		deferCutover: true,
+	})
+	st, apply, task, capture, h := f.st, f.apply, f.task, f.capture, f.handler
+
+	h.postAndTrackComment(ctx, "org/repo-cutover-parked", 154, 12345, apply, state.Comment.Progress, "Copy complete — waiting for cutover")
+	progressID := requireCommentCreate(t, capture)
+
+	fake := clock.NewFake(task.CreatedAt)
+	obs := f.newObserver(st, fake)
+
+	// The first tick at the parked gate posts the prompt as a new comment.
+	obs.OnProgress(apply, []*storage.Task{task})
+
+	var promptID int64
+	select {
+	case created := <-capture.creates:
+		promptID = created.ID
+		assert.Contains(t, created.Body, "**Status**: Waiting for Cutover")
+		assert.Contains(t, created.Body, "To proceed with cutover:")
+		assert.Contains(t, created.Body, fmt.Sprintf("schemabot cutover %s -e staging", apply.ApplyIdentifier))
+	case edited := <-capture.edits:
+		t.Fatalf("the parked gate posts the prompt as a new comment, not an edit; got an edit of %d: %s", edited.CommentID, edited.Body)
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the cutover prompt to be posted at the parked gate")
+	}
+	assert.NotEqual(t, progressID, promptID, "the prompt is its own comment, not the progress comment")
+
+	// The cutover row tracks the prompt so a restart's fresh observer finds it.
+	cutoverRow, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Cutover)
+	require.NoError(t, err)
+	require.NotNil(t, cutoverRow)
+	assert.Equal(t, promptID, cutoverRow.GitHubCommentID)
+	assert.Nil(t, cutoverRow.SupersededAt, "the prompt row stays live while the gate waits for its answer")
+
+	// Later ticks at the gate are muted behind the live prompt: nothing is
+	// posted and nothing is edited.
+	fake.Advance(activeInterval + time.Second)
+	obs.OnProgress(apply, []*storage.Task{task})
+	select {
+	case created := <-capture.creates:
+		t.Fatalf("a later tick at the gate must not post another comment; got %d: %s", created.ID, created.Body)
+	case edited := <-capture.edits:
+		t.Fatalf("a later tick at the gate must not edit while the prompt is live; got an edit of %d: %s", edited.CommentID, edited.Body)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// When the operator's cutover on a parked deferred-cutover apply resolves
+// directly to a terminal state, the cutover prompt is the completion comment:
+// the terminal edit turns it into the applied summary and the summary marker
+// records it as the terminal publish. The tracked progress comment — still
+// rendering the cutover gate and its pasteable cutover command — also
+// receives its final per-operation status freeze, so no comment on the
+// timeline keeps advertising the spent gate as live.
+func TestE2EDeferredCutoverFastTerminalFinalizesProgressComment(t *testing.T) {
+	ctx := t.Context()
+
+	f := setupApplyCommentFixture(t, applyCommentFixtureParams{
+		repo:         "org/repo-cutover-fast-terminal",
+		pr:           155,
+		database:     "e2e_cutover_fast_terminal_db",
+		applyState:   state.Apply.WaitingForCutover,
+		deferCutover: true,
+	})
+	st, apply, task, capture, h := f.st, f.apply, f.task, f.capture, f.handler
+
+	h.postAndTrackComment(ctx, "org/repo-cutover-fast-terminal", 155, 12345, apply, state.Comment.Progress, "Copy complete — waiting for cutover")
+	progressID := requireCommentCreate(t, capture)
+
+	fake := clock.NewFake(task.CreatedAt)
+	obs := f.newObserver(st, fake)
+
+	// The tick at the parked gate posts and tracks the cutover prompt.
+	obs.OnProgress(apply, []*storage.Task{task})
+	promptID := requireCommentCreate(t, capture)
+
+	// The operator's cutover completes the apply before another progress tick
+	// lands.
+	apply.State = state.Apply.Completed
+	task.State = state.Task.Completed
+	task.RowsCopied = 1000
+	task.ProgressPercent = 100
+	obs.OnTerminal(apply, []*storage.Task{task})
+
+	// The prompt is edited into the terminal summary — it is the completion
+	// comment.
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, promptID, edited.CommentID, "the terminal summary lands on the cutover prompt")
+		assert.Contains(t, edited.Body, "✅ Schema Change Applied")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the cutover prompt to be edited into the terminal summary")
+	}
+
+	// The tracked progress comment receives its final status freeze: the
+	// completed rendering, with no live cutover instruction left behind.
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, progressID, edited.CommentID, "the status freeze lands on the tracked progress comment")
+		assert.Contains(t, edited.Body, "**Status**: Applied")
+		assert.NotContains(t, edited.Body, "To proceed with cutover:", "the frozen progress comment must not advertise the spent gate")
+		assert.NotContains(t, edited.Body, "schemabot cutover", "the frozen progress comment must not carry a live cutover command")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the tracked progress comment to be frozen at its final status")
+	}
+
+	// No extra comment is posted — the prompt already sits at the bottom of
+	// the PR as the summary.
+	select {
+	case created := <-capture.creates:
+		t.Fatalf("a cutover apply's terminal publish edits the prompt, it must not post a new comment; got %d: %s", created.ID, created.Body)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// The summary marker records the prompt as the terminal publish, and the
+	// progress row — never superseded — still tracks its own comment.
+	marker, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Summary)
+	require.NoError(t, err)
+	require.NotNil(t, marker)
+	assert.Equal(t, promptID, marker.GitHubCommentID, "the summary marker records the completed prompt")
+	prog, err := st.ApplyComments().Get(ctx, apply.ID, state.Comment.Progress)
+	require.NoError(t, err)
+	require.NotNil(t, prog)
+	assert.Equal(t, progressID, prog.GitHubCommentID)
+	assert.Nil(t, prog.SupersededAt, "the frozen progress comment stays tracked, not superseded")
+}
+
 // An apply stopped at the deferred-cutover gate completes the prompt itself:
 // the terminal edit turns the prompt into the stop record and consumes its
 // row, so the prompt is never folded under a false "Cutover complete" record.
@@ -1416,6 +1560,16 @@ func TestE2EStopAtCutoverGateThenResumeRotatesFreshComment(t *testing.T) {
 		assert.Contains(t, edited.Body, "Schema Change Stopped")
 	case <-time.After(5 * time.Second):
 		t.Fatal("expected the cutover prompt to be edited into the stop record")
+	}
+	// The tracked progress comment is frozen at the stopped rendering too, so
+	// it stops advertising the gate's cutover command.
+	select {
+	case edited := <-capture.edits:
+		assert.Equal(t, preStopProgressID, edited.CommentID, "the status freeze lands on the pre-stop progress comment")
+		assert.Contains(t, edited.Body, "**Status**: Stopped")
+		assert.NotContains(t, edited.Body, "schemabot cutover", "the frozen progress comment must not carry a live cutover command")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the tracked progress comment to be frozen at the stopped rendering")
 	}
 	select {
 	case created := <-capture.creates:

--- a/pkg/webhook/apply_comment_integration_test.go
+++ b/pkg/webhook/apply_comment_integration_test.go
@@ -1440,6 +1440,21 @@ func TestE2EDeferredCutoverParkedGatePostsPrompt(t *testing.T) {
 		t.Fatalf("a later tick at the gate must not edit while the prompt is live; got an edit of %d: %s", edited.CommentID, edited.Body)
 	case <-time.After(100 * time.Millisecond):
 	}
+
+	// A pod restart or re-claimed drive hands the parked apply to a fresh
+	// observer with no in-memory record of the prompt. The durable cutover row
+	// is what keeps a multi-day park from re-posting the prompt on every
+	// restart: the fresh observer rehydrates from the row and stays muted.
+	obs2 := f.newObserver(st, fake)
+	fake.Advance(activeInterval + time.Second)
+	obs2.OnProgress(apply, []*storage.Task{task})
+	select {
+	case created := <-capture.creates:
+		t.Fatalf("a fresh observer at the parked gate must not re-post the prompt; got %d: %s", created.ID, created.Body)
+	case edited := <-capture.edits:
+		t.Fatalf("a fresh observer at the parked gate must not edit while the prompt is live; got an edit of %d: %s", edited.CommentID, edited.Body)
+	case <-time.After(100 * time.Millisecond):
+	}
 }
 
 // When the operator's cutover on a parked deferred-cutover apply resolves

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -453,7 +453,7 @@ func (o *CommentObserver) OnTerminal(apply *storage.Apply, tasks []*storage.Task
 		// comment still gets its final per-operation status freeze — it last
 		// rendered the cutover gate and its pasteable cutover command, and must
 		// not keep advertising a spent gate as live.
-		o.finalizeTrackedProgressCommentAtTerminal(ctx, apply, cutover.GitHubCommentID, ops, opsErr, tasks, shardsByTable)
+		o.finalizeTrackedProgressCommentAtTerminal(apply, cutover.GitHubCommentID, ops, opsErr, tasks, shardsByTable)
 		if state.IsState(apply.State, state.Apply.Stopped) {
 			// Stopped is the only terminal state that returns to active. The
 			// prompt now carries the stop record, so consume its row —
@@ -533,15 +533,18 @@ func (o *CommentObserver) shouldPublishSeparateSummary(apply *storage.Apply, ops
 // folded into a details block pointing at its successor and must not be
 // unfolded by an edit; a row tracking the prompt's own GitHub comment already
 // carries the terminal summary and must not be edited over it.
-func (o *CommentObserver) finalizeTrackedProgressCommentAtTerminal(ctx context.Context, apply *storage.Apply, promptCommentID int64, ops []*storage.ApplyOperation, opsErr error, tasks []*storage.Task, shardsByTable map[string][]*storage.Task) {
+func (o *CommentObserver) finalizeTrackedProgressCommentAtTerminal(apply *storage.Apply, promptCommentID int64, ops []*storage.ApplyOperation, opsErr error, tasks []*storage.Task, shardsByTable map[string][]*storage.Task) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
 	tracked, err := o.stor.ApplyComments().Get(ctx, o.applyID, state.Comment.Progress)
 	if err != nil {
 		o.logError(apply, "observer: failed to load tracked progress comment for its terminal status freeze; it stays at its last progress rendering", "error", err)
 		return
 	}
 	if tracked == nil {
-		// No tracked progress comment exists — nothing renders the gate, so
-		// there is nothing to freeze.
+		// Nothing renders the gate, so there is nothing to freeze.
+		o.logInfo(apply, "observer: no tracked progress comment to freeze at terminal")
 		return
 	}
 	if tracked.SupersededAt != nil {

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -274,11 +274,11 @@ func (o *CommentObserver) OnProgress(apply *storage.Apply, tasks []*storage.Task
 	// the tracked one.
 	adopted := o.pendingRotation == nil || o.adoptPendingRotationComment(apply)
 
-	// Post cutover comment when entering cutting_over with defer_cutover,
+	// Post the cutover prompt when the apply is at the deferred-cutover gate,
 	// but only if one hasn't been posted already. A failed post leaves
 	// hasCutoverComment unset so the next tick retries, instead of muting the
 	// observer for the rest of the drive over one transient GitHub error.
-	if currentState == state.Apply.CuttingOver && o.shouldDeferCutover(apply) && !o.hasCutoverComment {
+	if atDeferredCutoverGate(currentState) && o.shouldDeferCutover(apply) && !o.hasCutoverComment {
 		body := o.formatStatusComment(apply, tasks)
 		if _, posted, _ := o.postAndTrackComment(apply, state.Comment.Cutover, body, nil); posted {
 			o.hasCutoverComment = true
@@ -449,6 +449,11 @@ func (o *CommentObserver) OnTerminal(apply *storage.Apply, tasks []*storage.Task
 		finalBody := o.summaryCommentFromOps(ctx, apply, ops, opsErr, tasks, shardsByTable)
 		o.editTrackedComment(apply, activeCommentState, finalBody)
 		o.markSummaryPosted(apply, activeCommentState)
+		// The prompt is the completion comment, but the tracked progress
+		// comment still gets its final per-operation status freeze — it last
+		// rendered the cutover gate and its pasteable cutover command, and must
+		// not keep advertising a spent gate as live.
+		o.finalizeTrackedProgressCommentAtTerminal(ctx, apply, cutover.GitHubCommentID, ops, opsErr, tasks, shardsByTable)
 		if state.IsState(apply.State, state.Apply.Stopped) {
 			// Stopped is the only terminal state that returns to active. The
 			// prompt now carries the stop record, so consume its row —
@@ -515,6 +520,40 @@ func (o *CommentObserver) shouldPublishSeparateSummary(apply *storage.Apply, ops
 		return false
 	}
 	return true
+}
+
+// finalizeTrackedProgressCommentAtTerminal edits the tracked progress comment
+// to its final per-operation status rendering when the cutover prompt is the
+// completion comment. The prompt carries the terminal summary, and the
+// progress comment gets the same status freeze the non-cutover terminal path
+// writes, so no comment on the timeline keeps rendering the cutover gate as
+// live. It runs for every terminal state, including stopped — a stopped
+// rendering is a correct record, and the resume rotation posts the fresh
+// comment when the apply returns to active. A superseded row was already
+// folded into a details block pointing at its successor and must not be
+// unfolded by an edit; a row tracking the prompt's own GitHub comment already
+// carries the terminal summary and must not be edited over it.
+func (o *CommentObserver) finalizeTrackedProgressCommentAtTerminal(ctx context.Context, apply *storage.Apply, promptCommentID int64, ops []*storage.ApplyOperation, opsErr error, tasks []*storage.Task, shardsByTable map[string][]*storage.Task) {
+	tracked, err := o.stor.ApplyComments().Get(ctx, o.applyID, state.Comment.Progress)
+	if err != nil {
+		o.logError(apply, "observer: failed to load tracked progress comment for its terminal status freeze; it stays at its last progress rendering", "error", err)
+		return
+	}
+	if tracked == nil {
+		// No tracked progress comment exists — nothing renders the gate, so
+		// there is nothing to freeze.
+		return
+	}
+	if tracked.SupersededAt != nil {
+		o.logInfo(apply, "observer: tracked progress comment already superseded; skipping its terminal status freeze")
+		return
+	}
+	if tracked.GitHubCommentID == promptCommentID {
+		o.logInfo(apply, "observer: tracked progress comment is the cutover prompt; the terminal summary already covers it")
+		return
+	}
+	finalBody := o.statusCommentFromOps(apply, ops, opsErr, tasks, shardsByTable)
+	o.editTrackedComment(apply, state.Comment.Progress, finalBody)
 }
 
 // formatStatusComment renders the apply's progress/cutover status comment,
@@ -631,6 +670,16 @@ func (o *CommentObserver) summaryCommentFromOps(ctx context.Context, apply *stor
 
 func (o *CommentObserver) shouldDeferCutover(apply *storage.Apply) bool {
 	return o.deferCutover || apply.GetOptions().DeferCutover
+}
+
+// atDeferredCutoverGate reports whether the apply is at the deferred-cutover
+// gate, where the cutover prompt comment belongs. waiting_for_cutover is the
+// parked state the apply holds until the operator's cutover command;
+// cutting_over is the transient window while the cutover executes. A tick can
+// first observe the apply in either state, so the prompt posts from both.
+func atDeferredCutoverGate(applyState string) bool {
+	return state.IsState(applyState, state.Apply.WaitingForCutover) ||
+		state.IsState(applyState, state.Apply.CuttingOver)
 }
 
 func (o *CommentObserver) leaseStillOwnsObserver(apply *storage.Apply, operation string) bool {

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -242,8 +242,10 @@ func (o *CommentObserver) OnProgress(apply *storage.Apply, tasks []*storage.Task
 	// Check if a cutover comment was posted by an external handler. A
 	// superseded row is an already-rotated-away prompt from an earlier drive,
 	// not a live cutover comment — treating it as live would re-mute the
-	// observer. This must happen before the CuttingOver branch below — without
-	// it, the observer would post a duplicate cutover comment.
+	// observer. This must happen before the deferred-cutover-gate branch below
+	// — it is the restart-time dedup: an apply can park at the gate for days,
+	// and without the durable-row check every fresh observer on a restart or
+	// re-claimed drive would post a duplicate prompt.
 	if !o.hasCutoverComment {
 		checkCtx, checkCancel := context.WithTimeout(context.Background(), 2*time.Second)
 		cutover, err := o.stor.ApplyComments().Get(checkCtx, o.applyID, state.Comment.Cutover)
@@ -681,8 +683,7 @@ func (o *CommentObserver) shouldDeferCutover(apply *storage.Apply) bool {
 // cutting_over is the transient window while the cutover executes. A tick can
 // first observe the apply in either state, so the prompt posts from both.
 func atDeferredCutoverGate(applyState string) bool {
-	return state.IsState(applyState, state.Apply.WaitingForCutover) ||
-		state.IsState(applyState, state.Apply.CuttingOver)
+	return state.IsState(applyState, state.Apply.WaitingForCutover, state.Apply.CuttingOver)
 }
 
 func (o *CommentObserver) leaseStillOwnsObserver(apply *storage.Apply, operation string) bool {


### PR DESCRIPTION
## Why it matters

A deferred-cutover apply parks at the cutover gate in `waiting_for_cutover`; `cutting_over` is only the transient window while the cutover executes. The comment observer posted the cutover prompt only from `cutting_over`, so an apply that reached the gate between progress ticks never got its prompt — the tracked progress comment kept being edited at the gate instead. When the operator later ran the cutover, a tick landing in the transient window posted a stray prompt mid-cutover, the terminal summary completed that prompt, and the old progress comment was left mid-timeline fully expanded, still advertising a live-looking `schemabot cutover` instruction for a cutover that had already happened.

## What it does

- The prompt-post condition is now a named predicate, `atDeferredCutoverGate`, covering both `waiting_for_cutover` and `cutting_over`, so the first tick that finds the apply parked posts the prompt, tracks it, and mutes progress edits behind it.
- On the cutover-terminal path (the prompt is the completion comment), the tracked progress comment now also receives its final per-operation status freeze — the same rendering the non-cutover terminal path writes — guarded so a superseded (already folded) comment is never unfolded and the prompt is never edited twice.

```
before:  progress comment (live "run schemabot cutover" forever) ... ✅ summary
after:   prompt posted at the gate → progress muted → terminal:
         prompt → ✅ summary, progress → frozen final status
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)