### PR TITLE
fix(github): describe a superseded comment's own era in rotation fold headlines

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -3417,7 +3417,7 @@ Use `schemabot status -e <environment>` to find the apply ID.
 <summary><a name="volume-changed-superseded-progress-comment"></a><strong>Volume Changed: Superseded Progress Comment</strong></summary>
 
 
-⏩ Volume changed to **8/11** — progress continues in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
+⏩ Progress at volume **3/11** — superseded by the change to **8/11**; progress continues in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
 
 <details>
 <summary>Progress before the volume change</summary>
@@ -3456,7 +3456,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="resumed-superseded-progress-comment"></a><strong>Resumed: Superseded Progress Comment</strong></summary>
 
 
-▶️ Schema change resumed — progress continues in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
+⏸️ Progress before the stop — the schema change resumed in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
 
 <details>
 <summary>Progress before the stop</summary>
@@ -3493,7 +3493,7 @@ schemabot start apply-a1b2c3d4e5f6 -e staging
 <summary><a name="revert-superseded-progress-comment"></a><strong>Revert: Superseded Progress Comment</strong></summary>
 
 
-Schema change reverting — the revert is tracked in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
+⏪ Progress before the revert — the revert is tracked in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
 
 <details>
 <summary>Progress before the revert</summary>
@@ -3536,7 +3536,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="skip-revert-superseded-progress-comment"></a><strong>Skip Revert: Superseded Progress Comment</strong></summary>
 
 
-Revert skipped — the schema change is finalizing in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
+⏭️ Revert window before the skip — the schema change is finalizing in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
 
 <details>
 <summary>Progress before the revert was skipped</summary>
@@ -3579,7 +3579,7 @@ _Last updated: <relative-time datetime="2026-01-01T00:00:00Z">2026-01-01 00:00:0
 <summary><a name="cutover-complete-superseded-cutover-prompt"></a><strong>Cutover Complete: Superseded Cutover Prompt</strong></summary>
 
 
-Cutover complete — progress continues in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
+⏸️ Cutover prompt — the cutover completed; progress continues in [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-2222222222).
 
 <details>
 <summary>Cutover prompt</summary>

