### PR TITLE
fix(github): refresh stale plans after missed webhooks

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -1003,6 +1003,10 @@ func (ic *InstallationClient) FetchChangedFilesBetween(ctx context.Context, repo
 	if err != nil {
 		return nil, err
 	}
+	status := readResult.GetStatus()
+	if status != "ahead" && status != "identical" {
+		return nil, fmt.Errorf("compare commits %s...%s for %s cannot prove linear history: status %q", base, head, repo, status)
+	}
 
 	files := make([]PRFile, 0, len(readResult.Files))
 	for _, f := range readResult.Files {

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -103,6 +103,44 @@ func TestAddReactionToCommentRetriesSecondaryRateLimitedWrite(t *testing.T) {
 	assert.Equal(t, int64(2), attempts.Load())
 }
 
+func TestFetchChangedFilesBetweenRequiresLinearHistory(t *testing.T) {
+	tests := []struct {
+		status  string
+		wantErr bool
+	}{
+		{status: "ahead"},
+		{status: "identical"},
+		{status: "behind", wantErr: true},
+		{status: "diverged", wantErr: true},
+		{wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			client, mux := setupRateLimitedTestGitHubServer(t)
+			mux.HandleFunc("GET /repos/octocat/hello-world/compare/base...head", func(w http.ResponseWriter, _ *http.Request) {
+				require.NoError(t, json.NewEncoder(w).Encode(gh.CommitsComparison{
+					Status: &tt.status,
+					Files: []*gh.CommitFile{{
+						Filename: new("app/service.go"),
+						Status:   new("modified"),
+					}},
+				}))
+			})
+
+			ic := NewInstallationClient(client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+			files, err := ic.FetchChangedFilesBetween(t.Context(), "octocat/hello-world", "base", "head")
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "cannot prove linear history")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, "app/service.go", files[0].Filename)
+		})
+	}
+}
+
 func TestEditIssueCommentDoesNotRetryNonRateLimitWriteError(t *testing.T) {
 	client, mux := setupRateLimitedTestGitHubServer(t)
 	var attempts atomic.Int64

--- a/pkg/webhook/auto_plan_integration_test.go
+++ b/pkg/webhook/auto_plan_integration_test.go
@@ -114,10 +114,21 @@ func TestE2EAutoPlanSynchronizeApplicationOnlyChangeSkipsComment(t *testing.T) {
 	}
 
 	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
+	result.HeadSHAs = []string{"newsha"}
 	registerCompareFiles(t, mux, "oldsha", "newsha", []*gh.CommitFile{{
 		Filename: new("app/service.go"),
 		Status:   new("modified"),
 	}})
+	require.NoError(t, svc.Storage().PlanComments().Insert(t.Context(), &storage.PlanComment{
+		Repository:       "octocat/hello-world",
+		PullRequest:      1,
+		DatabaseName:     dbName,
+		DatabaseType:     "mysql",
+		EnvironmentScope: "staging",
+		HeadSHA:          "oldsha",
+		GitHubCommentID:  98,
+		GitHubNodeID:     "IC_98",
+	}))
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	installClient := ghclient.NewInstallationClient(client, logger)
@@ -152,6 +163,78 @@ func TestE2EAutoPlanSynchronizeApplicationOnlyChangeSkipsComment(t *testing.T) {
 		t.Fatalf("expected no comment for application-only synchronize, got: %s", body)
 	case <-time.After(3 * time.Second):
 	}
+}
+
+// A non-schema push posts a replacement plan when the visible plan predates
+// schema changes, covering a schema-changing webhook that was never processed
+// followed by an empty retrigger commit.
+func TestE2EAutoPlanSynchronizeApplicationOnlyChangeRefreshesStalePlan(t *testing.T) {
+	dbName := "webhook_autoplan_app_only_sync_stale_plan"
+	svc := setupE2EService(t, dbName)
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+
+	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
+	result.HeadSHAs = []string{"newsha"}
+	registerCompareFiles(t, mux, "oldsha", "newsha", []*gh.CommitFile{{
+		Filename: new("app/service.go"),
+		Status:   new("modified"),
+	}})
+	registerCompareFiles(t, mux, "plannedsha", "newsha", []*gh.CommitFile{{
+		Filename: new("schema/" + dbName + "/users.sql"),
+		Status:   new("modified"),
+	}})
+	require.NoError(t, svc.Storage().PlanComments().Insert(t.Context(), &storage.PlanComment{
+		Repository:       "octocat/hello-world",
+		PullRequest:      1,
+		DatabaseName:     dbName,
+		DatabaseType:     "mysql",
+		EnvironmentScope: "staging",
+		HeadSHA:          "plannedsha",
+		GitHubCommentID:  97,
+		GitHubNodeID:     "IC_97",
+	}))
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	installClient := ghclient.NewInstallationClient(client, logger)
+	h := NewHandler(svc, &fakeClientFactory{client: installClient}, nil, logger)
+
+	req := buildPRWebhookRequest(t, prWebhookPayloadOpts{
+		action:    "synchronize",
+		beforeSHA: "oldsha",
+		headSHA:   "newsha",
+		headRef:   "feature-branch",
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "## Schema Change Plan")
+		assert.Contains(t, body, dbName)
+	case <-time.After(webhookIntegrationPollDeadline):
+		t.Fatal("timed out waiting for replacement auto-plan comment")
+	}
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		comments, err := svc.Storage().PlanComments().ListUnminimizedForSlot(
+			t.Context(), "octocat/hello-world", 1, dbName, "mysql")
+		if !assert.NoError(collect, err) || !assert.NotEmpty(collect, comments) {
+			return
+		}
+		assert.Equal(collect, "newsha", comments[len(comments)-1].HeadSHA)
+	}, webhookIntegrationPollDeadline, 100*time.Millisecond)
 }
 
 // TestE2EAutoPlanNoticesUnmanagedConfigOnNonAggregateRepo verifies that when a

