### PR TITLE
refactor: extract per-boundary TableChange conversion helpers

### DIFF
--- a/pkg/api/proto_helpers.go
+++ b/pkg/api/proto_helpers.go
@@ -12,6 +12,7 @@ import (
 	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
 	"github.com/block/schemabot/pkg/schema"
 	"github.com/block/schemabot/pkg/storage"
+	"github.com/block/schemabot/pkg/tern"
 )
 
 const vSchemaArtifactName = "vschema.json"
@@ -164,6 +165,23 @@ func protoSchemaFilesToAPI(sf map[string]*ternv1.SchemaFiles) map[string]*apityp
 	return result
 }
 
+// tableChangeResponseFromProto converts a proto table change to its HTTP API
+// form. This is the single proto→apitypes hop for table changes: every field —
+// identity, unsafe, and execution-mode annotations — is mapped here so a new
+// field crosses the boundary with one edit.
+func tableChangeResponseFromProto(t *ternv1.TableChange) *apitypes.TableChangeResponse {
+	return &apitypes.TableChangeResponse{
+		TableName:     t.TableName,
+		Namespace:     t.Namespace,
+		DDL:           t.Ddl,
+		ChangeType:    protoChangeTypeToOperation(t.ChangeType),
+		IsUnsafe:      t.IsUnsafe,
+		UnsafeReason:  t.UnsafeReason,
+		ExecutionMode: t.ExecutionMode,
+		ModeReason:    t.ModeReason,
+	}
+}
+
 // planResponseFromProto converts a protobuf PlanResponse to an HTTP PlanResponse.
 func planResponseFromProto(resp *ternv1.PlanResponse) *apitypes.PlanResponse {
 	httpResp := &apitypes.PlanResponse{
@@ -184,16 +202,7 @@ func planResponseFromProto(resp *ternv1.PlanResponse) *apitypes.PlanResponse {
 			Metadata:  sc.Metadata,
 		}
 		for _, t := range sc.TableChanges {
-			apiSC.TableChanges = append(apiSC.TableChanges, &apitypes.TableChangeResponse{
-				TableName:     t.TableName,
-				Namespace:     t.Namespace,
-				DDL:           t.Ddl,
-				ChangeType:    protoChangeTypeToOperation(t.ChangeType),
-				IsUnsafe:      t.IsUnsafe,
-				UnsafeReason:  t.UnsafeReason,
-				ExecutionMode: t.ExecutionMode,
-				ModeReason:    t.ModeReason,
-			})
+			apiSC.TableChanges = append(apiSC.TableChanges, tableChangeResponseFromProto(t))
 		}
 		httpResp.Changes = append(httpResp.Changes, apiSC)
 	}
@@ -221,16 +230,7 @@ func planResponseFromProto(resp *ternv1.PlanResponse) *apitypes.PlanResponse {
 			if t == nil {
 				continue
 			}
-			apiSP.Changes = append(apiSP.Changes, &apitypes.TableChangeResponse{
-				TableName:     t.TableName,
-				Namespace:     t.Namespace,
-				DDL:           t.Ddl,
-				ChangeType:    protoChangeTypeToOperation(t.ChangeType),
-				IsUnsafe:      t.IsUnsafe,
-				UnsafeReason:  t.UnsafeReason,
-				ExecutionMode: t.ExecutionMode,
-				ModeReason:    t.ModeReason,
-			})
+			apiSP.Changes = append(apiSP.Changes, tableChangeResponseFromProto(t))
 		}
 		// An empty shard plan is a shard that already matches the desired schema
 		// while sibling shards change (a partially-applied keyspace). Keep it so the
@@ -261,15 +261,7 @@ func protoChangesToNamespaces(changes []*ternv1.SchemaChange, schemaFiles map[st
 		}
 		nsData := &storage.NamespacePlanData{}
 		for _, t := range sc.TableChanges {
-			nsData.Tables = append(nsData.Tables, storage.TableChange{
-				Table:         t.TableName,
-				DDL:           t.Ddl,
-				Operation:     protoChangeTypeToOperation(t.ChangeType),
-				IsUnsafe:      t.IsUnsafe,
-				UnsafeReason:  t.UnsafeReason,
-				ExecutionMode: t.ExecutionMode,
-				ModeReason:    t.ModeReason,
-			})
+			nsData.Tables = append(nsData.Tables, tern.StorageTableChangeFromProto(t, "", t.TableName, t.Ddl, protoChangeTypeToOperation(t.ChangeType)))
 		}
 		if len(sc.OriginalFiles) > 0 {
 			nsData.OriginalFiles = sc.OriginalFiles
@@ -338,16 +330,7 @@ func protoShardPlansToStorage(shards []*ternv1.ShardPlan) ([]storage.ShardPlan, 
 			if cn := strings.TrimSpace(ch.Namespace); cn != "" && cn != namespace {
 				return nil, fmt.Errorf("shard plan %d shard %q change %d (table %q) namespace %q disagrees with shard namespace %q", i, shardName, j, table, cn, namespace)
 			}
-			sp.Changes = append(sp.Changes, storage.TableChange{
-				Namespace:     namespace,
-				Table:         table,
-				DDL:           changeDDL,
-				Operation:     protoChangeTypeToOperation(ch.ChangeType),
-				IsUnsafe:      ch.IsUnsafe,
-				UnsafeReason:  ch.UnsafeReason,
-				ExecutionMode: ch.ExecutionMode,
-				ModeReason:    ch.ModeReason,
-			})
+			sp.Changes = append(sp.Changes, tern.StorageTableChangeFromProto(ch, namespace, table, changeDDL, protoChangeTypeToOperation(ch.ChangeType)))
 		}
 		out = append(out, sp)
 	}

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -1266,15 +1266,7 @@ func (c *LocalClient) Plan(ctx context.Context, req *ternv1.PlanRequest) (*ternv
 	// Store the plan in SchemaBot's storage
 	ddlChanges := make([]storage.TableChange, len(result.FlatTableChanges()))
 	for i, t := range result.FlatTableChanges() {
-		ddlChanges[i] = storage.TableChange{
-			Table:         t.Table,
-			DDL:           t.DDL,
-			Operation:     ddl.StatementTypeToOp(t.Operation),
-			IsUnsafe:      t.IsUnsafe,
-			UnsafeReason:  t.UnsafeReason,
-			ExecutionMode: t.ExecutionMode,
-			ModeReason:    t.ModeReason,
-		}
+		ddlChanges[i] = storageTableChangeFromEngine(t, "")
 	}
 
 	// Build per-namespace plan data from the engine's changes.
@@ -1298,15 +1290,7 @@ func (c *LocalClient) Plan(ctx context.Context, req *ternv1.PlanRequest) (*ternv
 				continue
 			}
 			seenTable[ns][tc.Table] = true
-			nsData.Tables = append(nsData.Tables, storage.TableChange{
-				Table:         tc.Table,
-				DDL:           tc.DDL,
-				Operation:     ddl.StatementTypeToOp(tc.Operation),
-				IsUnsafe:      tc.IsUnsafe,
-				UnsafeReason:  tc.UnsafeReason,
-				ExecutionMode: tc.ExecutionMode,
-				ModeReason:    tc.ModeReason,
-			})
+			nsData.Tables = append(nsData.Tables, storageTableChangeFromEngine(tc, ""))
 		}
 		// Record each changing shard's own changes so apply-create can rebuild
 		// per-shard operation groups with per-shard DDL (a keyspace whose shards
@@ -1316,16 +1300,7 @@ func (c *LocalClient) Plan(ctx context.Context, req *ternv1.PlanRequest) (*ternv
 		if shardName := strings.TrimSpace(sc.Shard.Name); shardName != "" {
 			sp := storage.ShardPlan{Shard: shardName, Namespace: ns}
 			for _, tc := range sc.TableChanges {
-				sp.Changes = append(sp.Changes, storage.TableChange{
-					Namespace:     ns,
-					Table:         tc.Table,
-					DDL:           tc.DDL,
-					Operation:     ddl.StatementTypeToOp(tc.Operation),
-					IsUnsafe:      tc.IsUnsafe,
-					UnsafeReason:  tc.UnsafeReason,
-					ExecutionMode: tc.ExecutionMode,
-					ModeReason:    tc.ModeReason,
-				})
+				sp.Changes = append(sp.Changes, storageTableChangeFromEngine(tc, ns))
 			}
 			nsData.Shards = append(nsData.Shards, sp)
 			allShardPlans = append(allShardPlans, sp)
@@ -1508,32 +1483,14 @@ func (c *LocalClient) planResultToProtoChanges(result *engine.PlanResult) (chang
 				continue
 			}
 			protoTableSeen[ns][t.Table] = true
-			protoSC.TableChanges = append(protoSC.TableChanges, &ternv1.TableChange{
-				TableName:     t.Table,
-				ChangeType:    changeTypeToProto(t.Operation),
-				Ddl:           t.DDL,
-				IsUnsafe:      t.IsUnsafe,
-				UnsafeReason:  t.UnsafeReason,
-				ExecutionMode: t.ExecutionMode,
-				ModeReason:    t.ModeReason,
-				Namespace:     ns,
-			})
+			protoSC.TableChanges = append(protoSC.TableChanges, protoTableChangeFromEngine(t, ns))
 		}
 		// A SchemaChange with an empty shard targets the whole namespace
 		// (non-sharded engines) and contributes no shard rows.
 		if shardName := strings.TrimSpace(sc.Shard.Name); shardName != "" {
 			protoSP := &ternv1.ShardPlan{Shard: shardName, Namespace: ns}
 			for _, t := range sc.TableChanges {
-				protoSP.Changes = append(protoSP.Changes, &ternv1.TableChange{
-					Namespace:     ns,
-					TableName:     t.Table,
-					Ddl:           t.DDL,
-					ChangeType:    changeTypeToProto(t.Operation),
-					IsUnsafe:      t.IsUnsafe,
-					UnsafeReason:  t.UnsafeReason,
-					ExecutionMode: t.ExecutionMode,
-					ModeReason:    t.ModeReason,
-				})
+				protoSP.Changes = append(protoSP.Changes, protoTableChangeFromEngine(t, ns))
 			}
 			shards = append(shards, protoSP)
 		}
@@ -1674,16 +1631,7 @@ func scopedDispatchDDLChanges(changes []*ternv1.TableChange) ([]storage.TableCha
 		if op == "unknown" || op == "vschema_update" {
 			return nil, fmt.Errorf("shard-scoped dispatch ddl_change %d (table %q) has unsupported change type %v", i, table, ch.ChangeType)
 		}
-		out = append(out, storage.TableChange{
-			Namespace:     namespace,
-			Table:         table,
-			DDL:           ddl,
-			Operation:     op,
-			IsUnsafe:      ch.IsUnsafe,
-			UnsafeReason:  ch.UnsafeReason,
-			ExecutionMode: ch.ExecutionMode,
-			ModeReason:    ch.ModeReason,
-		})
+		out = append(out, StorageTableChangeFromProto(ch, namespace, table, ddl, op))
 	}
 	return out, nil
 }
@@ -1839,16 +1787,7 @@ func (c *LocalClient) namespacesFromApplyRequest(changes []*ternv1.TableChange, 
 			return nil, err
 		}
 		nsData := ensure(ch.Namespace)
-		nsData.Tables = append(nsData.Tables, storage.TableChange{
-			Namespace:     ch.Namespace,
-			Table:         ch.TableName,
-			DDL:           ch.Ddl,
-			Operation:     op,
-			IsUnsafe:      ch.IsUnsafe,
-			UnsafeReason:  ch.UnsafeReason,
-			ExecutionMode: ch.ExecutionMode,
-			ModeReason:    ch.ModeReason,
-		})
+		nsData.Tables = append(nsData.Tables, StorageTableChangeFromProto(ch, ch.Namespace, ch.TableName, ch.Ddl, op))
 	}
 
 	for ns := range vschemaChangedNamespaces {

--- a/pkg/tern/tablechange_convert.go
+++ b/pkg/tern/tablechange_convert.go
@@ -1,0 +1,69 @@
+package tern
+
+// Per-boundary TableChange conversion helpers. A table change crosses three
+// boundaries — engine → storage, engine → proto, and proto → storage — and
+// every hop must carry the full advisory annotation set (unsafe and
+// execution-mode fields). Each helper owns one hop's field mapping so a new
+// annotation field is added here once per boundary instead of at every
+// conversion site, and a helper that stops compiling is the signal that a
+// boundary was missed.
+//
+// Identity fields that call sites derive differently (namespace scoping,
+// trimming, validation, operation mapping) are passed in explicitly: the
+// boundary that owns a rule keeps it.
+
+import (
+	"github.com/block/schemabot/pkg/ddl"
+	"github.com/block/schemabot/pkg/engine"
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// storageTableChangeFromEngine converts an engine table change to its stored
+// form. namespace may be empty when the containing structure already keys by
+// namespace (flat plan-level lists and per-namespace table sets).
+func storageTableChangeFromEngine(tc engine.TableChange, namespace string) storage.TableChange {
+	return storage.TableChange{
+		Namespace:     namespace,
+		Table:         tc.Table,
+		DDL:           tc.DDL,
+		Operation:     ddl.StatementTypeToOp(tc.Operation),
+		IsUnsafe:      tc.IsUnsafe,
+		UnsafeReason:  tc.UnsafeReason,
+		ExecutionMode: tc.ExecutionMode,
+		ModeReason:    tc.ModeReason,
+	}
+}
+
+// protoTableChangeFromEngine converts an engine table change to its proto
+// wire form for plan responses.
+func protoTableChangeFromEngine(tc engine.TableChange, namespace string) *ternv1.TableChange {
+	return &ternv1.TableChange{
+		Namespace:     namespace,
+		TableName:     tc.Table,
+		Ddl:           tc.DDL,
+		ChangeType:    changeTypeToProto(tc.Operation),
+		IsUnsafe:      tc.IsUnsafe,
+		UnsafeReason:  tc.UnsafeReason,
+		ExecutionMode: tc.ExecutionMode,
+		ModeReason:    tc.ModeReason,
+	}
+}
+
+// StorageTableChangeFromProto builds a storage.TableChange from a proto table
+// change. The identity fields — namespace, table, DDL text, and operation —
+// are passed in because each proto→storage boundary derives them under its
+// own rules (trimming, fail-closed validation, change-type mapping); the
+// advisory annotations are copied verbatim from the proto message.
+func StorageTableChangeFromProto(ch *ternv1.TableChange, namespace, table, ddlText, operation string) storage.TableChange {
+	return storage.TableChange{
+		Namespace:     namespace,
+		Table:         table,
+		DDL:           ddlText,
+		Operation:     operation,
+		IsUnsafe:      ch.IsUnsafe,
+		UnsafeReason:  ch.UnsafeReason,
+		ExecutionMode: ch.ExecutionMode,
+		ModeReason:    ch.ModeReason,
+	}
+}


### PR DESCRIPTION
## Why this matters

A table change crosses four boundaries (engine→storage, engine→proto, proto→storage, proto→apitypes), and each hop hand-copied the full field set across eleven struct-literal sites. Every new field — most recently `execution_mode`/`mode_reason`, `is_unsafe`/`unsafe_reason` before it — had to be added at every site by hand, and a missed site compiled fine while silently dropping the field at one hop.

## What it does

- Adds one conversion helper per boundary: `storageTableChangeFromEngine`, `protoTableChangeFromEngine`, and `StorageTableChangeFromProto` in `pkg/tern` (the last exported and shared with `pkg/api`), plus `tableChangeResponseFromProto` in `pkg/api`.
- Replaces all eleven copy sites. Identity fields (namespace scoping, trimming, fail-closed validation, change-type mapping) stay at the call sites that own those rules; the advisory annotations are mapped once per boundary.

The next field addition is one edit per hop instead of eleven, with the helper as the single place a reviewer checks for coverage.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (Fable 5)