--- a/pkg/webhook/apply_comment_integration_test.go
+++ b/pkg/webhook/apply_comment_integration_test.go
@@ -408,7 +408,7 @@ func TestE2EResumeRotatesProgressComment(t *testing.T) {
 	select {
 	case edited := <-capture.edits:
 		assert.Equal(t, stoppedProgressID, edited.CommentID, "the freeze edit lands on the superseded comment")
-		assert.Contains(t, edited.Body, "Schema change resumed")
+		assert.Contains(t, edited.Body, "⏸️ Progress before the stop — the schema change resumed in")
 		assert.Contains(t, edited.Body, fmt.Sprintf("#issuecomment-%d", newProgressID), "the frozen comment links to its successor")
 		assert.Contains(t, edited.Body, "<details>")
 		assert.Contains(t, edited.Body, "Stopped at 21%", "the pre-stop body is preserved inside the fold")
@@ -516,7 +516,7 @@ func TestE2EResumeRotationFreezesAcrossIterations(t *testing.T) {
 	select {
 	case edited := <-capture.edits:
 		assert.Equal(t, secondProgressID, edited.CommentID, "the freeze edit lands on the second cycle's comment")
-		assert.Contains(t, edited.Body, "Schema change resumed")
+		assert.Contains(t, edited.Body, "⏸️ Progress before the stop — the schema change resumed in")
 		assert.Contains(t, edited.Body, fmt.Sprintf("#issuecomment-%d", thirdProgressID), "the frozen comment links to its successor")
 		assert.Contains(t, edited.Body, "Stopped at 63%", "the superseded body is preserved inside the fold")
 	case <-time.After(5 * time.Second):
@@ -756,7 +756,8 @@ func TestE2EVolumeChangeRotatesProgressComment(t *testing.T) {
 	select {
 	case edited := <-capture.edits:
 		assert.Equal(t, initialProgressID, edited.CommentID, "the freeze edit lands on the superseded comment")
-		assert.Contains(t, edited.Body, "Volume changed to **5/11**")
+		assert.Contains(t, edited.Body, "⏩ Progress at volume **3/11**", "the fold names the level the frozen comment covered")
+		assert.Contains(t, edited.Body, "superseded by the change to **5/11**", "the new level appears only as what superseded the era")
 		assert.Contains(t, edited.Body, fmt.Sprintf("#issuecomment-%d", newProgressID), "the frozen comment links to its successor")
 		assert.Contains(t, edited.Body, "<details>")
 		assert.Contains(t, edited.Body, "Volume: 3/11", "the pre-change body is preserved inside the fold")
@@ -838,7 +839,7 @@ func TestE2ERevertRotatesProgressComment(t *testing.T) {
 	select {
 	case edited := <-capture.edits:
 		assert.Equal(t, preRevertID, edited.CommentID, "the freeze edit lands on the superseded comment")
-		assert.Contains(t, edited.Body, "Schema change reverting")
+		assert.Contains(t, edited.Body, "⏪ Progress before the revert — the revert is tracked in")
 		assert.Contains(t, edited.Body, fmt.Sprintf("#issuecomment-%d", newProgressID), "the frozen comment links to its successor")
 		assert.Contains(t, edited.Body, "<details>")
 		assert.Contains(t, edited.Body, "Revert window open", "the pre-revert body is preserved inside the fold")
@@ -950,7 +951,7 @@ func TestE2ESkipRevertRotatesProgressComment(t *testing.T) {
 	select {
 	case edited := <-capture.edits:
 		assert.Equal(t, preSkipID, edited.CommentID, "the freeze edit lands on the superseded comment")
-		assert.Contains(t, edited.Body, "Revert skipped")
+		assert.Contains(t, edited.Body, "⏭️ Revert window before the skip — the schema change is finalizing in")
 		assert.Contains(t, edited.Body, fmt.Sprintf("#issuecomment-%d", newProgressID), "the frozen comment links to its successor")
 		assert.Contains(t, edited.Body, "<details>")
 		assert.Contains(t, edited.Body, "Revert window open", "the revert-window body is preserved inside the fold")
@@ -1179,7 +1180,7 @@ func TestE2EDeferredCutoverRotatesProgressComment(t *testing.T) {
 	select {
 	case edited := <-capture.edits:
 		assert.Equal(t, cutoverPromptID, edited.CommentID, "the freeze edit lands on the cutover prompt")
-		assert.Contains(t, edited.Body, "Cutover complete")
+		assert.Contains(t, edited.Body, "⏸️ Cutover prompt — the cutover completed")
 		assert.Contains(t, edited.Body, fmt.Sprintf("#issuecomment-%d", newProgressID), "the frozen prompt links to its successor")
 		assert.Contains(t, edited.Body, "<details>")
 		assert.Contains(t, edited.Body, "Ready for cutover", "the prompt body is preserved inside the fold")
@@ -1276,7 +1277,7 @@ func TestE2EDeferredCutoverSupersedeRetriedUntilItLands(t *testing.T) {
 	select {
 	case edited := <-capture.edits:
 		assert.Equal(t, cutoverPromptID, edited.CommentID, "the freeze edit lands on the cutover prompt")
-		assert.Contains(t, edited.Body, "Cutover complete")
+		assert.Contains(t, edited.Body, "⏸️ Cutover prompt — the cutover completed")
 	case <-time.After(5 * time.Second):
 		t.Fatal("expected the cutover prompt to be frozen")
 	}
@@ -1326,7 +1327,7 @@ func TestE2EDeferredCutoverSupersedeRetriedUntilItLands(t *testing.T) {
 // from a completed cutover — a restart recovery re-copying the parked apply, a
 // retryable failure at the gate, the gate state itself — keep the observer
 // muted: no fresh progress comment is posted and the prompt is never folded
-// under a false "Cutover complete" record. Only a post-cutover phase (revert
+// under a false record claiming the cutover completed. Only a post-cutover phase (revert
 // window, reverting, skipping revert) proves the operator's cutover happened
 // and unmutes.
 func TestE2EDeferredCutoverPromptStaysMutedWithoutCutover(t *testing.T) {
@@ -1380,7 +1381,7 @@ func TestE2EDeferredCutoverPromptStaysMutedWithoutCutover(t *testing.T) {
 
 // An apply stopped at the deferred-cutover gate completes the prompt itself:
 // the terminal edit turns the prompt into the stop record and consumes its
-// row, so the prompt is never folded under a false "Cutover complete" record.
+// row, so the prompt is never folded under a false record claiming the cutover completed.
 // When the operator resumes, the consumed row no longer mutes the fresh
 // observer, and the summary marker triggers the resume rotation: the resumed
 // apply is tracked in a fresh progress comment at the bottom of the PR while
@@ -1460,7 +1461,7 @@ func TestE2EStopAtCutoverGateThenResumeRotatesFreshComment(t *testing.T) {
 	case edited := <-capture.edits:
 		assert.Equal(t, preStopProgressID, edited.CommentID, "the freeze edit lands on the pre-stop progress comment")
 		assert.Contains(t, edited.Body, fmt.Sprintf("#issuecomment-%d", resumedProgressID), "the frozen comment links to its successor")
-		assert.NotContains(t, edited.Body, "Cutover complete", "nothing renders a cutover that never happened")
+		assert.NotContains(t, edited.Body, "the cutover completed", "nothing renders a cutover that never happened")
 	case <-time.After(5 * time.Second):
 		t.Fatal("expected the pre-stop progress comment to be frozen")
 	}
@@ -1566,7 +1567,7 @@ func TestE2EDeferredCutoverUntrackedFreshCommentAdoptedWhenStorageHeals(t *testi
 	select {
 	case edited := <-capture.edits:
 		assert.Equal(t, cutoverPromptID, edited.CommentID, "the freeze edit lands on the cutover prompt")
-		assert.Contains(t, edited.Body, "Cutover complete")
+		assert.Contains(t, edited.Body, "⏸️ Cutover prompt — the cutover completed")
 		assert.Contains(t, edited.Body, fmt.Sprintf("#issuecomment-%d", freshProgressID), "the frozen prompt links to its adopted successor")
 	case created := <-capture.creates:
 		t.Fatalf("adoption must not post another comment; got %d", created.ID)
@@ -1847,7 +1848,7 @@ func TestE2EPendingRotationAdoptedBeforeCutoverPrompt(t *testing.T) {
 	select {
 	case edited := <-capture.edits:
 		assert.Equal(t, cutoverPromptID, edited.CommentID, "the freeze edit lands on the cutover prompt")
-		assert.Contains(t, edited.Body, "Cutover complete")
+		assert.Contains(t, edited.Body, "⏸️ Cutover prompt — the cutover completed")
 	case <-time.After(5 * time.Second):
 		t.Fatal("expected the cutover prompt to be frozen")
 	}
@@ -1950,7 +1951,7 @@ func TestE2ERevertRotationUntrackedFreshCommentAdoptedWhenStorageHeals(t *testin
 	select {
 	case edited := <-capture.edits:
 		assert.Equal(t, preRevertID, edited.CommentID, "the freeze edit lands on the superseded comment")
-		assert.Contains(t, edited.Body, "Schema change reverting")
+		assert.Contains(t, edited.Body, "⏪ Progress before the revert — the revert is tracked in")
 		assert.Contains(t, edited.Body, fmt.Sprintf("#issuecomment-%d", freshProgressID), "the frozen comment links to its adopted successor")
 	case created := <-capture.creates:
 		t.Fatalf("adoption must not post another comment; got %d", created.ID)
@@ -2282,7 +2283,8 @@ func TestE2EVolumeRotationUntrackedFreshCommentAdoptedWhenStorageHeals(t *testin
 	select {
 	case edited := <-capture.edits:
 		assert.Equal(t, initialProgressID, edited.CommentID, "the freeze edit lands on the superseded comment")
-		assert.Contains(t, edited.Body, "Volume changed to **5/11**")
+		assert.Contains(t, edited.Body, "⏩ Progress at volume **3/11**", "the adoption freeze names the level the frozen comment covered")
+		assert.Contains(t, edited.Body, "superseded by the change to **5/11**", "the new level appears only as what superseded the era")
 		assert.Contains(t, edited.Body, fmt.Sprintf("#issuecomment-%d", freshProgressID), "the frozen comment links to its adopted successor")
 		assert.Contains(t, edited.Body, "<details>")
 	case created := <-capture.creates:
@@ -2325,7 +2327,8 @@ func TestE2EVolumeRotationUntrackedFreshCommentAdoptedWhenStorageHeals(t *testin
 	select {
 	case edited := <-capture.edits:
 		assert.Equal(t, freshProgressID, edited.CommentID, "the adopted comment is frozen in turn")
-		assert.Contains(t, edited.Body, "Volume changed to **3/11**")
+		assert.Contains(t, edited.Body, "⏩ Progress at volume **5/11**", "the fold names the adopted comment's own era level")
+		assert.Contains(t, edited.Body, "superseded by the change to **3/11**", "the reverted level appears only as what superseded the era")
 		assert.Contains(t, edited.Body, fmt.Sprintf("#issuecomment-%d", revertedProgressID), "the frozen comment links to the revert's fresh comment")
 	case <-time.After(5 * time.Second):
 		t.Fatal("expected the adopted comment to be frozen after the revert")

--- a/pkg/webhook/comment_observer.go
+++ b/pkg/webhook/comment_observer.go
@@ -103,6 +103,10 @@ type pendingProgressRotation struct {
 	commentID int64
 	// volume is the level the comment was posted at.
 	volume int
+	// previousVolume is the level the superseded comment was posted at, read
+	// only for the volume-change fold so the adoption freeze renders the same
+	// era-descriptive headline as the direct path.
+	previousVolume int
 	// phase is the control phase the comment was posted in (empty when none),
 	// recorded on the tracked row at adoption so the durable rotation signal
 	// survives the retried write.
@@ -297,7 +301,7 @@ func (o *CommentObserver) OnProgress(apply *storage.Apply, tasks []*storage.Task
 	// comment itself. Every other state keeps the observer muted — a restart
 	// recovery re-copying a parked apply, a retryable failure at the gate, a
 	// stop — because no cutover has happened, so a rotation would fold the
-	// unanswered prompt under a false "Cutover complete" record.
+	// unanswered prompt under a false record claiming the cutover completed.
 	if o.hasCutoverComment {
 		if !postCutoverPhase(controlPhase(apply.State)) {
 			return
@@ -784,7 +788,7 @@ func (o *CommentObserver) rotateProgressCommentForResume(apply *storage.Apply, t
 			// frozen rendering — the freeze edit failed or the pod died before it
 			// landed. Retry it now; on success the marker is cleared.
 			o.freezeSupersededProgressComment(apply, *tracked.PendingFreezeCommentID, tracked.GitHubCommentID,
-				supersededByPriorRotation, 0)
+				supersededByPriorRotation, 0, 0)
 		}
 		pendingFreeze = &tracked.GitHubCommentID
 	}
@@ -801,7 +805,7 @@ func (o *CommentObserver) rotateProgressCommentForResume(apply *storage.Apply, t
 	o.resumeRotated = true
 
 	if trackedNew && tracked != nil {
-		o.freezeSupersededProgressComment(apply, tracked.GitHubCommentID, newCommentID, supersededByResume, 0)
+		o.freezeSupersededProgressComment(apply, tracked.GitHubCommentID, newCommentID, supersededByResume, 0, 0)
 	}
 	// When the fresh comment posted but its tracking write failed
 	// (postAndTrackComment logged it), the prior comment is still the tracked
@@ -962,7 +966,7 @@ func (o *CommentObserver) rotateProgressCommentForControlPhase(apply *storage.Ap
 		// this phase and no new rotation follows); on success the marker is
 		// cleared.
 		o.freezeSupersededProgressComment(apply, *tracked.PendingFreezeCommentID, tracked.GitHubCommentID,
-			supersededByPriorRotation, 0)
+			supersededByPriorRotation, 0, 0)
 	}
 	if trackedPhase(tracked) == phase {
 		// The tracked comment was posted while the apply was already in this
@@ -998,7 +1002,7 @@ func (o *CommentObserver) rotateProgressCommentForControlPhase(apply *storage.Ap
 	}
 	o.markPhaseRotated(phase)
 
-	o.freezeSupersededProgressComment(apply, tracked.GitHubCommentID, newCommentID, supersededReasonForPhase(phase), 0)
+	o.freezeSupersededProgressComment(apply, tracked.GitHubCommentID, newCommentID, supersededReasonForPhase(phase), 0, 0)
 
 	o.logger.Info("observer: posted fresh progress comment for control phase",
 		"apply_id", o.applyID, "repo", o.repo, "pr", o.pr, "state", apply.State, "phase", phase)
@@ -1074,7 +1078,7 @@ func (o *CommentObserver) rotateProgressCommentAfterCutover(apply *storage.Apply
 		// Retry any fold still owed, then resume normal editing.
 		if tracked != nil && tracked.PendingFreezeCommentID != nil {
 			o.freezeSupersededProgressComment(apply, *tracked.PendingFreezeCommentID, tracked.GitHubCommentID,
-				supersededByPriorRotation, 0)
+				supersededByPriorRotation, 0, 0)
 		}
 		if cutover.SupersededAt == nil {
 			o.supersedeCutoverComment(ctx, apply)
@@ -1089,7 +1093,7 @@ func (o *CommentObserver) rotateProgressCommentAfterCutover(apply *storage.Apply
 		// frozen rendering — the freeze edit failed or the pod died before it
 		// landed. Retry it now; on success the marker is cleared.
 		o.freezeSupersededProgressComment(apply, *tracked.PendingFreezeCommentID, tracked.GitHubCommentID,
-			supersededByPriorRotation, 0)
+			supersededByPriorRotation, 0, 0)
 	}
 
 	body := o.formatStatusComment(apply, tasks)
@@ -1125,7 +1129,7 @@ func (o *CommentObserver) rotateProgressCommentAfterCutover(apply *storage.Apply
 	o.cutoverRotated = true
 	o.hasCutoverComment = false
 
-	o.freezeSupersededProgressComment(apply, cutover.GitHubCommentID, newCommentID, supersededByCutover, 0)
+	o.freezeSupersededProgressComment(apply, cutover.GitHubCommentID, newCommentID, supersededByCutover, 0, 0)
 	o.supersedeCutoverComment(ctx, apply)
 
 	o.logInfo(apply, "observer: posted fresh progress comment after deferred cutover", "state", apply.State)
@@ -1162,9 +1166,10 @@ const (
 )
 
 // frozenSupersededProgressBody renders the folded body written over a
-// superseded progress comment, headlined by the reason it was rotated away
-// from. volume is read only for the volume-change rendering.
-func (o *CommentObserver) frozenSupersededProgressBody(reason supersededProgressReason, volume int, newCommentID int64, previousBody string) string {
+// superseded progress comment, headlined by the era the comment covered.
+// volume (the new level) and previousVolume (the level the superseded comment
+// was posted at) are read only for the volume-change rendering.
+func (o *CommentObserver) frozenSupersededProgressBody(reason supersededProgressReason, volume, previousVolume int, newCommentID int64, previousBody string) string {
 	switch reason {
 	case supersededByResume:
 		return templates.RenderResumeSupersededProgressComment(templates.SupersededProgressData{
@@ -1203,11 +1208,12 @@ func (o *CommentObserver) frozenSupersededProgressBody(reason supersededProgress
 		})
 	}
 	return templates.RenderVolumeSupersededProgressComment(templates.VolumeSupersededProgressData{
-		Volume:       volume,
-		Repo:         o.repo,
-		PR:           o.pr,
-		NewCommentID: newCommentID,
-		PreviousBody: previousBody,
+		Volume:         volume,
+		PreviousVolume: previousVolume,
+		Repo:           o.repo,
+		PR:             o.pr,
+		NewCommentID:   newCommentID,
+		PreviousBody:   previousBody,
 	})
 }
 
@@ -1283,7 +1289,7 @@ func (o *CommentObserver) rotateProgressCommentForVolumeChange(apply *storage.Ap
 		// frozen rendering — the freeze edit failed or the pod died before it
 		// landed. Retry it now; on success the marker is cleared.
 		o.freezeSupersededProgressComment(apply, *tracked.PendingFreezeCommentID, tracked.GitHubCommentID,
-			supersededByPriorRotation, 0)
+			supersededByPriorRotation, 0, 0)
 	}
 	o.trackedPostedVolume = *tracked.PostedVolume
 	o.trackedPostedVolumeKnown = true
@@ -1308,6 +1314,7 @@ func (o *CommentObserver) rotateProgressCommentForVolumeChange(apply *storage.Ap
 		o.pendingRotation = &pendingProgressRotation{
 			commentID:           newCommentID,
 			volume:              currentVolume,
+			previousVolume:      *tracked.PostedVolume,
 			phase:               controlPhase(apply.State),
 			reason:              supersededByVolumeChange,
 			supersededCommentID: tracked.GitHubCommentID,
@@ -1319,7 +1326,7 @@ func (o *CommentObserver) rotateProgressCommentForVolumeChange(apply *storage.Ap
 	o.volumeRotatedTo = currentVolume
 	o.logInfo(apply, "observer: posted fresh progress comment for volume change",
 		"previous_volume", *tracked.PostedVolume, "volume", currentVolume)
-	o.freezeSupersededProgressComment(apply, tracked.GitHubCommentID, newCommentID, supersededByVolumeChange, currentVolume)
+	o.freezeSupersededProgressComment(apply, tracked.GitHubCommentID, newCommentID, supersededByVolumeChange, currentVolume, *tracked.PostedVolume)
 	return true
 }
 
@@ -1355,7 +1362,7 @@ func (o *CommentObserver) adoptPendingRotationComment(apply *storage.Apply) bool
 	}
 	o.logInfo(apply, "observer: adopted posted-but-untracked progress comment; progress edits now land on it",
 		"github_comment_id", p.commentID, "volume", p.volume, "phase", p.phase)
-	o.freezeSupersededProgressComment(apply, p.supersededCommentID, p.commentID, p.reason, p.volume)
+	o.freezeSupersededProgressComment(apply, p.supersededCommentID, p.commentID, p.reason, p.volume, p.previousVolume)
 	return true
 }
 
@@ -1364,12 +1371,12 @@ func (o *CommentObserver) adoptPendingRotationComment(apply *storage.Apply) bool
 // the comment that replaced it. Collapsing rather than deleting keeps the
 // pre-change progress on the PR as a record while decluttering the timeline;
 // without the fold a reader has no way to tell a frozen comment from a live
-// one. reason selects the fold's headline (volume is read only for the
-// volume-change rendering). A failure leaves the tracked row's pending-freeze
-// marker in place (it is written alongside the successor's tracking), so a
-// later tick or a later drive's observer retries; the marker is cleared only
-// once the frozen rendering is on GitHub.
-func (o *CommentObserver) freezeSupersededProgressComment(apply *storage.Apply, oldCommentID, newCommentID int64, reason supersededProgressReason, volume int) {
+// one. reason selects the fold's headline (volume and previousVolume are read
+// only for the volume-change rendering). A failure leaves the tracked row's
+// pending-freeze marker in place (it is written alongside the successor's
+// tracking), so a later tick or a later drive's observer retries; the marker
+// is cleared only once the frozen rendering is on GitHub.
+func (o *CommentObserver) freezeSupersededProgressComment(apply *storage.Apply, oldCommentID, newCommentID int64, reason supersededProgressReason, volume, previousVolume int) {
 	if !o.leaseStillOwnsObserver(apply, "create GitHub client before freezing superseded comment") {
 		return
 	}
@@ -1394,7 +1401,7 @@ func (o *CommentObserver) freezeSupersededProgressComment(apply *storage.Apply, 
 		if !o.leaseStillOwnsObserver(apply, "freeze superseded progress comment") {
 			return
 		}
-		frozen := o.frozenSupersededProgressBody(reason, volume, newCommentID, oldBody)
+		frozen := o.frozenSupersededProgressBody(reason, volume, previousVolume, newCommentID, oldBody)
 		if err := client.EditIssueComment(ctx, o.repo, oldCommentID, frozen); err != nil {
 			o.logError(apply, "observer: failed to freeze superseded progress comment; the pending-freeze marker stays set and the next observer pass that reads the tracked row retries",
 				"error", err, "github_comment_id", oldCommentID)

--- a/pkg/webhook/templates/issue_comment.go
+++ b/pkg/webhook/templates/issue_comment.go
@@ -311,6 +311,10 @@ func PreviewCommentVolumeMissingApplyID() string {
 type VolumeSupersededProgressData struct {
 	// Volume is the new level (1=slowest, 11=fastest) that took effect.
 	Volume int
+	// PreviousVolume is the level the superseded comment was posted at — the
+	// era its frozen headline describes. Zero means the comment was posted
+	// before any explicit level, so the headline describes the default volume.
+	PreviousVolume int
 	// Repo is the "owner/name" repository, used to link the successor comment.
 	Repo string
 	// PR is the pull request number, used to link the successor comment.
@@ -326,7 +330,7 @@ type VolumeSupersededProgressData struct {
 // volumeSupersededPrefix opens every frozen body written when a volume change
 // superseded a progress comment; IsSupersededProgressComment keys on it so a
 // freeze retry can tell an already-frozen comment from a live one.
-const volumeSupersededPrefix = "⏩ Volume changed to"
+const volumeSupersededPrefix = "⏩ Progress at"
 
 // supersededFoldMarker is the successor-link text renderSupersededFold embeds
 // in the headline of every frozen body. IsSupersededProgressComment requires
@@ -356,6 +360,13 @@ type SupersededProgressData struct {
 // comment's last rendered body preserved inside a collapsed details block.
 // Every rotation flavor shares this shape and differs only in its headline
 // (which must start with that flavor's superseded prefix) and fold label.
+//
+// Headlines must describe the era the frozen comment covered, never announce
+// the event that retired it: the frozen comment sits above the operator
+// command that caused the rotation in the PR timeline, so a headline naming
+// the retiring event reads as an effect appearing before its cause. The
+// retiring event appears only in subordinate "superseded by …" phrasing after
+// the era description.
 func renderSupersededFold(headline, foldLabel, repo string, pr int, newCommentID int64, previousBody string) string {
 	return fmt.Sprintf(
 		"%s"+supersededFoldMarker+"%s/pull/%d#issuecomment-%d).\n\n"+
@@ -364,11 +375,18 @@ func renderSupersededFold(headline, foldLabel, repo string, pr int, newCommentID
 }
 
 // RenderVolumeSupersededProgressComment renders the frozen body written over a
-// progress comment once a volume change rotates in a fresh one. The old
-// comment's final progress stays on the PR as a record, collapsed into a
-// details block, with a pointer to the comment where progress continues.
+// progress comment once a volume change rotates in a fresh one. The headline
+// names the level the frozen comment covered (its own era), with the new level
+// mentioned only as what superseded it. The old comment's final progress stays
+// on the PR as a record, collapsed into a details block, with a pointer to the
+// comment where progress continues.
 func RenderVolumeSupersededProgressComment(data VolumeSupersededProgressData) string {
-	headline := fmt.Sprintf("%s **%d/%d** — progress continues in", volumeSupersededPrefix, data.Volume, storage.MaxVolume)
+	era := fmt.Sprintf("volume **%d/%d**", data.PreviousVolume, storage.MaxVolume)
+	if data.PreviousVolume == 0 {
+		era = "the default volume"
+	}
+	headline := fmt.Sprintf("%s %s — superseded by the change to **%d/%d**; progress continues in",
+		volumeSupersededPrefix, era, data.Volume, storage.MaxVolume)
 	return renderSupersededFold(headline, "Progress before the volume change",
 		data.Repo, data.PR, data.NewCommentID, data.PreviousBody)
 }
@@ -376,28 +394,30 @@ func RenderVolumeSupersededProgressComment(data VolumeSupersededProgressData) st
 // resumeSupersededPrefix opens every frozen body written when a resume
 // superseded a progress comment; IsSupersededProgressComment keys on it so a
 // freeze retry can tell an already-frozen comment from a live one.
-const resumeSupersededPrefix = "▶️ Schema change resumed"
+const resumeSupersededPrefix = "⏸️ Progress before the stop"
 
 // RenderResumeSupersededProgressComment renders the frozen body written over a
-// progress comment once a resumed apply rotates in a fresh one. The old
-// comment's final pre-stop progress stays on the PR as a record, collapsed
-// into a details block, with a pointer to the comment where progress
-// continues.
+// progress comment once a resumed apply rotates in a fresh one. The headline
+// names the pre-stop era the frozen comment covered, with the resume mentioned
+// only as where progress continues. The old comment's final pre-stop progress
+// stays on the PR as a record, collapsed into a details block, with a pointer
+// to the comment where progress continues.
 func RenderResumeSupersededProgressComment(data SupersededProgressData) string {
-	return renderSupersededFold(resumeSupersededPrefix+" — progress continues in", "Progress before the stop",
+	return renderSupersededFold(resumeSupersededPrefix+" — the schema change resumed in", "Progress before the stop",
 		data.Repo, data.PR, data.NewCommentID, data.PreviousBody)
 }
 
 // revertSupersededPrefix opens every frozen body written when a revert
 // superseded a progress comment; IsSupersededProgressComment keys on it so a
 // freeze retry can tell an already-frozen comment from a live one.
-const revertSupersededPrefix = "Schema change reverting"
+const revertSupersededPrefix = "⏪ Progress before the revert"
 
 // RenderRevertSupersededProgressComment renders the frozen body written over a
-// progress comment once a user revert rotates in a fresh one. The old
-// comment's final pre-revert progress stays on the PR as a record, collapsed
-// into a details block, with a pointer to the comment where the revert is
-// tracked.
+// progress comment once a user revert rotates in a fresh one. The headline
+// names the pre-revert era the frozen comment covered, with the revert
+// mentioned only as where tracking continues. The old comment's final
+// pre-revert progress stays on the PR as a record, collapsed into a details
+// block, with a pointer to the comment where the revert is tracked.
 func RenderRevertSupersededProgressComment(data SupersededProgressData) string {
 	return renderSupersededFold(revertSupersededPrefix+" — the revert is tracked in", "Progress before the revert",
 		data.Repo, data.PR, data.NewCommentID, data.PreviousBody)
@@ -406,13 +426,15 @@ func RenderRevertSupersededProgressComment(data SupersededProgressData) string {
 // skipRevertSupersededPrefix opens every frozen body written when a
 // skip-revert superseded a progress comment; IsSupersededProgressComment keys
 // on it so a freeze retry can tell an already-frozen comment from a live one.
-const skipRevertSupersededPrefix = "Revert skipped"
+const skipRevertSupersededPrefix = "⏭️ Revert window before the skip"
 
 // RenderSkipRevertSupersededProgressComment renders the frozen body written
 // over a progress comment once a user skip-revert rotates in a fresh one. The
-// old comment's final revert-window rendering stays on the PR as a record,
-// collapsed into a details block, with a pointer to the comment where the
-// finalization is tracked.
+// headline names the revert-window era the frozen comment covered, with the
+// skip mentioned only as where finalization continues. The old comment's final
+// revert-window rendering stays on the PR as a record, collapsed into a
+// details block, with a pointer to the comment where the finalization is
+// tracked.
 func RenderSkipRevertSupersededProgressComment(data SupersededProgressData) string {
 	return renderSupersededFold(skipRevertSupersededPrefix+" — the schema change is finalizing in", "Progress before the revert was skipped",
 		data.Repo, data.PR, data.NewCommentID, data.PreviousBody)
@@ -422,15 +444,17 @@ func RenderSkipRevertSupersededProgressComment(data SupersededProgressData) stri
 // cutover superseded the cutover prompt comment; IsSupersededProgressComment
 // keys on it so a freeze retry can tell an already-frozen comment from a live
 // one.
-const cutoverSupersededPrefix = "Cutover complete"
+const cutoverSupersededPrefix = "⏸️ Cutover prompt"
 
 // RenderCutoverSupersededComment renders the frozen body written over the
 // cutover prompt comment once the operator's cutover has completed and the
-// apply continues (e.g. into its revert window). The prompt stays on the PR as
-// a record, collapsed into a details block, with a pointer to the comment
-// where progress is tracked.
+// apply continues (e.g. into its revert window). The headline names what the
+// frozen comment was — the prompt — with the completed cutover mentioned only
+// as what superseded it. The prompt stays on the PR as a record, collapsed
+// into a details block, with a pointer to the comment where progress is
+// tracked.
 func RenderCutoverSupersededComment(data SupersededProgressData) string {
-	return renderSupersededFold(cutoverSupersededPrefix+" — progress continues in", "Cutover prompt",
+	return renderSupersededFold(cutoverSupersededPrefix+" — the cutover completed; progress continues in", "Cutover prompt",
 		data.Repo, data.PR, data.NewCommentID, data.PreviousBody)
 }
 
@@ -449,26 +473,42 @@ func RenderSupersededProgressComment(data SupersededProgressData) string {
 		data.Repo, data.PR, data.NewCommentID, data.PreviousBody)
 }
 
+// legacySupersededPrefixes are headline prefixes that earlier server versions
+// rendered on frozen bodies. They are recognition-only — nothing renders them
+// anymore. A comment frozen by an earlier version can still carry a
+// pending-freeze marker if the marker-clear write failed; without recognizing
+// its headline, the freeze retry would wrap the already-frozen body in a
+// second fold.
+var legacySupersededPrefixes = []string{
+	"⏩ Volume changed to",
+	"▶️ Schema change resumed",
+	"Schema change reverting",
+	"Revert skipped",
+	"Cutover complete",
+}
+
 // IsSupersededProgressComment reports whether a comment body is already a
-// frozen superseded rendering — any rotation flavor — so a freeze retry does
-// not wrap a frozen body in a second fold. A frozen body opens with a flavor
-// prefix and carries the successor link on that same headline; both are
-// required, so a live body that merely opens with the same words as a prefix
-// (e.g. an edited comment starting "Cutover complete") is never mistaken for
-// a frozen one and skipped by a freeze retry.
+// frozen superseded rendering — any rotation flavor, current or legacy — so a
+// freeze retry does not wrap a frozen body in a second fold. A frozen body
+// opens with a flavor prefix and carries the successor link on that same
+// headline; both are required, so a live body that merely opens with the same
+// words as a prefix (e.g. an edited comment starting "Cutover complete") is
+// never mistaken for a frozen one and skipped by a freeze retry.
 func IsSupersededProgressComment(body string) bool {
 	headline, _, _ := strings.Cut(body, "\n")
 	if !strings.Contains(headline, supersededFoldMarker) {
 		return false
 	}
-	for _, prefix := range []string{
+	prefixes := []string{
 		volumeSupersededPrefix,
 		resumeSupersededPrefix,
 		revertSupersededPrefix,
 		skipRevertSupersededPrefix,
 		cutoverSupersededPrefix,
 		genericSupersededPrefix,
-	} {
+	}
+	prefixes = append(prefixes, legacySupersededPrefixes...)
+	for _, prefix := range prefixes {
 		if strings.HasPrefix(headline, prefix) {
 			return true
 		}

--- a/pkg/webhook/templates/issue_comment_test.go
+++ b/pkg/webhook/templates/issue_comment_test.go
@@ -199,18 +199,24 @@ func TestRenderVolumeInvalidLevel(t *testing.T) {
 }
 
 // TestRenderVolumeSupersededProgressComment verifies the frozen body written
-// over an old progress comment after a volume change: it names the new level,
-// links the successor comment, and folds the final pre-change progress into a
-// details block so the record stays on the PR without looking live.
+// over an old progress comment after a volume change: the headline names the
+// level the frozen comment covered (its own era) with the new level mentioned
+// only as what superseded it, links the successor comment, and folds the final
+// pre-change progress into a details block so the record stays on the PR
+// without looking live.
 func TestRenderVolumeSupersededProgressComment(t *testing.T) {
 	rendered := RenderVolumeSupersededProgressComment(VolumeSupersededProgressData{
-		Volume:       8,
-		Repo:         "acme/testapp",
-		PR:           42,
-		NewCommentID: 2222222222,
-		PreviousBody: "## Schema Change Progress\n\nVolume: 3/11",
+		Volume:         8,
+		PreviousVolume: 3,
+		Repo:           "acme/testapp",
+		PR:             42,
+		NewCommentID:   2222222222,
+		PreviousBody:   "## Schema Change Progress\n\nVolume: 3/11",
 	})
-	assert.Contains(t, rendered, "Volume changed to **8/11**")
+	assert.Contains(t, rendered, "⏩ Progress at volume **3/11**",
+		"the headline names the frozen comment's own era level")
+	assert.Contains(t, rendered, "superseded by the change to **8/11**",
+		"the new level appears only as what superseded the era")
 	assert.Contains(t, rendered, "https://github.com/acme/testapp/pull/42#issuecomment-2222222222")
 	assert.Contains(t, rendered, "<details>")
 	assert.Contains(t, rendered, "<summary>Progress before the volume change</summary>")
@@ -218,10 +224,33 @@ func TestRenderVolumeSupersededProgressComment(t *testing.T) {
 		"the superseded body is preserved inside the fold")
 }
 
+// TestRenderVolumeSupersededProgressCommentDefaultVolumeEra verifies the
+// frozen body for a comment posted before any explicit level: the headline
+// describes the default-volume era instead of rendering a zero level.
+func TestRenderVolumeSupersededProgressCommentDefaultVolumeEra(t *testing.T) {
+	rendered := RenderVolumeSupersededProgressComment(VolumeSupersededProgressData{
+		Volume:         2,
+		PreviousVolume: 0,
+		Repo:           "acme/testapp",
+		PR:             42,
+		NewCommentID:   2222222222,
+		PreviousBody:   "## Schema Change Progress\n\nCopying",
+	})
+	assert.Contains(t, rendered, "⏩ Progress at the default volume",
+		"a zero recorded level renders as the default-volume era")
+	assert.Contains(t, rendered, "superseded by the change to **2/11**")
+	assert.NotContains(t, rendered, "**0/11**",
+		"a zero level is never rendered as a numeric era")
+	assert.Contains(t, rendered, "https://github.com/acme/testapp/pull/42#issuecomment-2222222222")
+	assert.Contains(t, rendered, "<summary>Progress before the volume change</summary>")
+}
+
 // TestRenderResumeSupersededProgressComment verifies the frozen body written
-// over an old progress comment after a resume: it links the successor comment
-// and folds the final pre-stop progress into a details block so the record
-// stays on the PR without looking live.
+// over an old progress comment after a resume: the headline names the pre-stop
+// era the frozen comment covered with the resume mentioned only as where
+// progress continues, links the successor comment, and folds the final
+// pre-stop progress into a details block so the record stays on the PR without
+// looking live.
 func TestRenderResumeSupersededProgressComment(t *testing.T) {
 	rendered := RenderResumeSupersededProgressComment(SupersededProgressData{
 		Repo:         "acme/testapp",
@@ -229,12 +258,72 @@ func TestRenderResumeSupersededProgressComment(t *testing.T) {
 		NewCommentID: 2222222222,
 		PreviousBody: "## Schema Change Progress\n\nStopped at 21%",
 	})
-	assert.Contains(t, rendered, "Schema change resumed")
+	assert.Contains(t, rendered, "⏸️ Progress before the stop — the schema change resumed in",
+		"the headline names the pre-stop era, with the resume subordinate")
 	assert.Contains(t, rendered, "https://github.com/acme/testapp/pull/42#issuecomment-2222222222")
 	assert.Contains(t, rendered, "<details>")
 	assert.Contains(t, rendered, "<summary>Progress before the stop</summary>")
 	assert.Contains(t, rendered, "Stopped at 21%",
 		"the superseded body is preserved inside the fold")
+}
+
+// TestRenderRevertSupersededProgressComment verifies the frozen body written
+// over an old progress comment after a revert: the headline names the
+// pre-revert era the frozen comment covered with the revert mentioned only as
+// where tracking continues, links the successor comment, and folds the final
+// pre-revert progress into a details block.
+func TestRenderRevertSupersededProgressComment(t *testing.T) {
+	rendered := RenderRevertSupersededProgressComment(SupersededProgressData{
+		Repo:         "acme/testapp",
+		PR:           42,
+		NewCommentID: 2222222222,
+		PreviousBody: "## Schema Change Progress\n\nRevert window open",
+	})
+	assert.Contains(t, rendered, "⏪ Progress before the revert — the revert is tracked in",
+		"the headline names the pre-revert era, with the revert subordinate")
+	assert.Contains(t, rendered, "https://github.com/acme/testapp/pull/42#issuecomment-2222222222")
+	assert.Contains(t, rendered, "<summary>Progress before the revert</summary>")
+	assert.Contains(t, rendered, "Revert window open",
+		"the superseded body is preserved inside the fold")
+}
+
+// TestRenderSkipRevertSupersededProgressComment verifies the frozen body
+// written over an old progress comment after a skip-revert: the headline names
+// the revert-window era the frozen comment covered with the skip mentioned
+// only as where finalization continues, links the successor comment, and folds
+// the final revert-window rendering into a details block.
+func TestRenderSkipRevertSupersededProgressComment(t *testing.T) {
+	rendered := RenderSkipRevertSupersededProgressComment(SupersededProgressData{
+		Repo:         "acme/testapp",
+		PR:           42,
+		NewCommentID: 2222222222,
+		PreviousBody: "## Schema Change Progress\n\nRevert window open",
+	})
+	assert.Contains(t, rendered, "⏭️ Revert window before the skip — the schema change is finalizing in",
+		"the headline names the revert-window era, with the skip subordinate")
+	assert.Contains(t, rendered, "https://github.com/acme/testapp/pull/42#issuecomment-2222222222")
+	assert.Contains(t, rendered, "<summary>Progress before the revert was skipped</summary>")
+	assert.Contains(t, rendered, "Revert window open",
+		"the superseded body is preserved inside the fold")
+}
+
+// TestRenderCutoverSupersededComment verifies the frozen body written over the
+// spent cutover prompt: the headline names what the frozen comment was — the
+// prompt — with the completed cutover mentioned only as what superseded it,
+// links the successor comment, and folds the prompt into a details block.
+func TestRenderCutoverSupersededComment(t *testing.T) {
+	rendered := RenderCutoverSupersededComment(SupersededProgressData{
+		Repo:         "acme/testapp",
+		PR:           42,
+		NewCommentID: 2222222222,
+		PreviousBody: "## Ready for cutover\n\nRun the cutover command.",
+	})
+	assert.Contains(t, rendered, "⏸️ Cutover prompt — the cutover completed; progress continues in",
+		"the headline names the prompt era, with the completed cutover subordinate")
+	assert.Contains(t, rendered, "https://github.com/acme/testapp/pull/42#issuecomment-2222222222")
+	assert.Contains(t, rendered, "<summary>Cutover prompt</summary>")
+	assert.Contains(t, rendered, "Ready for cutover",
+		"the prompt body is preserved inside the fold")
 }
 
 // TestRenderSupersededProgressComment verifies the frozen body written over a
@@ -254,7 +343,7 @@ func TestRenderSupersededProgressComment(t *testing.T) {
 	assert.Contains(t, rendered, "<summary>Earlier progress</summary>")
 	assert.Contains(t, rendered, "Stopped at 21%",
 		"the superseded body is preserved inside the fold")
-	assert.NotContains(t, rendered, "Volume changed",
+	assert.NotContains(t, rendered, "superseded by the change to",
 		"the generic fold does not claim a volume change caused it")
 	assert.NotContains(t, rendered, "resumed",
 		"the generic fold does not claim a resume caused it")
@@ -282,6 +371,25 @@ func TestIsSupersededProgressComment(t *testing.T) {
 	for flavor, body := range frozen {
 		assert.Truef(t, IsSupersededProgressComment(body),
 			"a %s-frozen body is recognized as frozen", flavor)
+	}
+
+	// Bodies frozen by earlier server versions carry the headlines those
+	// versions rendered. They can still hold a pending-freeze marker (the
+	// marker-clear write may have failed), so the retry must recognize them as
+	// frozen rather than wrap them in a second fold.
+	legacyFold := func(headline string) string {
+		return headline + " [a new progress comment](https://github.com/acme/testapp/pull/42#issuecomment-1).\n\n<details>\n<summary>Earlier progress</summary>\n\nold\n\n</details>\n"
+	}
+	legacyFrozen := map[string]string{
+		"volume":      legacyFold("⏩ Volume changed to **8/11** — progress continues in"),
+		"resume":      legacyFold("▶️ Schema change resumed — progress continues in"),
+		"revert":      legacyFold("Schema change reverting — the revert is tracked in"),
+		"skip-revert": legacyFold("Revert skipped — the schema change is finalizing in"),
+		"cutover":     legacyFold("Cutover complete — progress continues in"),
+	}
+	for flavor, body := range legacyFrozen {
+		assert.Truef(t, IsSupersededProgressComment(body),
+			"a %s body frozen by an earlier version is recognized as frozen", flavor)
 	}
 
 	live := map[string]string{

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -1585,11 +1585,12 @@ func PreviewCommentVolumeSupersededProgress() string {
 	data := sampleSingleApplyData(state.Apply.Running, table)
 	data.Volume = 3
 	return RenderVolumeSupersededProgressComment(VolumeSupersededProgressData{
-		Volume:       8,
-		Repo:         "acme/testapp",
-		PR:           42,
-		NewCommentID: 2222222222,
-		PreviousBody: RenderApplyStatusComment(data),
+		Volume:         8,
+		PreviousVolume: 3,
+		Repo:           "acme/testapp",
+		PR:             42,
+		NewCommentID:   2222222222,
+		PreviousBody:   RenderApplyStatusComment(data),
 	})
 }
 


### PR DESCRIPTION
## Why

When the comment observer rotates a progress comment (volume change, resume, revert, skip-revert, cutover), the superseded comment is frozen into a collapsed fold — but that fold necessarily sits **above** the operator command that caused the rotation in the PR timeline. Because each fold headline named the retiring event, every fold read as announcing an effect before its cause:

**Before**
```
[fold] "⏩ Volume changed to 9/11"        ← appears before any volume command
operator: schemabot volume ... -v 9
bot: Volume Request Accepted (9)
[fold] "▶️ Schema change resumed"          ← before the stop was even issued
operator: schemabot stop
```

**After**
```
[fold] "⏩ Progress at volume 2/11 — superseded by the change to 9/11; …"
operator: schemabot volume ... -v 9
bot: Volume Request Accepted (9)
[fold] "⏸️ Progress before the stop — the schema change resumed in …"
operator: schemabot stop
```

## What

- Fold headlines are now era-descriptive: they describe the period the frozen comment covered, with the retiring event mentioned only in subordinate "superseded by / resumed in / completed" phrasing.
- The volume fold names both the era's level and the new level (`⏩ Progress at volume **2/11** — superseded by the change to **9/11**`), rendering "the default volume" when the frozen comment predates any explicit level. The previous level is threaded through both the direct freeze path and the posted-but-untracked adoption path so both render the same fold.
- Resume, revert, skip-revert, and cutover-prompt folds get the same treatment; the generic retry fold was already era-neutral and is unchanged.
- `IsSupersededProgressComment` keeps recognizing the headlines rendered by earlier server versions (recognition only — never rendered), so a freeze retry against a comment frozen before the upgrade never wraps it in a second fold.

*This PR was written by an agent (Claude Code, Fable 5).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)