### PR TITLE
refactor(webhook): split apply command into error-returning core

### DIFF
--- a/pkg/webhook/apply_error_contract_test.go
+++ b/pkg/webhook/apply_error_contract_test.go
@@ -1,0 +1,66 @@
+package webhook
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/webhook/action"
+)
+
+// applyCommandCore returns a durability disposition (retry, err) that a future
+// durable issue_comment driver consumes. The synchronous goSafe wrapper discards
+// it, so these tests pin the contract directly on the core. See decision 0002.
+
+// A command bootstrap failure (here, the per-installation GitHub client cannot be
+// created) is a transient infrastructure failure the same delivery could clear on
+// a later attempt, so the core must report it as retryable with a non-nil error.
+func TestApplyCommandCoreBootstrapFailureIsRetryable(t *testing.T) {
+	h := &Handler{
+		ghClients: ghclient.NewSingleClientSet(defaultAppName, &fakeClientFactory{
+			forInstallationErr: errors.New("installation token unavailable"),
+		}),
+		logger: testLogger(),
+	}
+
+	retry, err := h.applyCommandCore("octocat/hello-world", 1, "staging", "", 12345, "hubot", CommandResult{Action: action.Apply})
+
+	require.Error(t, err)
+	assert.True(t, retry, "a command bootstrap failure is a transient infra failure a durable driver should re-drive")
+}
+
+// Terminal outcomes are the command's answer — a static skip or a config-shape
+// rejection the same input will always produce — so the core reports them as
+// (retry=false, err=nil): a durable driver must not re-drive them.
+func TestApplyCommandCoreTerminalDispositions(t *testing.T) {
+	// An unscoped fan-out apply for a database this deployment does not own is a
+	// deliberate silent no-op, not a failure.
+	t.Run("unowned unscoped fan-out is terminal and silent", func(t *testing.T) {
+		h, mux, comments := newFanOutSkipHandler(t, aggregateLeaderConfig())
+		serveSchemaConfigForDatabase(t, mux, "orders")
+
+		retry, err := h.applyCommandCore("octocat/hello-world", 1, "staging", "", 12345, "hubot", CommandResult{Action: action.Apply})
+
+		require.NoError(t, err)
+		assert.False(t, retry, "a non-owning fan-out skip is the command's terminal answer, not a retryable failure")
+		assert.Empty(t, comments, "the terminal skip must stay silent")
+	})
+
+	// A schema-request rejection (database not configured on this server) posts
+	// the command's answer as a PR comment; re-driving would only re-post it, so
+	// it is terminal despite the visible error comment.
+	t.Run("schema request rejection is terminal", func(t *testing.T) {
+		h, mux, comments := newFanOutSkipHandler(t, nonAggregateConfig())
+		serveSchemaConfigForDatabase(t, mux, "orders")
+
+		retry, err := h.applyCommandCore("octocat/hello-world", 1, "staging", "", 12345, "hubot", CommandResult{Action: action.Apply})
+
+		require.NoError(t, err)
+		assert.False(t, retry, "a config-shape rejection is the command's answer, not a transient failure")
+		body := requireComment(t, comments, "database-not-configured apply error")
+		assert.Contains(t, body, `database "orders" is not configured on this server`)
+	})
+}

--- a/pkg/webhook/apply_error_contract_test.go
+++ b/pkg/webhook/apply_error_contract_test.go
@@ -1,19 +1,22 @@
 package webhook
 
 import (
+	"encoding/json"
 	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/block/schemabot/pkg/api"
 	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/webhook/action"
 )
 
 // applyCommandCore returns a durability disposition (retry, err) that a future
 // durable issue_comment driver consumes. The synchronous goSafe wrapper discards
-// it, so these tests pin the contract directly on the core. See decision 0002.
+// it, so these tests pin the contract directly on the core.
 
 // A command bootstrap failure (here, the per-installation GitHub client cannot be
 // created) is a transient infrastructure failure the same delivery could clear on
