### PR TITLE
feat(github): disclose engine-blocked changes in the plan comment

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -59,6 +59,44 @@ schemabot apply -e staging
 </details>
 
 <details>
+<summary><a name="mysql-plan-engineblocked-change"></a><strong>MySQL Plan (Engine-blocked Change)</strong></summary>
+
+
+## Schema Change Plan — Staging
+
+**Database**: `testapp` | **Type**: `MySQL` | **Schema Name**: `testapp`
+
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
+
+```sql
+ALTER TABLE `users`
+    DROP PRIMARY KEY,
+    ADD PRIMARY KEY(`id`, `tenant_id`);
+
+ALTER TABLE `orders` ADD CONSTRAINT `fk_orders_user` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`);
+
+ALTER TABLE `orders` ADD COLUMN `notes` text;
+```
+
+⛔ **Cannot apply**: **2** changes not supported by the schema-change engine
+- `users`: dropping primary key is not supported
+- `orders`: adding foreign key constraints is not supported
+
+An apply will fail on these statements. Rewrite them as a supported schema change, or contact your SchemaBot operators for help.
+
+📋 **Plan**: **3** tables to alter
+
+
+---
+
+💡 **To apply** all schema changes from this PR, comment:
+```
+schemabot apply -e staging
+```
+
+</details>
+
+<details>
 <summary><a name="mysql-plan-tenant-target"></a><strong>MySQL Plan (Tenant Target)</strong></summary>
 
 

--- a/pkg/cmd/commands/preview.go
+++ b/pkg/cmd/commands/preview.go
@@ -70,7 +70,8 @@ func (cmd *PreviewCmd) Run(g *Globals) error {
 		templates.PreviewUnsafeAllowed, templates.PreviewLintAll:
 		templates.PreviewCLIOutput(previewType)
 	// Comment template types
-	case templates.PreviewCommentPlan, templates.PreviewCommentPlanTenant,
+	case templates.PreviewCommentPlan, templates.PreviewCommentPlanBlocked,
+		templates.PreviewCommentPlanTenant,
 		templates.PreviewCommentPlanEmpty,
 		templates.PreviewCommentNoManagedSchema,
 		templates.PreviewCommentReconcileInProgress,
@@ -87,7 +88,8 @@ func (cmd *PreviewCmd) Run(g *Globals) error {
 		templates.PreviewCommentApplyPlanUnsafe,
 		templates.PreviewCommentApplyProgress, templates.PreviewCommentApplyCompleted,
 		templates.PreviewCommentApplyEstimateExceeded,
-		templates.PreviewCommentApplyFailed, templates.PreviewCommentApplyRetrying,
+		templates.PreviewCommentApplyFailed,
+		templates.PreviewCommentApplyRetrying,
 		templates.PreviewCommentApplyStopped,
 		templates.PreviewCommentApplyWaitingCutover, templates.PreviewCommentApplyCuttingOver,
 		templates.PreviewCommentMultiDeployInProgress, templates.PreviewCommentMultiDeployFailed,
@@ -242,6 +244,7 @@ Interactive TUI:
 
 Comment Templates (GitHub PR comments):
   comment_plan                  Plan comment with DDL changes + lint violations
+  comment_plan_blocked          Plan with a statement the engine refuses (blocked verdict)
   comment_plan_tenant           Tenant-targeted plan comment
   comment_plan_empty            Plan comment with no changes
   comment_no_managed_schema     No managed schema changes in current PR

--- a/pkg/cmd/internal/templates/preview.go
+++ b/pkg/cmd/internal/templates/preview.go
@@ -111,6 +111,7 @@ const (
 
 	// Comment template previews (GitHub PR comments)
 	PreviewCommentPlan                         PreviewType = "comment_plan"                            // Plan comment with DDL changes + lint violations
+	PreviewCommentPlanBlocked                  PreviewType = "comment_plan_blocked"                    // Plan with a statement the engine refuses (blocked verdict)
 	PreviewCommentPlanTenant                   PreviewType = "comment_plan_tenant"                     // Tenant-targeted plan comment
 	PreviewCommentPlanEmpty                    PreviewType = "comment_plan_empty"                      // Plan comment with no changes
 	PreviewCommentNoManagedSchema              PreviewType = "comment_no_managed_schema"               // No managed schema changes in current PR

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -40,6 +40,7 @@ func previewCommentAllOutput() {
 		fn   func()
 	}{
 		{"PLAN COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentPlan()) }},
+		{"PLAN COMMENT (ENGINE-BLOCKED CHANGE)", func() { fmt.Print(webhooktemplates.PreviewCommentPlanBlocked()) }},
 		{"PLAN COMMENT (TENANT TARGET)", func() { fmt.Print(webhooktemplates.PreviewCommentPlanTenant()) }},
 		{"PLAN COMMENT (NO CHANGES)", func() { fmt.Print(webhooktemplates.PreviewCommentPlanNoChanges()) }},
 		{"NO MANAGED SCHEMA CHANGES", func() { fmt.Print(webhooktemplates.PreviewCommentNoManagedSchemaChanges()) }},
@@ -125,6 +126,7 @@ func previewCommentPlanAllOutput() {
 		fn   func()
 	}{
 		{"MYSQL PLAN", func() { fmt.Print(webhooktemplates.PreviewCommentPlan()) }},
+		{"MYSQL PLAN (ENGINE-BLOCKED CHANGE)", func() { fmt.Print(webhooktemplates.PreviewCommentPlanBlocked()) }},
 		{"MYSQL PLAN (TENANT TARGET)", func() { fmt.Print(webhooktemplates.PreviewCommentPlanTenant()) }},
 		{"MYSQL PLAN (NO CHANGES)", func() { fmt.Print(webhooktemplates.PreviewCommentPlanNoChanges()) }},
 		{"NO MANAGED SCHEMA CHANGES", func() { fmt.Print(webhooktemplates.PreviewCommentNoManagedSchemaChanges()) }},

--- a/pkg/cmd/internal/templates/preview_dispatch.go
+++ b/pkg/cmd/internal/templates/preview_dispatch.go
@@ -116,6 +116,8 @@ func PreviewCLIOutput(previewType PreviewType) {
 	// Comment template previews
 	case PreviewCommentPlan:
 		fmt.Print(webhooktemplates.PreviewCommentPlan())
+	case PreviewCommentPlanBlocked:
+		fmt.Print(webhooktemplates.PreviewCommentPlanBlocked())
 	case PreviewCommentPlanTenant:
 		fmt.Print(webhooktemplates.PreviewCommentPlanTenant())
 	case PreviewCommentPlanEmpty:

--- a/pkg/ddl/verdict.go
+++ b/pkg/ddl/verdict.go
@@ -37,12 +37,16 @@ const (
 // but that depends on live table state, not the statement text, so it cannot
 // be claimed here — it surfaces as an apply-time failure instead.
 //
-// Statements a preflight check would refuse but that can complete through the
-// engine's instant-DDL fast path are not reported here — the verdict must
-// never claim an apply will fail when it can succeed. The fast path is only
-// guaranteed for single-ALTER applies: when the engine batches several ALTERs
-// into one run it may skip the fast path and refuse such a statement anyway.
-// That is a tolerated false negative — the verdict errs toward silence.
+// The engine tags its statement-scope preflight checks with
+// check.ScopeStatement, but that set is broader than what this function may
+// claim: the engine attempts MySQL's native DDL (ALGORITHM=INSTANT, then a
+// safe-INPLACE subset) before running preflight checks, so a statement those
+// checks would refuse can still complete through that fast path — for example
+// dropping and re-adding a column of the same name, or renaming a column.
+// The verdict must never claim an apply will fail when it can succeed, so
+// only checks no fast path can bypass are mirrored here; the rest err toward
+// silence, a tolerated false negative that surfaces as an apply-time failure
+// at worst. Agreement with the engine's own checks is enforced by test.
 // Only ALTER TABLE statements can be refused; everything else returns false.
 func EngineRefusalReason(stmt string) (string, bool, error) {
 	stmts, err := statement.New(stmt)

--- a/pkg/ddl/verdict_test.go
+++ b/pkg/ddl/verdict_test.go
@@ -1,8 +1,11 @@
 package ddl
 
 import (
+	"log/slog"
 	"testing"
 
+	"github.com/block/spirit/pkg/migration/check"
+	"github.com/block/spirit/pkg/statement"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -93,6 +96,68 @@ func TestEngineRefusalReason(t *testing.T) {
 			} else {
 				assert.Empty(t, reason)
 			}
+		})
+	}
+}
+
+// runEngineStatementChecks runs the engine's own statement-scope preflight
+// checks against a single statement, returning the engine's refusal error
+// (nil when the checks accept the statement).
+func runEngineStatementChecks(t *testing.T, stmt string) error {
+	t.Helper()
+	stmts, err := statement.New(stmt)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+	resources := check.Resources{Statement: stmts[0]}
+	return check.RunChecks(t.Context(), resources, slog.New(slog.DiscardHandler), check.ScopeStatement)
+}
+
+// TestEngineRefusalReasonAgreesWithEngineChecks pins the refusal predicate to
+// the engine: every statement this package refuses must also be refused by
+// the engine's statement-scope preflight checks, with the same reason. If the
+// engine relaxes or rewords one of these checks, this test fails and the
+// predicate must be revisited — a refusal claimed here that the engine no
+// longer enforces would wrongly block an apply that can succeed.
+func TestEngineRefusalReasonAgreesWithEngineChecks(t *testing.T) {
+	refused := []string{
+		"ALTER TABLE `users` DROP PRIMARY KEY",
+		"ALTER TABLE `users` DROP PRIMARY KEY, ADD PRIMARY KEY (`id`, `tenant_id`)",
+		"ALTER TABLE `users` ADD COLUMN `email` VARCHAR(255), ALGORITHM=INPLACE",
+		"ALTER TABLE `users` ADD COLUMN `email` VARCHAR(255), LOCK=NONE",
+		"ALTER TABLE `orders` ADD CONSTRAINT `fk_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)",
+		"ALTER TABLE `orders` ADD FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)",
+	}
+	for _, stmt := range refused {
+		t.Run(stmt, func(t *testing.T) {
+			reason, isRefused, err := EngineRefusalReason(stmt)
+			require.NoError(t, err)
+			require.True(t, isRefused)
+			checkErr := runEngineStatementChecks(t, stmt)
+			require.Error(t, checkErr, "engine statement-scope checks accept a statement this package refuses")
+			assert.Equal(t, reason, checkErr.Error())
+		})
+	}
+}
+
+// TestEngineRefusalReasonToleratesFastPathStatements documents the deliberate
+// gap between this package's refusals and the engine's statement-scope
+// checks: these statements fail a statement-scope check, but the engine
+// attempts MySQL's native DDL fast path before preflight checks and the fast
+// path can complete them, so the verdict must stay silent rather than claim
+// an apply will fail.
+func TestEngineRefusalReasonToleratesFastPathStatements(t *testing.T) {
+	fastPath := []string{
+		"ALTER TABLE `users` DROP COLUMN `email`, ADD COLUMN `email` VARCHAR(255)",
+		"ALTER TABLE `users` RENAME COLUMN `email` TO `contact_email`, ADD COLUMN `email` VARCHAR(255)",
+	}
+	for _, stmt := range fastPath {
+		t.Run(stmt, func(t *testing.T) {
+			reason, isRefused, err := EngineRefusalReason(stmt)
+			require.NoError(t, err)
+			assert.False(t, isRefused)
+			assert.Empty(t, reason)
+			require.Error(t, runEngineStatementChecks(t, stmt),
+				"engine statement-scope checks accept this statement, so it no longer documents a tolerated gap — remove it from this corpus")
 		})
 	}
 }

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/block/schemabot/pkg/api"
 	"github.com/block/schemabot/pkg/apitypes"
