### PR TITLE
docs: note that an idle SchemaBot is never query-idle

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -663,6 +663,8 @@ In a multi-pod deployment, every SchemaBot pod runs its own operator. Each opera
 
 The storage arrows represent operator coordination. The GitHub arrows represent optional observer notifications; CLI applies simply run without an observer.
 
+**An idle SchemaBot is never query-idle.** Polling is how drivers find work: every pod's drivers scan storage on each poll tick — claim queries with `FOR UPDATE SKIP LOCKED`, plus pending-stop and ordered-cutover precedence checks — whether or not any applies exist. The result is a steady baseline of query traffic against the storage database that scales with pods × drivers, even when no schema change is running. This is expected claim-loop traffic, not a leak or a stuck apply. To check whether a deployment is actually busy, look for non-terminal applies (`schemabot status`) rather than storage query volume. If the idle baseline ever matters, replica count and `drivers` are the knobs.
+
 A **claim** is an atomic storage operation: it selects one apply that needs work,
 refreshes its `updated_at` heartbeat, and rotates an apply lease token in the
 same transaction. The heartbeat timestamp decides when another driver may try to


### PR DESCRIPTION
## Summary
Documents an operational behavior that surprises operators watching database dashboards: a SchemaBot deployment with zero schema changes in flight still generates a steady baseline of queries against its storage database.

## What
Adds a paragraph to the Operator section of `docs/architecture.md` explaining that the baseline comes from the driver claim loop (poll-tick claim scans with `FOR UPDATE SKIP LOCKED`, plus pending-stop and ordered-cutover precedence checks), scales with pods × drivers, and is expected traffic rather than a leak or stuck apply — with `schemabot status` as the right way to check whether a deployment is actually busy.

## Why
Idle-but-busy storage graphs prompt "is something wrong?" investigations. Answering it once in the architecture doc, next to the existing claim-loop description, saves operators from re-deriving it from code.
