### PR TITLE
fix(cli): name the offending tables and stray files when onboard verification fails

### DIFF
--- a/pkg/cmd/commands/onboard.go
+++ b/pkg/cmd/commands/onboard.go
@@ -78,6 +78,11 @@ func (cmd *OnboardCmd) Run(g *Globals) error {
 			}
 			fmt.Printf("  %s\n", path)
 		}
+		strays, strayErr := plan.strayFiles()
+		if strayErr != nil {
+			return strayErr
+		}
+		printStrayFileWarning(strays)
 		return nil
 	}
 
@@ -88,10 +93,15 @@ func (cmd *OnboardCmd) Run(g *Globals) error {
 	for _, path := range plan.paths() {
 		fmt.Printf("  %s\n", path)
 	}
+	strays, strayErr := plan.strayFiles()
+	if strayErr != nil {
+		return strayErr
+	}
+	printStrayFileWarning(strays)
 	if !cmd.SkipVerify {
 		fmt.Println()
 		fmt.Println("Verifying pulled schema against the source environment...")
-		if err := verifyOnboardPlan(ep, resp, cmd.SchemaDir); err != nil {
+		if err := verifyOnboardPlan(ep, resp, plan); err != nil {
 			return err
 		}
 		fmt.Println("Verified: pulled schema produces no schema changes in the source environment.")
@@ -260,6 +270,64 @@ func (p *onboardWritePlan) checkConflicts(force bool) error {
 	return nil
 }
 
+// strayFiles returns schema files in the pulled namespace directories that
+// this pull did not write. The pull covers every table in each pulled
+// namespace, so a leftover file there describes a table absent in the target:
+// verification will fail on it as a spurious create, and an onboard PR would
+// propose recreating the table.
+func (p *onboardWritePlan) strayFiles() ([]string, error) {
+	planned := make(map[string]struct{}, len(p.files))
+	namespaceDirs := make(map[string]struct{})
+	for relativePath := range p.files {
+		planned[relativePath] = struct{}{}
+		if dir := filepath.Dir(relativePath); dir != "." {
+			namespaceDirs[dir] = struct{}{}
+		}
+	}
+	var strays []string
+	for dir := range namespaceDirs {
+		path := filepath.Join(p.root, dir)
+		entries, err := os.ReadDir(path)
+		if err != nil {
+			// A namespace directory that doesn't exist yet (dry run before any
+			// write) has nothing to scan.
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("scan namespace directory %s for stray files: %w", path, err)
+		}
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			name := entry.Name()
+			// Only files SchemaBot reads as schema inputs can go stray; other
+			// files (docs, tooling) are ignored by plans and applies alike.
+			if !strings.HasSuffix(name, ".sql") && name != "vschema.json" {
+				continue
+			}
+			relativePath := filepath.Join(dir, name)
+			if _, ok := planned[relativePath]; !ok {
+				strays = append(strays, filepath.Join(p.root, relativePath))
+			}
+		}
+	}
+	sort.Strings(strays)
+	return strays, nil
+}
+
+func printStrayFileWarning(strays []string) {
+	if len(strays) == 0 {
+		return
+	}
+	fmt.Println()
+	fmt.Printf("%sWarning:%s the schema root contains schema files this pull did not write — their tables are absent in the target. Verification will fail on them, and an onboard PR would propose recreating the tables:\n", templates.ANSIYellow, templates.ANSIReset)
+	for _, path := range strays {
+		fmt.Printf("  %s\n", path)
+	}
+	fmt.Println("Delete the stray files, or restore the missing tables in the target before onboarding.")
+}
+
 func fileStatusForDryRun(path string) (exists bool, statErr error) {
 	_, err := os.Stat(path)
 	if err == nil {
@@ -293,11 +361,11 @@ func formatOnboardWriteError(operation, path string, written []string, err error
 	return fmt.Errorf("%s %s after writing files:\n  %s\nerror: %w", operation, path, strings.Join(written, "\n  "), err)
 }
 
-func verifyOnboardPlan(endpoint string, resp *apitypes.PullSchemaResponse, schemaDir string) error {
+func verifyOnboardPlan(endpoint string, resp *apitypes.PullSchemaResponse, plan *onboardWritePlan) error {
 	var planResult *apitypes.PlanResponse
 	err := withLoading("Verifying pulled schema...", true, func() error {
 		var planErr error
-		planResult, planErr = client.CallPlanAPI(endpoint, resp.Database, resp.Type, resp.Environment, schemaDir, "", 0)
+		planResult, planErr = client.CallPlanAPI(endpoint, resp.Database, resp.Type, resp.Environment, plan.root, "", 0)
 		return planErr
 	})
 	if err != nil {
@@ -306,20 +374,65 @@ func verifyOnboardPlan(endpoint string, resp *apitypes.PullSchemaResponse, schem
 		}
 		return fmt.Errorf("verify pulled schema for database %s environment %s: %w", resp.Database, resp.Environment, err)
 	}
-	return validateOnboardPlanResult(planResult)
-}
-
-func validateOnboardPlanResult(result *apitypes.PlanResponse) error {
-	if result == nil {
-		return fmt.Errorf("verify pulled schema: plan response is empty")
-	}
-	if len(result.Errors) > 0 {
-		return fmt.Errorf("verify pulled schema: plan returned errors:\n  %s", strings.Join(result.Errors, "\n  "))
-	}
-	if hasResultChanges(result) {
-		return fmt.Errorf("verify pulled schema: pulled files still produce schema changes in %s", result.Environment)
+	if validateErr := validateOnboardPlanResult(planResult, resp.Database, resp.Environment); validateErr != nil {
+		strays, strayErr := plan.strayFiles()
+		if strayErr != nil {
+			return errors.Join(validateErr, strayErr)
+		}
+		if len(strays) > 0 {
+			return fmt.Errorf("%w\nstray schema files not written by this pull (their tables are absent in the target; delete the files or restore the tables):\n  %s", validateErr, strings.Join(strays, "\n  "))
+		}
+		return validateErr
 	}
 	return nil
+}
+
+func validateOnboardPlanResult(result *apitypes.PlanResponse, database, environment string) error {
+	if result == nil {
+		return fmt.Errorf("verify pulled schema for database %s environment %s: plan response is empty", database, environment)
+	}
+	if len(result.Errors) > 0 {
+		return fmt.Errorf("verify pulled schema for database %s environment %s: plan returned errors:\n  %s", database, environment, strings.Join(result.Errors, "\n  "))
+	}
+	if hasResultChanges(result) {
+		return fmt.Errorf("verify pulled schema for database %s environment %s: pulled files still produce schema changes:\n  %s", database, environment, strings.Join(describeOnboardPlanChanges(result), "\n  "))
+	}
+	return nil
+}
+
+// onboardVerifyDDLPreviewLimit bounds the single-line DDL preview in a failed
+// verification's change listing so a full CREATE TABLE body doesn't drown the
+// table-by-table summary.
+const onboardVerifyDDLPreviewLimit = 120
+
+// describeOnboardPlanChanges renders one line per planned change so a failed
+// verification names the offending tables and DDL without a separate plan run.
+func describeOnboardPlanChanges(result *apitypes.PlanResponse) []string {
+	var lines []string
+	for _, change := range result.Changes {
+		if change == nil {
+			continue
+		}
+		for _, tableChange := range change.TableChanges {
+			if tableChange == nil {
+				continue
+			}
+			lines = append(lines, fmt.Sprintf("%s/%s (%s): %s", change.Namespace, tableChange.TableName, strings.ToLower(tableChange.ChangeType), onboardDDLPreview(tableChange.DDL)))
+		}
+		if change.HasVSchemaChange() {
+			lines = append(lines, fmt.Sprintf("%s: vschema change", change.Namespace))
+		}
+	}
+	return lines
+}
+
+func onboardDDLPreview(ddl string) string {
+	collapsed := strings.Join(strings.Fields(ddl), " ")
+	runes := []rune(collapsed)
+	if len(runes) > onboardVerifyDDLPreviewLimit {
+		return string(runes[:onboardVerifyDDLPreviewLimit]) + "…"
+	}
+	return collapsed
 }
 
 func outputSchemaPullRequestError(operation, database, environment string, err error) bool {

--- a/pkg/cmd/commands/onboard.go
+++ b/pkg/cmd/commands/onboard.go
@@ -101,7 +101,7 @@ func (cmd *OnboardCmd) Run(g *Globals) error {
 	if !cmd.SkipVerify {
 		fmt.Println()
 		fmt.Println("Verifying pulled schema against the source environment...")
-		if err := verifyOnboardPlan(ep, resp, plan); err != nil {
+		if err := verifyOnboardPlan(ep, cmd.Database, cmd.Environment, plan); err != nil {
 			return err
 		}
 		fmt.Println("Verified: pulled schema produces no schema changes in the source environment.")
@@ -113,8 +113,9 @@ func (cmd *OnboardCmd) Run(g *Globals) error {
 }
 
 type onboardWritePlan struct {
-	root  string
-	files map[string]string
+	root         string
+	databaseType string
+	files        map[string]string
 }
 
 func onboardPullNamespaces(namespaces []string) ([]string, error) {
@@ -222,7 +223,7 @@ func buildOnboardWritePlan(schemaRoot string, resp *apitypes.PullSchemaResponse)
 		}
 	}
 
-	return &onboardWritePlan{root: root, files: files}, nil
+	return &onboardWritePlan{root: root, databaseType: resp.Type, files: files}, nil
 }
 
 func validateRelativePathPart(kind, value string) error {
@@ -272,9 +273,10 @@ func (p *onboardWritePlan) checkConflicts(force bool) error {
 
 // strayFiles returns schema files in the pulled namespace directories that
 // this pull did not write. The pull covers every table in each pulled
-// namespace, so a leftover file there describes a table absent in the target:
-// verification will fail on it as a spurious create, and an onboard PR would
-// propose recreating the table.
+// namespace, so a leftover table file there describes a table absent in the
+// target, and a leftover vschema.json (Vitess) proposes a VSchema the target
+// doesn't have: verification will fail on either as a spurious change, and an
+// onboard PR would propose applying it.
 func (p *onboardWritePlan) strayFiles() ([]string, error) {
 	planned := make(map[string]struct{}, len(p.files))
 	namespaceDirs := make(map[string]struct{})
@@ -301,9 +303,13 @@ func (p *onboardWritePlan) strayFiles() ([]string, error) {
 				continue
 			}
 			name := entry.Name()
-			// Only files SchemaBot reads as schema inputs can go stray; other
+			// Only files the engine reads as schema inputs can go stray; other
 			// files (docs, tooling) are ignored by plans and applies alike.
-			if !strings.HasSuffix(name, ".sql") && name != "vschema.json" {
+			// vschema.json is a schema input for Vitess only — MySQL planning
+			// never reads it.
+			isSchemaInput := strings.HasSuffix(name, ".sql") ||
+				(name == "vschema.json" && p.databaseType == storage.DatabaseTypeVitess)
+			if !isSchemaInput {
 				continue
 			}
 			relativePath := filepath.Join(dir, name)
@@ -321,11 +327,11 @@ func printStrayFileWarning(strays []string) {
 		return
 	}
 	fmt.Println()
-	fmt.Printf("%sWarning:%s the schema root contains schema files this pull did not write — their tables are absent in the target. Verification will fail on them, and an onboard PR would propose recreating the tables:\n", templates.ANSIYellow, templates.ANSIReset)
+	fmt.Printf("%sWarning:%s the schema root contains schema files this pull did not write. Verification will fail on them, and an onboard PR would propose the spurious changes they describe (recreating absent tables, or an unexpected VSchema change):\n", templates.ANSIYellow, templates.ANSIReset)
 	for _, path := range strays {
 		fmt.Printf("  %s\n", path)
 	}
-	fmt.Println("Delete the stray files, or restore the missing tables in the target before onboarding.")
+	fmt.Println("Delete the stray files, or restore the missing tables or VSchema in the target before onboarding.")
 }
 
 func fileStatusForDryRun(path string) (exists bool, statErr error) {
@@ -361,26 +367,26 @@ func formatOnboardWriteError(operation, path string, written []string, err error
 	return fmt.Errorf("%s %s after writing files:\n  %s\nerror: %w", operation, path, strings.Join(written, "\n  "), err)
 }
 
-func verifyOnboardPlan(endpoint string, resp *apitypes.PullSchemaResponse, plan *onboardWritePlan) error {
+func verifyOnboardPlan(endpoint, database, environment string, plan *onboardWritePlan) error {
 	var planResult *apitypes.PlanResponse
 	err := withLoading("Verifying pulled schema...", true, func() error {
 		var planErr error
-		planResult, planErr = client.CallPlanAPI(endpoint, resp.Database, resp.Type, resp.Environment, plan.root, "", 0)
+		planResult, planErr = client.CallPlanAPI(endpoint, database, plan.databaseType, environment, plan.root, "", 0)
 		return planErr
 	})
 	if err != nil {
-		if outputPlanRequestError(resp.Database, resp.Environment, err) {
+		if outputPlanRequestError(database, environment, err) {
 			return ErrSilent
 		}
-		return fmt.Errorf("verify pulled schema for database %s environment %s: %w", resp.Database, resp.Environment, err)
+		return fmt.Errorf("verify pulled schema for database %s environment %s: %w", database, environment, err)
 	}
-	if validateErr := validateOnboardPlanResult(planResult, resp.Database, resp.Environment); validateErr != nil {
+	if validateErr := validateOnboardPlanResult(planResult, database, environment); validateErr != nil {
 		strays, strayErr := plan.strayFiles()
 		if strayErr != nil {
 			return errors.Join(validateErr, strayErr)
 		}
 		if len(strays) > 0 {
-			return fmt.Errorf("%w\nstray schema files not written by this pull (their tables are absent in the target; delete the files or restore the tables):\n  %s", validateErr, strings.Join(strays, "\n  "))
+			return fmt.Errorf("%w\nstray schema files not written by this pull (delete them, or restore the missing tables or VSchema in the target):\n  %s", validateErr, strings.Join(strays, "\n  "))
 		}
 		return validateErr
 	}

--- a/pkg/cmd/commands/onboard_test.go
+++ b/pkg/cmd/commands/onboard_test.go
@@ -317,12 +317,35 @@ func TestOnboardWritePlanStrayFiles(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(root, "orders", "vschema.json"), []byte("{}"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(root, "orders", "README.md"), []byte("docs"), 0o644))
 
+	// MySQL planning never reads vschema.json, so only the table file is stray.
 	strays, err = plan.strayFiles()
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		filepath.Join(root, "orders", "legacy_bak.sql"),
-		filepath.Join(root, "orders", "vschema.json"),
 	}, strays)
+}
+
+// For Vitess, vschema.json is a schema input: a leftover copy the pull did not
+// write proposes a VSchema the target doesn't have, so it must be flagged
+// alongside stray table files.
+func TestOnboardWritePlanStrayFilesFlagsVSchemaForVitess(t *testing.T) {
+	root := t.TempDir()
+	plan, err := buildOnboardWritePlan(root, &apitypes.PullSchemaResponse{
+		Database:    "orders",
+		Type:        "vitess",
+		Environment: "production",
+		Namespaces: map[string]*apitypes.PulledNamespace{
+			"orders": {Tables: map[string]string{"users": "CREATE TABLE `users` (`id` bigint NOT NULL);\n"}},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, plan.write())
+
+	require.NoError(t, os.WriteFile(filepath.Join(root, "orders", "vschema.json"), []byte("{\"sharded\": true}"), 0o644))
+
+	strays, err := plan.strayFiles()
+	require.NoError(t, err)
+	assert.Equal(t, []string{filepath.Join(root, "orders", "vschema.json")}, strays)
 }
 
 func validPullSchemaResponse() *apitypes.PullSchemaResponse {

--- a/pkg/cmd/commands/onboard_test.go
+++ b/pkg/cmd/commands/onboard_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -231,24 +232,97 @@ func TestFileStatusForDryRunTreatsStatErrorsAsExisting(t *testing.T) {
 }
 
 func TestValidateOnboardPlanResult(t *testing.T) {
-	assert.NoError(t, validateOnboardPlanResult(&apitypes.PlanResponse{Environment: "production"}))
+	assert.NoError(t, validateOnboardPlanResult(&apitypes.PlanResponse{Environment: "production"}, "orders", "production"))
 	assert.NoError(t, validateOnboardPlanResult(&apitypes.PlanResponse{
 		Environment: "production",
 		LintResults: []*apitypes.LintViolationResponse{{Severity: "error", Message: "existing lint violation"}},
-	}))
+	}, "orders", "production"))
 
 	err := validateOnboardPlanResult(&apitypes.PlanResponse{
 		Environment: "production",
 		Changes: []*apitypes.SchemaChangeResponse{
-			{TableChanges: []*apitypes.TableChangeResponse{{TableName: "users", ChangeType: "ALTER"}}},
+			{
+				Namespace: "orders",
+				TableChanges: []*apitypes.TableChangeResponse{{
+					TableName:  "users",
+					ChangeType: "ALTER",
+					DDL:        "ALTER TABLE `users`\n  ADD COLUMN `email` varchar(255)",
+				}},
+			},
+		},
+	}, "orders", "production")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database orders environment production")
+	assert.Contains(t, err.Error(), "still produce schema changes")
+	assert.Contains(t, err.Error(), "orders/users (alter): ALTER TABLE `users` ADD COLUMN `email` varchar(255)")
+
+	err = validateOnboardPlanResult(&apitypes.PlanResponse{Errors: []string{"syntax error"}}, "orders", "production")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database orders environment production")
+	assert.Contains(t, err.Error(), "plan returned errors")
+	assert.Contains(t, err.Error(), "syntax error")
+
+	err = validateOnboardPlanResult(nil, "orders", "production")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database orders environment production")
+	assert.Contains(t, err.Error(), "plan response is empty")
+}
+
+func TestDescribeOnboardPlanChangesIncludesVSchemaAndClampsDDL(t *testing.T) {
+	longDDL := "ALTER TABLE `users` ADD COLUMN " + strings.Repeat("`c` varchar(255), ", 20)
+	lines := describeOnboardPlanChanges(&apitypes.PlanResponse{
+		Changes: []*apitypes.SchemaChangeResponse{
+			{
+				Namespace:    "orders",
+				TableChanges: []*apitypes.TableChangeResponse{{TableName: "users", ChangeType: "ALTER", DDL: longDDL}},
+				Metadata:     map[string]string{"vschema": "{\"sharded\": true}"},
+			},
 		},
 	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "still produce schema changes")
+	require.Len(t, lines, 2)
+	assert.True(t, strings.HasPrefix(lines[0], "orders/users (alter): ALTER TABLE `users` ADD COLUMN"), lines[0])
+	assert.True(t, strings.HasSuffix(lines[0], "…"), lines[0])
+	assert.LessOrEqual(t, len([]rune(lines[0])), onboardVerifyDDLPreviewLimit+len("orders/users (alter): ")+len("…"))
+	assert.Equal(t, "orders: vschema change", lines[1])
+}
 
-	err = validateOnboardPlanResult(&apitypes.PlanResponse{Errors: []string{"syntax error"}})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "plan returned errors")
+// A leftover schema file for a table that no longer exists in the target is
+// the classic cause of a failed onboarding verification: the pull rewrites
+// every table in the namespace but never deletes strays, so the stale file
+// resurfaces as a spurious create. strayFiles must name exactly those files —
+// and ignore non-schema files — so the operator knows what to delete.
+func TestOnboardWritePlanStrayFiles(t *testing.T) {
+	root := t.TempDir()
+	plan, err := buildOnboardWritePlan(root, &apitypes.PullSchemaResponse{
+		Database:    "orders",
+		Type:        "mysql",
+		Environment: "production",
+		Namespaces: map[string]*apitypes.PulledNamespace{
+			"orders": {Tables: map[string]string{"users": "CREATE TABLE `users` (`id` bigint NOT NULL);\n"}},
+		},
+	})
+	require.NoError(t, err)
+
+	// Namespace directory absent (dry run before any write): nothing to scan.
+	strays, err := plan.strayFiles()
+	require.NoError(t, err)
+	assert.Empty(t, strays)
+
+	require.NoError(t, plan.write())
+	strays, err = plan.strayFiles()
+	require.NoError(t, err)
+	assert.Empty(t, strays)
+
+	require.NoError(t, os.WriteFile(filepath.Join(root, "orders", "legacy_bak.sql"), []byte("CREATE TABLE `legacy_bak` (`id` bigint NOT NULL);\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "orders", "vschema.json"), []byte("{}"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "orders", "README.md"), []byte("docs"), 0o644))
+
+	strays, err = plan.strayFiles()
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		filepath.Join(root, "orders", "legacy_bak.sql"),
+		filepath.Join(root, "orders", "vschema.json"),
+	}, strays)
 }
 
 func validPullSchemaResponse() *apitypes.PullSchemaResponse {


### PR DESCRIPTION
## Why this matters

When `schemabot onboard`'s post-pull verification fails, the operator gets `pulled files still produce schema changes in <env>` — with the environment sometimes empty and no indication of *which* changes. The most common cause is a stray schema file left in the namespace directory for a table that no longer exists in the target: the pull overwrites files but never deletes leftovers, so the stray resurfaces as a spurious create and the verify failure can't be diagnosed without a manual plan run.

## What it does

- The verification failure now names the database and environment (taken from the pull request context rather than a response field that can be empty) and lists every planned change as `namespace/table (change type): <one-line DDL preview>`, with the DDL whitespace-collapsed and clamped so a full `CREATE TABLE` body doesn't drown the listing. VSchema changes get their own line, and the plan-errors and empty-response failure modes carry the identifiers too.
- New stray-file detection on the write plan: schema files (`.sql` / `vschema.json`) in the pulled namespace directories that the pull did not write are flagged — a warning after writing (also on `--dry-run`, and still surfaced under `--skip-verify`), and the concrete paths appended to the verification error so it stands alone. Strays are listed, never auto-deleted: removing files a user may have hand-written is its own hazard, and the failed verification already blocks a bad onboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)