### PR TITLE
fix(planetscale): make cancel idempotent and throttle remote control retransmission

### DIFF
--- a/pkg/engine/planetscale/control.go
+++ b/pkg/engine/planetscale/control.go
@@ -35,7 +35,30 @@ func (e *Engine) cancelDeployRequest(ctx context.Context, operation engine.Contr
 		Database:     req.Database,
 		Number:       meta.DeployRequestID,
 	}); err != nil {
-		return nil, fmt.Errorf("cancel deploy request #%d (may have been deleted): %w", meta.DeployRequestID, err)
+		// Cancel must be idempotent: PlanetScale rejects a cancel of a deploy
+		// request that is already closed, and a prior cancel attempt (this
+		// driver's or another's) may have closed it. Read the deploy request's
+		// live state to distinguish "already cancelled" — the goal state, report
+		// success — from a deploy request that closed by completing or failing,
+		// where reporting a successful cancel would misrepresent a schema change
+		// that actually landed.
+		dr, getErr := client.GetDeployRequest(ctx, &ps.GetDeployRequestRequest{
+			Organization: credOrg(req.Credentials),
+			Database:     req.Database,
+			Number:       meta.DeployRequestID,
+		})
+		if getErr != nil {
+			return nil, fmt.Errorf("cancel deploy request #%d (may have been deleted; state read also failed: %w): %w", meta.DeployRequestID, getErr, err)
+		}
+		switch dr.DeploymentState {
+		case deployState.InProgressCancel, deployState.CompleteCancel, deployState.Cancelled:
+			return &engine.ControlResult{
+				Accepted:    true,
+				Message:     fmt.Sprintf("Deploy request #%d already cancelled", meta.DeployRequestID),
+				ResumeState: req.ResumeState,
+			}, nil
+		}
+		return nil, fmt.Errorf("cancel deploy request #%d rejected in deployment state %q: %w", meta.DeployRequestID, dr.DeploymentState, err)
 	}
 
 	return &engine.ControlResult{

--- a/pkg/engine/planetscale/control_test.go
+++ b/pkg/engine/planetscale/control_test.go
@@ -65,6 +65,102 @@ func TestStart_AcceptsDeferredDeploy(t *testing.T) {
 	assert.NotContains(t, err.Error(), "not supported")
 }
 
+// cancelDeployRequestClient fails every cancel attempt with a fixed error and
+// serves a fixed deploy request (or read error) for the follow-up state read.
+type cancelDeployRequestClient struct {
+	psclient.PSClient
+	cancelErr error
+	dr        *ps.DeployRequest
+	getErr    error
+}
+
+func (c *cancelDeployRequestClient) CancelDeployRequest(context.Context, *ps.CancelDeployRequestRequest) (*ps.DeployRequest, error) {
+	return nil, c.cancelErr
+}
+
+func (c *cancelDeployRequestClient) GetDeployRequest(context.Context, *ps.GetDeployRequestRequest) (*ps.DeployRequest, error) {
+	if c.getErr != nil {
+		return nil, c.getErr
+	}
+	return c.dr, nil
+}
+
+// PlanetScale rejects a cancel of a deploy request that is already closed, and
+// a prior cancel attempt may be what closed it — cancel is retried across
+// drives and pods, so a rejection of an already-cancelled deploy request must
+// read as success. A deploy request that closed any other way (completed,
+// errored) must stay an error naming its live state: reporting a successful
+// cancel there would misrepresent a schema change that actually landed.
+func TestCancel_AlreadyClosedDeployRequest(t *testing.T) {
+	meta, err := encodePSMetadata(&psMetadata{
+		BranchName:       "schemabot-mydb-abc",
+		DeployRequestID:  121,
+		DeployRequestURL: "https://example.test/deploys/121",
+	})
+	require.NoError(t, err)
+
+	controlReq := func() *engine.ControlRequest {
+		return &engine.ControlRequest{
+			Database:    "mydb",
+			ResumeState: &engine.ResumeState{Metadata: meta},
+			Credentials: &engine.Credentials{Metadata: map[string]string{
+				"organization": "org",
+				"token_name":   "tn",
+				"token_value":  "tv",
+			}},
+		}
+	}
+
+	newEngine := func(client *cancelDeployRequestClient) *Engine {
+		return NewWithClient(slog.New(slog.NewTextHandler(os.Stdout, nil)),
+			func(_, _ string) (psclient.PSClient, error) {
+				return client, nil
+			})
+	}
+	closedErr := errors.New("The deploy request is closed.")
+
+	for _, cancelledState := range []string{deployState.InProgressCancel, deployState.CompleteCancel, deployState.Cancelled} {
+		t.Run("cancelled deploy request in state "+cancelledState+" reads as success", func(t *testing.T) {
+			e := newEngine(&cancelDeployRequestClient{
+				cancelErr: closedErr,
+				dr:        &ps.DeployRequest{Number: 121, DeploymentState: cancelledState},
+			})
+
+			result, err := e.Cancel(t.Context(), controlReq())
+
+			require.NoError(t, err)
+			assert.True(t, result.Accepted)
+			assert.Contains(t, result.Message, "Deploy request #121 already cancelled")
+		})
+	}
+
+	t.Run("deploy request closed by completing stays an error naming its state", func(t *testing.T) {
+		e := newEngine(&cancelDeployRequestClient{
+			cancelErr: closedErr,
+			dr:        &ps.DeployRequest{Number: 121, DeploymentState: deployState.Complete},
+		})
+
+		_, err := e.Cancel(t.Context(), controlReq())
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `cancel deploy request #121 rejected in deployment state "complete"`)
+		assert.Contains(t, err.Error(), "The deploy request is closed.")
+	})
+
+	t.Run("failed state read keeps both errors", func(t *testing.T) {
+		e := newEngine(&cancelDeployRequestClient{
+			cancelErr: closedErr,
+			getErr:    errors.New("deploy request not found"),
+		})
+
+		_, err := e.Cancel(t.Context(), controlReq())
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cancel deploy request #121 (may have been deleted; state read also failed: deploy request not found)")
+		assert.Contains(t, err.Error(), "The deploy request is closed.")
+	})
+}
+
 // applyDeployRequestErrorClient fails every cutover attempt with a fixed error.
 type applyDeployRequestErrorClient struct {
 	psclient.PSClient

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -634,6 +634,7 @@ func AdjustActiveApplies(ctx context.Context, delta int64, database, deployment,
 var knownControlOperations = map[string]bool{
 	"cutover":       true,
 	"stop":          true,
+	"cancel":        true,
 	"start":         true,
 	"volume":        true,
 	"revert":        true,
@@ -655,6 +656,25 @@ func RecordControlOperation(ctx context.Context, operation, database, deployment
 		DeploymentAttribute(deployment),
 		EnvironmentAttribute(environment),
 		attribute.String("status", status),
+	)
+}
+
+// RecordRemoteControlRequestStale counts retransmissions of a durable
+// stop/cancel control request that the data plane accepted but has not
+// consumed within the stale threshold. A non-zero rate means an accepted
+// operator command is not taking effect on the remote apply — the data plane's
+// own driver is failing to consume it (its logs carry the failing consume
+// error) — and the apply will not converge until that is resolved.
+func RecordRemoteControlRequestStale(ctx context.Context, operation, database, deployment, environment string) {
+	if !knownControlOperations[operation] {
+		operation = "unknown"
+	}
+	addCounter(ctx, "schemabot.remote_control_requests.stale_resends_total",
+		"Total retransmissions of remote control requests still unconsumed by the data plane past the stale threshold", "{resend}",
+		attribute.String("operation", operation),
+		attribute.String("database", database),
+		DeploymentAttribute(deployment),
+		EnvironmentAttribute(environment),
 	)
 }
 

--- a/pkg/tern/grpc_client.go
+++ b/pkg/tern/grpc_client.go
@@ -146,6 +146,10 @@ type GRPCClient struct {
 	observerMu      sync.RWMutex
 	observers       map[int64]ProgressObserver
 	pendingObserver ProgressObserver
+
+	// controlSendGate throttles retransmission of pending stop/cancel control
+	// requests to the data plane (see remoteControlResendInterval).
+	controlSendGate remoteControlSendGate
 }
 
 // Compile-time check that GRPCClient implements Client.
@@ -814,6 +818,7 @@ func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply
 		if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStop); err != nil {
 			return true, err
 		}
+		c.controlSendGate.clear(controlReq.ID)
 		return true, nil
 	}
 	remoteID := scope.remoteApplyID(apply)
