### PR TITLE
feat(engine): record a plan-time execution-mode verdict on table changes

### DIFF
--- a/pkg/api/proto_helpers.go
+++ b/pkg/api/proto_helpers.go
@@ -185,12 +185,14 @@ func planResponseFromProto(resp *ternv1.PlanResponse) *apitypes.PlanResponse {
 		}
 		for _, t := range sc.TableChanges {
 			apiSC.TableChanges = append(apiSC.TableChanges, &apitypes.TableChangeResponse{
-				TableName:    t.TableName,
-				Namespace:    t.Namespace,
-				DDL:          t.Ddl,
-				ChangeType:   protoChangeTypeToOperation(t.ChangeType),
-				IsUnsafe:     t.IsUnsafe,
-				UnsafeReason: t.UnsafeReason,
+				TableName:     t.TableName,
+				Namespace:     t.Namespace,
+				DDL:           t.Ddl,
+				ChangeType:    protoChangeTypeToOperation(t.ChangeType),
+				IsUnsafe:      t.IsUnsafe,
+				UnsafeReason:  t.UnsafeReason,
+				ExecutionMode: t.ExecutionMode,
+				ModeReason:    t.ModeReason,
 			})
 		}
 		httpResp.Changes = append(httpResp.Changes, apiSC)
@@ -220,12 +222,14 @@ func planResponseFromProto(resp *ternv1.PlanResponse) *apitypes.PlanResponse {
 				continue
 			}
 			apiSP.Changes = append(apiSP.Changes, &apitypes.TableChangeResponse{
-				TableName:    t.TableName,
-				Namespace:    t.Namespace,
-				DDL:          t.Ddl,
-				ChangeType:   protoChangeTypeToOperation(t.ChangeType),
-				IsUnsafe:     t.IsUnsafe,
-				UnsafeReason: t.UnsafeReason,
+				TableName:     t.TableName,
+				Namespace:     t.Namespace,
+				DDL:           t.Ddl,
+				ChangeType:    protoChangeTypeToOperation(t.ChangeType),
+				IsUnsafe:      t.IsUnsafe,
+				UnsafeReason:  t.UnsafeReason,
+				ExecutionMode: t.ExecutionMode,
+				ModeReason:    t.ModeReason,
 			})
 		}
 		// An empty shard plan is a shard that already matches the desired schema
