### PR TITLE
chore(deps): update Spirit to latest main

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.43.3
-	github.com/block/spirit v0.15.2-0.20260717204329-9dd2b80e44ca
+	github.com/block/spirit v0.15.2-0.20260724130620-48b5ea432a74
 	github.com/bradleyfalzon/ghinstallation/v2 v2.18.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
@@ -273,4 +273,4 @@ replace github.com/pingcap/tidb/pkg/parser => github.com/block/tidb/pkg/parser v
 // Pinned to a fork with the in-flight RenderJSONAsMySQLText flag for
 // type-preserving JSON binlog decoding. Revert to upstream go-mysql once
 // the new flag lands. See https://github.com/morgo/go-mysql/tree/mysql-text-json-rendering.
-replace github.com/go-mysql-org/go-mysql => github.com/morgo/go-mysql v0.0.0-20260513151644-11038310b494
+replace github.com/go-mysql-org/go-mysql => github.com/morgo/go-mysql v1.16.1-0.20260723231236-3aced1dddcf4

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/block/spirit v0.15.2-0.20260717204329-9dd2b80e44ca h1:oVtH8EUC1qqvFlOZVwuITqIx5qooRFULFWYAdAsWfb4=
-github.com/block/spirit v0.15.2-0.20260717204329-9dd2b80e44ca/go.mod h1:NeJcaVY5Sfwd11iDgR3hz8aYB9XSLSxfGTguu9Wj2Dg=
+github.com/block/spirit v0.15.2-0.20260724130620-48b5ea432a74 h1:fIIkkFjAqM+cwlgGE71dOC4i3Kr8ie+8j7QKEf/ioRA=
+github.com/block/spirit v0.15.2-0.20260724130620-48b5ea432a74/go.mod h1:eSX+yt8Ukl+v7ZMNLuVbBreM+2X4gDnR+ree6rLM6tQ=
 github.com/block/tidb/pkg/parser v0.0.0-20260506200501-e528fd979fc8 h1:+OfdTacrEyjlqcRUpBFX9uJ6ROBq6cUjwY4DClhnsdU=
 github.com/block/tidb/pkg/parser v0.0.0-20260506200501-e528fd979fc8/go.mod h1:zDLDsfNBU5+L6T4J9/OgWAHc/WZvMUjbpgHqQ/t3yKo=
 github.com/block/vitess v0.0.0-20260703150944-881ec2298245 h1:R7e7uAxl6WIZpeY957JDsrZtuihck6vm7QgRooI295U=
@@ -452,8 +452,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/morgo/go-mysql v0.0.0-20260513151644-11038310b494 h1:Bh5iqCxLIvJrVzGLYGllHocWglkVsf98kkEhkCcKDA4=
-github.com/morgo/go-mysql v0.0.0-20260513151644-11038310b494/go.mod h1:VjBTZTTDKL8OMXUAhNbg3VHaVVq9HOXJEBLpAKBFIfE=
+github.com/morgo/go-mysql v1.16.1-0.20260723231236-3aced1dddcf4 h1:SzlaZsFlpQhKPnGrmiJZtXSzSd5y5kHm6LHkrdRLtOs=
+github.com/morgo/go-mysql v1.16.1-0.20260723231236-3aced1dddcf4/go.mod h1:VjBTZTTDKL8OMXUAhNbg3VHaVVq9HOXJEBLpAKBFIfE=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 h1:ZK8zHtRHOkbHy6Mmr5D264iyp3TiX5OmNcI5cIARiQI=


### PR DESCRIPTION
## Why this matters

Picks up the statement-scope refusal classification checks (`ScopeStatement`), the prerequisite for swapping `ddl.EngineRefusalReason` from its hand-maintained mirror to Spirit's own preflight checks — which removes drift risk and grows execution-verdict coverage. The swap itself lands separately; this bump keeps the dependency move out of that review.

## What it does

Bumps `github.com/block/spirit` from the 2026-07-17 pin to latest main (`48b5ea43`), pulling in:

- **check:** `ScopeStatement` flag for statement-level refusal classification, and deterministic name-ordered `RunChecks` results
- **fix(checksum):** asymmetric JSON casts (source round-trips, target renders strictly) plus JSON value-fidelity fixes in the buffered applier
- **fix(gtid):** validate checkpoint GTID sets against `gtid_executed` on resume; don't promote GTIDs early on unparseable mid-group query events
- **feat(copier):** dynamic byte-based chunking (fixes byte sizing crawling through auto-increment gaps; sizes buffered chunks for read-ahead)
- **feat(observability):** applier pipeline `Stats()` with queue-wait/write-time percentiles, surfaced in status lines and metrics gauges
- **feat(throttler):** reserve vCPU headroom when auto-sizing write threads on Aurora
- log disambiguation for advisory locks, chunk-floor log-flood suppression, lint fixes, and a flaky-test fix

Spirit temporarily pins a go-mysql fork for the JSON render-fidelity fixes via a `replace` directive, which does not propagate to consumers — so this also moves our existing go-mysql fork replace to the same snapshot Spirit builds against.

No SchemaBot code changes; the Spirit API surface is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)