@@ -840,27 +845,36 @@ func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply
 		return true, nil
 	}
 
-	resp, err := c.client.Stop(ctx, &ternv1.StopRequest{
-		ApplyId:     remoteID,
-		Environment: apply.Environment,
-	})
-	if err != nil {
-		if completed, completeErr := c.completeRemoteStopFromTerminalProgress(ctx, apply, controlReq, scope); completeErr == nil && completed {
-			return true, nil
-		} else if completeErr != nil {
-			return true, fmt.Errorf("request remote gRPC stop for apply %s remote %s: %w; terminal progress reconciliation also failed: %w", apply.ApplyIdentifier, remoteID, err, completeErr)
+	// The data plane stores the stop durably on first receipt and its own
+	// driver consumes it, so retransmission is redelivery insurance on a bounded
+	// cadence — not a per-tick send (see the cancel counterpart).
+	if now := time.Now(); c.controlSendGate.shouldSend(controlReq.ID, now) {
+		resp, err := c.client.Stop(ctx, &ternv1.StopRequest{
+			ApplyId:     remoteID,
+			Environment: apply.Environment,
+		})
+		if err != nil {
+			if completed, completeErr := c.completeRemoteStopFromTerminalProgress(ctx, apply, controlReq, scope); completeErr == nil && completed {
+				return true, nil
+			} else if completeErr != nil {
+				return true, fmt.Errorf("request remote gRPC stop for apply %s remote %s: %w; terminal progress reconciliation also failed: %w", apply.ApplyIdentifier, remoteID, err, completeErr)
+			}
+			return true, fmt.Errorf("request remote gRPC stop for apply %s remote %s: %w", apply.ApplyIdentifier, remoteID, err)
 		}
-		return true, fmt.Errorf("request remote gRPC stop for apply %s remote %s: %w", apply.ApplyIdentifier, remoteID, err)
-	}
-	if resp == nil || !resp.Accepted {
-		errorMessage := "not accepted"
-		if resp != nil && resp.ErrorMessage != "" {
-			errorMessage = resp.ErrorMessage
+		if resp == nil || !resp.Accepted {
+			errorMessage := "not accepted"
+			if resp != nil && resp.ErrorMessage != "" {
+				errorMessage = resp.ErrorMessage
+			}
+			return true, fmt.Errorf("request remote gRPC stop for apply %s remote %s: %s", apply.ApplyIdentifier, remoteID, errorMessage)
 		}
-		return true, fmt.Errorf("request remote gRPC stop for apply %s remote %s: %s", apply.ApplyIdentifier, remoteID, errorMessage)
+		if c.controlSendGate.recordSend(controlReq.ID, now) {
+			c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested,
+				fmt.Sprintf("Remote stop accepted for apply %s%s", remoteID, callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
+		} else {
+			logRemoteControlResend(ctx, apply, controlReq, now)
+		}
 	}
-	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested,
-		fmt.Sprintf("Remote stop accepted for apply %s%s", remoteID, callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
 
 	progress, err := c.client.Progress(ctx, &ternv1.ProgressRequest{
 		ApplyId:     remoteID,
@@ -901,6 +915,7 @@ func (c *GRPCClient) processPendingStopControlRequest(ctx context.Context, apply
 		if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStop); err != nil {
 			return true, err
 		}
+		c.controlSendGate.clear(controlReq.ID)
 		if hasPendingStart, startErr := hasPendingStartControlRequest(ctx, c.storage, apply); startErr != nil {
 			return true, startErr
 		} else if hasPendingStart {
@@ -945,30 +960,42 @@ func (c *GRPCClient) processPendingCancelControlRequest(ctx context.Context, app
 		if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationCancel); err != nil {
 			return true, err
 		}
+		c.controlSendGate.clear(controlReq.ID)
 		return true, nil
 	}
 	remoteID := scope.remoteApplyID(apply)
 	if remoteID == "" {
 		return true, fmt.Errorf("cancel gRPC apply %s: remote apply id is not available", apply.ApplyIdentifier)
 	}
-	resp, err := c.client.Cancel(ctx, &ternv1.CancelRequest{ApplyId: remoteID, Environment: apply.Environment})
-	if err != nil {
-		if completed, completeErr := c.completeRemoteCancelFromTerminalProgress(ctx, apply, controlReq, scope); completeErr == nil && completed {
-			return true, nil
-		} else if completeErr != nil {
-			return true, fmt.Errorf("request remote gRPC cancel for apply %s remote %s: %w; terminal progress reconciliation also failed: %w", apply.ApplyIdentifier, remoteID, err, completeErr)
+	// The data plane stores the cancel durably on first receipt and its own
+	// driver consumes it, so retransmission is redelivery insurance on a bounded
+	// cadence — not a per-tick send, which floods the data plane with duplicate
+	// cancels and the apply log with duplicate accept events while the remote
+	// works (or fails) to consume the first one.
+	if now := time.Now(); c.controlSendGate.shouldSend(controlReq.ID, now) {
+		resp, err := c.client.Cancel(ctx, &ternv1.CancelRequest{ApplyId: remoteID, Environment: apply.Environment})
+		if err != nil {
+			if completed, completeErr := c.completeRemoteCancelFromTerminalProgress(ctx, apply, controlReq, scope); completeErr == nil && completed {
+				return true, nil
+			} else if completeErr != nil {
+				return true, fmt.Errorf("request remote gRPC cancel for apply %s remote %s: %w; terminal progress reconciliation also failed: %w", apply.ApplyIdentifier, remoteID, err, completeErr)
+			}
+			return true, fmt.Errorf("request remote gRPC cancel for apply %s remote %s: %w", apply.ApplyIdentifier, remoteID, err)
 		}
-		return true, fmt.Errorf("request remote gRPC cancel for apply %s remote %s: %w", apply.ApplyIdentifier, remoteID, err)
-	}
-	if resp == nil || !resp.Accepted {
-		errorMessage := "not accepted"
-		if resp != nil && resp.ErrorMessage != "" {
-			errorMessage = resp.ErrorMessage
+		if resp == nil || !resp.Accepted {
+			errorMessage := "not accepted"
+			if resp != nil && resp.ErrorMessage != "" {
+				errorMessage = resp.ErrorMessage
+			}
+			return true, fmt.Errorf("request remote gRPC cancel for apply %s remote %s: %s", apply.ApplyIdentifier, remoteID, errorMessage)
 		}
-		return true, fmt.Errorf("request remote gRPC cancel for apply %s remote %s: %s", apply.ApplyIdentifier, remoteID, errorMessage)
+		if c.controlSendGate.recordSend(controlReq.ID, now) {
+			c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventCancelRequested,
+				fmt.Sprintf("Remote cancel accepted for apply %s%s", remoteID, callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
+		} else {
+			logRemoteControlResend(ctx, apply, controlReq, now)
+		}
 	}
-	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventCancelRequested,
-		fmt.Sprintf("Remote cancel accepted for apply %s%s", remoteID, callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
 	progress, err := c.client.Progress(ctx, &ternv1.ProgressRequest{ApplyId: remoteID, Environment: apply.Environment})
 	if err != nil {
 		return true, fmt.Errorf("sync remote gRPC cancel for apply %s remote %s: %w", apply.ApplyIdentifier, remoteID, err)
@@ -996,6 +1023,7 @@ func (c *GRPCClient) processPendingCancelControlRequest(ctx context.Context, app
 		if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationCancel); err != nil {
 			return true, err
 		}
+		c.controlSendGate.clear(controlReq.ID)
 		return true, nil
 	}
 	if _, err := c.persistParentApply(ctx, apply, scope, "sync nonterminal gRPC cancel"); err != nil {
@@ -1066,6 +1094,7 @@ func (c *GRPCClient) completeRemoteStopFromTerminalProgress(ctx context.Context,
 	if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationStop); err != nil {
 		return false, err
 	}
+	c.controlSendGate.clear(controlReq.ID)
 	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventStopRequested,
 		fmt.Sprintf("Remote stop request completed from terminal progress (remote state: %s) after stop error%s", remoteState, callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
 	return true, nil
@@ -1147,6 +1176,7 @@ func (c *GRPCClient) completeRemoteCancelFromTerminalProgress(ctx context.Contex
 	if err := completePendingControlRequests(ctx, c.storage, apply, storage.ControlOperationCancel); err != nil {
 		return false, err
 	}
+	c.controlSendGate.clear(controlReq.ID)
 	c.logApplyEvent(ctx, apply.ID, nil, storage.LogLevelInfo, storage.LogEventCancelRequested,
 		fmt.Sprintf("Remote cancel request completed from terminal progress (remote state: %s) after cancel error%s", remoteState, callerApplyLogSuffix(controlRequestCaller(controlReq))), "", "")
 	return true, nil

--- a/pkg/tern/grpc_client_test.go
+++ b/pkg/tern/grpc_client_test.go
@@ -532,6 +532,8 @@ type capturingTernServer struct {
 	cutoverAccepted   bool
 	cutoverMessage    string
 	startCalled       bool // tracks whether Start was actually invoked
+	stopCalls         int
+	cancelCalls       int
 }
 
 func (s *capturingTernServer) Apply(_ context.Context, req *ternv1.ApplyRequest) (*ternv1.ApplyResponse, error) {
@@ -568,6 +570,7 @@ func (s *capturingTernServer) Start(_ context.Context, req *ternv1.StartRequest)
 func (s *capturingTernServer) Stop(_ context.Context, req *ternv1.StopRequest) (*ternv1.StopResponse, error) {
 	s.mu.Lock()
 	s.stopApplyID = req.ApplyId
+	s.stopCalls++
 	s.mu.Unlock()
 	return &ternv1.StopResponse{Accepted: true}, nil
 }
@@ -575,6 +578,7 @@ func (s *capturingTernServer) Stop(_ context.Context, req *ternv1.StopRequest) (
 func (s *capturingTernServer) Cancel(_ context.Context, req *ternv1.CancelRequest) (*ternv1.CancelResponse, error) {
 	s.mu.Lock()
 	s.cancelApplyID = req.ApplyId
+	s.cancelCalls++
 	err := s.cancelErr
 	s.mu.Unlock()
 	if err != nil {
@@ -657,6 +661,18 @@ func (s *capturingTernServer) getCancelApplyID() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.cancelApplyID
+}
+
+func (s *capturingTernServer) getStopCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.stopCalls
+}
+
+func (s *capturingTernServer) getCancelCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.cancelCalls
 }
 
 func (s *capturingTernServer) getSkipRevertApplyID() string {

--- a/pkg/tern/grpc_control_resend.go
+++ b/pkg/tern/grpc_control_resend.go
@@ -1,0 +1,93 @@
+package tern
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/block/schemabot/pkg/metrics"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+const (
+	// remoteControlResendInterval bounds how often a driver retransmits a
+	// pending stop/cancel control request to the data plane. The data plane
+	// records the request durably on first receipt and its own driver consumes
+	// it, so retransmission is redelivery insurance, not the mechanism of
+	// record — re-sending on every progress tick only floods the data plane
+	// with duplicate RPCs and the apply log with duplicate accept events.
+	remoteControlResendInterval = 30 * time.Second
+
+	// remoteControlStaleThreshold is how long an accepted stop/cancel may
+	// remain pending (measured from the durable request's creation) before the
+	// driver escalates each retransmission from info to warn and counts it in
+	// the stale-control metric. A healthy data plane consumes a stop/cancel
+	// within seconds; past this threshold the remote is not converging and an
+	// operator should look at the data-plane logs for the failing consume.
+	remoteControlStaleThreshold = 2 * time.Minute
+)
+
+// remoteControlSendGate throttles retransmission of durable control requests
+// to the data plane. Entries are keyed by control-request row ID, so a new
+// request (a fresh operator command) always transmits immediately. State is
+// in-memory by design: it is a per-process optimization over the durable
+// request row — after a restart the driver re-sends once and re-enters the
+// throttled cadence.
+type remoteControlSendGate struct {
+	mu       sync.Mutex
+	lastSent map[int64]time.Time
+}
+
+// shouldSend reports whether the control request should be (re-)transmitted
+// now: always for a request this process has not sent yet, and at most once
+// per remoteControlResendInterval afterwards.
+func (g *remoteControlSendGate) shouldSend(controlReqID int64, now time.Time) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	last, ok := g.lastSent[controlReqID]
+	return !ok || now.Sub(last) >= remoteControlResendInterval
+}
+
+// recordSend records a successful transmission and reports whether it was this
+// process's first for the request.
+func (g *remoteControlSendGate) recordSend(controlReqID int64, now time.Time) (first bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.lastSent == nil {
+		g.lastSent = make(map[int64]time.Time)
+	}
+	_, seen := g.lastSent[controlReqID]
+	g.lastSent[controlReqID] = now
+	return !seen
+}
+
+// clear forgets a control request once it is completed or failed, so the map
+// does not accumulate entries for resolved requests.
+func (g *remoteControlSendGate) clear(controlReqID int64) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	delete(g.lastSent, controlReqID)
+}
+
+// logRemoteControlResend records a retransmission of a still-pending control
+// request. Only the first transmission writes an operator-facing apply-log
+// event (the caller does that); retransmissions log server-side, escalating to
+// warn with a metric once the request has been pending past
+// remoteControlStaleThreshold — at that point the data plane is not consuming
+// an accepted command and an operator must check its logs for the failing
+// consume.
+func logRemoteControlResend(ctx context.Context, apply *storage.Apply, controlReq *storage.ApplyControlRequest, now time.Time) {
+	pendingFor := now.Sub(controlReq.CreatedAt)
+	attrs := append(apply.LogAttrs(),
+		"operation", string(controlReq.Operation),
+		"requested_by", controlReq.RequestedBy,
+		"pending_for", pendingFor.Round(time.Second),
+	)
+	if pendingFor >= remoteControlStaleThreshold {
+		metrics.RecordRemoteControlRequestStale(ctx, string(controlReq.Operation), apply.Database, apply.Deployment, apply.Environment)
+		slog.Warn("remote control request accepted but still unconsumed by the data plane; driver keeps re-sending and polling — check data-plane logs for the failing consume", attrs...)
+		return
+	}
+	slog.Info("re-sent pending remote control request to the data plane", attrs...)
+}

--- a/pkg/tern/grpc_control_resend_test.go
+++ b/pkg/tern/grpc_control_resend_test.go
@@ -1,0 +1,162 @@
+package tern
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ternv1 "github.com/block/schemabot/pkg/proto/ternv1"
+	"github.com/block/schemabot/pkg/state"
+	"github.com/block/schemabot/pkg/storage"
+)
+
+func TestRemoteControlSendGate(t *testing.T) {
+	gate := &remoteControlSendGate{}
+	base := time.Now()
+
+	assert.True(t, gate.shouldSend(1, base), "a request never sent by this process transmits immediately")
+	assert.True(t, gate.recordSend(1, base), "the first transmission is reported as first")
+
+	assert.False(t, gate.shouldSend(1, base.Add(time.Second)), "a just-sent request is not retransmitted within the interval")
+	assert.True(t, gate.shouldSend(1, base.Add(remoteControlResendInterval)), "the request retransmits once the interval elapses")
+	assert.False(t, gate.recordSend(1, base.Add(remoteControlResendInterval)), "a retransmission is not reported as first")
+
+	assert.True(t, gate.shouldSend(2, base), "gating is per control request, not per process")
+
+	gate.clear(1)
+	assert.True(t, gate.shouldSend(1, base.Add(2*time.Second)), "a cleared request transmits immediately again")
+	assert.True(t, gate.recordSend(1, base.Add(2*time.Second)), "a cleared request's next transmission is first again")
+}
+
+// An accepted cancel is stored durably by the data plane and consumed by its
+// own driver, so the control plane's progress-poll loop must not re-send the
+// Cancel RPC (or append another operator-facing accept event) on every tick
+// while the remote works to consume it — it retransmits on a bounded cadence
+// and keeps polling progress in between.
+func TestGRPCClient_PendingCancelRetransmissionThrottled(t *testing.T) {
+	server := &capturingTernServer{
+		progressState:    ternv1.State_STATE_RUNNING,
+		progressStateSet: true,
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              7,
+		ApplyIdentifier: "apply-grpc-cancel-throttle",
+		ExternalID:      "remote-grpc-cancel-throttle",
+		PlanID:          99,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+		State:           state.Apply.Running,
+	}
+	controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationCancel,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "cli:alice",
+		CreatedAt:   time.Now(),
+	}}}
+	storedApply := *apply
+	logs := &mockApplyLogStore{}
+	client.storage = &mockStorage{
+		applies:         &mockApplyStore{apply: &storedApply},
+		tasks:           &mockTaskStore{},
+		logs:            logs,
+		controlRequests: controlRequests,
+	}
+
+	for range 3 {
+		handled, err := client.processPendingCancelControlRequest(t.Context(), apply, wholeApplyTaskScope())
+		require.NoError(t, err)
+		assert.False(t, handled, "a nonterminal remote keeps the cancel pending")
+	}
+	assert.Equal(t, 1, server.getCancelCalls(), "polling passes within the resend interval must not re-send the cancel")
+	assert.Equal(t, 1, countLogMessages(logs.logs, "Remote cancel accepted"), "only the first transmission appends an operator-facing accept event")
+
+	// Once the resend interval elapses the driver retransmits as redelivery
+	// insurance — without appending another accept event.
+	client.controlSendGate.mu.Lock()
+	for id := range client.controlSendGate.lastSent {
+		client.controlSendGate.lastSent[id] = time.Now().Add(-remoteControlResendInterval)
+	}
+	client.controlSendGate.mu.Unlock()
+
+	handled, err := client.processPendingCancelControlRequest(t.Context(), apply, wholeApplyTaskScope())
+	require.NoError(t, err)
+	assert.False(t, handled)
+	assert.Equal(t, 2, server.getCancelCalls(), "the cancel retransmits after the resend interval elapses")
+	assert.Equal(t, 1, countLogMessages(logs.logs, "Remote cancel accepted"), "retransmissions must not append duplicate accept events")
+}
+
+// The stop counterpart: an accepted stop retransmits on the same bounded
+// cadence while the remote drains, with a single operator-facing accept event.
+func TestGRPCClient_PendingStopRetransmissionThrottled(t *testing.T) {
+	server := &capturingTernServer{
+		progressState:    ternv1.State_STATE_RUNNING,
+		progressStateSet: true,
+		progressTables: []*ternv1.TableProgress{{
+			Namespace: "default",
+			TableName: "users",
+			Status:    state.Task.Running,
+		}},
+	}
+	client, cleanup := testCapturingGRPCClient(t, server)
+	defer cleanup()
+
+	apply := &storage.Apply{
+		ID:              7,
+		ApplyIdentifier: "apply-grpc-stop-throttle",
+		ExternalID:      "remote-grpc-stop-throttle",
+		PlanID:          99,
+		Database:        "testdb",
+		DatabaseType:    storage.DatabaseTypeMySQL,
+		Environment:     "staging",
+		State:           state.Apply.Running,
+	}
+	task := &storage.Task{
+		ID:             11,
+		TaskIdentifier: "task-users",
+		ApplyID:        apply.ID,
+		Namespace:      "default",
+		TableName:      "users",
+		State:          state.Task.Running,
+	}
+	controlRequests := &testControlRequestStore{requests: []*storage.ApplyControlRequest{{
+		ApplyID:     apply.ID,
+		Operation:   storage.ControlOperationStop,
+		Status:      storage.ControlRequestPending,
+		RequestedBy: "cli:alice",
+		CreatedAt:   time.Now(),
+	}}}
+	storedApply := *apply
+	logs := &mockApplyLogStore{}
+	client.storage = &mockStorage{
+		applies:         &mockApplyStore{apply: &storedApply},
+		tasks:           &mockTaskStore{tasks: []*storage.Task{task}},
+		logs:            logs,
+		controlRequests: controlRequests,
+	}
+
+	for range 3 {
+		handled, err := client.processPendingStopControlRequest(t.Context(), apply, wholeApplyTaskScope())
+		require.NoError(t, err)
+		assert.False(t, handled, "a nonterminal remote keeps the stop pending")
+	}
+	assert.Equal(t, 1, server.getStopCalls(), "polling passes within the resend interval must not re-send the stop")
+	assert.Equal(t, 1, countLogMessages(logs.logs, "Remote stop accepted"), "only the first transmission appends an operator-facing accept event")
+}
+
+func countLogMessages(logs []*storage.ApplyLog, messagePrefix string) int {
+	count := 0
+	for _, log := range logs {
+		if strings.HasPrefix(log.Message, messagePrefix) {
+			count++
+		}
+	}
+	return count
+}


### PR DESCRIPTION
## Why this matters

A cancel of a PlanetScale schema change can permanently wedge the apply. If a prior cancel attempt already closed the deploy request, the engine treats the API's "The deploy request is closed" rejection as fatal — so the durable pending cancel request can never be consumed. The remote driver re-claims the apply and dies on every drive, the apply parks non-terminal forever (holding its database lock), and the operator's accepted cancel has no visible effect.

Meanwhile the control-plane driver retransmits the pending cancel on every 500ms progress tick, unbounded, appending a duplicate operator-facing "Remote cancel accepted" event to the apply log each time — over 100k rows in a matter of hours, drowning the signal an operator needs during triage.

## What it does

**Data plane — idempotent cancel.** When `CancelDeployRequest` is rejected, the engine now reads the deploy request's live state to distinguish the cases:

```
cancel rejected ("deploy request is closed")
  └─ GetDeployRequest
       ├─ in_progress_cancel / complete_cancel / cancelled → success (goal state reached)
       ├─ any other closed state (e.g. complete)          → error naming the state
       └─ state read fails                                 → error carrying both causes
```

Fail-closed where it matters: only the cancelled family reads as success. A deploy request that closed by *completing* stays an error — a schema change that actually landed is never misreported as cancelled.

**Control plane — bounded retransmission.** The durable `apply_control_requests` row is the mechanism of record; the data plane records it on first receipt, so retransmission is redelivery insurance, not the delivery mechanism. The driver now:

- re-sends a pending stop/cancel at most once per 30s (per control request; a fresh operator command still transmits immediately),
- writes the operator-facing accept event only on the first send,
- escalates to a warn log plus a new `schemabot.remote_control_requests.stale_resends_total` counter once a request has been pending past 2 minutes — the signal that the data plane is not consuming an accepted command and its logs need a look.

Progress still polls on every tick, so terminal reconciliation timing is unchanged.

## How it moves us toward the northstar

Control operations must be durable and convergent on every engine: an accepted cancel either takes effect or surfaces a triageable failure — never a silent wedge. This closes the non-terminal-remote gap left after the terminal-progress reconciliation work, and the stale-resend metric gives the `cancelling`/`stopping` first-class states (designed, queued next) the exact signal they will surface to operators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)