### PR TITLE
feat(github): always enforce base-branch schema freshness

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -452,14 +452,9 @@ Set `require_passing_checks: false` to disable this gate.
 
 ## Base Branch Schema Freshness
 
-SchemaBot can reject `apply` and `apply-confirm` when a PR does not include
-schema changes that landed on its base branch after the PR diverged:
-
-```yaml
-repos:
-  myorg/monorepo:
-    require_up_to_date_with_base: true
-```
+SchemaBot rejects `apply` and `apply-confirm` when a PR does not include
+schema changes that landed on its base branch after the PR diverged. A stale
+branch's plan would otherwise revert schema that already landed.
 
 This is path-scoped rather than a whole-branch freshness requirement. At apply
 time, SchemaBot resolves the base branch ref to its current tip commit and
@@ -474,9 +469,7 @@ unsafe-change prompt: a stale branch whose plan would revert newer base schema
 is told to update the branch, never to re-run with `--allow-unsafe`.
 
 The gate fails closed when GitHub cannot resolve the base branch tip, the
-merge base, or either tree. It defaults to disabled for compatibility; enable
-it per repository after confirming the repository's schema directories are
-dedicated to schema inputs.
+merge base, or either tree.
 
 ## Review Gate
 

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -724,12 +724,6 @@ type RepoConfig struct {
 	// own safety gates. Defaults to true when not configured.
 	EnableChecks *bool `yaml:"enable_checks,omitempty"`
 
-	// RequireUpToDateWithBase rejects applies when the configured schema
-	// directory changed on the base branch after the PR diverged. Unlike a
-	// whole-branch freshness gate, unrelated base-branch commits do not block
-	// applies. Defaults to false when not configured.
-	RequireUpToDateWithBase bool `yaml:"require_up_to_date_with_base,omitempty"`
-
 	// GitHubApp names the App in ServerConfig.Apps that owns webhooks and
 	// outbound GitHub API calls for this repository. Required when Apps is
 	// configured and must match a key in ServerConfig.Apps. Setting it
@@ -1680,17 +1674,6 @@ func (c *ServerConfig) AreChecksEnabled(repo string) bool {
 		return true
 	}
 	return *repoConfig.EnableChecks
-}
-
-// RequiresUpToDateWithBase reports whether repo applies must use a branch
-// whose managed schema directory includes every schema change on the current
-// base branch.
-func (c *ServerConfig) RequiresUpToDateWithBase(repo string) bool {
-	if c == nil {
-		return false
-	}
-	repoConfig, ok := c.Repos[repo]
-	return ok && repoConfig.RequireUpToDateWithBase
 }
 
 // ResolvedGitHubApp identifies which configured GitHub App owns a repository.

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -114,7 +114,6 @@ tern_deployments:
 repos:
   org/repo:
     enable_checks: false
