### PR TITLE
fix(github): publish a fresh aggregate Check Run when rewinding a concluded one to in progress

### DIFF
--- a/docs/check-runs.md
+++ b/docs/check-runs.md
@@ -302,7 +302,7 @@ Important columns:
 | `head_sha` | Commit SHA the record represents. GitHub only displays checks for the current PR head. |
 | `status` | `in_progress` or `completed`. |
 | `conclusion` | `success`, `failure`, or `action_required` when complete. |
-| `apply_id` | Storage apply ID represented by the row. It is set when an apply or rollback starts, and normal apply completion leaves it set so later cleanup can tell that live work started. |
+| `apply_id` | Internal numeric apply row ID represented by the row (distinct from the user-facing apply identifier that logs report as `apply_id`). It is set when an apply or rollback starts, and normal apply completion leaves it set so later cleanup can tell that live work started. |
 | `blocking_reason` | Stable machine-readable reason for fail-closed states that operators may need to triage. |
 | `check_run_id` | GitHub check run ID for aggregate records. |
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1355,6 +1355,7 @@ var knownStatusCheckStatuses = map[string]bool{
 	"blocked":   true,
 	"scheduled": true,
 	"exhausted": true,
+	"recreated": true,
 }
 
 // StatusCheckOperation describes one status-check storage or GitHub operation.

--- a/pkg/webhook/aggregate_check_integration_test.go
+++ b/pkg/webhook/aggregate_check_integration_test.go
@@ -12,6 +12,8 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -450,19 +452,28 @@ func TestE2EAggregateCheckStaleCleanupBlocksStartedApply(t *testing.T) {
 	})
 
 	checkRuns := make(chan checkRunCapture, 10)
+	checkRunState := &fakeCheckRunStore{}
 	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
 		var body checkRunCapture
 		_ = json.NewDecoder(r.Body).Decode(&body)
 		checkRuns <- body
+		id := checkRunState.create(body)
 		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(map[string]any{"id": 300})
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": id})
 	})
 	mux.HandleFunc("PATCH /repos/octocat/hello-world/check-runs/", func(w http.ResponseWriter, r *http.Request) {
 		var body checkRunCapture
 		_ = json.NewDecoder(r.Body).Decode(&body)
 		checkRuns <- body
-		_ = json.NewEncoder(w).Encode(map[string]any{"id": 300})
+		id, err := strconv.ParseInt(path.Base(r.URL.Path), 10, 64)
+		if err != nil {
+			http.Error(w, "invalid check run id", http.StatusBadRequest)
+			return
+		}
+		checkRunState.update(id, body)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": id})
 	})
+	registerCheckStatusRESTHandlersForAnyRef(mux, func() []checkStatusNode { return nil }, checkRunState)
 
 	h := newE2EHandler(t, svc, client)
 
@@ -484,7 +495,7 @@ func TestE2EAggregateCheckStaleCleanupBlocksStartedApply(t *testing.T) {
 		t.Fatal("timed out waiting for in-progress aggregate check run")
 	}
 