@@ -63,4 +66,52 @@ func TestApplyCommandCoreTerminalDispositions(t *testing.T) {
 		body := requireComment(t, comments, "database-not-configured apply error")
 		assert.Contains(t, body, `database "orders" is not configured on this server`)
 	})
+
+	// Requesting an environment the database does not configure is a targeting
+	// rejection the same command will always reproduce, so it is terminal even
+	// though it surfaces through the generic schema-request error comment.
+	t.Run("environment rejection is terminal", func(t *testing.T) {
+		cfg := nonAggregateConfig()
+		cfg.Databases = map[string]api.DatabaseConfig{
+			"orders": {Environments: map[string]api.EnvironmentConfig{"production": {}}},
+		}
+		h, mux, comments := newFanOutSkipHandler(t, cfg)
+		serveSchemaConfigForDatabase(t, mux, "orders")
+
+		retry, err := h.applyCommandCore("octocat/hello-world", 1, "staging", "", 12345, "hubot", CommandResult{Action: action.Apply})
+
+		require.NoError(t, err)
+		assert.False(t, retry, "an unconfigured-environment rejection is the command's answer, not a transient failure")
+		body := requireComment(t, comments, "environment-not-configured apply error")
+		assert.Contains(t, body, `database "orders" environment "staging" is not configured on this server`)
+	})
+}
+
+// A GitHub read failure during config discovery (here, fetching the changed
+// schemabot.yaml returns a server error) is a transient infrastructure failure:
+// the same delivery could succeed once GitHub recovers, so the core must report
+// it as retryable rather than treating the posted error comment as terminal.
+func TestApplyCommandCoreTransientConfigReadFailureIsRetryable(t *testing.T) {
+	h, mux, _ := newFanOutSkipHandler(t, nonAggregateConfig())
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"head": map[string]any{"sha": "abc123", "ref": "feature-branch"},
+			"base": map[string]any{"sha": "def456", "ref": "main"},
+			"user": map[string]any{"login": "testuser"},
+		}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode([]map[string]string{{
+			"filename": "schemabot.yaml",
+			"status":   "modified",
+		}}))
+	})
+	mux.HandleFunc("GET /repos/octocat/hello-world/contents/schemabot.yaml", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	retry, err := h.applyCommandCore("octocat/hello-world", 1, "staging", "", 12345, "hubot", CommandResult{Action: action.Apply})
+
+	require.Error(t, err)
+	assert.True(t, retry, "a transient GitHub config read failure must stay retryable for a durable driver")
 }

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -16,22 +16,42 @@ import (
 )
 
 // handleApplyCommand handles the "schemabot apply -e <env>" PR comment command.
-// It generates a plan, acquires a lock, and applies automatically unless safety
-// rechecks require a manual confirmation.
+// It is the synchronous goSafe entry point: it runs applyCommandCore and
+// discards the durability disposition, so behaviour is identical to before the
+// error-contract rework. The disposition (retry-vs-terminal) is consumed only by
+// the durable issue_comment driver (WH-9b); see decision 0002.
 func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseName string, installationID int64, requestedBy string, result CommandResult) {
+	_, _ = h.applyCommandCore(repo, pr, environment, databaseName, installationID, requestedBy, result)
+}
+
+// applyCommandCore generates a plan, acquires a lock, and applies automatically
+// unless safety rechecks require a manual confirmation. It returns a durability
+// disposition for a future durable issue_comment driver:
+//
+//   - retry=true, err!=nil — a transient infrastructure failure (command
+//     bootstrap, a GitHub read, or a storage operation) that a durable driver
+//     should re-drive; the same window may succeed on a later attempt.
+//   - retry=false, err=nil — a terminal outcome that is the command's answer,
+//     including every user-facing block or error it already posted (lock
+//     conflict, apply-in-progress, gate blocks, stale-schema rejection, no
+//     changes, unsafe changes, downgrade-to-manual, or a dispatched apply).
+//
+// The core logs each failure at its site, so the synchronous wrapper can discard
+// the result without losing observability.
+func (h *Handler) applyCommandCore(repo string, pr int, environment, databaseName string, installationID int64, requestedBy string, result CommandResult) (bool, error) {
 	ctx, cancel, client, err := h.commandBootstrap(repo, installationID)
 	if err != nil {
 		h.logger.Error("apply: failed to bootstrap command", "repo", repo, "pr", pr, "database", databaseName, "environment", environment, "error", err)
-		return
+		return true, fmt.Errorf("apply command bootstrap %s#%d: %w", repo, pr, err)
 	}
 	defer cancel()
 
 	if handled, err := h.handleNoManagedSchemaChangesForCommand(ctx, client, repo, pr, installationID, action.Apply, environment, databaseName, requestedBy); err != nil {
 		h.logger.Error("failed to check whether apply command needs schema change reconciliation", "repo", repo, "pr", pr, "environment", environment, "database", databaseName, "error", err)
 		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, err.Error())
-		return
+		return true, fmt.Errorf("apply command managed-schema check %s#%d: %w", repo, pr, err)
 	} else if handled {
-		return
+		return false, nil
 	}
 
 	ackedEarly := h.acknowledgeCommandEarlyIfOwned(ctx, client, repo, pr, databaseName, result.Tenant, installationID, result.CommentID)