--- a/pkg/webhook/auto_plan_integration_test.go
+++ b/pkg/webhook/auto_plan_integration_test.go
@@ -237,6 +237,65 @@ func TestE2EAutoPlanSynchronizeApplicationOnlyChangeRefreshesStalePlan(t *testin
 	}, webhookIntegrationPollDeadline, 100*time.Millisecond)
 }
 
+// A non-schema push posts a plan comment when no tracked plan comment exists
+// for the managed database. Suppression requires proof that a visible plan
+// already covers the schema inputs; without tracking there is no proof, so the
+// safe outcome is a fresh comment rather than preserved silence.
+func TestE2EAutoPlanSynchronizeApplicationOnlyChangeWithoutTrackedPlanPostsComment(t *testing.T) {
+	dbName := "webhook_autoplan_app_only_sync_untracked"
+	svc := setupE2EService(t, dbName)
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	schemaFiles := map[string]string{
+		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
+	}
+
+	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
+	result.HeadSHAs = []string{"newsha"}
+	registerCompareFiles(t, mux, "oldsha", "newsha", []*gh.CommitFile{{
+		Filename: new("app/service.go"),
+		Status:   new("modified"),
+	}})
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	installClient := ghclient.NewInstallationClient(client, logger)
+	h := NewHandler(svc, &fakeClientFactory{client: installClient}, nil, logger)
+
+	req := buildPRWebhookRequest(t, prWebhookPayloadOpts{
+		action:    "synchronize",
+		beforeSHA: "oldsha",
+		headSHA:   "newsha",
+		headRef:   "feature-branch",
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "## Schema Change Plan")
+		assert.Contains(t, body, dbName)
+	case <-time.After(webhookIntegrationPollDeadline):
+		t.Fatal("timed out waiting for auto-plan comment")
+	}
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		comments, err := svc.Storage().PlanComments().ListUnminimizedForSlot(
+			t.Context(), "octocat/hello-world", 1, dbName, "mysql")
+		if !assert.NoError(collect, err) || !assert.NotEmpty(collect, comments) {
+			return
+		}
+		assert.Equal(collect, "newsha", comments[len(comments)-1].HeadSHA)
+	}, webhookIntegrationPollDeadline, 100*time.Millisecond)
+}
+
 // TestE2EAutoPlanNoticesUnmanagedConfigOnNonAggregateRepo verifies that when a
 // PR's schema config resolves but its directory is outside the deployment's
 // allowed_dirs on a repo with no aggregate role, auto-plan posts a PR-visible

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -198,7 +198,7 @@ func (h *Handler) autoPlanBootstrap(parent context.Context, repo string, install
 	return ctx, cancel, client, nil
 }
 