-	installClient := ghclient.NewInstallationClient(client, h.logger)
+	installClient := ghclient.NewInstallationClientWithSlug(client, h.logger, "schemabot")
 	h.postPassingAggregates(ctx, installClient, "octocat/hello-world", 1, "newsha222")
 	select {
 	case cr := <-checkRuns:

--- a/pkg/webhook/aggregate_fold_core_test.go
+++ b/pkg/webhook/aggregate_fold_core_test.go
@@ -27,6 +27,7 @@ type foldCheckStore struct {
 	getErr      error
 	upsertErr   error
 	upsertCalls int
+	upserted    []*storage.Check
 }
 
 func (s *foldCheckStore) GetByPR(_ context.Context, _ string, _ int) ([]*storage.Check, error) {
@@ -37,8 +38,9 @@ func (s *foldCheckStore) Get(_ context.Context, _ string, _ int, _, _, _ string)
 	return s.get, s.getErr
 }
 
-func (s *foldCheckStore) Upsert(_ context.Context, _ *storage.Check) error {
+func (s *foldCheckStore) Upsert(_ context.Context, check *storage.Check) error {
 	s.upsertCalls++
+	s.upserted = append(s.upserted, check)
 	return s.upsertErr
 }
 

--- a/pkg/webhook/aggregate_fold_core_test.go
+++ b/pkg/webhook/aggregate_fold_core_test.go
@@ -258,7 +258,7 @@ func TestUpdateAggregateCheckOnceFollowUpContract(t *testing.T) {
 		assert.Equal(t, 1, store.upsertCalls)
 	})
 
-	t.Run("a per-environment upsert failure still attempts every environment and joins the errors", func(t *testing.T) {
+	t.Run("a per-environment upsert failure still attempts every environment, joins the errors, and schedules a re-fold", func(t *testing.T) {
 		cfg := &api.ServerConfig{
 			AllowedEnvironments: []string{"staging", "production"},
 			Repos:               map[string]api.RepoConfig{"octocat/hello-world": {}},
@@ -276,8 +276,29 @@ func TestUpdateAggregateCheckOnceFollowUpContract(t *testing.T) {
 
 		followUp, err := h.updateAggregateCheckOnce(t.Context(), client, "octocat/hello-world", 1, "abc123")
 
-		assert.Equal(t, aggregateFoldClearParticipantRefoldBudget, followUp)
+		assert.Equal(t, aggregateFoldScheduleParticipantRefold, followUp,
+			"a failed aggregate publish must arm the bounded re-fold, not clear the budget: the fire-and-forget callers have no retry of their own")
 		assert.Error(t, err)
 		assert.Equal(t, 2, store.upsertCalls, "a failed environment write must not skip the remaining environments")
+	})
+
+	t.Run("a failed Check Run create schedules a re-fold and returns an error", func(t *testing.T) {
+		store := &foldCheckStore{
+			byPR: []*storage.Check{
+				{Repository: "octocat/hello-world", PullRequest: 1, HeadSHA: "abc123", Environment: "staging", DatabaseType: "mysql", DatabaseName: "orders", Status: checkStatusInProgress},
+			},
+		}
+		h, mux, client := newFoldHandler(t, nonAggregateConfig(), store)
+		serveHeadSHA(t, mux, "abc123")
+		mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+
+		followUp, err := h.updateAggregateCheckOnce(t.Context(), client, "octocat/hello-world", 1, "abc123")
+
+		assert.Equal(t, aggregateFoldScheduleParticipantRefold, followUp,
+			"a failed Check Run write must arm the bounded re-fold so the gate converges without waiting for an external event")
+		assert.Error(t, err)
+		assert.Empty(t, store.upserted, "no stored state may record a Check Run that was never created")
 	})
 }

--- a/pkg/webhook/apply_check_records.go
+++ b/pkg/webhook/apply_check_records.go
@@ -23,15 +23,36 @@ func (h *Handler) storeApplyPlanCheckRecord(ctx context.Context, client *ghclien
 // when an apply begins execution. The aggregate check is updated to reflect the
 // state. If the apply is already terminal by the time the claim lands, the
 // stored check state is immediately refreshed to the apply's terminal outcome.
+//
+// The apply parameter is the caller's pre-claim snapshot: only its identifiers
+// (ID, ApplyIdentifier) are read here. Live state is reloaded from storage
+// after the claim lands, so a snapshot that went stale between accept and
+// claim cannot leak outdated state into the check row.
 func (h *Handler) updateCheckRecordForApplyStart(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, environment string, apply *storage.Apply) error {
 	// Fail closed on a missing or non-persisted apply before touching check
 	// state: claiming the check row without a real apply row would record
 	// ownership nothing can ever reconcile.
 	if apply == nil {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:    "apply_started",
+			Repository:   repo,
+			Database:     schema.Database,
+			DatabaseType: schema.Type,
+			Environment:  environment,
+			Status:       "error",
+		})
 		return fmt.Errorf("update check state for apply start repo %s pr %d environment %s database_type %s database %s: apply is nil",
 			repo, pr, environment, schema.Type, schema.Database)
 	}
 	if apply.ID == 0 {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:    "apply_started",
+			Repository:   repo,
+			Database:     schema.Database,
+			DatabaseType: schema.Type,
+			Environment:  environment,
+			Status:       "error",
+		})
 		return fmt.Errorf("update check state for apply start repo %s pr %d environment %s database_type %s database %s apply_id %s: apply row ID is unset",
 			repo, pr, environment, schema.Type, schema.Database, apply.ApplyIdentifier)
 	}

--- a/pkg/webhook/apply_check_records.go
+++ b/pkg/webhook/apply_check_records.go
@@ -24,6 +24,18 @@ func (h *Handler) storeApplyPlanCheckRecord(ctx context.Context, client *ghclien
 // state. If the apply is already terminal by the time the claim lands, the
 // stored check state is immediately refreshed to the apply's terminal outcome.
 func (h *Handler) updateCheckRecordForApplyStart(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, environment string, apply *storage.Apply) error {
+	// Fail closed on a missing or non-persisted apply before touching check
+	// state: claiming the check row without a real apply row would record
+	// ownership nothing can ever reconcile.
+	if apply == nil {
+		return fmt.Errorf("update check state for apply start repo %s pr %d environment %s database_type %s database %s: apply is nil",
+			repo, pr, environment, schema.Type, schema.Database)
+	}
+	if apply.ID == 0 {
+		return fmt.Errorf("update check state for apply start repo %s pr %d environment %s database_type %s database %s apply_id %s: apply row ID is unset",
+			repo, pr, environment, schema.Type, schema.Database, apply.ApplyIdentifier)
+	}
+
 	check, err := h.service.Storage().Checks().Get(ctx, repo, pr, environment, schema.Type, schema.Database)
 	if err != nil {
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{

--- a/pkg/webhook/apply_check_records.go
+++ b/pkg/webhook/apply_check_records.go
@@ -23,7 +23,7 @@ func (h *Handler) storeApplyPlanCheckRecord(ctx context.Context, client *ghclien
 // when an apply begins execution. The aggregate check is updated to reflect the
 // state. If the apply is already terminal by the time the claim lands, the
 // stored check state is immediately refreshed to the apply's terminal outcome.
-func (h *Handler) updateCheckRecordForApplyStart(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, environment string, applyID int64) error {
+func (h *Handler) updateCheckRecordForApplyStart(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, schema *ghclient.SchemaRequestResult, environment string, apply *storage.Apply) error {
 	check, err := h.service.Storage().Checks().Get(ctx, repo, pr, environment, schema.Type, schema.Database)
 	if err != nil {
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
@@ -34,8 +34,8 @@ func (h *Handler) updateCheckRecordForApplyStart(ctx context.Context, client *gh
 			Environment:  environment,
 			Status:       "error",
 		})
-		return fmt.Errorf("look up stored check state for apply start repo %s pr %d environment %s database_type %s database %s apply_id %d: %w",
-			repo, pr, environment, schema.Type, schema.Database, applyID, err)
+		return fmt.Errorf("look up stored check state for apply start repo %s pr %d environment %s database_type %s database %s apply_id %s: %w",
+			repo, pr, environment, schema.Type, schema.Database, apply.ApplyIdentifier, err)
 	}
 
 	// A stored review-time deployment drift block must not be cleared by starting
@@ -55,9 +55,9 @@ func (h *Handler) updateCheckRecordForApplyStart(ctx context.Context, client *gh
 		h.logger.Warn("apply start refused: review-time deployment drift block is present; reconcile the deployment drift before applying",
 			"repo", repo, "pr", pr, "environment", environment,
 			"database_type", schema.Type, "database", schema.Database,
-			"apply_id", applyID, "head_sha", check.HeadSHA)
-		return fmt.Errorf("apply start refused for repo %s pr %d environment %s database_type %s database %s apply_id %d: review-time deployment drift block present",
-			repo, pr, environment, schema.Type, schema.Database, applyID)
+			"apply_id", apply.ApplyIdentifier, "head_sha", check.HeadSHA)
+		return fmt.Errorf("apply start refused for repo %s pr %d environment %s database_type %s database %s apply_id %s: review-time deployment drift block present",
+			repo, pr, environment, schema.Type, schema.Database, apply.ApplyIdentifier)
 	}
 
 	if check == nil {
@@ -72,8 +72,8 @@ func (h *Handler) updateCheckRecordForApplyStart(ctx context.Context, client *gh
 				Environment:  environment,
 				Status:       "error",
 			})
-			return fmt.Errorf("fetch PR for apply start check repo %s pr %d environment %s database_type %s database %s apply_id %d: %w",
-				repo, pr, environment, schema.Type, schema.Database, applyID, err)
+			return fmt.Errorf("fetch PR for apply start check repo %s pr %d environment %s database_type %s database %s apply_id %s: %w",
+				repo, pr, environment, schema.Type, schema.Database, apply.ApplyIdentifier, err)
 		}
 		check = &storage.Check{
 			Repository:   repo,
@@ -82,13 +82,13 @@ func (h *Handler) updateCheckRecordForApplyStart(ctx context.Context, client *gh
 			Environment:  environment,
 			DatabaseType: schema.Type,
 			DatabaseName: schema.Database,
-			ApplyID:      applyID,
+			ApplyID:      apply.ID,
 			HasChanges:   true,
 			Status:       checkStatusInProgress,
 			Conclusion:   "",
 		}
 	} else {
-		check.ApplyID = applyID
+		check.ApplyID = apply.ID
 		check.HasChanges = true
 		check.Status = checkStatusInProgress
 		check.Conclusion = ""
@@ -105,13 +105,13 @@ func (h *Handler) updateCheckRecordForApplyStart(ctx context.Context, client *gh
 			Environment:  environment,
 			Status:       "error",
 		})
-		return fmt.Errorf("upsert stored check state for apply start repo %s pr %d environment %s database_type %s database %s apply_id %d head_sha %s: %w",
-			repo, pr, environment, schema.Type, schema.Database, applyID, check.HeadSHA, err)
+		return fmt.Errorf("upsert stored check state for apply start repo %s pr %d environment %s database_type %s database %s apply_id %s head_sha %s: %w",
+			repo, pr, environment, schema.Type, schema.Database, apply.ApplyIdentifier, check.HeadSHA, err)
 	}
 	h.logger.Info("check record marked in_progress for apply",
 		"repo", repo, "pr", pr, "database", schema.Database,
 		"database_type", schema.Type, "environment", environment,
-		"apply_id", applyID, "head_sha", check.HeadSHA)
+		"apply_id", apply.ApplyIdentifier, "head_sha", check.HeadSHA)
 
 	metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
 		Operation:    "apply_started",
@@ -129,19 +129,19 @@ func (h *Handler) updateCheckRecordForApplyStart(ctx context.Context, client *gh
 	// the terminal refresh here so the stored check state converges to the
 	// apply's outcome instead of staying in_progress with no writer left to
 	// complete it.
-	apply, err := h.service.Storage().Applies().Get(ctx, applyID)
+	reloaded, err := h.service.Storage().Applies().Get(ctx, apply.ID)
 	if err != nil {
-		return fmt.Errorf("reload apply after check claim repo %s pr %d environment %s database_type %s database %s apply_id %d: %w",
-			repo, pr, environment, schema.Type, schema.Database, applyID, err)
+		return fmt.Errorf("reload apply after check claim repo %s pr %d environment %s database_type %s database %s apply_id %s: %w",
+			repo, pr, environment, schema.Type, schema.Database, apply.ApplyIdentifier, err)
 	}
-	if apply == nil {
-		return fmt.Errorf("apply missing after check claim repo %s pr %d environment %s database_type %s database %s apply_id %d",
-			repo, pr, environment, schema.Type, schema.Database, applyID)
+	if reloaded == nil {
+		return fmt.Errorf("apply missing after check claim repo %s pr %d environment %s database_type %s database %s apply_id %s",
+			repo, pr, environment, schema.Type, schema.Database, apply.ApplyIdentifier)
 	}
-	if state.IsTerminalApplyState(apply.State) {
+	if state.IsTerminalApplyState(reloaded.State) {
 		h.logger.Info("apply finished before its check claim; refreshing stored check state to the terminal outcome",
-			apply.LogAttrs()...)
-		h.refreshChecksForTerminalApply(ctx, apply, "apply finished before check claim")
+			reloaded.LogAttrs()...)
+		h.refreshChecksForTerminalApply(ctx, reloaded, "apply finished before check claim")
 		// The refresh resolves its own GitHub client from the durable apply; if
 		// that resolution fails, the stored check state has still converged but
 		// the visible aggregate Check Run has not. Refresh it with the request's

--- a/pkg/webhook/apply_check_records_integration_test.go
+++ b/pkg/webhook/apply_check_records_integration_test.go
@@ -255,9 +255,9 @@ func TestUpdateCheckRecordForApplyStart_RollbackOnConcludedAggregatePublishesFre
 			"user": map[string]any{"login": "testuser"},
 		}))
 	})
-	var created []rewindCheckRunBody
+	var created []checkRunCapture
 	mux.HandleFunc("POST /repos/octocat/rollback-green-gate/check-runs", func(w http.ResponseWriter, r *http.Request) {
-		var body rewindCheckRunBody
+		var body checkRunCapture
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
 		created = append(created, body)
 		w.WriteHeader(http.StatusCreated)

--- a/pkg/webhook/apply_check_records_integration_test.go
+++ b/pkg/webhook/apply_check_records_integration_test.go
@@ -115,7 +115,7 @@ func TestUpdateCheckRecordForApplyStart_ConvergesWhenApplyAlreadyTerminal(t *tes
 	// stored check state to the apply's terminal outcome instead of leaving the
 	// row in_progress with no writer left to complete it.
 	schema := &ghclient.SchemaRequestResult{Type: "mysql", Database: dbn}
-	require.NoError(t, h.updateCheckRecordForApplyStart(ctx, installClient, repo, pr, schema, env, applyID))
+	require.NoError(t, h.updateCheckRecordForApplyStart(ctx, installClient, repo, pr, schema, env, apply))
 
 	check, err = st.Checks().Get(ctx, repo, pr, env, "mysql", dbn)
 	require.NoError(t, err)
@@ -179,6 +179,7 @@ func TestUpdateCheckRecordForApplyStart_KeepsInProgressForRunningApply(t *testin
 	}
 	applyID, err := st.Applies().Create(ctx, apply)
 	require.NoError(t, err)
+	apply.ID = applyID
 
 	require.NoError(t, st.Checks().Upsert(ctx, &storage.Check{
 		Repository:   repo,
@@ -194,7 +195,7 @@ func TestUpdateCheckRecordForApplyStart_KeepsInProgressForRunningApply(t *testin
 	}))
 
 	schema := &ghclient.SchemaRequestResult{Type: "mysql", Database: dbn}
-	require.NoError(t, h.updateCheckRecordForApplyStart(ctx, installClient, repo, pr, schema, env, applyID))
+	require.NoError(t, h.updateCheckRecordForApplyStart(ctx, installClient, repo, pr, schema, env, apply))
 
 	check, err := st.Checks().Get(ctx, repo, pr, env, "mysql", dbn)
 	require.NoError(t, err)

--- a/pkg/webhook/apply_check_records_integration_test.go
+++ b/pkg/webhook/apply_check_records_integration_test.go
@@ -5,7 +5,9 @@ package webhook
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"log/slog"
+	"net/http"
 	"net/url"
 	"os"
 	"testing"
@@ -204,4 +206,151 @@ func TestUpdateCheckRecordForApplyStart_KeepsInProgressForRunningApply(t *testin
 	assert.Empty(t, check.Conclusion)
 	assert.Equal(t, applyID, check.ApplyID)
 	assert.True(t, check.HasChanges)
+}
+
+// The full merge-gate chain for an apply that starts on a commit whose
+// aggregate Check Run already concluded green — the rollback-confirm flow: the
+// original apply completed and concluded the aggregate as success, then a
+// rollback begins on the same head SHA. The check claim must flip the stored
+// per-database state to in_progress, and the aggregate recompute must publish
+// the rewind as a fresh in-progress Check Run rather than updating the
+// concluded one (GitHub keeps a concluded run's conclusion, which would leave
+// a passing merge gate over the active rollback drive).
+func TestUpdateCheckRecordForApplyStart_RollbackOnConcludedAggregatePublishesFreshCheckRun(t *testing.T) {
+	ctx := t.Context()
+
+	db, err := sql.Open("mysql", e2eSchemabotDSN)
+	require.NoError(t, err)
+	require.NoError(t, db.PingContext(ctx))
+	t.Cleanup(func() { assert.NoError(t, db.Close()) })
+
+	const (
+		repo    = "octocat/rollback-green-gate"
+		pr      = 12
+		dbn     = "rollback_green_gate_db"
+		env     = "staging"
+		headSHA = "abc123"
+	)
+
+	clear := func(c context.Context) {
+		_, err := db.ExecContext(c, "DELETE FROM checks WHERE repository = ? AND pull_request = ?", repo, pr)
+		require.NoError(t, err)
+		_, err = db.ExecContext(c, "DELETE FROM applies WHERE repository = ? AND pull_request = ?", repo, pr)
+		require.NoError(t, err)
+	}
+	clear(ctx)
+	// Cleanup runs after t.Context() is cancelled, so derive a non-cancelled
+	// context from it for the cleanup deletes.
+	t.Cleanup(func() { clear(context.WithoutCancel(ctx)) })
+
+	st := mysqlstore.New(db)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := api.New(st, &api.ServerConfig{Repos: map[string]api.RepoConfig{repo: {}}}, nil, logger)
+
+	ghClient, mux := setupGitHubServer(t)
+	mux.HandleFunc("GET /repos/octocat/rollback-green-gate/pulls/12", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"head": map[string]any{"sha": headSHA, "ref": "feature-branch"},
+			"base": map[string]any{"sha": "def456", "ref": "main"},
+			"user": map[string]any{"login": "testuser"},
+		}))
+	})
+	var created []rewindCheckRunBody
+	mux.HandleFunc("POST /repos/octocat/rollback-green-gate/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		var body rewindCheckRunBody
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		created = append(created, body)
+		w.WriteHeader(http.StatusCreated)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 999}))
+	})
+	var patched bool
+	mux.HandleFunc("PATCH /repos/octocat/rollback-green-gate/check-runs/", func(w http.ResponseWriter, _ *http.Request) {
+		patched = true
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 555}))
+	})
+	installClient := ghclient.NewInstallationClient(ghClient, logger)
+	factory := &fakeClientFactory{client: installClient}
+	h := NewHandler(svc, factory, nil, logger)
+
+	// The original apply completed; its per-database check and the aggregate
+	// Check Run both concluded success.
+	originalApply := &storage.Apply{
+		ApplyIdentifier: "apply-original-completed",
+		Database:        dbn,
+		DatabaseType:    "mysql",
+		Repository:      repo,
+		PullRequest:     pr,
+		Environment:     env,
+		Engine:          storage.EngineSpirit,
+		InstallationID:  4242,
+		State:           state.Apply.Completed,
+	}
+	originalApplyID, err := st.Applies().Create(ctx, originalApply)
+	require.NoError(t, err)
+
+	require.NoError(t, st.Checks().Upsert(ctx, &storage.Check{
+		Repository:   repo,
+		PullRequest:  pr,
+		HeadSHA:      headSHA,
+		Environment:  env,
+		DatabaseType: "mysql",
+		DatabaseName: dbn,
+		ApplyID:      originalApplyID,
+		HasChanges:   true,
+		Status:       checkStatusCompleted,
+		Conclusion:   checkConclusionSuccess,
+	}))
+	require.NoError(t, st.Checks().Upsert(ctx, &storage.Check{
+		Repository:   repo,
+		PullRequest:  pr,
+		HeadSHA:      headSHA,
+		Environment:  aggregateSentinel,
+		DatabaseType: aggregateSentinel,
+		DatabaseName: aggregateSentinel,
+		CheckRunID:   555,
+		Status:       checkStatusCompleted,
+		Conclusion:   checkConclusionSuccess,
+	}))
+
+	// The rollback apply is running on the same head SHA.
+	rollbackApply := &storage.Apply{
+		ApplyIdentifier: "apply-rollback-drive",
+		Database:        dbn,
+		DatabaseType:    "mysql",
+		Repository:      repo,
+		PullRequest:     pr,
+		Environment:     env,
+		Engine:          storage.EngineSpirit,
+		InstallationID:  4242,
+		State:           state.Apply.Running,
+	}
+	rollbackApplyID, err := st.Applies().Create(ctx, rollbackApply)
+	require.NoError(t, err)
+	rollbackApply.ID = rollbackApplyID
+
+	schema := &ghclient.SchemaRequestResult{Type: "mysql", Database: dbn}
+	require.NoError(t, h.updateCheckRecordForApplyStart(ctx, installClient, repo, pr, schema, env, rollbackApply))
+
+	// The rollback now owns the per-database check, back in progress.
+	check, err := st.Checks().Get(ctx, repo, pr, env, "mysql", dbn)
+	require.NoError(t, err)
+	require.NotNil(t, check)
+	assert.Equal(t, checkStatusInProgress, check.Status)
+	assert.Empty(t, check.Conclusion)
+	assert.Equal(t, rollbackApplyID, check.ApplyID)
+
+	// The concluded Check Run was not reused; a fresh in-progress run gates the
+	// PR and the stored aggregate state tracks it.
+	assert.False(t, patched, "the concluded Check Run must not be reused: GitHub keeps its conclusion, leaving a passing check over the rollback drive")
+	require.Len(t, created, 1, "the rewind must publish exactly one fresh Check Run")
+	assert.Equal(t, aggregateCheckName, created[0].Name)
+	assert.Equal(t, checkStatusInProgress, created[0].Status)
+	assert.Empty(t, created[0].Conclusion)
+
+	aggregate, err := st.Checks().Get(ctx, repo, pr, aggregateSentinel, aggregateSentinel, aggregateSentinel)
+	require.NoError(t, err)
+	require.NotNil(t, aggregate)
+	assert.Equal(t, int64(999), aggregate.CheckRunID)
+	assert.Equal(t, checkStatusInProgress, aggregate.Status)
+	assert.Empty(t, aggregate.Conclusion)
 }