@@ -42,25 +62,25 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		if h.skipUnownedUnscopedCommand(repo, result.Tenant, err) {
 			h.logger.Debug("unscoped fan-out apply touches no schema this deployment owns; staying silent",
 				"repo", repo, "pr", pr, "environment", environment, "error", err)
-			return
+			return false, nil
 		}
 		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.Apply, err)
-		return
+		return false, nil
 	}
 	if err := h.attachServerEnvironments(schemaResult, environment); err != nil {
 		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.Apply, err)
-		return
+		return false, nil
 	}
 	if !ackedEarly {
 		h.acknowledgeCommandActPoint(repo, pr, installationID, result)
 	}
 
 	if blocked := h.enforceOpenPR(ctx, client, repo, pr, installationID, action.Apply, environment, requestedBy); blocked {
-		return
+		return false, nil
 	}
 
 	if blocked := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, schemaResult.Database, schemaResult.Type, environment, action.Apply); blocked {
-		return
+		return false, nil
 	}
 
 	// Fix checks stuck at "in_progress" from crashed applies after the actor
@@ -68,13 +88,13 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	if err := h.reconcileStaleChecks(ctx, client, repo, pr); err != nil {
 		h.logger.Error("failed to reconcile stale status checks", "repo", repo, "pr", pr, "error", err)
 		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Failed to reconcile stale status checks: "+err.Error())
-		return
+		return true, fmt.Errorf("apply command reconcile stale checks %s#%d: %w", repo, pr, err)
 	}
 
 	// Tier 1: review gate (server-owned review policy for this database)
 	if blocked := h.enforceReviewGate(ctx, client, repo, pr, installationID, schemaResult, environment, requestedBy, action.Apply); blocked {
 		h.logger.Info("apply blocked by review gate", "repo", repo, "pr", pr, "environment", environment, "requested_by", requestedBy)
-		return
+		return false, nil
 	}
 
 	// Tier 2: PR checks gate — block if non-SchemaBot checks are not passing
@@ -82,10 +102,10 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	if err != nil {
 		h.logger.Error("failed to fetch PR for checks gate", "repo", repo, "pr", pr, "database", schemaResult.Database, "database_type", schemaResult.Type, "environment", environment, "error", err)
 		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Failed to fetch PR info: "+err.Error())
-		return
+		return true, fmt.Errorf("apply command fetch PR for checks gate %s#%d: %w", repo, pr, err)
 	}
 	if blocked := h.enforcePassingChecks(ctx, client, repo, pr, installationID, prInfo.HeadSHA, environment); blocked {
-		return
+		return false, nil
 	}
 
 	database := schemaResult.Database
@@ -95,7 +115,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	// Environment ordering enforcement: prior server-configured environments must be clean before applying.
 	if blocked := h.checkPriorEnvironments(ctx, repo, pr, database, dbType, environment, schemaResult.Environments, installationID); blocked {
 		h.logger.Info("apply blocked by environment ordering", "repo", repo, "pr", pr, "database", database, "environment", environment)
-		return
+		return false, nil
 	}
 
 	// Check for existing lock
