### PR TITLE
refactor(storage): route named locks through a namedlock.Locker seam

### DIFF
--- a/pkg/api/ensure_schema.go
+++ b/pkg/api/ensure_schema.go
@@ -521,7 +521,7 @@ const ensureSchemaLockName = "schemabot_ensure_schema"
 // advisory lock held on the returned connection for the operation's lifetime.
 var ensureSchemaLocker namedlock.Locker = namedlock.MySQL{}
 
-// acquireEnsureSchemaLock acquires a MySQL advisory lock to serialize
+// acquireEnsureSchemaLock acquires a session-scoped advisory lock to serialize
 // EnsureSchema across pods. Returns the connection holding the lock — the
 // lock is released when the connection is closed.
 func acquireEnsureSchemaLock(ctx context.Context, dsn string, logger *slog.Logger) (*sql.Conn, error) {

--- a/pkg/api/ensure_schema.go
+++ b/pkg/api/ensure_schema.go
@@ -18,6 +18,7 @@ import (
 	"github.com/block/schemabot/pkg/engine/spirit"
 	"github.com/block/schemabot/pkg/metrics"
 	"github.com/block/schemabot/pkg/mysqlconn"
+	"github.com/block/schemabot/pkg/namedlock"
 	"github.com/block/schemabot/pkg/schema"
 )
 
@@ -512,9 +513,13 @@ func diagnoseStorageTarget(ctx context.Context, dsn string) (*storageDiagnostic,
 	return &diag, nil
 }
 
-// ensureSchemaLockName is the MySQL advisory lock name used to serialize
+// ensureSchemaLockName is the advisory lock name used to serialize
 // EnsureSchema across concurrent pod startups.
 const ensureSchemaLockName = "schemabot_ensure_schema"
+
+// ensureSchemaLocker serializes EnsureSchema across pods with a session-scoped
+// advisory lock held on the returned connection for the operation's lifetime.
+var ensureSchemaLocker namedlock.Locker = namedlock.MySQL{}
 
 // acquireEnsureSchemaLock acquires a MySQL advisory lock to serialize
 // EnsureSchema across pods. Returns the connection holding the lock — the
@@ -532,18 +537,14 @@ func acquireEnsureSchemaLock(ctx context.Context, dsn string, logger *slog.Logge
 		return nil, fmt.Errorf("get connection: %w", err)
 	}
 
-	// GET_LOCK returns 1 on success, 0 on timeout, NULL on error.
 	// Wait up to the full timeout for the lock — a trailing pod must outwait the
 	// leader's schema change, after which it re-plans and finds no changes.
-	var result sql.NullInt64
-	err = conn.QueryRowContext(ctx,
-		"SELECT GET_LOCK(?, ?)", ensureSchemaLockName, int(EnsureSchemaTimeout.Seconds()),
-	).Scan(&result)
+	acquired, err := ensureSchemaLocker.Acquire(ctx, conn, ensureSchemaLockName, EnsureSchemaTimeout)
 	if err != nil {
 		utils.CloseAndLog(conn)
-		return nil, fmt.Errorf("GET_LOCK: %w", err)
+		return nil, fmt.Errorf("acquire advisory lock: %w", err)
 	}
-	if !result.Valid || result.Int64 != 1 {
+	if !acquired {
 		utils.CloseAndLog(conn)
 		return nil, fmt.Errorf("timed out waiting for advisory lock %q (another pod may be running EnsureSchema)", ensureSchemaLockName)
 	}

--- a/pkg/namedlock/namedlock.go
+++ b/pkg/namedlock/namedlock.go
@@ -5,6 +5,13 @@
 // which are bound to a single connection's session, so every caller holds the
 // lock on a pinned *sql.Conn for the lock's whole lifetime and passes that same
 // connection to Release (or closes it) to drop the lock.
+//
+// Engine selection is per-target, not per-process: a single server can serve
+// multiple engines and the pending-drops cleaner iterates heterogeneous targets
+// in one pass. A second implementation should therefore be supplied as an
+// injected dependency chosen per target (a struct field or parameter), not by
+// swapping the package-level Locker bindings the call sites currently default
+// to MySQL.
 package namedlock
 
 import (

--- a/pkg/namedlock/namedlock.go
+++ b/pkg/namedlock/namedlock.go
@@ -1,0 +1,65 @@
+// Package namedlock abstracts the session-scoped advisory ("named") locks that
+// serialize SchemaBot's coordination points — apply-target execution,
+// pending-drops cleanup, and schema bootstrap — so those flows can run on
+// engines other than MySQL. MySQL implements them with GET_LOCK / RELEASE_LOCK,
+// which are bound to a single connection's session, so every caller holds the
+// lock on a pinned *sql.Conn for the lock's whole lifetime and passes that same
+// connection to Release (or closes it) to drop the lock.
+package namedlock
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// Locker acquires and releases session-scoped advisory locks on a pinned
+// connection. Implementations are engine-specific: MySQL uses GET_LOCK /
+// RELEASE_LOCK, a future Postgres implementation would use pg_advisory_lock.
+type Locker interface {
+	// Acquire attempts to take the named lock on conn, waiting up to wait for
+	// it. acquired reports whether the lock was taken; it is false when the
+	// wait elapses without obtaining the lock. err is non-nil for any driver or
+	// SQL failure. The lock lives on conn's session and is dropped by Release
+	// or when conn closes.
+	Acquire(ctx context.Context, conn *sql.Conn, name string, wait time.Duration) (acquired bool, err error)
+	// Release drops the named lock previously taken on conn. released reports
+	// whether this session held the lock; it is false when the lock was not
+	// held by this session (already released or expired). err is non-nil for
+	// any driver or SQL failure.
+	Release(ctx context.Context, conn *sql.Conn, name string) (released bool, err error)
+}
+
+// MySQL implements Locker with MySQL's GET_LOCK / RELEASE_LOCK. The lock is
+// bound to the connection's session, so callers must pass the same *sql.Conn to
+// Acquire and Release and keep it open for as long as the lock is held.
+type MySQL struct{}
+
+var _ Locker = MySQL{}
+
+// Acquire runs GET_LOCK(name, wait). GET_LOCK returns 1 when the lock is
+// obtained, 0 when the wait elapses first, and NULL on error (for example the
+// session was killed); a NULL result is surfaced as an error.
+func (MySQL) Acquire(ctx context.Context, conn *sql.Conn, name string, wait time.Duration) (bool, error) {
+	var result sql.NullInt64
+	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, ?)", name, int(wait.Seconds())).Scan(&result); err != nil {
+		return false, err
+	}
+	if !result.Valid {
+		return false, fmt.Errorf("GET_LOCK(%q) returned NULL", name)
+	}
+	return result.Int64 == 1, nil
+}
+
+// Release runs RELEASE_LOCK(name). RELEASE_LOCK returns 1 when this session
+// held the lock, 0 when another session holds it, and NULL when the lock does
+// not exist (never taken or already released); both 0 and NULL report
+// released=false, since neither released a lock this session was holding.
+func (MySQL) Release(ctx context.Context, conn *sql.Conn, name string) (bool, error) {
+	var result sql.NullInt64
+	if err := conn.QueryRowContext(ctx, "SELECT RELEASE_LOCK(?)", name).Scan(&result); err != nil {
+		return false, err
+	}
+	return result.Valid && result.Int64 == 1, nil
+}

--- a/pkg/namedlock/namedlock.go
+++ b/pkg/namedlock/namedlock.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math"
 	"time"
 )
 