--- a/pkg/webhook/apply_check_records_integration_test.go
+++ b/pkg/webhook/apply_check_records_integration_test.go
@@ -268,7 +268,11 @@ func TestUpdateCheckRecordForApplyStart_RollbackOnConcludedAggregatePublishesFre
 		patched = true
 		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 555}))
 	})
-	installClient := ghclient.NewInstallationClient(ghClient, logger)
+	serveTrustedCheckRuns(t, mux, repo, headSHA, ghclient.CheckRunResult{
+		ID: 555, Name: aggregateCheckName,
+		Status: checkStatusCompleted, Conclusion: checkConclusionSuccess,
+	})
+	installClient := ghclient.NewInstallationClientWithSlug(ghClient, logger, "schemabot")
 	factory := &fakeClientFactory{client: installClient}
 	h := NewHandler(svc, factory, nil, logger)
 

--- a/pkg/webhook/apply_check_records_test.go
+++ b/pkg/webhook/apply_check_records_test.go
@@ -63,7 +63,8 @@ func TestUpdateCheckRecordForApplyStartRefusesDriftBlock(t *testing.T) {
 		Type:     "mysql",
 	}
 
-	err := h.updateCheckRecordForApplyStart(t.Context(), nil, "octocat/hello-world", 1, schema, "production", 42)
+	apply := &storage.Apply{ID: 42, ApplyIdentifier: "apply-drift42"}
+	err := h.updateCheckRecordForApplyStart(t.Context(), nil, "octocat/hello-world", 1, schema, "production", apply)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "review-time deployment drift block present")