@@ -103,7 +123,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	if err != nil {
 		h.logger.Error("failed to check lock", "repo", repo, "pr", pr, "database", database, "database_type", dbType, "environment", environment, "error", err)
 		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Failed to check lock status: "+err.Error())
-		return
+		return true, fmt.Errorf("apply command check lock %s#%d: %w", repo, pr, err)
 	}
 
 	if existingLock != nil {
@@ -119,14 +139,14 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 				LockPR:      existingLock.PullRequest,
 				LockCreated: existingLock.CreatedAt,
 			}))
-			return
+			return false, nil
 		}
 
 		// Lock held by this PR — check for active applies
 		applies, err := h.service.Storage().Applies().GetByPR(ctx, repo, pr)
 		if err != nil {
 			h.logger.Error("failed to check active applies", "error", err)
-			return
+			return true, fmt.Errorf("apply command check active applies %s#%d: %w", repo, pr, err)
 		}
 		for _, a := range applies {
 			if a.Database == database && !state.IsTerminalApplyState(a.State) {
@@ -138,7 +158,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 					ApplyID:     a.ApplyIdentifier,
 					ApplyState:  a.State,
 				}))
-				return
+				return false, nil
 			}
 		}
 
@@ -169,13 +189,13 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 			"repo", repo, "pr", pr, "database", database, "database_type", dbType, "environment", environment, "error", prErr)
 		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy,
 			"SchemaBot could not verify the current PR state. The apply was rejected; retry the command.")
-		return
+		return true, fmt.Errorf("apply command fetch PR for stale-schema check %s#%d: %w", repo, pr, prErr)
 	}
 	if rejected := h.assertSchemaStillCurrent(ctx, repo, pr, installationID, schemaResult, prInfo.HeadSHA, environment, requestedBy, action.Apply); rejected {
-		return
+		return false, nil
 	}
 	if rejected := h.assertBaseSchemaStillCurrent(ctx, client, repo, pr, installationID, schemaResult, prInfo, environment, requestedBy, action.Apply); rejected {
-		return
+		return false, nil
 	}
 
 	// Generate plan
@@ -196,7 +216,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	if err != nil {
 		h.logger.Error("plan execution failed", "repo", repo, "pr", pr, "error", err)
 		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, err.Error())
-		return
+		return true, fmt.Errorf("apply command plan %s#%d: %w", repo, pr, err)
 	}
 
 	// No changes (neither table DDL nor a VSchema update) — post a regular plan
@@ -204,7 +224,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	if !planResp.HasChanges() {
 		commentData := buildPlanCommentData(schemaResult, planResp, environment, result.Tenant, requestedBy)
 		h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
-		return
+		return false, nil
 	}
 
 	// Block unsafe changes unless --allow-unsafe was specified
@@ -212,7 +232,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		commentData := buildPlanCommentData(schemaResult, planResp, environment, result.Tenant, requestedBy)
 		h.logger.Info("apply blocked by unsafe changes", "repo", repo, "pr", pr, "database", database, "environment", environment)
 		h.postComment(repo, pr, installationID, templates.RenderUnsafeChangesBlocked(commentData))
-		return
+		return false, nil
 	}
 
 	// Acquire lock. PendingPlanID pins the confirmation plan this lock was
@@ -229,7 +249,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	if err := h.service.Storage().Locks().Acquire(ctx, lock); err != nil {
 		h.logger.Error("failed to acquire lock", "error", err)
 		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Failed to acquire lock: "+err.Error())
-		return
+		return true, fmt.Errorf("apply command acquire lock %s#%d: %w", repo, pr, err)
 	}
 
 	// Build plan comment data with lock info
@@ -242,7 +262,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	commentData.AllowUnsafe = result.AllowUnsafe
 
 	// Re-evaluate the checks gate against the freshness-checked HEAD before