-    require_up_to_date_with_base: true
 `
 	err := os.WriteFile(configPath, []byte(content), 0644)
 	require.NoError(t, err, "write config file")
@@ -125,7 +124,6 @@ repos:
 	assert.Equal(t, 2, len(cfg.TernDeployments))
 	assert.Contains(t, cfg.Repos, "org/repo")
 	assert.False(t, cfg.AreChecksEnabled("org/repo"))
-	assert.True(t, cfg.RequiresUpToDateWithBase("org/repo"))
 }
 
 func TestLoadServerConfigFromFile_DSNFrom(t *testing.T) {
@@ -2408,26 +2406,6 @@ func TestServerConfig_AreChecksEnabled(t *testing.T) {
 			},
 		}
 		assert.True(t, cfg.AreChecksEnabled("org/repo"))
-	})
-}
-
-func TestServerConfig_RequiresUpToDateWithBase(t *testing.T) {
-	t.Run("defaults to disabled", func(t *testing.T) {
-		cfg := ServerConfig{Repos: map[string]RepoConfig{"org/repo": {}}}
-		assert.False(t, cfg.RequiresUpToDateWithBase("org/repo"))
-	})
-
-	t.Run("enabled for configured repo only", func(t *testing.T) {
-		cfg := ServerConfig{Repos: map[string]RepoConfig{
-			"org/repo": {RequireUpToDateWithBase: true},
-		}}
-		assert.True(t, cfg.RequiresUpToDateWithBase("org/repo"))
-		assert.False(t, cfg.RequiresUpToDateWithBase("org/other-repo"))
-	})
-
-	t.Run("nil config defaults to disabled", func(t *testing.T) {
-		var cfg *ServerConfig
-		assert.False(t, cfg.RequiresUpToDateWithBase("org/repo"))
 	})
 }
 

--- a/pkg/webhook/apply_integration_test.go
+++ b/pkg/webhook/apply_integration_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/block/spirit/pkg/utils"
 
-	"github.com/block/schemabot/pkg/api"
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/storage"
 )
@@ -1567,9 +1566,6 @@ func TestE2EApplyAutoConfirmRejectsWhenHEADAdvanced(t *testing.T) {
 func TestE2EApplyAutoConfirmRejectsStaleBaseSchema(t *testing.T) {
 	dbName := "webhook_auto_confirm_stale_base"
 	svc := setupE2EService(t, dbName)
-	svc.Config().Repos = map[string]api.RepoConfig{
-		"octocat/hello-world": {RequireUpToDateWithBase: true},
-	}
 
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
@@ -1583,7 +1579,7 @@ func TestE2EApplyAutoConfirmRejectsStaleBaseSchema(t *testing.T) {
 		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
 	}
 	result := setupFakeGitHubForPlan(t, mux, schemaFiles, schemabotConfig, dbName)
-	registerStaleBaseSchemaComparison(t, mux)
+	registerStaleBaseSchemaComparison(t, mux, result)
 
 	h := newE2EHandler(t, svc, client)
 	req := buildWebhookRequest(t, webhookPayloadOpts{
@@ -1626,9 +1622,6 @@ func TestE2EApplyAutoConfirmRejectsStaleBaseSchema(t *testing.T) {
 func TestE2EApplyStaleBaseSchemaOutranksUnsafePrompt(t *testing.T) {
 	dbName := "webhook_stale_base_unsafe"
 	svc := setupE2EService(t, dbName)
-	svc.Config().Repos = map[string]api.RepoConfig{
-		"octocat/hello-world": {RequireUpToDateWithBase: true},
-	}
 
 	// The live target already carries the column the newer base commit added.
 	targetDB, err := sql.Open("mysql", e2eTargetDSN+"&multiStatements=true")
@@ -1649,7 +1642,7 @@ func TestE2EApplyStaleBaseSchemaOutranksUnsafePrompt(t *testing.T) {
 	result := setupFakeGitHubForPlan(t, mux, map[string]string{
 		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
 	}, schemabotConfig, dbName)
-	registerStaleBaseSchemaComparison(t, mux)
+	registerStaleBaseSchemaComparison(t, mux, result)
 
 	h := newE2EHandler(t, svc, client)
 	req := buildWebhookRequest(t, webhookPayloadOpts{
@@ -1693,9 +1686,6 @@ func TestE2EApplyStaleBaseSchemaOutranksUnsafePrompt(t *testing.T) {
 func TestE2EApplyConfirmStaleBaseSchemaAtFinalGateOutranksUnsafePrompt(t *testing.T) {
 	dbName := "webhook_confirm_final_stale_base"
 	svc := setupE2EService(t, dbName)
-	svc.Config().Repos = map[string]api.RepoConfig{
-		"octocat/hello-world": {RequireUpToDateWithBase: true},
-	}
 
 	const pendingPlanID = "plan-pending-confirmation"
 	require.NoError(t, svc.Storage().Locks().Acquire(t.Context(), &storage.Lock{
@@ -1754,16 +1744,13 @@ func TestE2EApplyConfirmStaleBaseSchemaAtFinalGateOutranksUnsafePrompt(t *testin
 	// tree is immutable; only the ref moves, so the gate detects the advance
 	// only if it re-resolves the ref rather than reusing an earlier tip.
 	var refReads atomic.Int32
-	mux.HandleFunc("GET /repos/octocat/hello-world/git/ref/heads/main", func(w http.ResponseWriter, _ *http.Request) {
-		tipSHA := "base-tip-1"
+	tip := func() string {
 		if refReads.Add(1) > 1 {
-			tipSHA = "base-tip-2"
+			return "base-tip-2"
 		}
-		require.NoError(t, json.NewEncoder(w).Encode(gh.Reference{
-			Ref:    new("refs/heads/main"),
-			Object: &gh.GitObject{Type: new("commit"), SHA: &tipSHA},
-		}))
-	})
+		return "base-tip-1"
+	}
+	result.BaseTip.Store(&tip)
 	for _, tipSHA := range []string{"base-tip-1", "base-tip-2"} {
 		mux.HandleFunc("GET /repos/octocat/hello-world/compare/"+tipSHA+"...abc123", func(w http.ResponseWriter, _ *http.Request) {
 			require.NoError(t, json.NewEncoder(w).Encode(gh.CommitsComparison{
@@ -1818,9 +1805,6 @@ func TestE2EApplyConfirmStaleBaseSchemaAtFinalGateOutranksUnsafePrompt(t *testin
 func TestE2EApplyConfirmRejectsStaleBaseSchema(t *testing.T) {
 	dbName := "webhook_confirm_stale_base"
 	svc := setupE2EService(t, dbName)
-	svc.Config().Repos = map[string]api.RepoConfig{
-		"octocat/hello-world": {RequireUpToDateWithBase: true},
-	}
 	require.NoError(t, svc.Storage().Locks().Acquire(t.Context(), &storage.Lock{
 		DatabaseName:  dbName,
 		DatabaseType:  "mysql",
@@ -1840,7 +1824,7 @@ func TestE2EApplyConfirmRejectsStaleBaseSchema(t *testing.T) {
 	result := setupFakeGitHubForPlan(t, mux, map[string]string{
 		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
 	}, schemabotConfig, dbName)
-	registerStaleBaseSchemaComparison(t, mux)
+	registerStaleBaseSchemaComparison(t, mux, result)
 
 	h := newE2EHandler(t, svc, client)
 	req := buildWebhookRequest(t, webhookPayloadOpts{
@@ -1873,12 +1857,9 @@ func TestE2EApplyConfirmRejectsStaleBaseSchema(t *testing.T) {
 
 // apply-confirm validates lock intent before running freshness checks. A
 // rollback lock owned by the same PR must never be released by the apply path.
-func TestE2EApplyConfirmPreservesRollbackLockWithBaseFreshnessEnabled(t *testing.T) {
+func TestE2EApplyConfirmPreservesRollbackLock(t *testing.T) {
 	dbName := "webhook_confirm_rollback_lock"
 	svc := setupE2EService(t, dbName)
-	svc.Config().Repos = map[string]api.RepoConfig{
-		"octocat/hello-world": {RequireUpToDateWithBase: true},
-	}
 	require.NoError(t, svc.Storage().Locks().Acquire(t.Context(), &storage.Lock{
 		DatabaseName:  dbName,
 		DatabaseType:  "mysql",
@@ -1927,9 +1908,6 @@ func TestE2EApplyConfirmPreservesRollbackLockWithBaseFreshnessEnabled(t *testing
 func TestE2EApplyConfirmFreshnessRacePreservesReplacementRollbackLock(t *testing.T) {
 	dbName := "webhook_confirm_rollback_race"
 	svc := setupE2EService(t, dbName)
-	svc.Config().Repos = map[string]api.RepoConfig{
-		"octocat/hello-world": {RequireUpToDateWithBase: true},
-	}
 	require.NoError(t, svc.Storage().Locks().Acquire(t.Context(), &storage.Lock{
 		DatabaseName:  dbName,
 		DatabaseType:  "mysql",
@@ -1949,7 +1927,7 @@ func TestE2EApplyConfirmFreshnessRacePreservesReplacementRollbackLock(t *testing
 	result := setupFakeGitHubForPlan(t, mux, map[string]string{
 		"users.sql": "CREATE TABLE `users` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
 	}, schemabotConfig, dbName)
-	registerStaleBaseSchemaComparisonWithHook(t, mux, func() {
+	registerStaleBaseSchemaComparisonWithHook(t, mux, result, func() {
 		require.NoError(t, svc.Storage().Locks().Acquire(t.Context(), &storage.Lock{
 			DatabaseName:  dbName,
 			DatabaseType:  "mysql",
@@ -1982,9 +1960,9 @@ func TestE2EApplyConfirmFreshnessRacePreservesReplacementRollbackLock(t *testing
 	assert.Equal(t, rollbackPendingPlanPrefix+"replacement", lock.PendingPlanID)
 }
 
-func registerStaleBaseSchemaComparison(t *testing.T, mux *http.ServeMux) {
+func registerStaleBaseSchemaComparison(t *testing.T, mux *http.ServeMux, result *planFlowResult) {
 	t.Helper()
-	registerStaleBaseSchemaComparisonWithHook(t, mux, nil)
+	registerStaleBaseSchemaComparisonWithHook(t, mux, result, nil)
 }
 
 // registerStaleBaseSchemaComparisonWithHook wires the fake GitHub endpoints
@@ -1994,14 +1972,10 @@ func registerStaleBaseSchemaComparison(t *testing.T, mux *http.ServeMux) {
 // base, so only resolving the base ref reveals the advanced tip, whose schema
 // tree differs from the merge base's. The optional hook runs when the
 // merge-base comparison is fetched, mid-way through the gate's reads.
-func registerStaleBaseSchemaComparisonWithHook(t *testing.T, mux *http.ServeMux, hook func()) {
+func registerStaleBaseSchemaComparisonWithHook(t *testing.T, mux *http.ServeMux, result *planFlowResult, hook func()) {
 	t.Helper()
-	mux.HandleFunc("GET /repos/octocat/hello-world/git/ref/heads/main", func(w http.ResponseWriter, _ *http.Request) {
-		require.NoError(t, json.NewEncoder(w).Encode(gh.Reference{
-			Ref:    new("refs/heads/main"),
-			Object: &gh.GitObject{Type: new("commit"), SHA: new("base-tip-sha")},
-		}))
-	})
+	tip := func() string { return "base-tip-sha" }
+	result.BaseTip.Store(&tip)
 	mux.HandleFunc("GET /repos/octocat/hello-world/compare/base-tip-sha...abc123", func(w http.ResponseWriter, _ *http.Request) {
 		if hook != nil {
 			hook()
@@ -2352,6 +2326,7 @@ func TestE2EApplyConfirmRejectsWhenPlanSHAStale(t *testing.T) {
 	// cross-delivery guard must still reject because the stored plan's
 	// HeadSHA ("abc123") doesn't match.
 	result.HeadSHAs = []string{"newsha456"}
+	registerFreshBaseComparison(t, mux, "newsha456")
 	h := newE2EHandler(t, svc, client)
 
 	req := buildWebhookRequest(t, webhookPayloadOpts{
@@ -2621,6 +2596,7 @@ func TestE2EApplyConfirmRejectsWhenPlainPlanSupersedesApplyPlan(t *testing.T) {
 	// Current HEAD seen by every PR fetch in this delivery — matches the
 	// later plain plan, not the confirmation plan.
 	result.HeadSHAs = []string{"newsha456"}
+	registerFreshBaseComparison(t, mux, "newsha456")
 	h := newE2EHandler(t, svc, client)
 
 	confirmReq := buildWebhookRequest(t, webhookPayloadOpts{

--- a/pkg/webhook/review_gate_integration_test.go
+++ b/pkg/webhook/review_gate_integration_test.go
@@ -123,10 +123,14 @@ func setupFakeGitHubForReviewGate(
 			MergeBaseCommit: &gh.RepositoryCommit{SHA: new("def456")},
 		})
 	})
+	// The base commit's shallow root tree: the gate walks this level looking
+	// for the managed "schema" directory entry.
 	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/def456", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(gh.Tree{
-			SHA:       new("def456"),
-			Entries:   treeEntries,
+			SHA: new("def456"),
+			Entries: []*gh.TreeEntry{
+				{Path: new("schema"), Type: new("tree"), SHA: new("schema-tree-base")},
+			},
 			Truncated: new(false),
 		})
 	})

--- a/pkg/webhook/review_gate_integration_test.go
+++ b/pkg/webhook/review_gate_integration_test.go
@@ -109,6 +109,28 @@ func setupFakeGitHubForReviewGate(
 		})
 	})
 
+	// Base-branch freshness endpoints: the base ref still points at the PR's
+	// base commit, which is therefore also the merge base, so the base-schema
+	// freshness gate lets applies proceed.
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/ref/heads/main", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(gh.Reference{
+			Ref:    new("refs/heads/main"),
+			Object: &gh.GitObject{Type: new("commit"), SHA: new("def456")},
+		})
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/compare/def456...abc123", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(gh.CommitsComparison{
+			MergeBaseCommit: &gh.RepositoryCommit{SHA: new("def456")},
+		})
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/def456", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(gh.Tree{
+			SHA:       new("def456"),
+			Entries:   treeEntries,
+			Truncated: new(false),
+		})
+	})
+
 	// Blob content
 	mux.HandleFunc("GET /repos/octocat/hello-world/git/blobs/", func(w http.ResponseWriter, r *http.Request) {
 		sha := r.URL.Path[len("/repos/octocat/hello-world/git/blobs/"):]

--- a/pkg/webhook/schema_freshness.go
+++ b/pkg/webhook/schema_freshness.go
@@ -74,13 +74,15 @@ func metricActionKey(action string) string {
 	return strings.ReplaceAll(action, "-", "_")
 }
 
-// assertBaseSchemaStillCurrent enforces the opt-in repository policy that a PR
-// must include every base-branch change under its managed schema directory.
-// It compares Git tree object IDs at the PR merge base and the current tip of
-// the base branch (resolved from prInfo.BaseRef — the PR object's base SHA is
-// a creation-time snapshot that never observes later base commits), so
-// unrelated commits elsewhere in a monorepo never block an apply. GitHub read
-// uncertainty rejects the apply rather than silently bypassing the guard.
+// assertBaseSchemaStillCurrent enforces the invariant that a PR must include
+// every base-branch change under its managed schema directory before it can
+// apply — a stale branch's plan would otherwise revert schema that already
+// landed. It compares Git tree object IDs at the PR merge base and the
+// current tip of the base branch (resolved from prInfo.BaseRef — the PR
+// object's base SHA is a creation-time snapshot that never observes later
+// base commits), so unrelated commits elsewhere in a monorepo never block an
+// apply. GitHub read uncertainty rejects the apply rather than silently
+// bypassing the guard.
 func (h *Handler) assertBaseSchemaStillCurrent(
 	ctx context.Context,
 	client *ghclient.InstallationClient,
@@ -93,11 +95,6 @@ func (h *Handler) assertBaseSchemaStillCurrent(
 	requestedBy string,
 	action string,
 ) bool {
-	config, ok := h.serverConfig()
-	if !ok || !config.RequiresUpToDateWithBase(repo) {
-		return false
-	}
-
 	schemaPaths := []string{schema.SchemaPath}
 	if schema.SchemaLinkPath != "" {
 		schemaPaths = append(schemaPaths, schema.SchemaLinkPath)

--- a/pkg/webhook/webhook_integration_test.go
+++ b/pkg/webhook/webhook_integration_test.go
@@ -496,6 +496,20 @@ func setupFakeGitHubForPlanWithPRFiles(t *testing.T, mux *http.ServeMux, schemaS
 	})
 	mux.HandleFunc("GET /repos/octocat/hello-world/git/trees/", func(w http.ResponseWriter, r *http.Request) {
 		sha := r.URL.Path[len("/repos/octocat/hello-world/git/trees/"):]
+		if sha == "def456" {
+			// The base commit's shallow root tree. The base-schema freshness
+			// gate walks this level looking for the managed "schema"
+			// directory entry; serving it as a real tree entry exercises the
+			// gate's path resolution rather than the path-absent shortcut.
+			_ = json.NewEncoder(w).Encode(gh.Tree{
+				SHA: &sha,
+				Entries: []*gh.TreeEntry{
+					{Path: new("schema"), Type: new("tree"), SHA: new("schema-tree-base")},
+				},
+				Truncated: new(false),
+			})
+			return
+		}
 		_ = json.NewEncoder(w).Encode(gh.Tree{
 			SHA:       &sha,
 			Entries:   treeEntries,

--- a/pkg/webhook/webhook_integration_test.go
+++ b/pkg/webhook/webhook_integration_test.go
@@ -323,6 +323,14 @@ type planFlowResult struct {
 	// own re-fetch. False (the default) always serves the files.
 	FailPRFilesAfterFirstFetch atomic.Bool
 	prFilesRequests            atomic.Int64
+
+	// BaseTip overrides the commit SHA that /git/ref/heads/main resolves to.
+	// Nil (the default) serves "def456" — the same commit /pulls/1 reports as
+	// the PR base, so the base branch appears unmoved and the base-schema
+	// freshness gate lets applies proceed. Tests that simulate the base
+	// branch advancing after the PR diverged install a provider returning
+	// the moved tip and register comparison fixtures for it.
+	BaseTip atomic.Pointer[func() string]
 }
 
 func (p *planFlowResult) nextHeadSHA() string {
@@ -405,6 +413,22 @@ func setupFakeGitHubForPlanWithPRFiles(t *testing.T, mux *http.ServeMux, schemaS
 			User: &gh.User{Login: new("testuser")},
 		})
 	})
+
+	// Base-branch freshness endpoints. By default the base ref still points
+	// at the PR's base commit, which is therefore also the merge base of the
+	// default head — the schema tree cannot differ from itself, so the
+	// base-schema freshness gate lets applies proceed.
+	mux.HandleFunc("GET /repos/octocat/hello-world/git/ref/heads/main", func(w http.ResponseWriter, _ *http.Request) {
+		tip := "def456"
+		if provider := result.BaseTip.Load(); provider != nil {
+			tip = (*provider)()
+		}
+		_ = json.NewEncoder(w).Encode(gh.Reference{
+			Ref:    new("refs/heads/main"),
+			Object: &gh.GitObject{Type: new("commit"), SHA: &tip},
+		})
+	})
+	registerFreshBaseComparison(t, mux, "abc123")
 
 	// PR changed files — report schema files changed (in namespace subdir)
 	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, r *http.Request) {
@@ -560,6 +584,19 @@ func setupFakeGitHubForPlanWithPRFiles(t *testing.T, mux *http.ServeMux, schemaS
 	})
 
 	return result
+}
+
+// registerFreshBaseComparison serves the merge-base comparison for a head
+// whose merge base is the unmoved base tip "def456", so the base-schema
+// freshness gate sees no base-branch schema change for that head. Tests that
+// serve a head other than the default "abc123" register their head here.
+func registerFreshBaseComparison(t *testing.T, mux *http.ServeMux, headSHA string) {
+	t.Helper()
+	mux.HandleFunc("GET /repos/octocat/hello-world/compare/def456..."+headSHA, func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(gh.CommitsComparison{
+			MergeBaseCommit: &gh.RepositoryCommit{SHA: new("def456")},
+		}))
+	})
 }
 
 func registerCompareFiles(t *testing.T, mux *http.ServeMux, baseSHA, headSHA string, files []*gh.CommitFile) {


### PR DESCRIPTION
## Why this matters

The base-schema freshness gate prevents a stale PR branch from silently reverting schema that already landed on the base branch. That protection was opt-in via `require_up_to_date_with_base`, so any repository that never set the flag stayed exposed by default. There is no scenario where applying a plan derived from a stale base is safe, so the gate should not be optional.

## What it does

- Removes the `require_up_to_date_with_base` repository flag and its accessor; `assertBaseSchemaStillCurrent` now runs on every `apply` and `apply-confirm`.
- Gate semantics are unchanged: path-scoped tree comparison against the freshly resolved base-branch tip (unrelated base commits never block), fail-closed on GitHub read uncertainty, and the rejection still outranks the unsafe-change prompt.
- Config parsing is strict, so deployed configs must drop the removed key before rolling a build that includes this change.
- Test fakes now serve default "base branch unmoved" freshness endpoints; stale-base scenarios override the served base tip via `planFlowResult.BaseTip` instead of registering their own routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)