--- a/pkg/webhook/apply_execute.go
+++ b/pkg/webhook/apply_execute.go
@@ -238,7 +238,7 @@ func (h *Handler) executeApply(
 	h.postInitialProgressComment(ctx, repo, pr, installationID, apply, progressBody)
 
 	// Update stored check state to in_progress (transitions action_required to in_progress).
-	if err := h.updateCheckRecordForApplyStart(ctx, client, repo, pr, schemaResult, environment, applyID); err != nil {
+	if err := h.updateCheckRecordForApplyStart(ctx, client, repo, pr, schemaResult, environment, apply); err != nil {
 		h.logger.Error("failed to mark check in_progress for apply",
 			"repo", repo, "pr", pr, "database", database,
 			"database_type", schemaResult.Type, "environment", environment,

--- a/pkg/webhook/apply_execute.go
+++ b/pkg/webhook/apply_execute.go
@@ -212,14 +212,14 @@ func (h *Handler) executeApply(
 		h.logger.Error("failed to load apply after accepted apply",
 			"repo", repo, "pr", pr, "database", database,
 			"database_type", schemaResult.Type, "environment", environment,
-			"apply_id", applyID, "error", err)
+			"apply_id", applyResp.ApplyID, "error", err)
 		return
 	}
 	if apply == nil {
 		h.logger.Error("apply missing after accepted apply",
 			"repo", repo, "pr", pr, "database", database,
 			"database_type", schemaResult.Type, "environment", environment,
-			"apply_id", applyID)
+			"apply_id", applyResp.ApplyID)
 		return
 	}
 
@@ -240,9 +240,7 @@ func (h *Handler) executeApply(
 	// Update stored check state to in_progress (transitions action_required to in_progress).
 	if err := h.updateCheckRecordForApplyStart(ctx, client, repo, pr, schemaResult, environment, apply); err != nil {
 		h.logger.Error("failed to mark check in_progress for apply",
-			"repo", repo, "pr", pr, "database", database,
-			"database_type", schemaResult.Type, "environment", environment,
-			"apply_id", applyID, "error", err)
+			append(apply.LogAttrs(), "error", err)...)
 		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Apply was accepted, but SchemaBot could not update the required status check: "+err.Error())
 		return
 	}

--- a/pkg/webhook/check_publisher.go
+++ b/pkg/webhook/check_publisher.go
@@ -281,7 +281,18 @@ func (h *Handler) updateAggregateCheckOnce(ctx context.Context, client *ghclient
 	if participantsRetriable {
 		return aggregateFoldScheduleParticipantRefold, errors.Join(upsertErrs...)
 	}
-	return aggregateFoldClearParticipantRefoldBudget, errors.Join(upsertErrs...)
+	if len(upsertErrs) > 0 {
+		// A failed aggregate publish (the GitHub Check Run write or the storage
+		// write recording it) left at least one environment's gate not
+		// reflecting this fold. Callers that own a durable retry act on the
+		// returned error, but the fire-and-forget entry points (apply and
+		// rollback claims, webhook events) have none — arm the bounded re-fold
+		// so one transient write failure cannot strand the gate on its previous
+		// state, such as a passing aggregate persisting over a just-claimed
+		// rollback.
+		return aggregateFoldScheduleParticipantRefold, errors.Join(upsertErrs...)
+	}
+	return aggregateFoldClearParticipantRefoldBudget, nil
 }
 
 // prFilePaths extracts the changed-file paths from a PR file listing for

--- a/pkg/webhook/check_publisher.go
+++ b/pkg/webhook/check_publisher.go
@@ -316,14 +316,6 @@ func prFilePaths(files []ghclient.PRFile) []string {
 // returns the underlying error so a caller with a retry mechanism can react to a
 // failed GitHub or storage write. A stored blocking reason is an intentional
 // fail-closed skip, not an operational failure, so it returns nil.
-// rewindsConcludedCheckRun reports whether publishing the recomputed status to
-// the stored Check Run would move an already-concluded run out of "completed".
-// The GitHub Checks API does not allow that transition on an existing run, so
-// callers must publish the rewind as a fresh Check Run instead.
-func rewindsConcludedCheckRun(existing *storage.Check, status string) bool {
-	return existing.Status == checkStatusCompleted && status != checkStatusCompleted
-}
-
 func (h *Handler) upsertAggregateCheckRunOnce(
 	ctx context.Context, client *ghclient.InstallationClient,
 	repo string, pr int, headSHA string,
@@ -390,32 +382,71 @@ func (h *Handler) upsertAggregateCheckRunOnce(
 	// Create a new check run if no existing record, or if the HEAD SHA changed
 	// (new commit pushed). Updating an old check run tied to a previous SHA is
 	// invisible on the PR — GitHub only shows checks for the HEAD commit.
-	//
-	// A concluded Check Run also cannot be reused: GitHub does not move a
+	reuseExistingRun := existing != nil && existing.CheckRunID != 0 && existing.HeadSHA == headSHA
+
+	// Branch protection gates on the newest Check Run for this name on this
+	// commit, and stored state can skew from it: the GitHub write and the
+	// storage write are not atomic, and concurrent folds can each publish a
+	// run. Decide reuse against that newest run's real status, not the stored
+	// one — updating the run stored state names can leave a newer, concluded
+	// run gating the PR with a conclusion this fold never intended.
+	var liveRun *ghclient.CheckRunResult
+	if reuseExistingRun {
+		run, _, err := client.FindCheckRunByName(ctx, repo, headSHA, checkName)
+		if err != nil {
+			metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+				Operation:   "aggregate_check_sync",
+				Repository:  repo,
+				Environment: environment,
+				Status:      "error",
+			})
+			h.logger.Error("failed to resolve the newest aggregate check run, not publishing aggregate",
+				"repo", repo, "pr", pr, "check_name", checkName,
+				"environment", environment, "head_sha", headSHA,
+				"stored_check_run_id", existing.CheckRunID, "error", err)
+			return fmt.Errorf("resolve newest aggregate check run %q for %s#%d@%s (env %s): %w", checkName, repo, pr, headSHA, environment, err)
+		}
+		if run == nil {
+			// Stored state names a run for this commit that no trusted App run
+			// matches on GitHub. Publish a fresh run instead of updating a run
+			// this deployment cannot see.
+			h.logger.Warn("stored aggregate check run not found on the commit, publishing a fresh aggregate check run",
+				"repo", repo, "pr", pr, "check_name", checkName,
+				"environment", environment, "head_sha", headSHA,
+				"stored_check_run_id", existing.CheckRunID)
+			reuseExistingRun = false
+		}
+		liveRun = run
+	}
+
+	// A concluded Check Run cannot be rewound: GitHub does not move a
 	// completed run back to in_progress — it applies the new output but keeps
 	// the stored conclusion, leaving a passing Check Run whose text says an
 	// apply is running. Publish the rewind as a fresh Check Run on the same
-	// name and SHA instead; GitHub surfaces the most recent run per name, so
-	// the new in-progress run replaces the concluded one on the PR and in
-	// branch protection.
-	reuseExistingRun := existing != nil && existing.CheckRunID != 0 && existing.HeadSHA == headSHA
-	if reuseExistingRun && rewindsConcludedCheckRun(existing, status) {
-		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
-			Operation:   "aggregate_check_sync",
-			Repository:  repo,
-			Environment: environment,
-			Status:      "recreated",
-		})
-		h.logger.Info("re-creating aggregate check run: the existing run already concluded and GitHub cannot move it back out of completed",
+	// name and SHA instead; the new in-progress run replaces the concluded one
+	// on the PR and in branch protection.
+	rewound := reuseExistingRun && rewindsConcludedCheckRun(liveRun, status)
+	if rewound {
+		h.logger.Info("re-creating aggregate check run: the newest run already concluded and GitHub cannot move it back out of completed",
 			"repo", repo, "pr", pr, "check_name", checkName,
 			"environment", environment, "head_sha", headSHA,
-			"concluded_check_run_id", existing.CheckRunID,
-			"stored_conclusion", existing.Conclusion, "status", status)
+			"concluded_check_run_id", liveRun.ID,
+			"concluded_conclusion", liveRun.Conclusion, "status", status)
 		reuseExistingRun = false
 	}
 	var checkRunID int64
 	if reuseExistingRun {
-		if err := client.UpdateCheckRun(ctx, repo, existing.CheckRunID, opts); err != nil {
+		if liveRun.ID != existing.CheckRunID {
+			// The newest run is not the one stored state recorded — a previous
+			// fold published a run but failed the storage write, or another
+			// fold raced this one. Adopt the newest run: it is what gates the
+			// PR, and recording it below re-converges stored state with GitHub.
+			h.logger.Warn("adopting a newer aggregate check run than the stored one",
+				"repo", repo, "pr", pr, "check_name", checkName,
+				"environment", environment, "head_sha", headSHA,
+				"stored_check_run_id", existing.CheckRunID, "check_run_id", liveRun.ID)
+		}
+		if err := client.UpdateCheckRun(ctx, repo, liveRun.ID, opts); err != nil {
 			metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
 				Operation:   "aggregate_check_sync",
 				Repository:  repo,
@@ -424,12 +455,12 @@ func (h *Handler) upsertAggregateCheckRunOnce(
 			})
 			h.logger.Error("failed to update aggregate check run",
 				"repo", repo, "pr", pr, "check_name", checkName,
-				"environment", environment, "check_run_id", existing.CheckRunID,
+				"environment", environment, "check_run_id", liveRun.ID,
 				"head_sha", headSHA, "status", status,
 				"conclusion", conclusion, "error", err)
-			return fmt.Errorf("update aggregate check run %d for %s#%d (env %s): %w", existing.CheckRunID, repo, pr, environment, err)
+			return fmt.Errorf("update aggregate check run %d for %s#%d (env %s): %w", liveRun.ID, repo, pr, environment, err)
 		}
-		checkRunID = existing.CheckRunID
+		checkRunID = liveRun.ID
 	} else {
 		if existing != nil && existing.HeadSHA != headSHA {
 			h.logger.Info("re-creating aggregate check on new HEAD SHA",
@@ -449,6 +480,14 @@ func (h *Handler) upsertAggregateCheckRunOnce(
 				"environment", environment, "head_sha", headSHA,
 				"status", status, "conclusion", conclusion, "error", err)
 			return fmt.Errorf("create aggregate check run for %s#%d@%s (env %s): %w", repo, pr, headSHA, environment, err)
+		}
+		if rewound {
+			metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+				Operation:   "aggregate_check_sync",
+				Repository:  repo,
+				Environment: environment,
+				Status:      "recreated",
+			})
 		}
 		checkRunID = id
 	}
@@ -492,6 +531,15 @@ func (h *Handler) upsertAggregateCheckRunOnce(
 		"status", status, "conclusion", conclusion,
 		"per_database_checks", len(dbChecks))
 	return nil
+}
+
+// rewindsConcludedCheckRun reports whether publishing the recomputed status to
+// the given live Check Run would move an already-concluded run out of
+// "completed". The GitHub Checks API does not allow that transition on an
+// existing run, so callers must publish the rewind as a fresh Check Run
+// instead.
+func rewindsConcludedCheckRun(run *ghclient.CheckRunResult, status string) bool {
+	return run.Status == checkStatusCompleted && status != checkStatusCompleted
 }
 
 // postPassingAggregates posts a passing aggregate check for each allowed environment.