-	// executing. The early gate at the top of handleApplyCommand ran against
+	// executing. The early gate at the top of applyCommandCore ran against
 	// the discovery-time HeadSHA. On the automatic apply path there is no
 	// second user action between plan and apply, so a required check that
 	// transitioned to failing on the same SHA (e.g. CI re-ran red, or a
@@ -253,7 +273,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 	// since changed hands or been re-pinned is preserved.
 	if blocked := h.enforcePassingChecks(ctx, client, repo, pr, installationID, prInfo.HeadSHA, environment); blocked {
 		h.releaseApplyLockIfIntentUnchanged(ctx, repo, pr, database, dbType, environment, planResp.PlanID, "fresh-HEAD checks gate block")
-		return
+		return false, nil
 	}
 
 	// Look up the plan we just created for DDL comparison in executeApply.
@@ -272,7 +292,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 		if headSHA != "" {
 			h.updateAggregateCheck(ctx, client, repo, pr, headSHA)
 		}
-		return
+		return false, nil
 	}
 
 	h.postComment(repo, pr, installationID, templates.RenderPlanComment(commentData))
@@ -286,6 +306,7 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 
 	// Check 2 (DDL drift) happens inside executeApply after re-plan
 	h.executeApply(ctx, client, repo, pr, schemaResult, environment, installationID, requestedBy, result, storedPlan, planResp.PlanID)
+	return false, nil
 }
 
 // handleApplyConfirmCommand handles the "schemabot apply-confirm -e <env>" PR comment command.

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -38,6 +38,12 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 //     user-facing rejection; an unexpected failure there (for example a
 //     transient GitHub config read) stays retryable.
 //
+// Gate blocks are terminal even when the gate blocked because it could not
+// evaluate its own inputs (for example a GitHub read inside the gate failed):
+// gates fail closed and post their own retry guidance, so the block is the
+// command's answer and recovery is the user re-issuing the command, not a
+// driver re-driving the delivery.
+//
 // A posted PR comment does not imply a terminal disposition: retryable sites
 // post best-effort error comments too, so a durable driver re-driving one may
 // post the same comment again.
@@ -229,9 +235,11 @@ func (h *Handler) applyCommandCore(repo string, pr int, environment, databaseNam
 		if isTransientRemotePlanError(err) {
 			return true, fmt.Errorf("apply command plan %s#%d: %w", repo, pr, err)
 		}
-		// Policy, validation, and planning failures are deterministic: the
-		// posted error is the command's answer, and a re-drive would only
-		// reproduce it.
+		// Failures other than remote-deployment unavailability are treated
+		// as deterministic: the posted error is the command's answer. Some
+		// of them are not truly deterministic (planning runs against a live
+		// target database, which can be briefly unreachable), so recovery
+		// for those is the user re-issuing the command.
 		return false, nil
 	}
 

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -17,9 +17,8 @@ import (
 
 // handleApplyCommand handles the "schemabot apply -e <env>" PR comment command.
 // It is the synchronous goSafe entry point: it runs applyCommandCore and
-// discards the durability disposition, so behaviour is identical to before the
-// error-contract rework. The disposition (retry-vs-terminal) is consumed only by
-// the durable issue_comment driver (WH-9b); see decision 0002.
+// discards the durability disposition, which only a durable issue_comment
+// driver consumes.
 func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseName string, installationID int64, requestedBy string, result CommandResult) {
 	_, _ = h.applyCommandCore(repo, pr, environment, databaseName, installationID, requestedBy, result)
 }
@@ -31,10 +30,17 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 //   - retry=true, err!=nil — a transient infrastructure failure (command
 //     bootstrap, a GitHub read, or a storage operation) that a durable driver
 //     should re-drive; the same window may succeed on a later attempt.