+	"github.com/block/schemabot/pkg/ddl"
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/metrics"
 	"github.com/block/schemabot/pkg/webhook/action"
@@ -624,6 +625,48 @@ func shardedUnsafeChanges(shards []*apitypes.ShardPlanResponse) []templates.Unsa
 	return out
 }
 
+// engineBlocked reports whether the planner's execution-mode verdict says the
+// engine will refuse this change at apply time.
+func engineBlocked(t *apitypes.TableChangeResponse) bool {
+	return t != nil && t.ExecutionMode == ddl.ExecutionModeBlocked
+}
+
+// shardedBlockedChanges collects blocked per-shard changes, grouped by (table,
+// reason) so a change present on several shards lists them together rather
+// than repeating. Returns nil when the plan carries no per-shard changes (the
+// non-sharded path uses the namespace-level blocked view instead).
+func shardedBlockedChanges(shards []*apitypes.ShardPlanResponse) []templates.BlockedChangeData {
+	if len(shards) == 0 {
+		return nil
+	}
+	type key struct{ table, reason string }
+	var order []key
+	byKey := make(map[key]*templates.BlockedChangeData)
+	for _, sp := range shards {
+		if sp == nil {
+			continue
+		}
+		for _, t := range sp.Changes {
+			if !engineBlocked(t) {
+				continue
+			}
+			k := key{table: t.TableName, reason: t.ModeReason}
+			bc := byKey[k]
+			if bc == nil {
+				bc = &templates.BlockedChangeData{Table: t.TableName, Reason: t.ModeReason}
+				byKey[k] = bc
+				order = append(order, k)
+			}
+			bc.Shards = append(bc.Shards, sp.Shard)
+		}
+	}
+	out := make([]templates.BlockedChangeData, 0, len(order))
+	for _, k := range order {
+		out = append(out, *byKey[k])
+	}
+	return out
+}
+
 // buildPlanCommentData converts plan results into template data.
 func buildPlanCommentData(schema *ghclient.SchemaRequestResult, planResp *apitypes.PlanResponse, environment, tenant, requestedBy string) templates.PlanCommentData {
 	data := templates.PlanCommentData{
@@ -704,6 +747,28 @@ func buildPlanCommentData(schema *ghclient.SchemaRequestResult, planResp *apityp
 				Table:  uc.Table,
 				Reason: uc.Reason,
 			})
+		}
+	}
+
+	// Blocked changes — the engine will refuse these at apply time. Like the
+	// unsafe view, a sharded plan derives them per shard so a blocked change
+	// confined to one shard names the shard it applies to.
+	if blocked := shardedBlockedChanges(planResp.Shards); len(blocked) > 0 {
+		data.BlockedChanges = blocked
+	} else {
+		for _, sc := range planResp.Changes {
+			if sc == nil {
+				continue
+			}
+			for _, t := range sc.TableChanges {
+				if !engineBlocked(t) {
+					continue
+				}
+				data.BlockedChanges = append(data.BlockedChanges, templates.BlockedChangeData{
+					Table:  t.TableName,
+					Reason: t.ModeReason,
+				})
+			}
 		}
 	}
 