--- a/pkg/webhook/check_publisher.go
+++ b/pkg/webhook/check_publisher.go
@@ -316,6 +316,14 @@ func prFilePaths(files []ghclient.PRFile) []string {
 // returns the underlying error so a caller with a retry mechanism can react to a
 // failed GitHub or storage write. A stored blocking reason is an intentional
 // fail-closed skip, not an operational failure, so it returns nil.
+// rewindsConcludedCheckRun reports whether publishing the recomputed status to
+// the stored Check Run would move an already-concluded run out of "completed".
+// The GitHub Checks API does not allow that transition on an existing run, so
+// callers must publish the rewind as a fresh Check Run instead.
+func rewindsConcludedCheckRun(existing *storage.Check, status string) bool {
+	return existing.Status == checkStatusCompleted && status != checkStatusCompleted
+}
+
 func (h *Handler) upsertAggregateCheckRunOnce(
 	ctx context.Context, client *ghclient.InstallationClient,
 	repo string, pr int, headSHA string,
@@ -382,8 +390,31 @@ func (h *Handler) upsertAggregateCheckRunOnce(
 	// Create a new check run if no existing record, or if the HEAD SHA changed
 	// (new commit pushed). Updating an old check run tied to a previous SHA is
 	// invisible on the PR — GitHub only shows checks for the HEAD commit.
+	//
+	// A concluded Check Run also cannot be reused: GitHub does not move a
+	// completed run back to in_progress — it applies the new output but keeps
+	// the stored conclusion, leaving a passing Check Run whose text says an
+	// apply is running. Publish the rewind as a fresh Check Run on the same
+	// name and SHA instead; GitHub surfaces the most recent run per name, so
+	// the new in-progress run replaces the concluded one on the PR and in
+	// branch protection.
+	reuseExistingRun := existing != nil && existing.CheckRunID != 0 && existing.HeadSHA == headSHA
+	if reuseExistingRun && rewindsConcludedCheckRun(existing, status) {
+		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
+			Operation:   "aggregate_check_sync",
+			Repository:  repo,
+			Environment: environment,
+			Status:      "recreated",
+		})
+		h.logger.Info("re-creating aggregate check run: the existing run already concluded and GitHub cannot move it back out of completed",
+			"repo", repo, "pr", pr, "check_name", checkName,
+			"environment", environment, "head_sha", headSHA,
+			"concluded_check_run_id", existing.CheckRunID,
+			"stored_conclusion", existing.Conclusion, "status", status)
+		reuseExistingRun = false
+	}
 	var checkRunID int64
-	if existing != nil && existing.CheckRunID != 0 && existing.HeadSHA == headSHA {
+	if reuseExistingRun {
 		if err := client.UpdateCheckRun(ctx, repo, existing.CheckRunID, opts); err != nil {
 			metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
 				Operation:   "aggregate_check_sync",

--- a/pkg/webhook/check_publisher_rewind_test.go
+++ b/pkg/webhook/check_publisher_rewind_test.go
@@ -3,11 +3,13 @@ package webhook
 import (
 	"encoding/json"
 	"net/http"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ghclient "github.com/block/schemabot/pkg/github"
 	"github.com/block/schemabot/pkg/storage"
 )
 
@@ -38,6 +40,10 @@ func TestAggregateRewindFromConcludedCreatesFreshCheckRun(t *testing.T) {
 	}
 	h, mux, client := newFoldHandler(t, nonAggregateConfig(), store)
 	serveHeadSHA(t, mux, "abc123")
+	serveTrustedCheckRuns(t, mux, "octocat/hello-world", "abc123", ghclient.CheckRunResult{
+		ID: 555, Name: aggregateCheckName,
+		Status: checkStatusCompleted, Conclusion: checkConclusionSuccess,
+	})
 
 	var created []checkRunCapture
 	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
@@ -89,6 +95,10 @@ func TestAggregateRecomputeOnConcludedRunReusesItWhenStillCompleted(t *testing.T
 	}
 	h, mux, client := newFoldHandler(t, nonAggregateConfig(), store)
 	serveHeadSHA(t, mux, "abc123")
+	serveTrustedCheckRuns(t, mux, "octocat/hello-world", "abc123", ghclient.CheckRunResult{
+		ID: 555, Name: aggregateCheckName,
+		Status: checkStatusCompleted, Conclusion: checkConclusionActionRequired,
+	})
 
 	var created bool
 	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, _ *http.Request) {
@@ -114,4 +124,167 @@ func TestAggregateRecomputeOnConcludedRunReusesItWhenStillCompleted(t *testing.T
 
 	require.Len(t, store.upserted, 1)
 	assert.Equal(t, int64(555), store.upserted[0].CheckRunID)
+}
+
+// TestAggregateRewindDecidesFromLiveRunNotStoredState pins the skew case: the
+// stored aggregate row still says in_progress while the run on GitHub has
+// already concluded (the GitHub write landed but the storage write recording
+// it did not). Deciding reuse from the stored status would update the
+// concluded run in place — GitHub keeps its conclusion, so a passing Check
+// Run would gate the PR while an apply is running. The fold must decide from
+// the run's real status and publish the rewind as a fresh in-progress run.
+func TestAggregateRewindDecidesFromLiveRunNotStoredState(t *testing.T) {
+	store := &foldCheckStore{
+		byPR: []*storage.Check{{
+			Repository: "octocat/hello-world", PullRequest: 1, HeadSHA: "abc123",
+			Environment: "staging", DatabaseType: "mysql", DatabaseName: "orders",
+			ApplyID: 42, HasChanges: true,
+			Status: checkStatusInProgress, Conclusion: "",
+		}},
+		get: &storage.Check{
+			Repository: "octocat/hello-world", PullRequest: 1, HeadSHA: "abc123",
+			Environment: aggregateSentinel, DatabaseType: aggregateSentinel, DatabaseName: aggregateSentinel,
+			CheckRunID: 555,
+			Status:     checkStatusInProgress, Conclusion: "",
+		},
+	}
+	h, mux, client := newFoldHandler(t, nonAggregateConfig(), store)
+	serveHeadSHA(t, mux, "abc123")
+	serveTrustedCheckRuns(t, mux, "octocat/hello-world", "abc123", ghclient.CheckRunResult{
+		ID: 555, Name: aggregateCheckName,
+		Status: checkStatusCompleted, Conclusion: checkConclusionSuccess,
+	})
+
+	var created []checkRunCapture
+	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		var body checkRunCapture
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		created = append(created, body)
+		w.WriteHeader(http.StatusCreated)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 999}))
+	})
+	var patched bool
+	mux.HandleFunc("PATCH /repos/octocat/hello-world/check-runs/", func(w http.ResponseWriter, _ *http.Request) {
+		patched = true
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 555}))
+	})
+
+	_, err := h.updateAggregateCheckOnce(t.Context(), client, "octocat/hello-world", 1, "abc123")
+	require.NoError(t, err)
+
+	assert.False(t, patched, "the concluded run on GitHub must not be updated in place even when stored state says it is still in_progress")
+	require.Len(t, created, 1, "the rewind must publish exactly one fresh Check Run")
+	assert.Equal(t, checkStatusInProgress, created[0].Status)
+	assert.Empty(t, created[0].Conclusion)
+
+	require.Len(t, store.upserted, 1)
+	assert.Equal(t, int64(999), store.upserted[0].CheckRunID)
+}
+
+// TestAggregateFoldAdoptsNewestCheckRun pins the orphan-adoption case: a
+// previous fold published a fresh run but the storage write recording it
+// failed, so stored state still names the older run. GitHub gates on the
+// newest run per name, so publishing to the stored run would leave the
+// orphaned newest run in_progress forever — a permanent pending gate. The
+// fold must publish to the newest run and record it, converging stored state
+// with GitHub.
+func TestAggregateFoldAdoptsNewestCheckRun(t *testing.T) {
+	store := &foldCheckStore{
+		byPR: []*storage.Check{{
+			Repository: "octocat/hello-world", PullRequest: 1, HeadSHA: "abc123",
+			Environment: "staging", DatabaseType: "mysql", DatabaseName: "orders",
+			Status: checkStatusCompleted, Conclusion: checkConclusionSuccess,
+		}},
+		get: &storage.Check{
+			Repository: "octocat/hello-world", PullRequest: 1, HeadSHA: "abc123",
+			Environment: aggregateSentinel, DatabaseType: aggregateSentinel, DatabaseName: aggregateSentinel,
+			CheckRunID: 555,
+			Status:     checkStatusCompleted, Conclusion: checkConclusionSuccess,
+		},
+	}
+	h, mux, client := newFoldHandler(t, nonAggregateConfig(), store)
+	serveHeadSHA(t, mux, "abc123")
+	serveTrustedCheckRuns(t, mux, "octocat/hello-world", "abc123",
+		ghclient.CheckRunResult{
+			ID: 555, Name: aggregateCheckName,
+			Status: checkStatusCompleted, Conclusion: checkConclusionSuccess,
+		},
+		ghclient.CheckRunResult{
+			ID: 999, Name: aggregateCheckName,
+			Status: checkStatusInProgress,
+		})
+
+	var created bool
+	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		created = true
+		w.WriteHeader(http.StatusCreated)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 1000}))
+	})
+	var patchedIDs []string
+	var patchedBodies []checkRunCapture
+	mux.HandleFunc("PATCH /repos/octocat/hello-world/check-runs/", func(w http.ResponseWriter, r *http.Request) {
+		patchedIDs = append(patchedIDs, path.Base(r.URL.Path))
+		var body checkRunCapture
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		patchedBodies = append(patchedBodies, body)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 999}))
+	})
+
+	_, err := h.updateAggregateCheckOnce(t.Context(), client, "octocat/hello-world", 1, "abc123")
+	require.NoError(t, err)
+
+	assert.False(t, created, "the fold must adopt the newest run, not mint another duplicate")
+	require.Len(t, patchedIDs, 1, "exactly one Check Run update expected")
+	assert.Equal(t, "999", patchedIDs[0], "the newest run is what gates the PR and must receive the fold's outcome")
+	assert.Equal(t, checkStatusCompleted, patchedBodies[0].Status)
+	assert.Equal(t, checkConclusionSuccess, patchedBodies[0].Conclusion)
+
+	require.Len(t, store.upserted, 1)
+	assert.Equal(t, int64(999), store.upserted[0].CheckRunID, "stored state must converge on the run GitHub gates on")
+}
+
+// TestAggregateFoldPublishesFreshRunWhenStoredRunMissing covers stored state
+// naming a Check Run that no trusted run on the commit matches: the fold must
+// publish a fresh run rather than updating a run it cannot see.
+func TestAggregateFoldPublishesFreshRunWhenStoredRunMissing(t *testing.T) {
+	store := &foldCheckStore{
+		byPR: []*storage.Check{{
+			Repository: "octocat/hello-world", PullRequest: 1, HeadSHA: "abc123",
+			Environment: "staging", DatabaseType: "mysql", DatabaseName: "orders",
+			ApplyID: 42, HasChanges: true,
+			Status: checkStatusInProgress, Conclusion: "",
+		}},
+		get: &storage.Check{
+			Repository: "octocat/hello-world", PullRequest: 1, HeadSHA: "abc123",
+			Environment: aggregateSentinel, DatabaseType: aggregateSentinel, DatabaseName: aggregateSentinel,
+			CheckRunID: 555,
+			Status:     checkStatusInProgress, Conclusion: "",
+		},
+	}
+	h, mux, client := newFoldHandler(t, nonAggregateConfig(), store)
+	serveHeadSHA(t, mux, "abc123")
+	serveTrustedCheckRuns(t, mux, "octocat/hello-world", "abc123")
+
+	var created []checkRunCapture
+	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		var body checkRunCapture
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		created = append(created, body)
+		w.WriteHeader(http.StatusCreated)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 999}))
+	})
+	var patched bool
+	mux.HandleFunc("PATCH /repos/octocat/hello-world/check-runs/", func(w http.ResponseWriter, _ *http.Request) {
+		patched = true
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 555}))
+	})
+
+	_, err := h.updateAggregateCheckOnce(t.Context(), client, "octocat/hello-world", 1, "abc123")
+	require.NoError(t, err)
+
+	assert.False(t, patched, "a run absent from the commit must not be updated")
+	require.Len(t, created, 1)
+	assert.Equal(t, checkStatusInProgress, created[0].Status)
+	require.Len(t, store.upserted, 1)
+	assert.Equal(t, int64(999), store.upserted[0].CheckRunID)
 }

