### PR TITLE
fix(github): surface a failed table's own engine error for remote-driven applies

### DIFF
--- a/integration/grpc_integration_test.go
+++ b/integration/grpc_integration_test.go
@@ -458,6 +458,172 @@ func TestGRPC_TaskStateUpdatedOnCompletion(t *testing.T) {
 	}
 }
 
+// TestGRPC_FailedTableErrorSurfacesInTaskRecord drives a schema change through a
+// remote Tern over gRPC that fails at the engine: adding a unique index over
+// duplicate rows. The control plane never polls the engine directly, so the only
+// way the PR comment / CLI can show which table's engine error caused the
+// failure is the remote's per-table error being mirrored into SchemaBot's own
+// stored task row. The failed table must carry the engine error on its task
+// record, not just on the apply record.
+func TestGRPC_FailedTableErrorSurfacesInTaskRecord(t *testing.T) {
+	ctx := t.Context()
+
+	// Create a unique target database for this test
+	targetDB, err := sql.Open("mysql", targetDSN+"&multiStatements=true")
+	require.NoError(t, err, "open target db")
+	defer utils.CloseAndLog(targetDB)
+
+	appDBName := fmt.Sprintf("tblerr_%d", time.Now().UnixNano()%100000)
+	_, err = targetDB.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS "+appDBName)
+	require.NoError(t, err, "create app database")
+	t.Cleanup(func() {
+		_, _ = targetDB.ExecContext(t.Context(), "DROP DATABASE IF EXISTS "+appDBName)
+	})
+
+	// Seed a table with duplicate values so adding a unique index must fail in
+	// the engine with this table's own error.
+	_, err = targetDB.ExecContext(ctx, "CREATE TABLE `"+appDBName+"`.`dup_users` ("+
+		"`id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY, "+
+		"`name` VARCHAR(255) NOT NULL"+
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci")
+	require.NoError(t, err, "create seeded table")
+	_, err = targetDB.ExecContext(ctx, "INSERT INTO `"+appDBName+"`.`dup_users` (`name`) VALUES ('a'), ('a')")
+	require.NoError(t, err, "seed duplicate rows")
+
+	appDSN := strings.Replace(targetDSN, "/target_test", "/"+appDBName, 1)
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	// Set up a separate Tern gRPC server for this test (backed by LocalClient)
+	ternGRPCAddr, err := startTernGRPC(ctx, appDSN, ternStorageDSN)
+	require.NoError(t, err, "start tern grpc")
+
+	// Create SchemaBot with its own storage and a GRPCClient to remote Tern.
+	schemabotDB, err := sql.Open("mysql", schemabotDSN)
+	require.NoError(t, err, "open schemabot db")
+	defer utils.CloseAndLog(schemabotDB)
+	schemabotStorage := schemabotmysql.New(schemabotDB)
+
+	ternClient, err := tern.NewGRPCClient(tern.Config{
+		Address: ternGRPCAddr,
+		Storage: schemabotStorage,
+	})
+	require.NoError(t, err, "create tern client")
+	defer utils.CloseAndLog(ternClient)
+
+	serverConfig := &schemabotapi.ServerConfig{
+		Databases: map[string]schemabotapi.DatabaseConfig{
+			appDBName: {
+				Type: "mysql",
+				Environments: map[string]schemabotapi.EnvironmentConfig{
+					"staging": {Target: appDBName + "-target", Deployment: "default"},
+				},
+			},
+		},
+		TernDeployments: schemabotapi.TernConfig{
+			"default": {"staging": ternGRPCAddr},
+		},
+	}
+	svc := schemabotapi.New(schemabotStorage, serverConfig, map[string]tern.Client{
+		"default/staging": ternClient,
+	}, logger)
+	startTestOperator(t, svc)
+	defer utils.CloseAndLog(svc)
+
+	mux := http.NewServeMux()
+	svc.ConfigureRoutes(mux)
+	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "localhost:0")
+	require.NoError(t, err, "listen")
+	server := &http.Server{Handler: mux}
+	go func() { _ = server.Serve(listener) }()
+	defer utils.CloseAndLog(server)
+	schemabotAddr := listener.Addr().String()
+
+	// Wait for HTTP server readiness
+	testutil.Poll(t, 5*time.Second, 10*time.Millisecond,
+		func() bool {
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+schemabotAddr+"/health", nil)
+			require.NoError(t, err)
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				return false
+			}
+			_ = resp.Body.Close()
+			return resp.StatusCode == http.StatusOK
+		},
+		func() string { return "schemabot HTTP server did not become healthy" },
+	)
+
+	// Step 1: Plan — add a unique index the seeded duplicate rows cannot satisfy
+	schemaSQL := `CREATE TABLE dup_users (
+		id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		name VARCHAR(255) NOT NULL,
+		UNIQUE KEY uniq_name (name)
+	);`
+	planResp := postJSON(t, "http://"+schemabotAddr+"/api/plan", map[string]any{
+		"database":    appDBName,
+		"environment": "staging",
+		"type":        "mysql",
+		"schema_files": map[string]any{
+			"default": map[string]any{
+				"files": map[string]string{
+					"dup_users.sql": schemaSQL,
+				},
+			},
+		},
+		"repository":   "test/tableerror",
+		"pull_request": 148,
+	})
+	planID, ok := planResp["plan_id"].(string)
+	require.True(t, ok && planID != "", "plan response missing plan_id: %v", planResp)
+
+	// Step 2: Apply
+	applyResp := postJSON(t, "http://"+schemabotAddr+"/api/apply", map[string]any{
+		"plan_id":     planID,
+		"environment": "staging",
+	})
+	require.True(t, applyResp["accepted"] == true, "apply not accepted: %v", applyResp)
+	applyID, ok := applyResp["apply_id"].(string)
+	require.True(t, ok && applyID != "", "apply response missing apply_id: %v", applyResp)
+
+	// Step 3: Wait for the apply to fail on the duplicate rows
+	waitForState(t, "http://"+schemabotAddr, applyID, "failed", 15*time.Second)
+
+	// Step 4: Wait for the local apply record to be updated by pollForCompletion.
+	var storedApply *storage.Apply
+	testutil.Poll(t, 5*time.Second, 100*time.Millisecond,
+		func() bool {
+			storedApply, err = schemabotStorage.Applies().GetByApplyIdentifier(ctx, applyID)
+			require.NoError(t, err, "get apply by identifier")
+			require.NotNil(t, storedApply, "apply not found")
+			return storedApply.State == state.Apply.Failed
+		},
+		func() string {
+			return fmt.Sprintf("apply record should be failed in local storage, last state: %q", storedApply.State)
+		},
+	)
+	require.NotEmpty(t, storedApply.ErrorMessage, "failed apply record should carry the engine error")
+
+	// Step 5: The failed table's own engine error must be on SchemaBot's stored
+	// task row — the record the PR comment and CLI render from.
+	tasks, err := schemabotStorage.Tasks().GetByApplyID(ctx, storedApply.ID)
+	require.NoError(t, err, "get tasks by apply ID")
+	require.NotEmpty(t, tasks, "expected task records for apply %s", applyID)
+
+	var dupTask *storage.Task
+	for _, task := range tasks {
+		if task.TableName == "dup_users" && task.Shard == "" {
+			dupTask = task
+			break
+		}
+	}
+	require.NotNil(t, dupTask, "expected a task record for table dup_users")
+	assert.Equal(t, state.Task.Failed, dupTask.State,
+		"task %s should be failed, but is %q", dupTask.TaskIdentifier, dupTask.State)
+	assert.NotEmpty(t, dupTask.ErrorMessage,
+		"failed task should carry its own engine error mirrored from the remote per-table progress")
+}
+
 // TestGRPC_ServerSideTargetPlan verifies that HTTP plan succeeds when the
 // target is configured server-side. The Tern proto still exposes target for
 // remote implementations, but SchemaBot HTTP callers do not provide it.

