### PR TITLE
fix(cli): point unlock at the lock held under another database type

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -1463,6 +1463,17 @@ No lock found for testapp (mysql)
 </details>
 
 <details>
+<summary><a name="lock-exists-under-other-type"></a><strong>Lock Exists Under Other Type</strong></summary>
+
+```
+
+No lock found for testapp (mysql), but a vitess lock exists for this database.
+Release it with: schemabot unlock -d testapp -t vitess
+
+```
+</details>
+
+<details>
 <summary><a name="unlock-not-owned"></a><strong>Unlock Not Owned</strong></summary>
 
 ```

--- a/pkg/cmd/commands/preview.go
+++ b/pkg/cmd/commands/preview.go
@@ -40,7 +40,7 @@ func (cmd *PreviewCmd) Run(g *Globals) error {
 	// Lock types
 	case templates.PreviewLockAcquired, templates.PreviewLockConflict,
 		templates.PreviewLockConflictCLI, templates.PreviewNoLockFound,
-		templates.PreviewUnlockNotOwned,
+		templates.PreviewLockOtherType, templates.PreviewUnlockNotOwned,
 		templates.PreviewLockReleased, templates.PreviewLocksList:
 		templates.PreviewCLIOutput(previewType)
 	// Sequential mode types
@@ -177,6 +177,7 @@ Lock Types:
   lock_released         Show lock released messages
   locks_list            Show locks list output
   no_lock_found         Show no lock found message
+  lock_other_type       Show lock exists under another database type message
   unlock_not_owned      Show unlock not owned message
 
 Sequential Mode (multi-table, one at a time):

--- a/pkg/cmd/commands/unlock.go
+++ b/pkg/cmd/commands/unlock.go
@@ -86,7 +86,12 @@ func (cmd *UnlockCmd) Run(g *Globals) error {
 // name that lock and the command that targets it instead of reporting a bare
 // miss.
 func reportNoLockFound(ep, database, dbType string) {
-	locks, err := client.ListLocks(ep)
+	var locks []*client.LockInfo
+	err := withLoading("Checking database locks...", true, func() error {
+		var listErr error
+		locks, listErr = client.ListLocks(ep)
+		return listErr
+	})
 	if err != nil {
 		templates.WriteNoLockFound(database, dbType)
 		templates.WriteLockTypeScanFailed(err)

--- a/pkg/cmd/commands/unlock.go
+++ b/pkg/cmd/commands/unlock.go
@@ -36,7 +36,7 @@ func (cmd *UnlockCmd) Run(g *Globals) error {
 			return fmt.Errorf("check lock: %w", err)
 		}
 		if existingLock == nil {
-			templates.WriteNoLockFound(cmd.Database, cmd.Type)
+			reportNoLockFound(ep, cmd.Database, cmd.Type)
 			return nil
 		}
 
@@ -54,7 +54,7 @@ func (cmd *UnlockCmd) Run(g *Globals) error {
 		return client.ReleaseLock(ep, cmd.Database, cmd.Type, owner)
 	})
 	if errors.Is(err, client.ErrLockNotFound) {
-		templates.WriteNoLockFound(cmd.Database, cmd.Type)
+		reportNoLockFound(ep, cmd.Database, cmd.Type)
 		return nil
 	}
 	if errors.Is(err, client.ErrLockNotOwned) {
@@ -76,5 +76,36 @@ func (cmd *UnlockCmd) Run(g *Globals) error {
 	}
 
 	templates.WriteLockReleased(cmd.Database, cmd.Type)
+	return nil
+}
+
+// reportNoLockFound explains a missing lock. Lock lookups are keyed by
+// (database, type) and the type flag defaults to mysql, so an operator
+// releasing a vitess (or strata/postgres) database lock without -t searches
+// the wrong namespace. When the database is locked under a different type,
+// name that lock and the command that targets it instead of reporting a bare
+// miss.
+func reportNoLockFound(ep, database, dbType string) {
+	locks, err := client.ListLocks(ep)
+	if err != nil {
+		templates.WriteNoLockFound(database, dbType)
+		templates.WriteLockTypeScanFailed(err)
+		return
+	}
+	if other := lockUnderOtherType(locks, database, dbType); other != nil {
+		templates.WriteLockExistsUnderOtherType(database, dbType, other.DatabaseType)
+		return
+	}
+	templates.WriteNoLockFound(database, dbType)
+}
+
+// lockUnderOtherType returns a lock held on the database under a database
+// type other than the requested one, or nil if none exists.
+func lockUnderOtherType(locks []*client.LockInfo, database, dbType string) *client.LockInfo {
+	for _, lock := range locks {
+		if lock.Database == database && lock.DatabaseType != dbType {
+			return lock
+		}
+	}
 	return nil
 }

--- a/pkg/cmd/commands/unlock_test.go
+++ b/pkg/cmd/commands/unlock_test.go
@@ -1,0 +1,37 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/cmd/client"
+)
+
+func TestLockUnderOtherType(t *testing.T) {
+	locks := []*client.LockInfo{
+		{Database: "orders", DatabaseType: "mysql", Owner: "org/repo#1"},
+		{Database: "games", DatabaseType: "vitess", Owner: "org/repo#2"},
+	}
+
+	t.Run("finds lock held under another type", func(t *testing.T) {
+		lock := lockUnderOtherType(locks, "games", "mysql")
+		require.NotNil(t, lock)
+		assert.Equal(t, "games", lock.Database)
+		assert.Equal(t, "vitess", lock.DatabaseType)
+		assert.Equal(t, "org/repo#2", lock.Owner)
+	})
+
+	t.Run("ignores lock held under the requested type", func(t *testing.T) {
+		assert.Nil(t, lockUnderOtherType(locks, "orders", "mysql"))
+	})
+
+	t.Run("ignores locks on other databases", func(t *testing.T) {
+		assert.Nil(t, lockUnderOtherType(locks, "payments", "mysql"))
+	})
+
+	t.Run("no locks", func(t *testing.T) {
+		assert.Nil(t, lockUnderOtherType(nil, "games", "mysql"))
+	})
+}

--- a/pkg/cmd/internal/templates/locks.go
+++ b/pkg/cmd/internal/templates/locks.go
@@ -103,6 +103,23 @@ func WriteNoLockFound(database, dbType string) {
 	fmt.Printf("No lock found for %s (%s)\n", database, dbType)
 }
 
+// WriteLockExistsUnderOtherType writes the message when the database is not
+// locked under the requested type but does hold a lock under another database
+// type. Lock lookups are keyed by (database, type) and the type flag defaults
+// to mysql, so an operator targeting a vitess database without -t searches
+// the wrong namespace — point them at the lock that actually exists.
+func WriteLockExistsUnderOtherType(database, requestedType, foundType string) {
+	fmt.Printf("No lock found for %s (%s), but a %s lock exists for this database.\n", database, requestedType, foundType)
+	fmt.Printf("Release it with: schemabot unlock -d %s -t %s\n", database, foundType)
+}
+
+// WriteLockTypeScanFailed writes the message when the check for locks under
+// other database types could not run, so a "no lock found" answer is only
+// authoritative for the requested type.
+func WriteLockTypeScanFailed(err error) {
+	fmt.Printf("Could not check for locks under other database types: %v\n", err)
+}
+
 // WriteUnlockNotOwned writes the message when trying to unlock without ownership.
 func WriteUnlockNotOwned(database, dbType, currentOwner string) {
 	fmt.Println()

--- a/pkg/cmd/internal/templates/preview.go
+++ b/pkg/cmd/internal/templates/preview.go
@@ -35,6 +35,7 @@ const (
 	PreviewLockReleased      PreviewType = "lock_released"
 	PreviewLocksList         PreviewType = "locks_list"
 	PreviewNoLockFound       PreviewType = "no_lock_found"
+	PreviewLockOtherType     PreviewType = "lock_other_type"
 	PreviewUnlockNotOwned    PreviewType = "unlock_not_owned"
 	PreviewAll               PreviewType = "all"
 

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -332,6 +332,7 @@ func previewCLILockingAllOutput() {
 		{"LOCK CONFLICT (CLI)", previewLockConflictByCLIOutput},
 		{"LOCK RELEASED", previewLockReleasedOutput},
 		{"NO LOCK FOUND", previewNoLockFoundOutput},
+		{"LOCK EXISTS UNDER OTHER TYPE", previewLockExistsUnderOtherTypeOutput},
 		{"UNLOCK NOT OWNED", previewUnlockNotOwnedOutput},
 		{"LOCKS LIST", previewLocksListOutput},
 	}

--- a/pkg/cmd/internal/templates/preview_dispatch.go
+++ b/pkg/cmd/internal/templates/preview_dispatch.go
@@ -43,6 +43,8 @@ func PreviewCLIOutput(previewType PreviewType) {
 		previewLockConflictByCLIOutput()
 	case PreviewNoLockFound:
 		previewNoLockFoundOutput()
+	case PreviewLockOtherType:
+		previewLockExistsUnderOtherTypeOutput()
 	case PreviewUnlockNotOwned:
 		previewUnlockNotOwnedOutput()
 	case PreviewLockReleased:

--- a/pkg/cmd/internal/templates/preview_lock.go
+++ b/pkg/cmd/internal/templates/preview_lock.go
@@ -70,6 +70,10 @@ func previewNoLockFoundOutput() {
 	WriteNoLockFound("testapp", "mysql")
 }
 
+func previewLockExistsUnderOtherTypeOutput() {
+	WriteLockExistsUnderOtherType("testapp", "mysql", "vitess")
+}
+
 func previewUnlockNotOwnedOutput() {
 	WriteUnlockNotOwned("testapp", "mysql", "block/schemabot#123")
 }


### PR DESCRIPTION
## Why this matters

`unlock` scopes its lookup to a `(database, type)` pair, and `-t` silently defaults to `mysql`. An operator releasing a vitess lock without `-t` gets an unqualified "No lock found" — while `locks` plainly shows the lock. During an incident that answer reads as "vitess locks are unreachable," sending the operator toward storage surgery instead of the one flag they were missing.

## What it does

When the requested type has no lock but the same database is locked under another database type, `unlock` names that lock and prints the exact command that releases it:

```
No lock found for testapp (mysql), but a vitess lock exists for this database.
Release it with: schemabot unlock -d testapp -t vitess
```

If the cross-type check itself fails, the CLI says so, so a "no lock found" answer is never silently partial. Both the ownership-checked and `--force` paths get the hint. Includes a preview scenario and the regenerated TEMPLATES.md section.

## How it moves us toward the northstar

Operator commands must tell the truth about state during incidents. This closes a diagnostic trap where the CLI's answer contradicted the lock list and misdirected triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)