--- a/pkg/webhook/check_publisher_rewind_test.go
+++ b/pkg/webhook/check_publisher_rewind_test.go
@@ -1,0 +1,125 @@
+package webhook
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// rewindCheckRunBody captures the Check Run payload the fold publishes so the
+// tests can assert on the exact status and conclusion sent to GitHub.
+type rewindCheckRunBody struct {
+	Name       string `json:"name"`
+	Status     string `json:"status"`
+	Conclusion string `json:"conclusion"`
+}
+
+// TestAggregateRewindFromConcludedCreatesFreshCheckRun exercises the merge
+// gate when an apply starts on a PR whose aggregate Check Run already
+// concluded — the rollback-confirm flow, where the original apply completed
+// the aggregate as success before the rollback drive begins. GitHub does not
+// move a concluded Check Run back out of "completed" (an update lands the new
+// output but keeps the stored conclusion), so reusing the concluded run would
+// leave a passing check on the PR while the rollback is still driving. The
+// fold must publish the rewind as a fresh in-progress Check Run and store the
+// new run's ID so the PR stays blocked until the apply reaches a terminal
+// state.
+func TestAggregateRewindFromConcludedCreatesFreshCheckRun(t *testing.T) {
+	store := &foldCheckStore{
+		byPR: []*storage.Check{{
+			Repository: "octocat/hello-world", PullRequest: 1, HeadSHA: "abc123",
+			Environment: "staging", DatabaseType: "mysql", DatabaseName: "orders",
+			ApplyID: 42, HasChanges: true,
+			Status: checkStatusInProgress, Conclusion: "",
+		}},
+		get: &storage.Check{
+			Repository: "octocat/hello-world", PullRequest: 1, HeadSHA: "abc123",
+			Environment: aggregateSentinel, DatabaseType: aggregateSentinel, DatabaseName: aggregateSentinel,
+			CheckRunID: 555,
+			Status:     checkStatusCompleted, Conclusion: checkConclusionSuccess,
+		},
+	}
+	h, mux, client := newFoldHandler(t, nonAggregateConfig(), store)
+	serveHeadSHA(t, mux, "abc123")
+
+	var created []rewindCheckRunBody
+	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		var body rewindCheckRunBody
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		created = append(created, body)
+		w.WriteHeader(http.StatusCreated)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 999}))
+	})
+	var patched bool
+	mux.HandleFunc("PATCH /repos/octocat/hello-world/check-runs/", func(w http.ResponseWriter, _ *http.Request) {
+		patched = true
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 555}))
+	})
+
+	_, err := h.updateAggregateCheckOnce(t.Context(), client, "octocat/hello-world", 1, "abc123")
+	require.NoError(t, err)
+
+	assert.False(t, patched, "the concluded Check Run must not be reused: GitHub keeps its conclusion, leaving a passing check over a running apply")
+	require.Len(t, created, 1, "the rewind must publish exactly one fresh Check Run")
+	assert.Equal(t, aggregateCheckName, created[0].Name)
+	assert.Equal(t, checkStatusInProgress, created[0].Status)
+	assert.Empty(t, created[0].Conclusion)
+
+	require.Len(t, store.upserted, 1, "the fold must store the published aggregate state")
+	assert.Equal(t, int64(999), store.upserted[0].CheckRunID, "stored aggregate state must track the fresh Check Run, not the concluded one")
+	assert.Equal(t, checkStatusInProgress, store.upserted[0].Status)
+	assert.Empty(t, store.upserted[0].Conclusion)
+}
+
+// TestAggregateRecomputeOnConcludedRunReusesItWhenStillCompleted pins the
+// counterpart: a recompute that stays "completed" (for example a second
+// database's result landing after the aggregate already concluded) updates the
+// existing Check Run in place rather than creating a duplicate — re-concluding
+// an already-concluded run is a transition GitHub allows.
+func TestAggregateRecomputeOnConcludedRunReusesItWhenStillCompleted(t *testing.T) {
+	store := &foldCheckStore{
+		byPR: []*storage.Check{{
+			Repository: "octocat/hello-world", PullRequest: 1, HeadSHA: "abc123",
+			Environment: "staging", DatabaseType: "mysql", DatabaseName: "orders",
+			Status: checkStatusCompleted, Conclusion: checkConclusionSuccess,
+		}},
+		get: &storage.Check{
+			Repository: "octocat/hello-world", PullRequest: 1, HeadSHA: "abc123",
+			Environment: aggregateSentinel, DatabaseType: aggregateSentinel, DatabaseName: aggregateSentinel,
+			CheckRunID: 555,
+			Status:     checkStatusCompleted, Conclusion: checkConclusionActionRequired,
+		},
+	}
+	h, mux, client := newFoldHandler(t, nonAggregateConfig(), store)
+	serveHeadSHA(t, mux, "abc123")
+
+	var created bool
+	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		created = true
+		w.WriteHeader(http.StatusCreated)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 999}))
+	})
+	var patchedBodies []rewindCheckRunBody
+	mux.HandleFunc("PATCH /repos/octocat/hello-world/check-runs/", func(w http.ResponseWriter, r *http.Request) {
+		var body rewindCheckRunBody
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		patchedBodies = append(patchedBodies, body)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 555}))
+	})
+
+	_, err := h.updateAggregateCheckOnce(t.Context(), client, "octocat/hello-world", 1, "abc123")
+	require.NoError(t, err)
+
+	assert.False(t, created, "a completed-to-completed recompute must reuse the existing Check Run")
+	require.Len(t, patchedBodies, 1)
+	assert.Equal(t, checkStatusCompleted, patchedBodies[0].Status)
+	assert.Equal(t, checkConclusionSuccess, patchedBodies[0].Conclusion)
+
+	require.Len(t, store.upserted, 1)
+	assert.Equal(t, int64(555), store.upserted[0].CheckRunID)
+}

--- a/pkg/webhook/check_publisher_rewind_test.go
+++ b/pkg/webhook/check_publisher_rewind_test.go
@@ -11,14 +11,6 @@ import (
 	"github.com/block/schemabot/pkg/storage"
 )
 
-// rewindCheckRunBody captures the Check Run payload the fold publishes so the
-// tests can assert on the exact status and conclusion sent to GitHub.
-type rewindCheckRunBody struct {
-	Name       string `json:"name"`
-	Status     string `json:"status"`
-	Conclusion string `json:"conclusion"`
-}
-
 // TestAggregateRewindFromConcludedCreatesFreshCheckRun exercises the merge
 // gate when an apply starts on a PR whose aggregate Check Run already
 // concluded — the rollback-confirm flow, where the original apply completed
@@ -47,9 +39,9 @@ func TestAggregateRewindFromConcludedCreatesFreshCheckRun(t *testing.T) {
 	h, mux, client := newFoldHandler(t, nonAggregateConfig(), store)
 	serveHeadSHA(t, mux, "abc123")
 
-	var created []rewindCheckRunBody
+	var created []checkRunCapture
 	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
-		var body rewindCheckRunBody
+		var body checkRunCapture
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
 		created = append(created, body)
 		w.WriteHeader(http.StatusCreated)
@@ -104,9 +96,9 @@ func TestAggregateRecomputeOnConcludedRunReusesItWhenStillCompleted(t *testing.T
 		w.WriteHeader(http.StatusCreated)
 		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 999}))
 	})
-	var patchedBodies []rewindCheckRunBody
+	var patchedBodies []checkRunCapture
 	mux.HandleFunc("PATCH /repos/octocat/hello-world/check-runs/", func(w http.ResponseWriter, r *http.Request) {
-		var body rewindCheckRunBody
+		var body checkRunCapture
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
 		patchedBodies = append(patchedBodies, body)
 		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 555}))

--- a/pkg/webhook/checkrun_capture_test.go
+++ b/pkg/webhook/checkrun_capture_test.go
@@ -1,0 +1,17 @@
+package webhook
+
+import (
+	ghclient "github.com/block/schemabot/pkg/github"
+)
+
+// checkRunCapture captures the Check Run payload a test's fake GitHub server
+// receives, so assertions can inspect exactly what was published. It is shared
+// by the unit tests and (being untagged) the integration-tagged tests; tests
+// decode only the fields they assert on.
+type checkRunCapture struct {
+	Name       string                   `json:"name"`
+	HeadSHA    string                   `json:"head_sha"`
+	Status     string                   `json:"status"`
+	Conclusion string                   `json:"conclusion"`
+	Output     *ghclient.CheckRunOutput `json:"output"`
+}

--- a/pkg/webhook/checkrun_capture_test.go
+++ b/pkg/webhook/checkrun_capture_test.go
@@ -1,6 +1,12 @@
 package webhook
 
 import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
 	ghclient "github.com/block/schemabot/pkg/github"
 )
 
@@ -14,4 +20,32 @@ type checkRunCapture struct {
 	Status     string                   `json:"status"`
 	Conclusion string                   `json:"conclusion"`
 	Output     *ghclient.CheckRunOutput `json:"output"`
+}
+
+// serveTrustedCheckRuns registers the commit check-runs lookup used to resolve
+// the newest run for a check name, reporting each given run as created by the
+// trusted "schemabot" GitHub App. Like the real API, it honors the check_name
+// filter so lookups for other names see only their own runs.
+func serveTrustedCheckRuns(t *testing.T, mux *http.ServeMux, repo, sha string, runs ...ghclient.CheckRunResult) {
+	t.Helper()
+	mux.HandleFunc("GET /repos/"+repo+"/commits/"+sha+"/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		nameFilter := r.URL.Query().Get("check_name")
+		out := make([]map[string]any, 0, len(runs))
+		for _, run := range runs {
+			if nameFilter != "" && run.Name != nameFilter {
+				continue
+			}
+			out = append(out, map[string]any{
+				"id":         run.ID,
+				"name":       run.Name,
+				"status":     run.Status,
+				"conclusion": run.Conclusion,
+				"app":        map[string]any{"slug": "schemabot"},
+			})
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"total_count": len(out),
+			"check_runs":  out,
+		}))
+	})
 }

--- a/pkg/webhook/durable_merge_group_test.go
+++ b/pkg/webhook/durable_merge_group_test.go
@@ -105,9 +105,9 @@ func TestDurableMergeGroupWebhookDeduplicatesDelivery(t *testing.T) {
 // gated environment, then marks the delivery completed.
 func TestDurableMergeGroupDriverPostsChecks(t *testing.T) {
 	client, mux := setupGitHubServer(t)
-	created := make(chan createdCheckRun, 10)
+	created := make(chan checkRunCapture, 10)
 	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
-		var c createdCheckRun
+		var c checkRunCapture
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&c))
 		created <- c
 		w.WriteHeader(http.StatusCreated)