-//   - retry=false, err=nil — a terminal outcome that is the command's answer,
-//     including every user-facing block or error it already posted (lock
-//     conflict, apply-in-progress, gate blocks, stale-schema rejection, no
-//     changes, unsafe changes, downgrade-to-manual, or a dispatched apply).
+//   - retry=false, err=nil — a terminal outcome that is the command's answer
+//     (lock conflict, apply-in-progress, gate blocks, stale-schema rejection,
+//     no changes, unsafe changes, deterministic plan rejections,
+//     downgrade-to-manual, or a dispatched apply). A schema-request failure is
+//     terminal only when handleSchemaRequestError recognizes it as a
+//     user-facing rejection; an unexpected failure there (for example a
+//     transient GitHub config read) stays retryable.
+//
+// A posted PR comment does not imply a terminal disposition: retryable sites
+// post best-effort error comments too, so a durable driver re-driving one may
+// post the same comment again.
 //
 // The core logs each failure at its site, so the synchronous wrapper can discard
 // the result without losing observability.
@@ -64,12 +70,16 @@ func (h *Handler) applyCommandCore(repo string, pr int, environment, databaseNam
 				"repo", repo, "pr", pr, "environment", environment, "error", err)
 			return false, nil
 		}
-		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.Apply, err)
-		return false, nil
+		if h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.Apply, err) {
+			return false, nil
+		}
+		return true, fmt.Errorf("apply command schema request %s#%d: %w", repo, pr, err)
 	}
 	if err := h.attachServerEnvironments(schemaResult, environment); err != nil {
-		h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.Apply, err)
-		return false, nil
+		if h.handleSchemaRequestError(repo, pr, installationID, environment, databaseName, requestedBy, action.Apply, err) {
+			return false, nil
+		}
+		return true, fmt.Errorf("apply command attach server environments %s#%d: %w", repo, pr, err)
 	}
 	if !ackedEarly {
 		h.acknowledgeCommandActPoint(repo, pr, installationID, result)
@@ -216,7 +226,13 @@ func (h *Handler) applyCommandCore(repo string, pr int, environment, databaseNam
 	if err != nil {
 		h.logger.Error("plan execution failed", "repo", repo, "pr", pr, "error", err)
 		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, err.Error())
-		return true, fmt.Errorf("apply command plan %s#%d: %w", repo, pr, err)
+		if isTransientRemotePlanError(err) {
+			return true, fmt.Errorf("apply command plan %s#%d: %w", repo, pr, err)
+		}
+		// Policy, validation, and planning failures are deterministic: the
+		// posted error is the command's answer, and a re-drive would only
+		// reproduce it.
+		return false, nil
 	}
 
 	// No changes (neither table DDL nor a VSchema update) — post a regular plan
@@ -247,6 +263,14 @@ func (h *Handler) applyCommandCore(repo string, pr int, environment, databaseNam
 		PendingPlanID: planResp.PlanID,
 	}
 	if err := h.service.Storage().Locks().Acquire(ctx, lock); err != nil {
+		if errors.Is(err, storage.ErrLockHeld) {
+			// Another owner won the lock between the pre-check above and this
+			// acquire: the same answer the pre-check gives, so it is terminal.
+			h.logger.Info("apply blocked by lock conflict at acquire",
+				"repo", repo, "pr", pr, "database", database, "database_type", dbType, "environment", environment)
+			h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Failed to acquire lock: "+err.Error())
+			return false, nil
+		}
 		h.logger.Error("failed to acquire lock", "error", err)
 		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Failed to acquire lock: "+err.Error())
 		return true, fmt.Errorf("apply command acquire lock %s#%d: %w", repo, pr, err)

--- a/pkg/webhook/check_aggregate.go
+++ b/pkg/webhook/check_aggregate.go
@@ -134,7 +134,7 @@ func (h *Handler) attachServerEnvironments(schemaResult *ghclient.SchemaRequestR
 		return fmt.Errorf("resolve configured environments for database %q: %w", schemaResult.Database, err)
 	}
 	if environment != "" && !slices.Contains(environments, environment) {
-		return fmt.Errorf("database %q environment %q is not configured on this server", schemaResult.Database, environment)
+		return &environmentNotConfiguredError{Database: schemaResult.Database, Environment: environment}
 	}
 	schemaResult.Environments = environments
 	return nil

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -497,8 +497,12 @@ func (h *Handler) postFailingAggregateForMultiEnvSetupError(ctx context.Context,
 		h.aggregateMessagesForAllEnvironments(userError))
 }
 
-// handleSchemaRequestError maps schema request errors to GitHub comments.
-func (h *Handler) handleSchemaRequestError(repo string, pr int, installationID int64, environment, databaseName, requestedBy, commandName string, err error) {
+// handleSchemaRequestError maps schema request errors to GitHub comments. It
+// reports whether the error is a recognized user-facing rejection — the
+// command's answer, which the same input will always reproduce — as opposed to
+// an unexpected failure (for example a transient GitHub read error) that a
+// durable driver may re-drive.
+func (h *Handler) handleSchemaRequestError(repo string, pr int, installationID int64, environment, databaseName, requestedBy, commandName string, err error) bool {
 	data := templates.SchemaErrorData{
 		RequestedBy:  requestedBy,
 		Timestamp:    time.Now().UTC().Format("2006-01-02 15:04:05"),
@@ -520,7 +524,7 @@ func (h *Handler) handleSchemaRequestError(repo string, pr int, installationID i
 		h.logger.Warn("schema request: database not found", logFields...)
 		metrics.RecordSchemaRequestError(ctx, repo, commandName, databaseName, environment, "database_not_found")
 		h.postComment(repo, pr, installationID, templates.RenderDatabaseNotFound(data))
-		return
+		return true
 	}
 
 	var configNotAuthorizedErr *schemaConfigOutsideAllowedDirsError
@@ -533,21 +537,21 @@ func (h *Handler) handleSchemaRequestError(repo string, pr int, installationID i
 			"schema_path", data.SchemaPath, "action", commandName, "error", err)
 		metrics.RecordSchemaRequestError(ctx, repo, commandName, data.DatabaseName, environment, "config_not_authorized")
 		h.postComment(repo, pr, installationID, templates.RenderConfigNotAuthorized(data))
-		return
+		return true
 	}
 
 	if errors.Is(err, ghclient.ErrInvalidConfig) {
 		h.logger.Warn("schema request: invalid config", logFields...)
 		metrics.RecordSchemaRequestError(ctx, repo, commandName, databaseName, environment, "invalid_config")
 		h.postComment(repo, pr, installationID, templates.RenderInvalidConfig(data))
-		return
+		return true
 	}
 
 	if errors.Is(err, ghclient.ErrNoConfig) {
 		h.logger.Warn("schema request: no config found", logFields...)
 		metrics.RecordSchemaRequestError(ctx, repo, commandName, databaseName, environment, "no_config")
 		h.postComment(repo, pr, installationID, templates.RenderNoConfig(data))
-		return
+		return true
 	}
 
 	if errors.Is(err, ghclient.ErrMultipleConfigs) {
@@ -555,13 +559,32 @@ func (h *Handler) handleSchemaRequestError(repo string, pr int, installationID i
 		metrics.RecordSchemaRequestError(ctx, repo, commandName, databaseName, environment, "multiple_configs")
 		data.AvailableDatabases = templates.FormatAvailableDatabases(err.Error())
 		h.postComment(repo, pr, installationID, templates.RenderMultipleConfigs(data))
-		return
+		return true
+	}
+
+	var dbNotConfiguredErr *api.DatabaseNotConfiguredError
+	if errors.As(err, &dbNotConfiguredErr) {
+		h.logger.Warn("schema request: database not configured on this server", logFields...)
+		metrics.RecordSchemaRequestError(ctx, repo, commandName, databaseName, environment, "database_not_configured")
+		data.ErrorDetail = err.Error()
+		h.postComment(repo, pr, installationID, templates.RenderGenericError(data))
+		return true
+	}
+
+	var envNotConfiguredErr *environmentNotConfiguredError
+	if errors.As(err, &envNotConfiguredErr) {
+		h.logger.Warn("schema request: environment not configured on this server", logFields...)
+		metrics.RecordSchemaRequestError(ctx, repo, commandName, databaseName, environment, "environment_not_configured")
+		data.ErrorDetail = err.Error()
+		h.postComment(repo, pr, installationID, templates.RenderGenericError(data))
+		return true
 	}
 
 	h.logger.Error("schema request failed", logFields...)
 	metrics.RecordSchemaRequestError(ctx, repo, commandName, databaseName, environment, "unexpected")
 	data.ErrorDetail = err.Error()
 	h.postComment(repo, pr, installationID, templates.RenderGenericError(data))
+	return false
 }
 
 // shardedUnsafeChanges collects unsafe per-shard changes, grouped by (table,

--- a/pkg/webhook/schema_source_policy.go
+++ b/pkg/webhook/schema_source_policy.go
@@ -68,6 +68,18 @@ func (h *Handler) silentOnUnscopedFanOut(repo, tenant string) bool {
 	return config.AggregateRoleForRepo(repo) != ""
 }
 
+// environmentNotConfiguredError reports that the requested environment has no
+// entry for the database on this server — a targeting rejection the same
+// command will always reproduce, not a transient failure.
+type environmentNotConfiguredError struct {
+	Database    string
+	Environment string
+}
+
+func (e *environmentNotConfiguredError) Error() string {
+	return fmt.Sprintf("database %q environment %q is not configured on this server", e.Database, e.Environment)
+}
+
 type schemaConfigOutsideAllowedDirsError struct {
 	Database     string
 	DatabaseType string
@@ -208,7 +220,7 @@ func (h *Handler) validateRequestedDatabaseEnvironment(database, environment str
 	if slices.Contains(environments, environment) {
 		return nil
 	}
-	return fmt.Errorf("database %q environment %q is not configured on this server", database, environment)
+	return &environmentNotConfiguredError{Database: database, Environment: environment}
 }
 
 func (h *Handler) configPathManagedByRepo(ctx context.Context, repo string, pr int, headSHA string, config *ghclient.SchemabotConfig, schemaPath, source string) bool {


### PR DESCRIPTION
## Summary

Splits `handleApplyCommand` into a thin `goSafe` wrapper over a new error-returning core, `applyCommandCore`, that classifies every outcome as retryable-transient or terminal. This is the first prerequisite for durable `issue_comment`/`apply`: a later durable driver needs a retry-vs-terminal signal to decide whether to re-drive a delivery. Behavior is unchanged in this PR — the wrapper discards the disposition.

## What

- `handleApplyCommand` becomes the synchronous entry point; it calls `applyCommandCore` and discards the returned `(retry, err)`.
- `applyCommandCore` returns `(retry bool, err error)`:
  - `retry=true, err≠nil` — transient infrastructure failure (command bootstrap, a GitHub read, a storage op, plan execution) the same delivery could clear on a later attempt.
  - `retry=false, err=nil` — a terminal outcome that is the command's answer (silent skips, gate blocks, config/stale rejections, no-op plans, or a dispatched apply).
- Adds focused contract tests for the new core's disposition on both axes.
- `apply-confirm` is intentionally left for a follow-up PR to keep this change small.

## Why

Durable command dispatch must distinguish "re-drive this" from "this is the final answer." Extracting the classification now, without wiring a consumer, keeps the behavior-preserving refactor isolated from the durable-routing change that follows — smaller blast radius, reviewable independently.

Note: some retryable paths already post an operator-facing error comment before returning. A future durable retry would re-post those; that duplication is a known concern for the durable-driver slice, not introduced here.

Observability note: the two new typed schema-request errors shift the schema-request failure metric reason from `unexpected` to `database_not_configured` / `environment_not_configured` and the corresponding log level from Error to Warn — for every command routed through `handleSchemaRequestError`, not just apply.

## Before / after
```
Before:
handleApplyCommand(...)  ──▶  returns on error/blocked/dispatch (void)

After:
handleApplyCommand(...)                 (goSafe wrapper, behavior unchanged)
└─ _, _ = applyCommandCore(...)   discards disposition
│
├─ transient infra failure   ─▶ (retry=true,  err≠nil)
└─ terminal command answer    ─▶ (retry=false, err=nil)
```