@@ -258,11 +262,13 @@ func protoChangesToNamespaces(changes []*ternv1.SchemaChange, schemaFiles map[st
 		nsData := &storage.NamespacePlanData{}
 		for _, t := range sc.TableChanges {
 			nsData.Tables = append(nsData.Tables, storage.TableChange{
-				Table:        t.TableName,
-				DDL:          t.Ddl,
-				Operation:    protoChangeTypeToOperation(t.ChangeType),
-				IsUnsafe:     t.IsUnsafe,
-				UnsafeReason: t.UnsafeReason,
+				Table:         t.TableName,
+				DDL:           t.Ddl,
+				Operation:     protoChangeTypeToOperation(t.ChangeType),
+				IsUnsafe:      t.IsUnsafe,
+				UnsafeReason:  t.UnsafeReason,
+				ExecutionMode: t.ExecutionMode,
+				ModeReason:    t.ModeReason,
 			})
 		}
 		if len(sc.OriginalFiles) > 0 {
@@ -333,12 +339,14 @@ func protoShardPlansToStorage(shards []*ternv1.ShardPlan) ([]storage.ShardPlan, 
 				return nil, fmt.Errorf("shard plan %d shard %q change %d (table %q) namespace %q disagrees with shard namespace %q", i, shardName, j, table, cn, namespace)
 			}
 			sp.Changes = append(sp.Changes, storage.TableChange{
-				Namespace:    namespace,
-				Table:        table,
-				DDL:          changeDDL,
-				Operation:    protoChangeTypeToOperation(ch.ChangeType),
-				IsUnsafe:     ch.IsUnsafe,
-				UnsafeReason: ch.UnsafeReason,
+				Namespace:     namespace,
+				Table:         table,
+				DDL:           changeDDL,
+				Operation:     protoChangeTypeToOperation(ch.ChangeType),
+				IsUnsafe:      ch.IsUnsafe,
+				UnsafeReason:  ch.UnsafeReason,
+				ExecutionMode: ch.ExecutionMode,
+				ModeReason:    ch.ModeReason,
 			})
 		}
 		out = append(out, sp)

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -577,6 +577,11 @@ type TableChangeResponse struct {
 	ChangeType   string `json:"change_type"`
 	IsUnsafe     bool   `json:"is_unsafe,omitempty"`
 	UnsafeReason string `json:"unsafe_reason,omitempty"`
+	// ExecutionMode is the planner's execution-mode verdict. Empty means the
+	// engine's default path; "blocked" means the engine deterministically
+	// refuses the statement and the apply will fail.
+	ExecutionMode string `json:"execution_mode,omitempty"`
+	ModeReason    string `json:"mode_reason,omitempty"`
 }
 
 // GetTableName implements ddl.TableWithName for filtering Spirit internal tables.

--- a/pkg/ddl/verdict.go
+++ b/pkg/ddl/verdict.go
@@ -1,0 +1,88 @@
+package ddl
+
+import (
+	"fmt"
+
+	"github.com/block/spirit/pkg/statement"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+)
+
+// Execution-mode verdicts recorded on a planned table change. The verdict
+// answers "how will this statement actually run?" so operators learn about
+// engine limitations at plan time instead of at apply time.
+const (
+	// ExecutionModeBlocked marks a statement the MySQL schema-change engine
+	// deterministically refuses. An apply containing it will fail, and
+	// retrying cannot succeed until the statement changes.
+	ExecutionModeBlocked = "blocked"
+)
+
+// EngineRefusalReason reports whether the MySQL schema-change engine (Spirit)
+// deterministically refuses the given statement, and the engine's reason.
+//
+// It mirrors the engine's own run-time decision order, so it only claims a
+// refusal when one is certain:
+//
+//   - ALGORITHM=/LOCK= clauses are rejected at parse level before any DDL is
+//     attempted (Spirit prepends its own assertions, and MySQL resolves
+//     duplicate options last-one-wins).
+//   - DROP PRIMARY KEY never qualifies for MySQL's INSTANT algorithm or for
+//     the engine's safe-INPLACE clause set, so it always reaches the engine's
+//     preflight primary-key check, which refuses it unconditionally.
+//   - ADD FOREIGN KEY is refused unconditionally by the engine's preflight
+//     foreign-key check, which runs before any execution attempt — the
+//     engine's online copy cannot preserve referential constraints.
+//
+// The engine also refuses ALTERs on tables that already carry foreign keys,
+// but that depends on live table state, not the statement text, so it cannot
+// be claimed here — it surfaces as an apply-time failure instead.
+//
+// Statements a preflight check would refuse but that can complete through the
+// engine's instant-DDL fast path never reach that check, so they are not
+// reported here — the verdict must never claim an apply will fail when it can
+// succeed. Only ALTER TABLE statements can be refused; everything else
+// returns false.
+func EngineRefusalReason(stmt string) (string, bool, error) {
+	stmts, err := statement.New(stmt)
+	if err != nil {
+		return "", false, fmt.Errorf("parse statement for execution verdict %q: %w", statementPreview(stmt), err)
+	}
+	if len(stmts) != 1 {
+		return "", false, fmt.Errorf("execution verdict requires exactly one statement, got %d in %q", len(stmts), statementPreview(stmt))
+	}
+	abs := stmts[0]
+	if !abs.IsAlterTable() {
+		return "", false, nil
+	}
+	if err := abs.AlterContainsUnsupportedClause(); err != nil {
+		return err.Error(), true, nil
+	}
+	alterStmt, ok := abs.AsAlterTable()
+	if !ok {
+		return "", false, fmt.Errorf("statement classified as ALTER TABLE has no alter AST node: %q", statementPreview(stmt))
+	}
+	for _, spec := range alterStmt.Specs {
+		if spec.Tp == ast.AlterTableDropPrimaryKey {
+			return "dropping primary key is not supported", true, nil
+		}
+		if addsForeignKey(spec) {
+			return "adding foreign key constraints is not supported", true, nil
+		}
+	}
+	return "", false, nil
+}
+
+// addsForeignKey reports whether the alter spec adds a referential constraint,
+// matching the shapes the engine's preflight foreign-key check refuses: a
+// single ADD CONSTRAINT ... FOREIGN KEY, or a constraint list carrying one.
+func addsForeignKey(spec *ast.AlterTableSpec) bool {
+	if spec.Constraint != nil && spec.Constraint.Refer != nil {
+		return true
+	}
+	for _, constraint := range spec.NewConstraints {
+		if constraint.Refer != nil {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/ddl/verdict.go
+++ b/pkg/ddl/verdict.go
@@ -38,10 +38,12 @@ const (
 // be claimed here — it surfaces as an apply-time failure instead.
 //
 // Statements a preflight check would refuse but that can complete through the
-// engine's instant-DDL fast path never reach that check, so they are not
-// reported here — the verdict must never claim an apply will fail when it can
-// succeed. Only ALTER TABLE statements can be refused; everything else
-// returns false.
+// engine's instant-DDL fast path are not reported here — the verdict must
+// never claim an apply will fail when it can succeed. The fast path is only
+// guaranteed for single-ALTER applies: when the engine batches several ALTERs
+// into one run it may skip the fast path and refuse such a statement anyway.
+// That is a tolerated false negative — the verdict errs toward silence.
+// Only ALTER TABLE statements can be refused; everything else returns false.
 func EngineRefusalReason(stmt string) (string, bool, error) {
 	stmts, err := statement.New(stmt)
 	if err != nil {

--- a/pkg/ddl/verdict_test.go
+++ b/pkg/ddl/verdict_test.go
@@ -61,7 +61,7 @@ func TestEngineRefusalReason(t *testing.T) {
 			stmt: "ALTER TABLE `users` ADD INDEX `idx_email` (`email`)",
 		},
 		{
-			name: "replacing the primary key without dropping it runs on the engine",
+			name: "modifying a primary-key column runs on the engine",
 			stmt: "ALTER TABLE `users` MODIFY COLUMN `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT",
 		},
 		{

--- a/pkg/ddl/verdict_test.go
+++ b/pkg/ddl/verdict_test.go
@@ -1,0 +1,106 @@
+package ddl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEngineRefusalReason(t *testing.T) {
+	tests := []struct {
+		name        string
+		stmt        string
+		wantRefused bool
+		wantReason  string
+	}{
+		{
+			name:        "drop primary key is refused",
+			stmt:        "ALTER TABLE `users` DROP PRIMARY KEY",
+			wantRefused: true,
+			wantReason:  "dropping primary key is not supported",
+		},
+		{
+			name:        "drop primary key among other specs is refused",
+			stmt:        "ALTER TABLE `users` DROP PRIMARY KEY, ADD PRIMARY KEY (`id`, `tenant_id`)",
+			wantRefused: true,
+			wantReason:  "dropping primary key is not supported",
+		},
+		{
+			name:        "explicit algorithm clause is refused",
+			stmt:        "ALTER TABLE `users` ADD COLUMN `email` VARCHAR(255), ALGORITHM=INPLACE",
+			wantRefused: true,
+		},
+		{
+			name:        "explicit lock clause is refused",
+			stmt:        "ALTER TABLE `users` ADD COLUMN `email` VARCHAR(255), LOCK=NONE",
+			wantRefused: true,
+		},
+		{
+			name:        "add foreign key is refused",
+			stmt:        "ALTER TABLE `orders` ADD CONSTRAINT `fk_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)",
+			wantRefused: true,
+			wantReason:  "adding foreign key constraints is not supported",
+		},
+		{
+			name:        "add unnamed foreign key is refused",
+			stmt:        "ALTER TABLE `orders` ADD FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)",
+			wantRefused: true,
+			wantReason:  "adding foreign key constraints is not supported",
+		},
+		{
+			name: "add non-referential constraint runs on the engine",
+			stmt: "ALTER TABLE `orders` ADD CONSTRAINT `chk_qty` CHECK (`quantity` > 0)",
+		},
+		{
+			name: "add column runs on the engine",
+			stmt: "ALTER TABLE `users` ADD COLUMN `email` VARCHAR(255)",
+		},
+		{
+			name: "add index runs on the engine",
+			stmt: "ALTER TABLE `users` ADD INDEX `idx_email` (`email`)",
+		},
+		{
+			name: "replacing the primary key without dropping it runs on the engine",
+			stmt: "ALTER TABLE `users` MODIFY COLUMN `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT",
+		},
+		{
+			name: "create table is not an alter and never refused",
+			stmt: "CREATE TABLE `users` (`id` BIGINT UNSIGNED AUTO_INCREMENT, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+		},
+		{
+			name: "drop table is not an alter and never refused",
+			stmt: "DROP TABLE `users`",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, refused, err := EngineRefusalReason(tt.stmt)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantRefused, refused)
+			if tt.wantReason != "" {
+				assert.Equal(t, tt.wantReason, reason)
+			}
+			if refused {
+				assert.NotEmpty(t, reason)
+			} else {
+				assert.Empty(t, reason)
+			}
+		})
+	}
+}
+
+func TestEngineRefusalReasonErrors(t *testing.T) {
+	t.Run("unparseable statement", func(t *testing.T) {
+		_, _, err := EngineRefusalReason("ALTER TABLE `users` FLUX CAPACITOR")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parse statement")
+	})
+
+	t.Run("multiple statements", func(t *testing.T) {
+		_, _, err := EngineRefusalReason("ALTER TABLE `a` ADD COLUMN `x` INT; ALTER TABLE `b` ADD COLUMN `y` INT")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exactly one statement")
+	})
+}

--- a/pkg/ddl/verdict_test.go
+++ b/pkg/ddl/verdict_test.go
@@ -9,10 +9,11 @@ import (
 
 func TestEngineRefusalReason(t *testing.T) {
 	tests := []struct {
-		name        string
-		stmt        string
-		wantRefused bool
-		wantReason  string
+		name               string
+		stmt               string
+		wantRefused        bool
+		wantReason         string
+		wantReasonContains string
 	}{
 		{
 			name:        "drop primary key is refused",
@@ -27,14 +28,16 @@ func TestEngineRefusalReason(t *testing.T) {
 			wantReason:  "dropping primary key is not supported",
 		},
 		{
-			name:        "explicit algorithm clause is refused",
-			stmt:        "ALTER TABLE `users` ADD COLUMN `email` VARCHAR(255), ALGORITHM=INPLACE",
-			wantRefused: true,
+			name:               "explicit algorithm clause is refused",
+			stmt:               "ALTER TABLE `users` ADD COLUMN `email` VARCHAR(255), ALGORITHM=INPLACE",
+			wantRefused:        true,
+			wantReasonContains: "ALGORITHM",
 		},
 		{
-			name:        "explicit lock clause is refused",
-			stmt:        "ALTER TABLE `users` ADD COLUMN `email` VARCHAR(255), LOCK=NONE",
-			wantRefused: true,
+			name:               "explicit lock clause is refused",
+			stmt:               "ALTER TABLE `users` ADD COLUMN `email` VARCHAR(255), LOCK=NONE",
+			wantRefused:        true,
+			wantReasonContains: "LOCK",
 		},
 		{
 			name:        "add foreign key is refused",
@@ -81,6 +84,9 @@ func TestEngineRefusalReason(t *testing.T) {
 			assert.Equal(t, tt.wantRefused, refused)
 			if tt.wantReason != "" {
 				assert.Equal(t, tt.wantReason, reason)
+			}
+			if tt.wantReasonContains != "" {
+				assert.Contains(t, reason, tt.wantReasonContains)
 			}
 			if refused {
 				assert.NotEmpty(t, reason)

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -250,6 +250,14 @@ type TableChange struct {
 	// Unsafe change tracking
 	IsUnsafe     bool   // True if this is a destructive/unsafe change
 	UnsafeReason string // Human-readable reason (e.g., "DROP COLUMN removes data")
+
+	// Execution-mode verdict: how the engine will run this statement at apply
+	// time. Empty means the engine's default path. "blocked" means the engine
+	// deterministically refuses the statement — the apply will fail, and the
+	// plan surfaces that up front. Distinct from IsUnsafe, which flags a
+	// change the engine *can* run but the operator must acknowledge.
+	ExecutionMode string
+	ModeReason    string // Engine's reason when ExecutionMode is "blocked"
 }
 
 // ApplyRequest contains the input for starting a schema change.

--- a/pkg/engine/spirit/spirit.go
+++ b/pkg/engine/spirit/spirit.go
@@ -319,15 +319,20 @@ func (e *Engine) Plan(ctx context.Context, req *engine.PlanRequest) (*engine.Pla
 
 		// Execution-mode verdict: surface statements Spirit deterministically
 		// refuses so the operator learns at plan time that the apply will fail.
-		reason, refused, err := ddl.EngineRefusalReason(pc.Statement)
-		if err != nil {
-			return nil, fmt.Errorf("execution verdict for table %q: %w", pc.TableName, err)
-		}
-		if refused {
-			change.ExecutionMode = ddl.ExecutionModeBlocked
-			change.ModeReason = reason
-			e.logger.Info("plan contains a statement the engine will refuse at apply time",
-				"database", req.Database, "table", pc.TableName, "reason", reason)
+		// Only ALTERs can be refused, and gating here keeps the verdict — an
+		// informational field — from ever failing the plan on a statement type
+		// the verdict's own parser doesn't accept.
+		if stmtType == statement.StatementAlterTable {
+			reason, refused, err := ddl.EngineRefusalReason(pc.Statement)
+			if err != nil {
+				return nil, fmt.Errorf("execution verdict for table %q: %w", pc.TableName, err)
+			}
+			if refused {
+				change.ExecutionMode = ddl.ExecutionModeBlocked
+				change.ModeReason = reason
+				e.logger.Info("plan contains a statement the engine will refuse at apply time",
+					"database", database, "table", pc.TableName, "reason", reason)
+			}
 		}
 
 		changes = append(changes, change)

--- a/pkg/engine/spirit/spirit.go
+++ b/pkg/engine/spirit/spirit.go
@@ -317,6 +317,19 @@ func (e *Engine) Plan(ctx context.Context, req *engine.PlanRequest) (*engine.Pla
 			change.UnsafeReason = strings.Join(msgs, "; ")
 		}
 
+		// Execution-mode verdict: surface statements Spirit deterministically
+		// refuses so the operator learns at plan time that the apply will fail.
+		reason, refused, err := ddl.EngineRefusalReason(pc.Statement)
+		if err != nil {
+			return nil, fmt.Errorf("execution verdict for table %q: %w", pc.TableName, err)
+		}
+		if refused {
+			change.ExecutionMode = ddl.ExecutionModeBlocked
+			change.ModeReason = reason
+			e.logger.Info("plan contains a statement the engine will refuse at apply time",
+				"database", req.Database, "table", pc.TableName, "reason", reason)
+		}
+
 		changes = append(changes, change)
 
 		// Collect lint violations from all severity levels

--- a/pkg/engine/spirit/spirit_integration_test.go
+++ b/pkg/engine/spirit/spirit_integration_test.go
@@ -291,6 +291,12 @@ func TestEngine_Plan_DropTable(t *testing.T) {
 func TestEngine_Plan_ExecutionVerdictBlocked(t *testing.T) {
 	dsn, db := setupTestMySQL(t)
 	cleanupTables(t, db)
+	t.Cleanup(func() {
+		for _, table := range []string{"orders", "accounts", "notes"} {
+			_, err := db.ExecContext(t.Context(), "DROP TABLE IF EXISTS `"+table+"`")
+			assert.NoError(t, err, "drop table %s", table)
+		}
+	})
 
 	_, err := db.ExecContext(t.Context(), `CREATE TABLE accounts (
 		id INT NOT NULL AUTO_INCREMENT,
@@ -363,13 +369,6 @@ func TestEngine_Plan_ExecutionVerdictBlocked(t *testing.T) {
 	assert.Contains(t, orders.DDL, "fk_orders_note")
 	assert.Equal(t, "blocked", orders.ExecutionMode, "adding a foreign key carries the blocked verdict")
 	assert.Equal(t, "adding foreign key constraints is not supported", orders.ModeReason)
-
-	_, err = db.ExecContext(t.Context(), "DROP TABLE IF EXISTS `orders`")
-	require.NoError(t, err, "drop orders table")
-	_, err = db.ExecContext(t.Context(), "DROP TABLE IF EXISTS `accounts`")
-	require.NoError(t, err, "drop accounts table")
-	_, err = db.ExecContext(t.Context(), "DROP TABLE IF EXISTS `notes`")
-	require.NoError(t, err, "drop notes table")
 }
 
 func TestEngine_Plan_NoChanges(t *testing.T) {

--- a/pkg/engine/spirit/spirit_integration_test.go
+++ b/pkg/engine/spirit/spirit_integration_test.go
@@ -291,9 +291,10 @@ func TestEngine_Plan_DropTable(t *testing.T) {
 func TestEngine_Plan_ExecutionVerdictBlocked(t *testing.T) {
 	dsn, db := setupTestMySQL(t)
 	cleanupTables(t, db)
+	cleanupCtx := context.WithoutCancel(t.Context())
 	t.Cleanup(func() {
 		for _, table := range []string{"orders", "accounts", "notes"} {
-			_, err := db.ExecContext(t.Context(), "DROP TABLE IF EXISTS `"+table+"`")
+			_, err := db.ExecContext(cleanupCtx, "DROP TABLE IF EXISTS `"+table+"`")
 			assert.NoError(t, err, "drop table %s", table)
 		}
 	})

--- a/pkg/engine/spirit/spirit_integration_test.go
+++ b/pkg/engine/spirit/spirit_integration_test.go
@@ -281,6 +281,97 @@ func TestEngine_Plan_DropTable(t *testing.T) {
 	require.NoError(t, err, "drop table")
 }
 
+// A desired schema that swaps a table's primary key diffs to a DROP PRIMARY
+// KEY, and one that introduces a referential constraint diffs to an ADD
+// FOREIGN KEY — both statements Spirit deterministically refuses at apply
+// time. The plan carries the execution-mode verdict on those changes — mode
+// "blocked" with the engine's reason — so the operator learns at plan time
+// that the apply will fail, while an ordinary change in the same plan stays
+// on the engine's default path.
+func TestEngine_Plan_ExecutionVerdictBlocked(t *testing.T) {
+	dsn, db := setupTestMySQL(t)
+	cleanupTables(t, db)
+
+	_, err := db.ExecContext(t.Context(), `CREATE TABLE accounts (
+		id INT NOT NULL AUTO_INCREMENT,
+		tenant_id INT NOT NULL,
+		PRIMARY KEY (id)
+	)`)
+	require.NoError(t, err, "create accounts table")
+	_, err = db.ExecContext(t.Context(), `CREATE TABLE notes (
+		id INT NOT NULL AUTO_INCREMENT,
+		PRIMARY KEY (id)
+	)`)
+	require.NoError(t, err, "create notes table")
+	_, err = db.ExecContext(t.Context(), `CREATE TABLE orders (
+		id INT NOT NULL AUTO_INCREMENT,
+		note_id INT NOT NULL,
+		PRIMARY KEY (id)
+	)`)
+	require.NoError(t, err, "create orders table")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	eng := New(Config{Logger: logger})
+
+	result, err := eng.Plan(t.Context(), &engine.PlanRequest{
+		Database: "testdb",
+		SchemaFiles: testSchemaFiles(map[string]string{
+			"accounts.sql": `CREATE TABLE accounts (
+				id INT NOT NULL AUTO_INCREMENT,
+				tenant_id INT NOT NULL,
+				PRIMARY KEY (id, tenant_id)
+			)`,
+			"notes.sql": `CREATE TABLE notes (
+				id INT NOT NULL AUTO_INCREMENT,
+				body TEXT,
+				PRIMARY KEY (id)
+			)`,
+			"orders.sql": `CREATE TABLE orders (
+				id INT NOT NULL AUTO_INCREMENT,
+				note_id INT NOT NULL,
+				PRIMARY KEY (id),
+				CONSTRAINT fk_orders_note FOREIGN KEY (note_id) REFERENCES notes (id)
+			)`,
+		}),
+		Credentials: &engine.Credentials{
+			DSN: dsn,
+		},
+	})
+	require.NoError(t, err, "Plan()")
+	require.False(t, result.NoChanges, "expected changes, got NoChanges")
+
+	verdicts := make(map[string]engine.TableChange)
+	for _, tc := range result.FlatTableChanges() {
+		t.Logf("table %s: ddl=%s mode=%q reason=%q", tc.Table, tc.DDL, tc.ExecutionMode, tc.ModeReason)
+		verdicts[tc.Table] = tc
+	}
+
+	accounts, ok := verdicts["accounts"]
+	require.True(t, ok, "plan carries the accounts change")
+	assert.Contains(t, accounts.DDL, "DROP PRIMARY KEY")
+	assert.Equal(t, "blocked", accounts.ExecutionMode, "the refused statement carries the blocked verdict")
+	assert.Equal(t, "dropping primary key is not supported", accounts.ModeReason)
+
+	notes, ok := verdicts["notes"]
+	require.True(t, ok, "plan carries the notes change")
+	assert.Empty(t, notes.ExecutionMode, "an ordinary ADD COLUMN stays on the engine's default path")
+	assert.Empty(t, notes.ModeReason)
+
+	orders, ok := verdicts["orders"]
+	require.True(t, ok, "plan carries the orders change")
+	assert.Contains(t, orders.DDL, "FOREIGN KEY")
+	assert.Contains(t, orders.DDL, "fk_orders_note")
+	assert.Equal(t, "blocked", orders.ExecutionMode, "adding a foreign key carries the blocked verdict")
+	assert.Equal(t, "adding foreign key constraints is not supported", orders.ModeReason)
+
+	_, err = db.ExecContext(t.Context(), "DROP TABLE IF EXISTS `orders`")
+	require.NoError(t, err, "drop orders table")
+	_, err = db.ExecContext(t.Context(), "DROP TABLE IF EXISTS `accounts`")
+	require.NoError(t, err, "drop accounts table")
+	_, err = db.ExecContext(t.Context(), "DROP TABLE IF EXISTS `notes`")
+	require.NoError(t, err, "drop notes table")
+}
+
 func TestEngine_Plan_NoChanges(t *testing.T) {
 	dsn, db := setupTestMySQL(t)
 	cleanupTables(t, db) // Start with clean database

--- a/pkg/engine/spirit/spirit_integration_test.go
+++ b/pkg/engine/spirit/spirit_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 
+	"github.com/block/schemabot/pkg/ddl"
 	"github.com/block/schemabot/pkg/engine"
 	"github.com/block/schemabot/pkg/pendingdrops"
 	"github.com/block/schemabot/pkg/schema"
@@ -370,6 +371,89 @@ func TestEngine_Plan_ExecutionVerdictBlocked(t *testing.T) {
 	assert.Contains(t, orders.DDL, "fk_orders_note")
 	assert.Equal(t, "blocked", orders.ExecutionMode, "adding a foreign key carries the blocked verdict")
 	assert.Equal(t, "adding foreign key constraints is not supported", orders.ModeReason)
+}
+
+// The execution-mode verdict mirrors refusal checks that live inside the
+// engine, so this test proves the mirror against the engine itself: every
+// statement shape the verdict classifies as blocked is handed to a real
+// Spirit schema change, which must refuse it with the very reason the verdict
+// recorded. An engine upgrade that relaxes one of these checks — or rewords
+// its refusal — fails this test, signaling that ddl.EngineRefusalReason must
+// change in the same bump so the verdict never claims an apply will fail when
+// it can succeed.
+func TestEngine_SpiritRefusesVerdictBlockedStatements(t *testing.T) {
+	dsn, db := setupTestMySQL(t)
+	cleanupTables(t, db)
+	cleanupCtx := context.WithoutCancel(t.Context())
+	t.Cleanup(func() {
+		for _, table := range []string{"verdict_orders", "verdict_refs"} {
+			_, err := db.ExecContext(cleanupCtx, "DROP TABLE IF EXISTS `"+table+"`")
+			assert.NoError(t, err, "drop table %s", table)
+		}
+	})
+
+	_, err := db.ExecContext(t.Context(), `CREATE TABLE verdict_refs (
+		id INT NOT NULL AUTO_INCREMENT,
+		PRIMARY KEY (id)
+	)`)
+	require.NoError(t, err, "create verdict_refs table")
+	_, err = db.ExecContext(t.Context(), `CREATE TABLE verdict_orders (
+		id INT NOT NULL AUTO_INCREMENT,
+		tenant_id INT NOT NULL,
+		ref_id INT NOT NULL,
+		PRIMARY KEY (id)
+	)`)
+	require.NoError(t, err, "create verdict_orders table")
+
+	host, username, password, database, err := parseDSN(dsn)
+	require.NoError(t, err, "parseDSN")
+
+	tests := []struct {
+		name string
+		stmt string
+	}{
+		{
+			name: "drop primary key",
+			stmt: "ALTER TABLE `verdict_orders` DROP PRIMARY KEY, ADD PRIMARY KEY (`id`, `tenant_id`)",
+		},
+		{
+			name: "add foreign key",
+			stmt: "ALTER TABLE `verdict_orders` ADD CONSTRAINT `fk_verdict_ref` FOREIGN KEY (`ref_id`) REFERENCES `verdict_refs` (`id`)",
+		},
+		{
+			name: "explicit algorithm clause",
+			stmt: "ALTER TABLE `verdict_orders` ADD COLUMN `note` VARCHAR(64), ALGORITHM=INPLACE",
+		},
+		{
+			name: "explicit lock clause",
+			stmt: "ALTER TABLE `verdict_orders` ADD COLUMN `note` VARCHAR(64), LOCK=NONE",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, refused, err := ddl.EngineRefusalReason(tt.stmt)
+			require.NoError(t, err, "EngineRefusalReason")
+			require.True(t, refused, "the verdict must classify this statement as blocked")
+			require.NotEmpty(t, reason)
+
+			runner, err := spiritmigration.NewRunner(&spiritmigration.Migration{
+				Host:      host,
+				Username:  username,
+				Password:  &password,
+				Database:  database,
+				Statement: tt.stmt,
+			})
+			require.NoError(t, err, "NewRunner")
+			defer utils.CloseAndLog(runner)
+
+			runCtx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+			defer cancel()
+			runErr := runner.Run(runCtx)
+			require.Error(t, runErr, "the engine must refuse a statement the verdict marked blocked")
+			assert.Contains(t, runErr.Error(), reason,
+				"the engine's refusal must carry the reason the verdict recorded")
+		})
+	}
 }
 
 func TestEngine_Plan_NoChanges(t *testing.T) {

--- a/pkg/proto/tern.proto
+++ b/pkg/proto/tern.proto
@@ -436,6 +436,11 @@ message TableChange {
   // Unsafe change tracking
   bool is_unsafe = 5;
   string unsafe_reason = 6;
+  // Execution-mode verdict: how the engine will run this statement at apply
+  // time. Empty means the engine's default path; "blocked" means the engine
+  // deterministically refuses the statement and the apply will fail.
+  string execution_mode = 7;
+  string mode_reason = 8;
 }
 
 // SchemaChange is a namespace-level bundle. A PlanResponse must include at most

--- a/pkg/proto/ternv1/tern.pb.go
+++ b/pkg/proto/ternv1/tern.pb.go
@@ -1126,8 +1126,13 @@ type TableChange struct {
 	ChangeType ChangeType             `protobuf:"varint,3,opt,name=change_type,json=changeType,proto3,enum=tern.v1.ChangeType" json:"change_type,omitempty"`
 	Namespace  string                 `protobuf:"bytes,4,opt,name=namespace,proto3" json:"namespace,omitempty"`
 	// Unsafe change tracking
-	IsUnsafe      bool   `protobuf:"varint,5,opt,name=is_unsafe,json=isUnsafe,proto3" json:"is_unsafe,omitempty"`
-	UnsafeReason  string `protobuf:"bytes,6,opt,name=unsafe_reason,json=unsafeReason,proto3" json:"unsafe_reason,omitempty"`
+	IsUnsafe     bool   `protobuf:"varint,5,opt,name=is_unsafe,json=isUnsafe,proto3" json:"is_unsafe,omitempty"`
+	UnsafeReason string `protobuf:"bytes,6,opt,name=unsafe_reason,json=unsafeReason,proto3" json:"unsafe_reason,omitempty"`
+	// Execution-mode verdict: how the engine will run this statement at apply
+	// time. Empty means the engine's default path; "blocked" means the engine
+	// deterministically refuses the statement and the apply will fail.
+	ExecutionMode string `protobuf:"bytes,7,opt,name=execution_mode,json=executionMode,proto3" json:"execution_mode,omitempty"`
+	ModeReason    string `protobuf:"bytes,8,opt,name=mode_reason,json=modeReason,proto3" json:"mode_reason,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1200,6 +1205,20 @@ func (x *TableChange) GetIsUnsafe() bool {
 func (x *TableChange) GetUnsafeReason() string {
 	if x != nil {
 		return x.UnsafeReason
+	}
+	return ""
+}
+
+func (x *TableChange) GetExecutionMode() string {
+	if x != nil {
+		return x.ExecutionMode
+	}
+	return ""
+}
+
+func (x *TableChange) GetModeReason() string {
+	if x != nil {
+		return x.ModeReason
 	}
 	return ""
 }
@@ -3531,7 +3550,7 @@ const file_tern_proto_rawDesc = "" +
 	"schemaPath\x1aT\n" +
 	"\x10SchemaFilesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12*\n" +
-	"\x05value\x18\x02 \x01(\v2\x14.tern.v1.SchemaFilesR\x05value:\x028\x01J\x04\b\a\x10\b\"\xd4\x01\n" +
+	"\x05value\x18\x02 \x01(\v2\x14.tern.v1.SchemaFilesR\x05value:\x028\x01J\x04\b\a\x10\b\"\x9c\x02\n" +
 	"\vTableChange\x12\x1d\n" +
 	"\n" +
 	"table_name\x18\x01 \x01(\tR\ttableName\x12\x10\n" +
@@ -3540,7 +3559,10 @@ const file_tern_proto_rawDesc = "" +
 	"changeType\x12\x1c\n" +
 	"\tnamespace\x18\x04 \x01(\tR\tnamespace\x12\x1b\n" +
 	"\tis_unsafe\x18\x05 \x01(\bR\bisUnsafe\x12#\n" +
-	"\runsafe_reason\x18\x06 \x01(\tR\funsafeReason\"\xb0\x03\n" +
+	"\runsafe_reason\x18\x06 \x01(\tR\funsafeReason\x12%\n" +
+	"\x0eexecution_mode\x18\a \x01(\tR\rexecutionMode\x12\x1f\n" +
+	"\vmode_reason\x18\b \x01(\tR\n" +
+	"modeReason\"\xb0\x03\n" +
 	"\fSchemaChange\x12\x1c\n" +
 	"\tnamespace\x18\x01 \x01(\tR\tnamespace\x129\n" +
 	"\rtable_changes\x18\x02 \x03(\v2\x14.tern.v1.TableChangeR\ftableChanges\x12?\n" +

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -327,6 +327,14 @@ type TableChange struct {
 
 	// UnsafeReason records the planner's reason for unsafe changes.
 	UnsafeReason string `json:"unsafe_reason,omitempty"`
+
+	// ExecutionMode records the planner's execution-mode verdict. Empty means
+	// the engine's default path; "blocked" means the engine deterministically
+	// refuses the statement and the apply will fail.
+	ExecutionMode string `json:"execution_mode,omitempty"`
+
+	// ModeReason records the engine's reason when ExecutionMode is "blocked".
+	ModeReason string `json:"mode_reason,omitempty"`
 }
 
 // RequiresUnsafeOptIn reports whether applying this change requires explicit

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -1267,11 +1267,13 @@ func (c *LocalClient) Plan(ctx context.Context, req *ternv1.PlanRequest) (*ternv
 	ddlChanges := make([]storage.TableChange, len(result.FlatTableChanges()))
 	for i, t := range result.FlatTableChanges() {
 		ddlChanges[i] = storage.TableChange{
-			Table:        t.Table,
-			DDL:          t.DDL,
-			Operation:    ddl.StatementTypeToOp(t.Operation),
-			IsUnsafe:     t.IsUnsafe,
-			UnsafeReason: t.UnsafeReason,
+			Table:         t.Table,
+			DDL:           t.DDL,
+			Operation:     ddl.StatementTypeToOp(t.Operation),
+			IsUnsafe:      t.IsUnsafe,
+			UnsafeReason:  t.UnsafeReason,
+			ExecutionMode: t.ExecutionMode,
+			ModeReason:    t.ModeReason,
 		}
 	}
 
@@ -1297,11 +1299,13 @@ func (c *LocalClient) Plan(ctx context.Context, req *ternv1.PlanRequest) (*ternv
 			}
 			seenTable[ns][tc.Table] = true
 			nsData.Tables = append(nsData.Tables, storage.TableChange{
-				Table:        tc.Table,
-				DDL:          tc.DDL,
-				Operation:    ddl.StatementTypeToOp(tc.Operation),
-				IsUnsafe:     tc.IsUnsafe,
-				UnsafeReason: tc.UnsafeReason,
+				Table:         tc.Table,
+				DDL:           tc.DDL,
+				Operation:     ddl.StatementTypeToOp(tc.Operation),
+				IsUnsafe:      tc.IsUnsafe,
+				UnsafeReason:  tc.UnsafeReason,
+				ExecutionMode: tc.ExecutionMode,
+				ModeReason:    tc.ModeReason,
 			})
 		}
 		// Record each changing shard's own changes so apply-create can rebuild
@@ -1313,12 +1317,14 @@ func (c *LocalClient) Plan(ctx context.Context, req *ternv1.PlanRequest) (*ternv
 			sp := storage.ShardPlan{Shard: shardName, Namespace: ns}
 			for _, tc := range sc.TableChanges {
 				sp.Changes = append(sp.Changes, storage.TableChange{
-					Namespace:    ns,
-					Table:        tc.Table,
-					DDL:          tc.DDL,
-					Operation:    ddl.StatementTypeToOp(tc.Operation),
-					IsUnsafe:     tc.IsUnsafe,
-					UnsafeReason: tc.UnsafeReason,
+					Namespace:     ns,
+					Table:         tc.Table,
+					DDL:           tc.DDL,
+					Operation:     ddl.StatementTypeToOp(tc.Operation),
+					IsUnsafe:      tc.IsUnsafe,
+					UnsafeReason:  tc.UnsafeReason,
+					ExecutionMode: tc.ExecutionMode,
+					ModeReason:    tc.ModeReason,
 				})
 			}
 			nsData.Shards = append(nsData.Shards, sp)
@@ -1503,12 +1509,14 @@ func (c *LocalClient) planResultToProtoChanges(result *engine.PlanResult) (chang
 			}
 			protoTableSeen[ns][t.Table] = true
 			protoSC.TableChanges = append(protoSC.TableChanges, &ternv1.TableChange{
-				TableName:    t.Table,
-				ChangeType:   changeTypeToProto(t.Operation),
-				Ddl:          t.DDL,
-				IsUnsafe:     t.IsUnsafe,
-				UnsafeReason: t.UnsafeReason,
-				Namespace:    ns,
+				TableName:     t.Table,
+				ChangeType:    changeTypeToProto(t.Operation),
+				Ddl:           t.DDL,
+				IsUnsafe:      t.IsUnsafe,
+				UnsafeReason:  t.UnsafeReason,
+				ExecutionMode: t.ExecutionMode,
+				ModeReason:    t.ModeReason,
+				Namespace:     ns,
 			})
 		}
 		// A SchemaChange with an empty shard targets the whole namespace
@@ -1517,12 +1525,14 @@ func (c *LocalClient) planResultToProtoChanges(result *engine.PlanResult) (chang
 			protoSP := &ternv1.ShardPlan{Shard: shardName, Namespace: ns}
 			for _, t := range sc.TableChanges {
 				protoSP.Changes = append(protoSP.Changes, &ternv1.TableChange{
-					Namespace:    ns,
-					TableName:    t.Table,
-					Ddl:          t.DDL,
-					ChangeType:   changeTypeToProto(t.Operation),
-					IsUnsafe:     t.IsUnsafe,
-					UnsafeReason: t.UnsafeReason,
+					Namespace:     ns,
+					TableName:     t.Table,
+					Ddl:           t.DDL,
+					ChangeType:    changeTypeToProto(t.Operation),
+					IsUnsafe:      t.IsUnsafe,
+					UnsafeReason:  t.UnsafeReason,
+					ExecutionMode: t.ExecutionMode,
+					ModeReason:    t.ModeReason,
 				})
 			}
 			shards = append(shards, protoSP)
@@ -1665,12 +1675,14 @@ func scopedDispatchDDLChanges(changes []*ternv1.TableChange) ([]storage.TableCha
 			return nil, fmt.Errorf("shard-scoped dispatch ddl_change %d (table %q) has unsupported change type %v", i, table, ch.ChangeType)
 		}
 		out = append(out, storage.TableChange{
-			Namespace:    namespace,
-			Table:        table,
-			DDL:          ddl,
-			Operation:    op,
-			IsUnsafe:     ch.IsUnsafe,
-			UnsafeReason: ch.UnsafeReason,
+			Namespace:     namespace,
+			Table:         table,
+			DDL:           ddl,
+			Operation:     op,
+			IsUnsafe:      ch.IsUnsafe,
+			UnsafeReason:  ch.UnsafeReason,
+			ExecutionMode: ch.ExecutionMode,
+			ModeReason:    ch.ModeReason,
 		})
 	}
 	return out, nil
@@ -1828,12 +1840,14 @@ func (c *LocalClient) namespacesFromApplyRequest(changes []*ternv1.TableChange, 
 		}
 		nsData := ensure(ch.Namespace)
 		nsData.Tables = append(nsData.Tables, storage.TableChange{
-			Namespace:    ch.Namespace,
-			Table:        ch.TableName,
-			DDL:          ch.Ddl,
-			Operation:    op,
-			IsUnsafe:     ch.IsUnsafe,
-			UnsafeReason: ch.UnsafeReason,
+			Namespace:     ch.Namespace,
+			Table:         ch.TableName,
+			DDL:           ch.Ddl,
+			Operation:     op,
+			IsUnsafe:      ch.IsUnsafe,
+			UnsafeReason:  ch.UnsafeReason,
+			ExecutionMode: ch.ExecutionMode,
+			ModeReason:    ch.ModeReason,
 		})
 	}
 


### PR DESCRIPTION
## Why this matters

The MySQL schema-change engine deterministically refuses a class of valid DDL — `DROP PRIMARY KEY`, `ADD FOREIGN KEY`, and explicit `ALGORITHM=`/`LOCK=` clauses. Nothing in the plan data model records this today, so downstream surfaces (PR comments, API responses) cannot tell an operator that an apply is guaranteed to fail.

## What it does

- **`pkg/ddl.EngineRefusalReason`** — evaluates the refusal as a pure function of the statement text. It mirrors the engine's own preflight order and claims a refusal only when one is certain; statements that can complete through the instant-DDL fast path are never reported blocked.
- **`execution_mode` / `mode_reason`** travel on `TableChange` through engine → proto → storage → API types, beside the existing `is_unsafe`/`unsafe_reason` pair. The MySQL engine populates them at plan time.
- Data-model only: no comment or UX changes. The plan-comment disclosure stacks on top as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)