--- a/pkg/webhook/durable_push_test.go
+++ b/pkg/webhook/durable_push_test.go
@@ -100,9 +100,9 @@ func TestDurablePushWebhookIgnoresFeatureBranch(t *testing.T) {
 // each gated environment, then marks the delivery completed.
 func TestDurablePushDriverPostsChecks(t *testing.T) {
 	client, mux := setupGitHubServer(t)
-	created := make(chan createdCheckRun, 10)
+	created := make(chan checkRunCapture, 10)
 	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
-		var c createdCheckRun
+		var c checkRunCapture
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&c))
 		created <- c
 		w.WriteHeader(http.StatusCreated)

--- a/pkg/webhook/merge_group_test.go
+++ b/pkg/webhook/merge_group_test.go
@@ -56,19 +56,12 @@ func buildMergeGroupWebhookRequest(t *testing.T, action, headSHA string, secret 
 	return req
 }
 
-type createdCheckRun struct {
-	Name       string `json:"name"`
-	HeadSHA    string `json:"head_sha"`
-	Status     string `json:"status"`
-	Conclusion string `json:"conclusion"`
-}
-
-func mergeGroupTestHandler(t *testing.T, allowedEnvironments []string, repos map[string]api.RepoConfig) (*Handler, chan createdCheckRun) {
+func mergeGroupTestHandler(t *testing.T, allowedEnvironments []string, repos map[string]api.RepoConfig) (*Handler, chan checkRunCapture) {
 	t.Helper()
 	client, mux := setupGitHubServer(t)
-	created := make(chan createdCheckRun, 10)
+	created := make(chan checkRunCapture, 10)
 	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
-		var c createdCheckRun
+		var c checkRunCapture
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&c))
 		created <- c
 		w.WriteHeader(http.StatusCreated)
@@ -107,7 +100,7 @@ func TestWebhookMergeGroupPostsPassingChecks(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code)
 	assert.Contains(t, rr.Body.String(), "merge_group checks posted")
 
-	got := map[string]createdCheckRun{}
+	got := map[string]checkRunCapture{}
 	for range []int{0, 1} {
 		select {
 		case c := <-created:
@@ -184,7 +177,7 @@ func TestWebhookMergeGroupUpdatesExistingCheck(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"id": 7})
 	})
 	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
-		var c createdCheckRun
+		var c checkRunCapture
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&c))
 		created <- c.Name
 		w.WriteHeader(http.StatusCreated)

--- a/pkg/webhook/participant_nudge.go
+++ b/pkg/webhook/participant_nudge.go
@@ -114,13 +114,15 @@ func (h *Handler) participantRefoldBudgetRemaining(repo string, pr int) bool {
 	return h.participantRefoldAttempts[participantRefoldKey(repo, pr)] < maxParticipantRefoldAttempts
 }
 
-// scheduleParticipantRefold arms a delayed aggregate re-fold because at least
-// one expected participant resolved as retriable (not reported yet, or a
-// failed Checks API read). Participants publish their Check Runs moments after
-// the leader's first fold, and a participant with no schema work never
-// comments, so without this the leader's aggregate would stay blocked on a
-// participant that already reported green. Attempts are bounded per PR so a
-// participant that is genuinely down cannot keep a timer chain alive forever.
+// scheduleParticipantRefold arms a delayed aggregate re-fold because the fold
+// left retriable work behind: an expected participant resolved as retriable
+// (not reported yet, or a failed Checks API read), or an aggregate publish
+// failed (a GitHub Check Run write or the storage write recording it).
+// Participants publish their Check Runs moments after the leader's first fold,
+// and a participant with no schema work never comments, so without this the
+// leader's aggregate would stay blocked on a participant that already reported
+// green. Attempts are bounded per PR so a participant that is genuinely down
+// (or a persistently failing write) cannot keep a timer chain alive forever.
 func (h *Handler) scheduleParticipantRefold(ctx context.Context, repo string, pr int, installationID int64) {
 	key := participantRefoldKey(repo, pr)
 
@@ -128,7 +130,7 @@ func (h *Handler) scheduleParticipantRefold(ctx context.Context, repo string, pr
 	attempts := h.participantRefoldAttempts[key]
 	if attempts >= maxParticipantRefoldAttempts {
 		h.participantRefoldMu.Unlock()
-		h.logger.Warn("expected participants still unresolved after scheduled re-folds; aggregate stays blocked until a participant comment, new commit, or manual plan re-folds it",
+		h.logger.Warn("aggregate re-fold budget exhausted; the aggregate keeps its last published state until a participant comment, new commit, or manual plan re-folds it",
 			"repo", repo, "pr", pr, "refold_attempts", attempts)
 		metrics.RecordStatusCheckOperation(ctx, metrics.StatusCheckOperation{
 			Operation:  "participant_refold",

--- a/pkg/webhook/push_test.go
+++ b/pkg/webhook/push_test.go
@@ -57,7 +57,7 @@ func TestWebhookPushPostsPassingChecksOnDefaultBranch(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code)
 	assert.Contains(t, rr.Body.String(), "default-branch checks posted")
 
-	got := map[string]createdCheckRun{}
+	got := map[string]checkRunCapture{}
 	for range []int{0, 1} {
 		select {
 		case c := <-created:

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -434,21 +434,19 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment 
 		h.logger.Error("failed to load rollback apply after accepted rollback",
 			"repo", repo, "pr", pr, "database", database,
 			"database_type", dbType, "environment", environment,
-			"apply_id", applyID, "error", err)
+			"apply_id", applyResp.ApplyID, "error", err)
 		return
 	}
 	if apply == nil {
 		h.logger.Error("rollback apply missing after accepted apply",
 			"repo", repo, "pr", pr, "database", database,
 			"database_type", dbType, "environment", environment,
-			"apply_id", applyID)
+			"apply_id", applyResp.ApplyID)
 		return
 	}
 	if err := h.updateCheckRecordForApplyStart(ctx, client, repo, pr, schemaResult, environment, apply); err != nil {
 		h.logger.Error("failed to mark check in_progress for rollback",
-			"repo", repo, "pr", pr, "database", database,
-			"database_type", dbType, "environment", environment,
-			"apply_id", applyID, "error", err)
+			append(apply.LogAttrs(), "error", err)...)
 		h.postCommandError(repo, pr, installationID, action.RollbackConfirm, environment, requestedBy, "Rollback was accepted, but SchemaBot could not update the required status check: "+err.Error())
 		return
 	}

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -444,7 +444,7 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment 
 			"apply_id", applyID)
 		return
 	}
-	if err := h.updateCheckRecordForApplyStart(ctx, client, repo, pr, schemaResult, environment, applyID); err != nil {
+	if err := h.updateCheckRecordForApplyStart(ctx, client, repo, pr, schemaResult, environment, apply); err != nil {
 		h.logger.Error("failed to mark check in_progress for rollback",
 			"repo", repo, "pr", pr, "database", database,
 			"database_type", dbType, "environment", environment,

--- a/pkg/webhook/truncated_repo_integration_test.go
+++ b/pkg/webhook/truncated_repo_integration_test.go
@@ -14,6 +14,8 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path"
+	"strconv"
 	"testing"
 	"time"
 
@@ -32,7 +34,7 @@ import (
 func newE2EHandlerWithConfigDirHints(t *testing.T, svc *api.Service, client *gh.Client) *Handler {
 	t.Helper()
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
-	installClient := ghclient.NewInstallationClient(client, logger)
+	installClient := ghclient.NewInstallationClientWithSlug(client, logger, "schemabot")
 	installClient.SetConfigDirHints(svc.Config())
 	factory := &fakeClientFactory{client: installClient}
 	return NewHandler(svc, factory, nil, logger)
@@ -182,22 +184,30 @@ func setupFakeGitHubForPlanOnTruncatedRepoWithPRState(t *testing.T, mux *http.Se
 		w.WriteHeader(http.StatusCreated)
 		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
 	})
+	checkRunState := &fakeCheckRunStore{}
 	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
 		var body checkRunCapture
 		_ = json.NewDecoder(r.Body).Decode(&body)
 		result.checkRuns <- body
+		id := checkRunState.create(body)
 		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": id})
 	})
 	mux.HandleFunc("PATCH /repos/octocat/hello-world/check-runs/", func(w http.ResponseWriter, r *http.Request) {
 		var body checkRunCapture
 		_ = json.NewDecoder(r.Body).Decode(&body)
 		result.checkRuns <- body
+		id, err := strconv.ParseInt(path.Base(r.URL.Path), 10, 64)
+		if err != nil {
+			http.Error(w, "invalid check run id", http.StatusBadRequest)
+			return
+		}
+		checkRunState.update(id, body)
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": id})
 	})
 
-	registerCheckStatusRESTHandlersForAnyRef(mux, func() []checkStatusNode { return nil })
+	registerCheckStatusRESTHandlersForAnyRef(mux, func() []checkStatusNode { return nil }, checkRunState)
 
 	return result
 }

--- a/pkg/webhook/webhook_integration_test.go
+++ b/pkg/webhook/webhook_integration_test.go
@@ -71,7 +71,10 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path"
+	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -276,7 +279,7 @@ func seedCheck(t *testing.T, svc *api.Service, dbName, env, conclusion string) {
 func newE2EHandler(t *testing.T, svc *api.Service, client *gh.Client) *Handler {
 	t.Helper()
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
-	installClient := ghclient.NewInstallationClient(client, logger)
+	installClient := ghclient.NewInstallationClientWithSlug(client, logger, "schemabot")
 	factory := &fakeClientFactory{client: installClient}
 	return NewHandler(svc, factory, nil, logger)
 }
@@ -351,14 +354,101 @@ func registerPassingChecks(mux *http.ServeMux) {
 	registerCheckStatusRESTHandlers(mux, nil)
 }
 
-func registerCheckStatusRESTHandlersForAnyRef(mux *http.ServeMux, nodes func() []checkStatusNode) {
+// fakeCheckRunStore records every Check Run a fake GitHub server accepts so
+// the commit check-runs list can serve the same runs the real API would: each
+// run's latest state, attributed to the trusted "schemabot" App. The
+// aggregate fold resolves its reuse/rewind decision from that list, so a
+// harness whose handler can fold the same head more than once must list the
+// runs its own create and update calls produced.
+type fakeCheckRunStore struct {
+	mu   sync.Mutex
+	next int64
+	runs []*fakeCheckRunRecord
+}
+
+type fakeCheckRunRecord struct {
+	id         int64
+	name       string
+	headSHA    string
+	status     string
+	conclusion string
+}
+
+// create records a created Check Run and returns its assigned ID.
+func (s *fakeCheckRunStore) create(body checkRunCapture) int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.next++
+	s.runs = append(s.runs, &fakeCheckRunRecord{
+		id:         s.next,
+		name:       body.Name,
+		headSHA:    body.HeadSHA,
+		status:     body.Status,
+		conclusion: body.Conclusion,
+	})
+	return s.next
+}
+
+// update records an update to an existing run. Update payloads carry no head
+// SHA, so an update to an ID the store never saw created (for example a
+// seeded stored CheckRunID) is recorded without one and stays invisible to
+// every commit's list — like a run that lives on some other commit.
+func (s *fakeCheckRunStore) update(id int64, body checkRunCapture) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, run := range s.runs {
+		if run.id != id {
+			continue
+		}
+		run.status = body.Status
+		run.conclusion = body.Conclusion
+		return
+	}
+	s.runs = append(s.runs, &fakeCheckRunRecord{
+		id:         id,
+		name:       body.Name,
+		status:     body.Status,
+		conclusion: body.Conclusion,
+	})
+}
+
+// serveList writes GitHub's list-check-runs response for the recorded runs on
+// headSHA whose name matches checkName, each attributed to the trusted
+// "schemabot" App.
+func (s *fakeCheckRunStore) serveList(w http.ResponseWriter, headSHA, checkName string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]map[string]any, 0, len(s.runs))
+	for _, run := range s.runs {
+		if run.headSHA != headSHA || run.name != checkName {
+			continue
+		}
+		out = append(out, map[string]any{
+			"id":         run.id,
+			"name":       run.name,
+			"status":     run.status,
+			"conclusion": run.conclusion,
+			"app":        map[string]any{"slug": "schemabot"},
+		})
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{"total_count": len(out), "check_runs": out})
+}
+
+func registerCheckStatusRESTHandlersForAnyRef(mux *http.ServeMux, nodes func() []checkStatusNode, checkRuns *fakeCheckRunStore) {
 	prefix := "/repos/octocat/hello-world/commits/"
 	mux.HandleFunc("GET "+prefix, func(w http.ResponseWriter, r *http.Request) {
-		path := strings.TrimPrefix(r.URL.Path, prefix)
+		reqPath := strings.TrimPrefix(r.URL.Path, prefix)
 		switch {
-		case strings.HasSuffix(path, "/status"):
+		case strings.HasSuffix(reqPath, "/status"):
 			writeCommitStatusResponse(w, nodes())
-		case strings.HasSuffix(path, "/check-runs"):
+		case strings.HasSuffix(reqPath, "/check-runs"):
+			// A name-filtered list is the aggregate fold resolving the newest
+			// run for its check name; the unfiltered list is the apply gate
+			// reading the PR's checks.
+			if name := r.URL.Query().Get("check_name"); name != "" && checkRuns != nil {
+				checkRuns.serveList(w, strings.TrimSuffix(reqPath, "/check-runs"), name)
+				return
+			}
 			writeCheckRunsResponse(w, nodes())
 		default:
 			http.NotFound(w, r)
@@ -558,24 +648,32 @@ func setupFakeGitHubForPlanWithPRFiles(t *testing.T, mux *http.ServeMux, schemaS
 		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
 	})
 
-	// Capture check run creates (incrementing IDs so aggregate can distinguish create vs update)
-	var checkRunIDCounter atomic.Int64
+	// Capture check run creates and updates. Every write is also recorded in
+	// checkRunState (with incrementing IDs) so the commit's check-runs list
+	// serves the runs this server actually accepted — the aggregate fold
+	// resolves its reuse/rewind decision from that list.
+	checkRunState := &fakeCheckRunStore{}
 	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, r *http.Request) {
 		var body checkRunCapture
 		_ = json.NewDecoder(r.Body).Decode(&body)
 		result.checkRuns <- body
-		id := checkRunIDCounter.Add(1)
+		id := checkRunState.create(body)
 		w.WriteHeader(http.StatusCreated)
 		_ = json.NewEncoder(w).Encode(map[string]any{"id": id})
 	})
 
-	// Capture check run updates (PATCH)
 	mux.HandleFunc("PATCH /repos/octocat/hello-world/check-runs/", func(w http.ResponseWriter, r *http.Request) {
 		var body checkRunCapture
 		_ = json.NewDecoder(r.Body).Decode(&body)
 		result.checkRuns <- body
+		id, err := strconv.ParseInt(path.Base(r.URL.Path), 10, 64)
+		if err != nil {
+			http.Error(w, "invalid check run id", http.StatusBadRequest)
+			return
+		}
+		checkRunState.update(id, body)
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": id})
 	})
 
 	// PR check statuses for enforcePassingChecks. Defaults to all passing
@@ -587,7 +685,7 @@ func setupFakeGitHubForPlanWithPRFiles(t *testing.T, mux *http.ServeMux, schemaS
 			return (*provider)()
 		}
 		return nil
-	})
+	}, checkRunState)
 
 	return result
 }