--- a/pkg/webhook/templates/blocked_test.go
+++ b/pkg/webhook/templates/blocked_test.go
@@ -1,0 +1,105 @@
+package templates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// A statement the engine refuses is disclosed in its own ⛔ section, naming the
+// table and the engine's reason verbatim, separate from unsafe warnings. Unlike
+// unsafe changes it cannot be acknowledged away, so the section also renders on
+// the locked apply comment — the operator must see the guaranteed failure
+// before confirming.
+func TestRenderPlanComment_BlockedShownOnPlanAndApply(t *testing.T) {
+	data := PlanCommentData{
+		Database: "testapp", Environment: "staging", IsMySQL: true,
+		Changes: []KeyspaceChangeData{{
+			Keyspace:   "testapp",
+			Statements: []string{"ALTER TABLE `users` DROP PRIMARY KEY, ADD PRIMARY KEY (`id`, `tenant_id`)"},
+		}},
+		BlockedChanges: []BlockedChangeData{
+			{Table: "users", Reason: "dropping primary key is not supported"},
+		},
+	}
+
+	plan := RenderPlanComment(data)
+	assert.Contains(t, plan, "⛔ **Cannot apply**: **1** change not supported by the schema-change engine")
+	assert.Contains(t, plan, "`users`: dropping primary key is not supported")
+	assert.Contains(t, plan, "An apply will fail on these statements.")
+
+	data.IsLocked = true
+	apply := RenderPlanComment(data)
+	assert.Contains(t, apply, "⛔ **Cannot apply**", "the locked apply comment keeps the blocked disclosure")
+	assert.Contains(t, apply, "dropping primary key is not supported")
+}
+
+// A plan adding a foreign key — the most common statement the engine refuses —
+// discloses the refusal with the engine's foreign-key reason, alongside any
+// other blocked changes in the same section.
+func TestRenderPlanComment_BlockedForeignKey(t *testing.T) {
+	out := RenderPlanComment(PlanCommentData{
+		Database: "testapp", Environment: "staging", IsMySQL: true,
+		Changes: []KeyspaceChangeData{{
+			Keyspace: "testapp",
+			Statements: []string{
+				"ALTER TABLE `orders` ADD CONSTRAINT `fk_orders_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)",
+			},
+		}},
+		BlockedChanges: []BlockedChangeData{
+			{Table: "orders", Reason: "adding foreign key constraints is not supported"},
+		},
+	})
+
+	assert.Contains(t, out, "⛔ **Cannot apply**: **1** change not supported by the schema-change engine")
+	assert.Contains(t, out, "`orders`: adding foreign key constraints is not supported")
+	assert.Contains(t, out, "An apply will fail on these statements.")
+}
+
+// A blocked change confined to specific shards names them, matching the unsafe
+// section's shard scoping.
+func TestRenderPlanComment_BlockedNamesShards(t *testing.T) {
+	out := RenderPlanComment(PlanCommentData{
+		Database: "testapp", Environment: "staging", DatabaseType: "strata",
+		Changes: []KeyspaceChangeData{{
+			Keyspace:   "testapp_sharded",
+			Statements: []string{"ALTER TABLE `users` DROP PRIMARY KEY"},
+		}},
+		BlockedChanges: []BlockedChangeData{
+			{Table: "users", Reason: "dropping primary key is not supported", Shards: []string{"-40", "40-80"}},
+		},
+	})
+
+	assert.Contains(t, out, "`users` (shards `-40`, `40-80`): dropping primary key is not supported")
+}
+
+// A multi-environment plan renders each environment's own blocked section, so
+// an environment whose plan carries a refused statement discloses it in place.
+func TestRenderMultiEnvPlanComment_BlockedPerEnvironment(t *testing.T) {
+	stagingPlan := &PlanCommentData{
+		Environment: "staging", IsMySQL: true,
+		Changes: []KeyspaceChangeData{{
+			Keyspace:   "testapp",
+			Statements: []string{"ALTER TABLE `users` ADD COLUMN `email` varchar(255)"},
+		}},
+	}
+	productionPlan := &PlanCommentData{
+		Environment: "production", IsMySQL: true,
+		Changes: []KeyspaceChangeData{{
+			Keyspace:   "testapp",
+			Statements: []string{"ALTER TABLE `users` DROP PRIMARY KEY"},
+		}},
+		BlockedChanges: []BlockedChangeData{
+			{Table: "users", Reason: "dropping primary key is not supported"},
+		},
+	}
+
+	out := RenderMultiEnvPlanComment(MultiEnvPlanCommentData{
+		Database: "testapp", DatabaseType: "mysql", IsMySQL: true,
+		Environments: []string{"staging", "production"},
+		Plans:        map[string]*PlanCommentData{"staging": stagingPlan, "production": productionPlan},
+	})
+
+	assert.Contains(t, out, "⛔ **Cannot apply**")
+	assert.Contains(t, out, "dropping primary key is not supported")
+}