-func (h *Handler) shouldPostAutoPlanComment(ctx context.Context, client *ghclient.InstallationClient, action, repo string, pr int, beforeSHA, headSHA string) bool {
+func (h *Handler) shouldPostAutoPlanComment(ctx context.Context, client *ghclient.InstallationClient, action, repo string, pr int, beforeSHA, headSHA string, configs []ghclient.DiscoveredConfig) bool {
 	if action != "synchronize" {
 		return true
 	}
@@ -216,7 +216,62 @@ func (h *Handler) shouldPostAutoPlanComment(ctx context.Context, client *ghclien
 	if ghclient.HasSchemaInputFiles(files) {
 		return true
 	}
-	h.logger.Info("auto-plan will refresh checks without posting a plan comment because synchronize changed no schema inputs",
+
+	comparedHeads := make(map[string]bool)
+	for _, cfg := range configs {
+		environments, err := h.allowedDatabaseEnvironments(cfg.Config.Database)
+		if err != nil {
+			h.logger.Warn("auto-plan will post plan comment because the expected environment scope could not be resolved",
+				"repo", repo, "pr", pr, "database", cfg.Config.Database,
+				"database_type", cfg.Config.GetType(), "head_sha", headSHA, "error", err)
+			return true
+		}
+		expectedScope := (planCommentSlot{Environments: environments}).environmentScope()
+		comments, err := h.service.Storage().PlanComments().ListUnminimizedForSlot(ctx,
+			repo, pr, cfg.Config.Database, string(cfg.Config.GetType()))
+		if err != nil {
+			h.logger.Warn("auto-plan will post plan comment because prior plan comment state could not be read",
+				"repo", repo, "pr", pr, "database", cfg.Config.Database,
+				"database_type", cfg.Config.GetType(), "head_sha", headSHA, "error", err)
+			return true
+		}
+		var prior *storage.PlanComment
+		for i := len(comments) - 1; i >= 0; i-- {
+			if comments[i].EnvironmentScope == expectedScope {
+				prior = comments[i]
+				break
+			}
+		}
+		if prior == nil {
+			h.logger.Info("auto-plan will post plan comment because no prior visible plan comment is tracked",
+				"repo", repo, "pr", pr, "database", cfg.Config.Database,
+				"database_type", cfg.Config.GetType(), "environment_scope", expectedScope,
+				"head_sha", headSHA)
+			return true
+		}
+
+		planHeadSHA := prior.HeadSHA
+		if planHeadSHA == headSHA || comparedHeads[planHeadSHA] {
+			continue
+		}
+		filesSincePlan, err := client.FetchChangedFilesBetween(ctx, repo, planHeadSHA, headSHA)
+		if err != nil {
+			h.logger.Warn("auto-plan will post plan comment because plan freshness could not be compared",
+				"repo", repo, "pr", pr, "database", cfg.Config.Database,
+				"database_type", cfg.Config.GetType(), "plan_head_sha", planHeadSHA,
+				"head_sha", headSHA, "error", err)
+			return true
+		}
+		if ghclient.HasSchemaInputFiles(filesSincePlan) {
+			h.logger.Info("auto-plan will post plan comment because the visible plan predates schema input changes",
+				"repo", repo, "pr", pr, "database", cfg.Config.Database,
+				"database_type", cfg.Config.GetType(), "plan_head_sha", planHeadSHA,
+				"head_sha", headSHA)
+			return true
+		}
+		comparedHeads[planHeadSHA] = true
+	}
+	h.logger.Info("auto-plan will refresh checks without posting a plan comment because the visible plan covers the current schema inputs",
 		"repo", repo, "pr", pr, "before_sha", beforeSHA, "head_sha", headSHA)
 	return false
 }
@@ -262,7 +317,7 @@ func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.Install
 	// follow the same cadence, so the decision is memoized and computed at most
 	// once per delivery, only when a caller needs it.
 	shouldPostComment := sync.OnceValue(func() bool {
-		return h.shouldPostAutoPlanComment(ctx, client, action, repo, pr, beforeSHA, headSHA)
+		return h.shouldPostAutoPlanComment(ctx, client, action, repo, pr, beforeSHA, headSHA, configs)
 	})
 	h.notifyUnmanagedDiscoveredConfigs(repo, pr, installationID, source, headSHA, shouldPostComment, discovered, configs)
 

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -217,7 +217,9 @@ func (h *Handler) shouldPostAutoPlanComment(ctx context.Context, client *ghclien
 		return true
 	}
 
-	comparedHeads := make(map[string]bool)
+	// The synchronize range was just proven schema-neutral. Reuse that result
+	// when the visible plan was rendered at the immediately preceding head.
+	comparedHeads := map[string]bool{beforeSHA: true}
 	for _, cfg := range configs {
 		environments, err := h.allowedDatabaseEnvironments(cfg.Config.Database)
 		if err != nil {

--- a/pkg/webhook/webhook_integration_test.go
+++ b/pkg/webhook/webhook_integration_test.go
@@ -566,7 +566,7 @@ func registerCompareFiles(t *testing.T, mux *http.ServeMux, baseSHA, headSHA str
 	t.Helper()
 
 	mux.HandleFunc("GET /repos/octocat/hello-world/compare/"+baseSHA+"..."+headSHA, func(w http.ResponseWriter, _ *http.Request) {
-		require.NoError(t, json.NewEncoder(w).Encode(gh.CommitsComparison{Files: files}))
+		require.NoError(t, json.NewEncoder(w).Encode(gh.CommitsComparison{Status: new("ahead"), Files: files}))
 	})
 }
 


### PR DESCRIPTION
## Why this matters

A schema-changing `pull_request/synchronize` webhook can be lost before SchemaBot ingests it. If the next push changes only application files (or is an empty retrigger), the old cadence check looked only at that latest push range and suppressed the plan comment — leaving an older visible plan that no longer described the branch.

The merge gate self-heals when the later webhook refreshes checks, but the operator-facing plan does not. Reviewers can be left with stale DDL and an apply command for the wrong schema state until someone manually requests another plan.

## What it does

- A schema-neutral synchronize now suppresses its comment only when every managed database has a tracked, unminimized plan comment for the expected environment scope and that plan still covers the current schema inputs.
- When the visible plan predates the immediately previous head, SchemaBot compares from the plan's head to the current head. The common previous-head case reuses the synchronize comparison instead of making the same GitHub request twice.
- Missing tracking, storage errors, environment-resolution errors, incomplete comparisons, and nonlinear commit history all fail open by posting a replacement plan rather than preserving uncertain state.
- Integration coverage reproduces the lost schema webhook followed by an empty retrigger, preserves comment suppression when the existing plan is provably current, and pins fail-open posting when no plan comment is tracked.

```
Before

┌───────────────┐     ┌────────────────────┐     ┌───────────────────┐
│ Plan at A     │────▶│ Schema push B      │────▶│ Empty retrigger C │
│ is visible    │     │ webhook is lost    │     │ webhook arrives   │
└───────────────┘     └────────────────────┘     └─────────┬─────────┘
                                                          │
                                             compare B…C: no schema files
                                                          │
                                                          ▼
                                             suppress comment; plan A stays stale

After

┌───────────────┐     ┌────────────────────┐     ┌───────────────────┐
│ Plan at A     │────▶│ Schema push B      │────▶│ Empty retrigger C │
│ is tracked    │     │ webhook is lost    │     │ webhook arrives   │
└───────────────┘     └────────────────────┘     └─────────┬─────────┘
                                                          │
                                             compare B…C: no schema files
                                             compare A…C: schema changed
                                                          │
                                                          ▼
                                             post replacement plan at C
```

Deliberately not included: automatic redrive for deliveries lost before ingestion. That is a separate sender/reconciliation concern; this change makes the next successfully processed synchronize repair the visible PR state.

Northstar: comment suppression may reduce noise only when SchemaBot can prove it will not preserve a stale plan.

🤖 Generated with [Amp](https://ampcode.com)