--- a/pkg/webhook/webhook_integration_test.go
+++ b/pkg/webhook/webhook_integration_test.go
@@ -344,14 +344,6 @@ func (p *planFlowResult) nextHeadSHA() string {
 	return p.HeadSHAs[idx]
 }
 
-type checkRunCapture struct {
-	Name       string                   `json:"name"`
-	HeadSHA    string                   `json:"head_sha"`
-	Status     string                   `json:"status"`
-	Conclusion string                   `json:"conclusion"`
-	Output     *ghclient.CheckRunOutput `json:"output"`
-}
-
 // registerPassingChecks adds mock REST endpoints for PR check statuses that
 // return no checks. This prevents enforcePassingChecks from blocking apply
 // commands in e2e tests.


### PR DESCRIPTION
## Why this matters

The aggregate Check Run is SchemaBot's merge gate: branch protection, auto-merge, and merge queues trust its **conclusion** — none of them read its text. One lifecycle corner published that conclusion wrong, in the fail-open direction.

The sequence is strictly sequential — no overlap between the two applies:

1. An apply runs to completion. The aggregate Check Run concludes `success`. Correct — the change is live, the PR is green.
2. Later, on the **same commit** (no new push, so no new Check Run), an operator rolls that apply back (`rollback` → `rollback-confirm`). SchemaBot's stored check state correctly rewinds to `in_progress`.
3. The publisher updated the existing Check Run with `status: in_progress` — but GitHub never moves a concluded Check Run back out of `completed`. The API returns 200, accepts the new output text, and silently keeps the `success` conclusion.

```
apply completes ──▶ aggregate Check Run concluded: success ✓
       │
  time passes, no new commit
       ▼
rollback starts on the same head SHA
       │
       ▼
stored check state → in_progress        (already correct)
       │
       ▼
PATCH the concluded run → GitHub 200:   output text accepted,
                                        conclusion kept: success ✓
       │
       ▼
green merge gate over an active rollback drive     ← fail-open
```

For the duration of the rollback the PR shows a green, passing check titled "Apply in progress". A human driving the rollback knows not to merge — but auto-merge, merge bots, and anyone who just sees green will, landing schema files that assert a schema the database won't have when the drive finishes. The window is transient and self-healing (re-concluding a concluded run *is* allowed, so the terminal sync erases the evidence), which is exactly why it survived unnoticed: humans rarely look mid-drive, and machines don't need long.

## What it does

- The fold decides reuse-vs-create against the **newest trusted Check Run on the commit** (`FindCheckRunByName`), not stored check state alone. Branch protection gates on the newest run per name, and the GitHub write and the storage write are not atomic, so the two can skew — every skew broke the gate differently. Deciding from the live run means: a rewind is detected even when the storage write recording the conclusion was lost, a newer run whose recording write failed is **adopted** (published to, concluded, and re-recorded) instead of orphaned in permanent pending, and concurrent folds converge on the newest run instead of wedging the gate on whichever write landed last.
- When the newest run has already concluded and the recompute needs `in_progress`, the fold **publishes a fresh Check Run** on the same name and head SHA (`rewindsConcludedCheckRun`); the new in-progress run replaces the concluded one in branch protection. Completed→completed re-syncs still update in place — no run churn on routine recomputes.
- A **failed aggregate publish** — the GitHub Check Run write or the storage write recording it — arms the same bounded re-fold that head-verify and participant-read failures already use, on every repo, instead of ending the retry chain. One transient GitHub error can no longer leave a green gate standing over a just-claimed rollback until some external event happens by.
- Every rewind is observable: a log line with the concluded run ID and conclusion, plus an `aggregate_check_sync` / `recreated` metric counted only when the fresh run was actually created. Adoption of a newer run logs the stored and live run IDs.
- `updateCheckRecordForApplyStart` fails closed on a nil or unpersisted apply before touching check state (with the standard `apply_started` error metric), and the apply-start paths log the user-facing apply identifier instead of the internal row ID.

Tests pin the behavior at both altitudes:

- **Publisher seam** (wire-level, fake GitHub server): a rewind POSTs exactly one fresh in-progress run and never PATCHes the concluded one — including when stored state still says in_progress and only the live run has concluded; an orphaned newer run is adopted and receives the fold's outcome; a run missing from the commit triggers a fresh publish; completed→completed PATCHes in place; a failed create or storage write returns the re-fold disposition.
- **Full chain** (integration, MySQL-backed storage): completed apply + concluded-success aggregate, then a running rollback apply on the same head SHA driven through the real check-claim entry point — the per-database check flips to in_progress owned by the rollback, one fresh run is POSTed, no PATCH of the concluded run, and the stored aggregate tracks the new run.

Two boundaries are inherent to the design:

- The gate closes at the first aggregate fold after the rollback claim. Between the claim and the fresh run landing there is a short window where the previous green conclusion is still visible — auto-merge can fire inside it. The window is one Check Run create wide, and a failed create arms the bounded re-fold rather than widening it silently.
- A rollback that never reaches a terminal state leaves the fresh run `in_progress` indefinitely. That is deliberate fail-closed behavior: the gate must not pass while the target's schema state is unreconciled, and only operator action (cancel, retry, or manual reconciliation) releases it.

## How it moves us toward the northstar

Check Runs are the tier-0 safety gate that makes unattended workflows (auto-merge, merge queues, bot-driven applies) safe to adopt. This closes the one lifecycle corner where the gate reported fail-open — and makes the fold's view of that gate self-healing against write skew — so automation can trust the conclusion through the entire apply lifecycle, rollbacks included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