--- a/pkg/webhook/templates/plan.go
+++ b/pkg/webhook/templates/plan.go
@@ -29,6 +29,16 @@ type UnsafeChangeData struct {
 	Shards []string
 }
 
+// BlockedChangeData is a planned change the engine deterministically refuses:
+// an apply will fail on it, so the plan comment discloses it up front.
+type BlockedChangeData struct {
+	Table  string
+	Reason string
+	// Shards names the shards this blocked change applies to, for a sharded
+	// plan where only some shards carry it. Empty for a non-sharded change.
+	Shards []string
+}
+
 // PlanCommentData contains all data needed to render a plan comment.
 type PlanCommentData struct {
 	Database     string
@@ -50,6 +60,9 @@ type PlanCommentData struct {
 	HasUnsafeChanges bool
 	AllowUnsafe      bool
 	UnsafeChanges    []UnsafeChangeData
+
+	// Changes the engine refuses; the apply will fail on them.
+	BlockedChanges []BlockedChangeData
 
 	// Options
 	DeferCutover bool
@@ -127,6 +140,14 @@ func RenderPlanComment(data PlanCommentData) string {
 
 	// Detailed changes
 	writeKeyspaceChanges(&sb, data)
+
+	// Blocked changes — statements the engine refuses. Unlike unsafe changes,
+	// these cannot be acknowledged away: the apply will fail on them. Shown on
+	// the locked apply comment too, so the operator sees the guaranteed
+	// failure before confirming.
+	if len(data.BlockedChanges) > 0 {
+		writeBlockedChanges(&sb, data.BlockedChanges)
+	}
 
 	// Unsafe changes warning — shown on the plan comment for review, omitted on
 	// the locked apply comment: unsafe changes only reach an apply after the
@@ -524,6 +545,26 @@ func planShardList(shards []string) string {
 	return "shards " + strings.Join(quoted, ", ")
 }
 
+// writeBlockedChanges writes the section for statements the engine refuses,
+// naming each table and the engine's reason verbatim. There is no opt-in flag
+// that lets these through — the guidance is to rewrite the change, not retry.
+func writeBlockedChanges(sb *strings.Builder, changes []BlockedChangeData) {
+	n := len(changes)
+	fmt.Fprintf(sb, "⛔ **Cannot apply**: **%d** %s not supported by the schema-change engine\n", n, pluralize("change", n))
+	for _, c := range changes {
+		table := "`" + c.Table + "`"
+		if len(c.Shards) > 0 {
+			table = fmt.Sprintf("%s (%s)", table, planShardList(c.Shards))
+		}
+		if c.Reason != "" {
+			fmt.Fprintf(sb, "- %s: %s\n", table, c.Reason)
+		} else {
+			fmt.Fprintf(sb, "- %s\n", table)
+		}
+	}
+	sb.WriteString("\nAn apply will fail on these statements. Rewrite them as a supported schema change, or contact your SchemaBot operators for help.\n\n")
+}
+
 func writeUnsafeWarning(sb *strings.Builder, changes []UnsafeChangeData, isMySQL bool) {
 	n := len(changes)
 	fmt.Fprintf(sb, "⚠️ **Issues**: **%d** unsafe %s detected\n", n, pluralize("change", n))
@@ -822,6 +863,12 @@ func writeEnvironmentPlanSection(sb *strings.Builder, plan *PlanCommentData) {
 		writeKeyspaceChanges(sb, *plan)
 	} else {
 		writeCollapsibleKeyspaceChanges(sb, *plan, totalStatements)
+	}
+
+	// Blocked changes — statements the engine refuses; the apply will fail on
+	// them, so each environment's section discloses its own.
+	if len(plan.BlockedChanges) > 0 {
+		writeBlockedChanges(sb, plan.BlockedChanges)
 	}
 
 	// Unsafe changes warning

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -52,6 +52,34 @@ func PreviewCommentPlan() string {
 	})
 }
 
+// PreviewCommentPlanBlocked renders a sample plan containing a statement the
+// engine deterministically refuses (execution-mode verdict "blocked").
+func PreviewCommentPlanBlocked() string {
+	return RenderPlanComment(PlanCommentData{
+		Database:    "testapp",
+		SchemaName:  "testapp",
+		Environment: "staging",
+		HeadSHA:     previewHeadSHA,
+		Repository:  previewRepository,
+		RequestedBy: previewRequestedBy,
+		IsMySQL:     true,
+		Changes: []KeyspaceChangeData{
+			{
+				Keyspace: "testapp",
+				Statements: []string{
+					"ALTER TABLE `users` DROP PRIMARY KEY, ADD PRIMARY KEY (`id`, `tenant_id`)",
+					"ALTER TABLE `orders` ADD CONSTRAINT `fk_orders_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)",
+					"ALTER TABLE `orders` ADD COLUMN `notes` TEXT",
+				},
+			},
+		},
+		BlockedChanges: []BlockedChangeData{
+			{Table: "users", Reason: "dropping primary key is not supported"},
+			{Table: "orders", Reason: "adding foreign key constraints is not supported"},
+		},
+	})
+}
+
 // PreviewCommentPlanTenant renders a tenant-targeted plan comment.
 func PreviewCommentPlanTenant() string {
 	return RenderPlanComment(PlanCommentData{

--- a/pkg/webhook/verdict_test.go
+++ b/pkg/webhook/verdict_test.go
@@ -1,0 +1,82 @@
+package webhook
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/apitypes"
+	ghclient "github.com/block/schemabot/pkg/github"
+)
+
+// A change the planner's execution-mode verdict marks blocked is surfaced in
+// the plan comment's blocked section, naming the table and the engine's
+// reason, so the operator learns at plan time that the apply will fail.
+func TestBuildPlanCommentData_BlockedChanges(t *testing.T) {
+	schema := &ghclient.SchemaRequestResult{Database: "testapp", Type: "mysql"}
+	planResp := &apitypes.PlanResponse{
+		Changes: []*apitypes.SchemaChangeResponse{{
+			Namespace: "testapp",
+			TableChanges: []*apitypes.TableChangeResponse{
+				{TableName: "users", DDL: "ALTER TABLE `users` DROP PRIMARY KEY", ChangeType: "alter",
+					ExecutionMode: "blocked", ModeReason: "dropping primary key is not supported"},
+				{TableName: "orders", DDL: "ALTER TABLE `orders` ADD COLUMN `notes` TEXT", ChangeType: "alter"},
+			},
+		}},
+	}
+
+	data := buildPlanCommentData(schema, planResp, "staging", "", "testuser")
+
+	require.Len(t, data.BlockedChanges, 1)
+	assert.Equal(t, "users", data.BlockedChanges[0].Table)
+	assert.Equal(t, "dropping primary key is not supported", data.BlockedChanges[0].Reason)
+	assert.Empty(t, data.BlockedChanges[0].Shards)
+}
+
+// A blocked change on a sharded plan is derived per shard and grouped by
+// (table, reason), so a refused statement fanned out to several shards lists
+// them together instead of repeating.
+func TestBuildPlanCommentData_PerShardBlocked(t *testing.T) {
+	schema := &ghclient.SchemaRequestResult{Database: "cdb_resolute", Type: "strata"}
+	const dropPK = "ALTER TABLE `mutes` DROP PRIMARY KEY"
+	blockedChange := func() *apitypes.TableChangeResponse {
+		return &apitypes.TableChangeResponse{
+			TableName: "mutes", DDL: dropPK, ChangeType: "alter",
+			ExecutionMode: "blocked", ModeReason: "dropping primary key is not supported",
+		}
+	}
+	planResp := &apitypes.PlanResponse{
+		Changes: []*apitypes.SchemaChangeResponse{{
+			Namespace:    "cdb_resolute_sharded",
+			TableChanges: []*apitypes.TableChangeResponse{blockedChange()},
+		}},
+		Shards: []*apitypes.ShardPlanResponse{
+			{Namespace: "cdb_resolute_sharded", Shard: "-40", Changes: []*apitypes.TableChangeResponse{blockedChange()}},
+			{Namespace: "cdb_resolute_sharded", Shard: "40-80", Changes: []*apitypes.TableChangeResponse{blockedChange()}},
+		},
+	}
+
+	data := buildPlanCommentData(schema, planResp, "staging", "", "testuser")
+
+	require.Len(t, data.BlockedChanges, 1, "the same refused statement on two shards is grouped, not repeated")
+	assert.Equal(t, "mutes", data.BlockedChanges[0].Table)
+	assert.Equal(t, []string{"-40", "40-80"}, data.BlockedChanges[0].Shards)
+}
+
+// A plan with no blocked verdicts renders no blocked section.
+func TestBuildPlanCommentData_NoBlockedChanges(t *testing.T) {
+	schema := &ghclient.SchemaRequestResult{Database: "testapp", Type: "mysql"}
+	planResp := &apitypes.PlanResponse{
+		Changes: []*apitypes.SchemaChangeResponse{{
+			Namespace: "testapp",
+			TableChanges: []*apitypes.TableChangeResponse{
+				{TableName: "orders", DDL: "ALTER TABLE `orders` ADD COLUMN `notes` TEXT", ChangeType: "alter"},
+			},
+		}},
+	}
+
+	data := buildPlanCommentData(schema, planResp, "staging", "", "testuser")
+
+	assert.Empty(t, data.BlockedChanges)
+}


### PR DESCRIPTION
## Why this matters

The MySQL schema-change engine deterministically refuses a class of valid DDL — `DROP PRIMARY KEY`, `ADD FOREIGN KEY`, and explicit `ALGORITHM=`/`LOCK=` clauses. Today the plan renders these statements with no warning; the operator learns about the refusal only after starting an apply that was guaranteed to fail. A guaranteed failure should be disclosed at plan time, before anyone approves the apply.

## What it does

Builds on the execution-mode verdict fields to render a distinct ⛔ **Cannot apply** section in the plan comment, naming each blocked table and the engine's reason verbatim:

> ⛔ **Cannot apply**: **2** changes not supported by the schema-change engine
> - `users`: dropping primary key is not supported
> - `orders`: adding foreign key constraints is not supported

- Unlike ⚠️ unsafe warnings, the section also renders on the locked apply-confirmation comment — a guaranteed failure cannot be acknowledged away.
- Multi-environment plans disclose per environment; sharded plans group a refused statement's shards onto one line.
- Pins the refusal predicate to the engine: a drift-tripwire test runs Spirit's statement-scope preflight checks (`check.RunChecks(ScopeStatement)`) as an oracle, requiring every refusal claimed here to also be refused by the engine with identical reason text. The predicate deliberately stays narrower than the engine's check set — the runner attempts MySQL's native DDL fast path before preflight checks, so check failures the fast path can complete (drop-and-re-add of a column, column renames) must never be claimed as blocked. That tolerated gap is documented with explicit test cases.
- Previews + TEMPLATES.md regenerated.

Follow-up work routes refused statements to policy-gated native DDL execution and gates apply-start on blocked plans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)