@@ -40,11 +41,18 @@ var _ Locker = MySQL{}
 
 // Acquire runs GET_LOCK(name, wait). GET_LOCK returns 1 when the lock is
 // obtained, 0 when the wait elapses first, and NULL on error (for example the
-// session was killed); a NULL result is surfaced as an error.
+// session was killed); a NULL result is surfaced as an error. MySQL only
+// supports whole-second waits, so sub-second waits round up to the next
+// second. A negative wait is rejected rather than passed through, because
+// GET_LOCK treats a negative timeout as an infinite wait.
 func (MySQL) Acquire(ctx context.Context, conn *sql.Conn, name string, wait time.Duration) (bool, error) {
+	if wait < 0 {
+		return false, fmt.Errorf("acquire named lock %q: negative wait %s", name, wait)
+	}
+	waitSeconds := int64(math.Ceil(wait.Seconds()))
 	var result sql.NullInt64
-	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, ?)", name, int(wait.Seconds())).Scan(&result); err != nil {
-		return false, err
+	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, ?)", name, waitSeconds).Scan(&result); err != nil {
+		return false, fmt.Errorf("acquire named lock %q: %w", name, err)
 	}
 	if !result.Valid {
 		return false, fmt.Errorf("GET_LOCK(%q) returned NULL", name)
@@ -59,7 +67,7 @@ func (MySQL) Acquire(ctx context.Context, conn *sql.Conn, name string, wait time
 func (MySQL) Release(ctx context.Context, conn *sql.Conn, name string) (bool, error) {
 	var result sql.NullInt64
 	if err := conn.QueryRowContext(ctx, "SELECT RELEASE_LOCK(?)", name).Scan(&result); err != nil {
-		return false, err
+		return false, fmt.Errorf("release named lock %q: %w", name, err)
 	}
 	return result.Valid && result.Int64 == 1, nil
 }

--- a/pkg/namedlock/namedlock.go
+++ b/pkg/namedlock/namedlock.go
@@ -18,6 +18,12 @@ import (
 // Locker acquires and releases session-scoped advisory locks on a pinned
 // connection. Implementations are engine-specific: MySQL uses GET_LOCK /
 // RELEASE_LOCK, a future Postgres implementation would use pg_advisory_lock.
+//
+// name identifies the lock within an engine but is not guaranteed to round-trip
+// verbatim: MySQL uses it as the literal lock string, whereas Postgres advisory
+// locks are keyed by int64, so a Postgres implementation would hash name into a
+// key. Callers should treat name as an opaque identity, not a value they can
+// read back.
 type Locker interface {
 	// Acquire attempts to take the named lock on conn, waiting up to wait for
 	// it. acquired reports whether the lock was taken; it is false when the
@@ -34,7 +40,9 @@ type Locker interface {
 
 // MySQL implements Locker with MySQL's GET_LOCK / RELEASE_LOCK. The lock is
 // bound to the connection's session, so callers must pass the same *sql.Conn to
-// Acquire and Release and keep it open for as long as the lock is held.
+// Acquire and Release and keep it open for as long as the lock is held. MySQL 8
+// rejects lock names longer than 64 characters; callers are responsible for
+// keeping name within that bound.
 type MySQL struct{}
 
 var _ Locker = MySQL{}

--- a/pkg/namedlock/namedlock_integration_test.go
+++ b/pkg/namedlock/namedlock_integration_test.go
@@ -109,8 +109,8 @@ func TestMySQLLockExclusiveAcrossSessions(t *testing.T) {
 	assert.True(t, released)
 }
 
-// The same session re-acquiring a lock it already holds succeeds, and releasing
-// a lock this session never held reports released=false without an error.
+// Releasing a lock this session never held reports released=false without an
+// error, so a best-effort release of an unheld lock is a safe no-op.
 func TestMySQLReleaseUnheldLock(t *testing.T) {
 	locker := MySQL{}
 	conn := openConn(t)

--- a/pkg/namedlock/namedlock_integration_test.go
+++ b/pkg/namedlock/namedlock_integration_test.go
@@ -1,0 +1,121 @@
+//go:build integration
+
+package namedlock
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/block/schemabot/pkg/testutil"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+var sharedDSN string
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+
+	req := testcontainers.ContainerRequest{
+		Image:        "mysql:8.0",
+		ExposedPorts: []string{"3306/tcp"},
+		Env: map[string]string{
+			"MYSQL_ROOT_PASSWORD": "testpassword",
+			"MYSQL_DATABASE":      "testdb",
+		},
+		WaitingFor: wait.ForAll(
+			wait.ForLog("ready for connections").WithOccurrence(2).WithStartupTimeout(30*time.Second),
+			wait.ForListeningPort("3306/tcp"),
+		),
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		log.Fatalf("start mysql container: %v", err)
+	}
+
+	host, err := testutil.ContainerHost(ctx, container)
+	if err != nil {
+		log.Fatalf("get container host: %v", err)
+	}
+	port, err := testutil.ContainerPort(ctx, container, "3306")
+	if err != nil {
+		log.Fatalf("get container port: %v", err)
+	}
+	sharedDSN = fmt.Sprintf("root:testpassword@tcp(%s:%d)/testdb?parseTime=true", host, port)
+
+	code := m.Run()
+
+	if err := container.Terminate(ctx); err != nil {
+		log.Printf("terminate mysql container: %v", err)
+	}
+	os.Exit(code)
+}
+
+func openConn(t *testing.T) *sql.Conn {
+	t.Helper()
+	db, err := sql.Open("mysql", sharedDSN)
+	require.NoError(t, err)
+	require.NoError(t, db.PingContext(t.Context()))
+	conn, err := db.Conn(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = conn.Close()
+		_ = db.Close()
+	})
+	return conn
+}
+
+// A named lock is exclusive across sessions: the second connection to request
+// it with a zero wait is refused, and can only take it after the holder
+// releases it.
+func TestMySQLLockExclusiveAcrossSessions(t *testing.T) {
+	locker := MySQL{}
+	name := "namedlock_test_exclusive"
+
+	holder := openConn(t)
+	acquired, err := locker.Acquire(t.Context(), holder, name, 5*time.Second)
+	require.NoError(t, err)
+	require.True(t, acquired, "first session should take the lock")
+
+	contender := openConn(t)
+	acquired, err = locker.Acquire(t.Context(), contender, name, 0)
+	require.NoError(t, err)
+	assert.False(t, acquired, "second session should be refused while the lock is held")
+
+	released, err := locker.Release(t.Context(), holder, name)
+	require.NoError(t, err)
+	assert.True(t, released, "holder should report releasing the lock it held")
+
+	acquired, err = locker.Acquire(t.Context(), contender, name, 5*time.Second)
+	require.NoError(t, err)
+	assert.True(t, acquired, "second session should take the lock after release")
+
+	released, err = locker.Release(t.Context(), contender, name)
+	require.NoError(t, err)
+	assert.True(t, released)
+}
+
+// The same session re-acquiring a lock it already holds succeeds, and releasing
+// a lock this session never held reports released=false without an error.
+func TestMySQLReleaseUnheldLock(t *testing.T) {
+	locker := MySQL{}
+	conn := openConn(t)
+
+	released, err := locker.Release(t.Context(), conn, "namedlock_test_never_held")
+	require.NoError(t, err)
+	assert.False(t, released, "releasing a lock this session never held reports not-held")
+}

--- a/pkg/namedlock/namedlock_integration_test.go
+++ b/pkg/namedlock/namedlock_integration_test.go
@@ -73,8 +73,8 @@ func openConn(t *testing.T) *sql.Conn {
 	conn, err := db.Conn(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		_ = conn.Close()
-		_ = db.Close()
+		assert.NoError(t, conn.Close())
+		assert.NoError(t, db.Close())
 	})
 	return conn
 }

--- a/pkg/pendingdrops/cleaner.go
+++ b/pkg/pendingdrops/cleaner.go
@@ -13,12 +13,17 @@ import (
 
 	"github.com/block/schemabot/pkg/metrics"
 	"github.com/block/schemabot/pkg/mysqlconn"
+	"github.com/block/schemabot/pkg/namedlock"
 )
 
 const (
 	lockNamePrefix = "schemabot_pending_drops_"
 	lockHashLen    = 16
 )
+
+// cleanupLocker serializes pending-drops cleanup across SchemaBot instances
+// with a session-scoped advisory lock held on the pinned target connection.
+var cleanupLocker namedlock.Locker = namedlock.MySQL{}
 
 // Target is one database the cleaner inspects. The DSN must be resolved
 // (no secret references) and reachable from this process.
@@ -107,12 +112,12 @@ func (c *Cleaner) cleanTarget(ctx context.Context, target Target) error {
 	defer utils.CloseAndLog(conn)
 
 	lockName := targetLockName(target)
-	var locked int
-	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, 0)", lockName).Scan(&locked); err != nil {
+	acquired, err := cleanupLocker.Acquire(ctx, conn, lockName, 0)
+	if err != nil {
 		metrics.RecordPendingDropsCleanupError(ctx, target.Database, target.Environment, "target_error")
 		return fmt.Errorf("acquire advisory lock on %s/%s: %w", target.Database, target.Environment, err)
 	}
-	if locked != 1 {
+	if !acquired {
 		c.logger.Info("pending drops cleanup skipped: another instance holds the cleanup lock",
 			"database", target.Database,
 			"environment", target.Environment,
@@ -122,7 +127,7 @@ func (c *Cleaner) cleanTarget(ctx context.Context, target Target) error {
 		return nil
 	}
 	defer func() {
-		if _, err := conn.ExecContext(context.WithoutCancel(ctx), "SELECT RELEASE_LOCK(?)", lockName); err != nil {
+		if _, err := cleanupLocker.Release(context.WithoutCancel(ctx), conn, lockName); err != nil {
 			c.logger.Warn("failed to release pending drops cleanup lock; the lock releases when the session closes",
 				"database", target.Database,
 				"environment", target.Environment,

--- a/pkg/pendingdrops/cleaner.go
+++ b/pkg/pendingdrops/cleaner.go
@@ -103,7 +103,8 @@ func (c *Cleaner) cleanTarget(ctx context.Context, target Target) error {
 		return fmt.Errorf("ping target %s/%s: %w", target.Database, target.Environment, err)
 	}
 
-	// GET_LOCK is session-scoped, so hold one connection for the whole pass.
+	// The advisory lock is session-scoped, so hold one connection for the
+	// whole pass.
 	conn, err := db.Conn(ctx)
 	if err != nil {
 		metrics.RecordPendingDropsCleanupError(ctx, target.Database, target.Environment, "target_error")

--- a/pkg/pendingdrops/cleaner.go
+++ b/pkg/pendingdrops/cleaner.go
@@ -128,12 +128,20 @@ func (c *Cleaner) cleanTarget(ctx context.Context, target Target) error {
 		return nil
 	}
 	defer func() {
-		if _, err := cleanupLocker.Release(context.WithoutCancel(ctx), conn, lockName); err != nil {
+		released, err := cleanupLocker.Release(context.WithoutCancel(ctx), conn, lockName)
+		switch {
+		case err != nil:
 			c.logger.Warn("failed to release pending drops cleanup lock; the lock releases when the session closes",
 				"database", target.Database,
 				"environment", target.Environment,
 				"lock_name", lockName,
 				"error", err,
+			)
+		case !released:
+			c.logger.Warn("pending drops cleanup lock was no longer held at release; another instance may have run concurrently against this target",
+				"database", target.Database,
+				"environment", target.Environment,
+				"lock_name", lockName,
 			)
 		}
 	}()

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/block/schemabot/pkg/namedlock"
 	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 	"github.com/block/spirit/pkg/utils"
@@ -50,6 +51,10 @@ const (
 	applyTargetLockWait           = 10 * time.Second
 	applyTargetLockReleaseTimeout = 5 * time.Second
 )
+
+// applyTargetLocker serializes concurrent applies against the same target with
+// a session-scoped advisory lock held on the pinned apply connection.
+var applyTargetLocker namedlock.Locker = namedlock.MySQL{}
 
 // applyStore implements storage.ApplyStore using MySQL.
 type applyStore struct {
@@ -219,8 +224,7 @@ func acquireApplyTargetLockConn(ctx context.Context, db *sql.DB, database, dbTyp
 	}
 
 	lockName := applyTargetLockName(database, dbType, environment)
-	var result sql.NullInt64
-	err = conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, ?)", lockName, int(applyTargetLockWait.Seconds())).Scan(&result)
+	acquired, err := applyTargetLocker.Acquire(ctx, conn, lockName, applyTargetLockWait)
 	if err != nil {
 		slog.WarnContext(ctx, "failed to acquire apply target lock",
 			"database", database,
@@ -232,14 +236,13 @@ func acquireApplyTargetLockConn(ctx context.Context, db *sql.DB, database, dbTyp
 		closeApplyTargetLockConn(ctx, conn, lockName, "acquire apply target lock")
 		return nil, "", fmt.Errorf("acquire apply target lock for %s/%s/%s: %w", database, dbType, environment, err)
 	}
-	if !result.Valid || result.Int64 != 1 {
+	if !acquired {
 		slog.WarnContext(ctx, "timed out waiting for apply target lock",
 			"database", database,
 			"database_type", dbType,
 			"environment", environment,
 			"lock", lockName,
-			"wait", applyTargetLockWait,
-			"result", result)
+			"wait", applyTargetLockWait)
 		closeApplyTargetLockConn(ctx, conn, lockName, "acquire apply target lock")
 		return nil, "", fmt.Errorf("timed out waiting for apply target lock for %s/%s/%s", database, dbType, environment)
 	}
@@ -254,13 +257,11 @@ func releaseApplyTargetLockConn(ctx context.Context, conn *sql.Conn, lockName, o
 	releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), applyTargetLockReleaseTimeout)
 	defer cancel()
 
-	var result sql.NullInt64
-	err := conn.QueryRowContext(releaseCtx, "SELECT RELEASE_LOCK(?)", lockName).Scan(&result)
-	if err != nil || !result.Valid || result.Int64 != 1 {
+	released, err := applyTargetLocker.Release(releaseCtx, conn, lockName)
+	if err != nil || !released {
 		slog.WarnContext(releaseCtx, "failed to release apply target lock; discarding connection",
 			"operation", operation,
 			"lock", lockName,
-			"result", result,
 			"error", err)
 		if rawErr := conn.Raw(func(any) error { return driver.ErrBadConn }); rawErr != nil && !errors.Is(rawErr, driver.ErrBadConn) {
 			slog.WarnContext(releaseCtx, "failed to discard apply target lock connection",

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -258,20 +258,33 @@ func releaseApplyTargetLockConn(ctx context.Context, conn *sql.Conn, lockName, o
 	defer cancel()
 
 	released, err := applyTargetLocker.Release(releaseCtx, conn, lockName)
-	if err != nil || !released {
+	switch {
+	case err != nil:
 		slog.WarnContext(releaseCtx, "failed to release apply target lock; discarding connection",
 			"operation", operation,
 			"lock", lockName,
 			"error", err)
-		if rawErr := conn.Raw(func(any) error { return driver.ErrBadConn }); rawErr != nil && !errors.Is(rawErr, driver.ErrBadConn) {
-			slog.WarnContext(releaseCtx, "failed to discard apply target lock connection",
-				"operation", operation,
-				"lock", lockName,
-				"error", rawErr)
-		}
+		discardApplyTargetLockConn(releaseCtx, conn, lockName, operation)
+	case !released:
+		slog.WarnContext(releaseCtx, "apply target lock was not held by this session; discarding connection",
+			"operation", operation,
+			"lock", lockName)
+		discardApplyTargetLockConn(releaseCtx, conn, lockName, operation)
 	}
 
 	closeApplyTargetLockConn(releaseCtx, conn, lockName, operation)
+}
+
+// discardApplyTargetLockConn marks the pinned connection as bad so the pool
+// destroys it instead of reusing a session whose advisory-lock state is
+// uncertain.
+func discardApplyTargetLockConn(ctx context.Context, conn *sql.Conn, lockName, operation string) {
+	if rawErr := conn.Raw(func(any) error { return driver.ErrBadConn }); rawErr != nil && !errors.Is(rawErr, driver.ErrBadConn) {
+		slog.WarnContext(ctx, "failed to discard apply target lock connection",
+			"operation", operation,
+			"lock", lockName,
+			"error", rawErr)
+	}
 }
 
 func closeApplyTargetLockConn(ctx context.Context, conn *sql.Conn, lockName, operation string) {


### PR DESCRIPTION
## Summary

Extracts SchemaBot's session-scoped advisory (`GET_LOCK`/`RELEASE_LOCK`) locking behind a small `namedlock.Locker` seam so a non-MySQL engine can later supply its own advisory-lock strategy. Behavior-preserving for MySQL: the same lock names, wait timeouts, skip-vs-error handling, and connection pinning remain at each call site.

## What

- New `pkg/namedlock` package: a `Locker` interface (`Acquire`/`Release` on a pinned `*sql.Conn`) with a `MySQL` implementation over `GET_LOCK`/`RELEASE_LOCK`.
- Route all three lock domains through it: apply-target serialization (`mysqlstore/applies.go`), pending-drops cleanup (`pendingdrops/cleaner.go`), and schema bootstrap (`api/ensure_schema.go`).
- Each caller keeps its own domain logic — lock-name generation, wait timeout (10s wait / 0 try-lock / 5min), skip-vs-error interpretation, and the session-pinned connection lifetime.

## Why

MySQL named locks are session-scoped, so the lock lives on one connection for its whole lifetime. Consolidating only the SQL execution into one seam keeps that invariant in a single place and lets a future engine plug in `pg_advisory_lock` semantics without disturbing the callers' coordination logic. Kept separate from the SQL-rendering `Dialect` seam because locking differs by *execution*, not just syntax.

Two edge cases preserve today's behavior exactly:
- `Acquire` treats a `GET_LOCK` `NULL` result as an error — preserving every acquire site, including pending-drops' previous `int`-scan-on-NULL error.
- `Release` maps `RELEASE_LOCK` `0`/`NULL` to `released=false` — releasing a lock this session was not holding is a no-op, matching the old best-effort release path.

## Before / after
```
BEFORE — raw GET_LOCK / RELEASE_LOCK inlined in 3 places

    ┌─────────────────────────────┐
    │ applies.go                  │  SELECT GET_LOCK / RELEASE_LOCK
    │ pendingdrops/cleaner.go     │  SELECT GET_LOCK / RELEASE_LOCK
    │ api/ensure_schema.go        │  SELECT GET_LOCK / RELEASE_LOCK
    └─────────────────────────────┘

AFTER — callers depend on one seam that owns the SQL

    ┌─────────────────────────────┐
    │ applies.go                  │──┐
    │ pendingdrops/cleaner.go     │──┤
    │ api/ensure_schema.go        │──┤
    └─────────────────────────────┘  │
                                     ▼
                      ┌─────────────────────────────────┐
                      │ pkg/namedlock                   │
                      │   Locker{ Acquire, Release }    │
                      │   MySQL{} → GET/RELEASE_LOCK    │
                      └─────────────────────────────────┘
```