--- a/integration/grpc_integration_test.go
+++ b/integration/grpc_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/block/spirit/pkg/utils"
+	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -472,25 +473,32 @@ func TestGRPC_FailedTableErrorSurfacesInTaskRecord(t *testing.T) {
 	targetDB, err := sql.Open("mysql", targetDSN+"&multiStatements=true")
 	require.NoError(t, err, "open target db")
 	defer utils.CloseAndLog(targetDB)
+	require.NoError(t, targetDB.PingContext(ctx), "ping target db")
 
 	appDBName := fmt.Sprintf("tblerr_%d", time.Now().UnixNano()%100000)
-	_, err = targetDB.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS "+appDBName)
+	_, err = targetDB.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS "+quoteIdentifier(appDBName))
 	require.NoError(t, err, "create app database")
 	t.Cleanup(func() {
-		_, _ = targetDB.ExecContext(t.Context(), "DROP DATABASE IF EXISTS "+appDBName)
+		// Cleanup runs after the test context is cancelled, so it needs its own context.
+		if _, err := targetDB.ExecContext(t.Context(), "DROP DATABASE IF EXISTS "+quoteIdentifier(appDBName)); err != nil {
+			t.Logf("cleanup: drop database %s: %v", appDBName, err)
+		}
 	})
 
 	// Seed a table with duplicate values so adding a unique index must fail in
 	// the engine with this table's own error.
-	_, err = targetDB.ExecContext(ctx, "CREATE TABLE `"+appDBName+"`.`dup_users` ("+
+	_, err = targetDB.ExecContext(ctx, "CREATE TABLE "+quoteIdentifier(appDBName)+".`dup_users` ("+
 		"`id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY, "+
 		"`name` VARCHAR(255) NOT NULL"+
 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci")
 	require.NoError(t, err, "create seeded table")
-	_, err = targetDB.ExecContext(ctx, "INSERT INTO `"+appDBName+"`.`dup_users` (`name`) VALUES ('a'), ('a')")
+	_, err = targetDB.ExecContext(ctx, "INSERT INTO "+quoteIdentifier(appDBName)+".`dup_users` (`name`) VALUES ('a'), ('a')")
 	require.NoError(t, err, "seed duplicate rows")
 
-	appDSN := strings.Replace(targetDSN, "/target_test", "/"+appDBName, 1)
+	appCfg, err := mysql.ParseDSN(targetDSN)
+	require.NoError(t, err, "parse target DSN")
+	appCfg.DBName = appDBName
+	appDSN := appCfg.FormatDSN()
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 
@@ -502,6 +510,7 @@ func TestGRPC_FailedTableErrorSurfacesInTaskRecord(t *testing.T) {
 	schemabotDB, err := sql.Open("mysql", schemabotDSN)
 	require.NoError(t, err, "open schemabot db")
 	defer utils.CloseAndLog(schemabotDB)
+	require.NoError(t, schemabotDB.PingContext(ctx), "ping schemabot db")
 	schemabotStorage := schemabotmysql.New(schemabotDB)
 
 	ternClient, err := tern.NewGRPCClient(tern.Config{

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -1081,6 +1081,12 @@ func (s *Service) syncTasksFromTern(ctx context.Context, apply *storage.Apply, t
 		task.ProgressPercent = int(tp.PercentComplete)
 		task.ChecksumRowsChecked = tp.ChecksumRowsChecked
 		task.ChecksumRowsTotal = tp.ChecksumRowsTotal
+		// Mirror the table's own engine error so the PR comment / CLI can tell
+		// which table caused a failure. An empty remote error never wipes a
+		// stored one: a stale progress snapshot must not erase a durable error.
+		if tp.ErrorMessage != "" {
+			task.ErrorMessage = tp.ErrorMessage
+		}
 		task.UpdatedAt = now
 		if err := s.storage.Tasks().Update(ctx, task); err != nil {
 			s.logger.Error("sync task failed", append(task.LogAttrs(), "error", err)...)

--- a/pkg/proto/tern.proto
+++ b/pkg/proto/tern.proto
@@ -613,6 +613,10 @@ message TableProgress {
   // Populated while the table is checksumming (verifying copied data), 0 otherwise.
   int64 checksum_rows_checked = 14;
   int64 checksum_rows_total = 15;
+  // This table's own engine error, from the data plane's stored task record.
+  // Empty for tables that never produced an error themselves — including tables
+  // that failed only because an earlier table's failure blocked them.
+  string error_message = 16;
 }
 
 // ProgressResponse contains detailed progress information.

--- a/pkg/proto/ternv1/tern.pb.go
+++ b/pkg/proto/ternv1/tern.pb.go
@@ -2252,8 +2252,12 @@ type TableProgress struct {
 	// Populated while the table is checksumming (verifying copied data), 0 otherwise.
 	ChecksumRowsChecked int64 `protobuf:"varint,14,opt,name=checksum_rows_checked,json=checksumRowsChecked,proto3" json:"checksum_rows_checked,omitempty"`
 	ChecksumRowsTotal   int64 `protobuf:"varint,15,opt,name=checksum_rows_total,json=checksumRowsTotal,proto3" json:"checksum_rows_total,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// This table's own engine error, from the data plane's stored task record.
+	// Empty for tables that never produced an error themselves — including tables
+	// that failed only because an earlier table's failure blocked them.
+	ErrorMessage  string `protobuf:"bytes,16,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TableProgress) Reset() {
@@ -2389,6 +2393,13 @@ func (x *TableProgress) GetChecksumRowsTotal() int64 {
 		return x.ChecksumRowsTotal
 	}
 	return 0
+}
+
+func (x *TableProgress) GetErrorMessage() string {
+	if x != nil {
+		return x.ErrorMessage
+	}
+	return ""
 }
 
 // ProgressResponse contains detailed progress information.
@@ -3642,7 +3653,7 @@ const file_tern_proto_rawDesc = "" +
 	"etaSeconds\x12)\n" +
 	"\x10cutover_attempts\x18\x06 \x01(\x05R\x0fcutoverAttempts\x120\n" +
 	"\x14last_cutover_attempt\x18\a \x01(\tR\x12lastCutoverAttempt\x12*\n" +
-	"\x11ready_to_complete\x18\b \x01(\bR\x0freadyToComplete\"\xad\x04\n" +
+	"\x11ready_to_complete\x18\b \x01(\bR\x0freadyToComplete\"\xd2\x04\n" +
 	"\rTableProgress\x12\x17\n" +
 	"\atask_id\x18\x01 \x01(\tR\x06taskId\x12\x1c\n" +
 	"\tnamespace\x18\x02 \x01(\tR\tnamespace\x12\x1d\n" +
@@ -3665,7 +3676,8 @@ const file_tern_proto_rawDesc = "" +
 	"\vchange_type\x18\r \x01(\x0e2\x13.tern.v1.ChangeTypeR\n" +
 	"changeType\x122\n" +
 	"\x15checksum_rows_checked\x18\x0e \x01(\x03R\x13checksumRowsChecked\x12.\n" +
-	"\x13checksum_rows_total\x18\x0f \x01(\x03R\x11checksumRowsTotal\"\xc7\x03\n" +
+	"\x13checksum_rows_total\x18\x0f \x01(\x03R\x11checksumRowsTotal\x12#\n" +
+	"\rerror_message\x18\x10 \x01(\tR\ferrorMessage\"\xc7\x03\n" +
 	"\x10ProgressResponse\x12\x19\n" +
 	"\bapply_id\x18\x01 \x01(\tR\aapplyId\x12$\n" +
 	"\x05state\x18\x02 \x01(\x0e2\x0e.tern.v1.StateR\x05state\x12'\n" +

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -3071,6 +3071,13 @@ func (c *GRPCClient) syncStoredTasksFromRemoteTasks(
 			storedTask.ChecksumRowsChecked = remoteTask.ChecksumRowsChecked
 			storedTask.ChecksumRowsTotal = remoteTask.ChecksumRowsTotal
 		}
+		// Mirror the table's own engine error so the PR comment / CLI can tell
+		// which table caused a failure. An empty remote error never wipes a
+		// stored one: a stale progress snapshot must not erase a durable error,
+		// and clearing on retry is owned by the dispatch path.
+		if remoteTask.ErrorMessage != "" {
+			storedTask.ErrorMessage = remoteTask.ErrorMessage
+		}
 		if state.IsState(storedTask.State, state.Task.Completed) && storedTask.ProgressPercent != 100 {
 			storedTask.ProgressPercent = 100
 		}

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -3859,6 +3859,77 @@ func TestGRPCClient_SyncStoredTasksFromRemoteTasksUsesRemoteTaskState(t *testing
 	}
 }
 
+func TestGRPCClient_SyncStoredTasksFromRemoteTasksMirrorsTableError(t *testing.T) {
+	// A remote table's own engine error must land on the control plane's stored
+	// task row so the PR comment / CLI can tell which table caused a failure. A
+	// table without its own error (e.g. one that failed only because an earlier
+	// table's failure blocked it) must stay error-free, and an empty error in a
+	// stale remote snapshot must never wipe a durable stored error.
+	now := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+	testCases := []struct {
+		name            string
+		storedTaskState string
+		storedTaskError string
+		remoteTaskState string
+		remoteTaskError string
+		wantStoredError string
+	}{
+		{
+			name:            "failed remote table carries its engine error onto the stored task",
+			storedTaskState: state.Task.Running,
+			remoteTaskState: state.Task.Failed,
+			remoteTaskError: "ERROR 1062 (23000): Duplicate entry 'a' for key 'users.uniq_name'",
+			wantStoredError: "ERROR 1062 (23000): Duplicate entry 'a' for key 'users.uniq_name'",
+		},
+		{
+			name:            "failed remote table without its own error leaves the stored task error empty",
+			storedTaskState: state.Task.Running,
+			remoteTaskState: state.Task.Failed,
+			wantStoredError: "",
+		},
+		{
+			name:            "empty error in a remote snapshot keeps the stored task error",
+			storedTaskState: state.Task.Failed,
+			storedTaskError: "ERROR 1062 (23000): Duplicate entry 'a' for key 'users.uniq_name'",
+			remoteTaskState: state.Task.Running,
+			wantStoredError: "ERROR 1062 (23000): Duplicate entry 'a' for key 'users.uniq_name'",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			storedApply := &storage.Apply{
+				ID:              18,
+				ApplyIdentifier: "apply-remote-table-error",
+				State:           state.Apply.Running,
+			}
+			storedTask := &storage.Task{
+				ID:             22,
+				TaskIdentifier: "task-remote-table-error",
+				ApplyID:        storedApply.ID,
+				TableName:      "users",
+				State:          tc.storedTaskState,
+				ErrorMessage:   tc.storedTaskError,
+			}
+			client := &GRPCClient{
+				storage: &mockStorage{
+					tasks: &mockTaskStore{tasks: []*storage.Task{storedTask}},
+					logs:  &mockApplyLogStore{},
+				},
+			}
+
+			err := client.syncStoredTasksFromRemoteTasks(t.Context(), storedApply, []*storage.Task{storedTask}, []*ternv1.TableProgress{{
+				TableName:    "users",
+				Status:       tc.remoteTaskState,
+				ErrorMessage: tc.remoteTaskError,
+			}}, now)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.wantStoredError, storedTask.ErrorMessage)
+		})
+	}
+}
+
 func TestGRPCClient_SyncShardProgressFromRemote(t *testing.T) {
 	// A remote Tern Progress response carries per-shard ShardProgress. The control
 	// plane is a reader/mirror, so it must encode those into per-(table, shard) task

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -2397,13 +2397,16 @@ func (c *LocalClient) Progress(ctx context.Context, req *ternv1.ProgressRequest)
 
 	for _, t := range currentApplyTasks {
 		tp := &ternv1.TableProgress{
-			TableName:  t.TableName,
-			Ddl:        t.DDL,
-			Namespace:  t.Namespace,
-			Status:     t.State,
-			TaskId:     t.TaskIdentifier,
-			IsInstant:  t.IsInstant || vitessApplyIsInstant,
-			ChangeType: ddlActionToProtoChangeType(t.DDLAction),
+			TableName: t.TableName,
+			Ddl:       t.DDL,
+			Namespace: t.Namespace,
+			Status:    t.State,
+			TaskId:    t.TaskIdentifier,
+			IsInstant: t.IsInstant || vitessApplyIsInstant,
+			// The task's own engine error, so a remote control plane can tell
+			// which table caused a failure apart from tables its failure blocked.
+			ErrorMessage: t.ErrorMessage,
+			ChangeType:   ddlActionToProtoChangeType(t.DDLAction),
 		}
 
 		// Table figures come from the stored task row the drive maintains.

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -1481,6 +1481,117 @@ func TestLocalClient_Progress(t *testing.T) {
 	assert.Equal(t, task.DDL, progress.Tables[0].Ddl)
 }
 
+// TestLocalClient_ProgressCarriesPerTableError exercises the Progress read
+// projection for a failed apply where one table produced its own engine error
+// and another failed only because that earlier failure blocked it. The response
+// must attribute the engine error to the failing table alone — a remote control
+// plane mirrors these per-table errors into its stored task rows, and the
+// blocked table staying error-free is what lets the PR comment distinguish the
+// root-cause table from tables that never ran.
+func TestLocalClient_ProgressCarriesPerTableError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, dsn := setupMySQLContainer(t)
+	setupStorageSchema(t, dsn)
+	cleanupTasks(t, dsn)
+	cleanupTestTables(t, dsn)
+
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	stor := createStorage(t, dsn)
+	defer utils.CloseAndLog(stor)
+
+	client, err := NewLocalClient(LocalConfig{
+		Database:  "testdb",
+		Type:      storage.DatabaseTypeMySQL,
+		TargetDSN: dsn,
+	}, stor, logger)
+	require.NoError(t, err)
+	defer utils.CloseAndLog(client)
+
+	now := time.Now()
+	engineError := "ERROR 1062 (23000): Duplicate entry 'a' for key 'users.uniq_name'"
+	apply := &storage.Apply{
+		ApplyIdentifier: fmt.Sprintf("apply-table-error-%d", now.UnixNano()),
+		PlanID:          1,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Deployment:      "testdb",
+		Environment:     localClientTestEnvironment,
+		Engine:          storage.EngineSpirit,
+		State:           state.Apply.Failed,
+		ErrorMessage:    engineError,
+		Caller:          "test",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	applyID, err := stor.Applies().Create(ctx, apply)
+	require.NoError(t, err)
+
+	failedTask := &storage.Task{
+		TaskIdentifier: fmt.Sprintf("task-table-error-failed-%d", now.UnixNano()),
+		ApplyID:        applyID,
+		PlanID:         apply.PlanID,
+		Database:       apply.Database,
+		DatabaseType:   apply.DatabaseType,
+		Engine:         apply.Engine,
+		Environment:    apply.Environment,
+		State:          state.Task.Failed,
+		Namespace:      "testdb",
+		TableName:      "users",
+		DDL:            "ALTER TABLE `users` ADD UNIQUE KEY `uniq_name` (`name`)",
+		DDLAction:      "alter",
+		ErrorMessage:   engineError,
+		CompletedAt:    &now,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	_, err = stor.Tasks().Create(ctx, failedTask)
+	require.NoError(t, err)
+
+	blockedTask := &storage.Task{
+		TaskIdentifier: fmt.Sprintf("task-table-error-blocked-%d", now.UnixNano()),
+		ApplyID:        applyID,
+		PlanID:         apply.PlanID,
+		Database:       apply.Database,
+		DatabaseType:   apply.DatabaseType,
+		Engine:         apply.Engine,
+		Environment:    apply.Environment,
+		State:          state.Task.Failed,
+		Namespace:      "testdb",
+		TableName:      "orders",
+		DDL:            "ALTER TABLE `orders` ADD COLUMN `note` VARCHAR(255)",
+		DDLAction:      "alter",
+		CompletedAt:    &now,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	_, err = stor.Tasks().Create(ctx, blockedTask)
+	require.NoError(t, err)
+
+	progress, err := client.Progress(ctx, &ternv1.ProgressRequest{
+		ApplyId:     apply.ApplyIdentifier,
+		Environment: localClientTestEnvironment,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, ternv1.State_STATE_FAILED, progress.State)
+	assert.Equal(t, engineError, progress.ErrorMessage)
+	require.Len(t, progress.Tables, 2)
+	byTable := make(map[string]*ternv1.TableProgress, len(progress.Tables))
+	for _, tp := range progress.Tables {
+		byTable[tp.TableName] = tp
+	}
+	require.Contains(t, byTable, "users")
+	require.Contains(t, byTable, "orders")
+	assert.Equal(t, state.Task.Failed, byTable["users"].Status)
+	assert.Equal(t, engineError, byTable["users"].ErrorMessage)
+	assert.Equal(t, state.Task.Failed, byTable["orders"].Status)
+	assert.Empty(t, byTable["orders"].ErrorMessage)
+}
+
 func TestLocalClient_GroupedApplyKeepsClaimLeaseRunning(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")


### PR DESCRIPTION
**Why this matters:** When a gRPC-driven apply fails, operators triaging from the PR comment or CLI can only see the apply-level error. The Tern proto had no per-table error field, so stored control-plane task rows never received an `ErrorMessage` and nothing user-facing could show *which table's* engine error caused the failure.

**What it does:**
- Adds `error_message` to `TableProgress` in the Tern proto (engine-agnostic string).
- The Tern server populates it in the Progress projection from the stored task's own error.
- The control plane mirrors it into its stored task rows in the gRPC progress sync paths — the rows the PR comment and CLI render from.

```
data plane task error
      └─▶ TableProgress.error_message      (Progress RPC)
              └─▶ control-plane task row   (gRPC sync)
                      └─▶ PR comment / CLI per-table error line
```

**Visible effect:** the PR comment's "Interrupted — retrying" row already renders the interrupting error under the table (see *Middle Table Retrying* in TEMPLATES.md):

> **`users`**: 🟧🟧🟧🟧🟧🟧⬜… 🔄 Interrupted — retrying automatically (attempt 2/10)
> ⚠️ Last error: lock wait timeout exceeded; try restarting transaction

For remote-driven applies that error line never appeared — the stored task row had no error, so operators watched retry attempts tick by with no indication of what was interrupting the copy until the apply hard-failed. It now renders with the table's own engine error. No comment copy changes, so TEMPLATES.md is unchanged: existing rendering gets real data.

The mirror is set-if-nonempty, preserving per-table attribution: a table with no engine error of its own stays error-free, and an empty error in a stale remote snapshot never wipes a durable stored error (clearing on retry stays owned by the dispatch path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
