### PR TITLE
feat(observability): surface and preserve stuck-pending apply diagnostics

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -322,7 +322,7 @@ jobs:
           # test-e2e-grpc-multideploy tears its own stack down, so it captures
           # grpc-multideploy-containers.log itself before teardown; the stack is
           # already gone by the time this step runs.
-          echo "=== tail of container logs (full logs in the uploaded e2e-grpc-md-logs artifact) ==="
+          echo "=== tail of container logs (full logs in the uploaded e2e-grpc-md-logs-shard-${{ matrix.shard }} artifact) ==="
           tail -n 200 e2e-logs/grpc-multideploy-containers.log 2>/dev/null || echo "no container logs captured (stack failed before tests ran; see the job log above)"
       - name: "Upload container logs on failure"
         if: failure()
@@ -413,7 +413,7 @@ jobs:
         run: |
           mkdir -p e2e-logs
           docker compose -f deploy/e2e/docker-compose.yml logs --no-color --timestamps > e2e-logs/containers.log 2>&1 || true
-          echo "=== tail of container logs (full logs in the uploaded e2e-vitess-logs artifact) ==="
+          echo "=== tail of container logs (full logs in the uploaded e2e-vitess-logs-shard-${{ matrix.shard }} artifact) ==="
           tail -n 200 e2e-logs/containers.log || true
       - name: "Upload container logs on failure"
         if: failure()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -267,9 +267,15 @@ jobs:
         if: failure()
         run: |
           mkdir -p e2e-logs
-          docker compose -f deploy/e2e/docker-compose.yml logs --no-color --timestamps > e2e-logs/containers.log 2>&1 || true
-          echo "=== tail of container logs (full logs in the uploaded e2e-mysql-logs artifact) ==="
-          tail -n 200 e2e-logs/containers.log || true
+          # test-e2e-mysql (test-e2e-local) leaves its stack up, so capture it here.
+          docker compose -f deploy/e2e/docker-compose.yml logs --no-color --timestamps > e2e-logs/mysql-containers.log 2>&1 || true
+          echo "=== tail of MySQL container logs (full logs in the uploaded e2e-mysql-logs artifact) ==="
+          tail -n 200 e2e-logs/mysql-containers.log || true
+          # test-e2e-grpc tears its own stack down, so it captures grpc-containers.log itself.
+          if [ -f e2e-logs/grpc-containers.log ]; then
+            echo "=== tail of gRPC container logs ==="
+            tail -n 200 e2e-logs/grpc-containers.log || true
+          fi
       - name: "Upload container logs on failure"
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4.6.2
@@ -310,13 +316,14 @@ jobs:
           restore-keys: go-${{ runner.os }}-${{ runner.arch }}-
       - name: "Test"
         run: make test-e2e-grpc-multideploy E2E_GRPC_MD_RUN='${{ matrix.run }}'
-      - name: "Capture container logs on failure"
+      - name: "Show captured container logs on failure"
         if: failure()
         run: |
-          mkdir -p e2e-logs
-          docker compose -p schemabot-e2e-grpc-md -f deploy/local/docker-compose.grpc-multideploy.yml logs --no-color --timestamps > e2e-logs/containers.log 2>&1 || true
+          # test-e2e-grpc-multideploy tears its own stack down, so it captures
+          # grpc-multideploy-containers.log itself before teardown; the stack is
+          # already gone by the time this step runs.
           echo "=== tail of container logs (full logs in the uploaded e2e-grpc-md-logs artifact) ==="
-          tail -n 200 e2e-logs/containers.log || true
+          tail -n 200 e2e-logs/grpc-multideploy-containers.log 2>/dev/null || echo "no container logs captured (stack failed before tests ran; see the job log above)"
       - name: "Upload container logs on failure"
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4.6.2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -263,10 +263,21 @@ jobs:
           restore-keys: go-${{ runner.os }}-${{ runner.arch }}-
       - name: "Test"
         run: make test-e2e-mysql test-e2e-grpc
-      - name: "Container logs on failure"
+      - name: "Capture container logs on failure"
         if: failure()
         run: |
-          docker compose -f deploy/e2e/docker-compose.yml logs --tail=300 schemabot localscale 2>/dev/null || true
+          mkdir -p e2e-logs
+          docker compose -f deploy/e2e/docker-compose.yml logs --no-color --timestamps > e2e-logs/containers.log 2>&1 || true
+          echo "=== tail of container logs (full logs in the uploaded e2e-mysql-logs artifact) ==="
+          tail -n 200 e2e-logs/containers.log || true
+      - name: "Upload container logs on failure"
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4.6.2
+        with:
+          name: e2e-mysql-logs
+          path: e2e-logs/
+          retention-days: 7
+          if-no-files-found: ignore
 
   e2e-grpc-multideploy:
     name: "E2E gRPC Multi-Deployment Tests (${{ matrix.shard }})"
@@ -299,10 +310,21 @@ jobs:
           restore-keys: go-${{ runner.os }}-${{ runner.arch }}-
       - name: "Test"
         run: make test-e2e-grpc-multideploy E2E_GRPC_MD_RUN='${{ matrix.run }}'
-      - name: "Container logs on failure"
+      - name: "Capture container logs on failure"
         if: failure()
         run: |
-          docker compose -p schemabot-e2e-grpc-md -f deploy/local/docker-compose.grpc-multideploy.yml logs --tail=300 2>/dev/null || true
+          mkdir -p e2e-logs
+          docker compose -p schemabot-e2e-grpc-md -f deploy/local/docker-compose.grpc-multideploy.yml logs --no-color --timestamps > e2e-logs/containers.log 2>&1 || true
+          echo "=== tail of container logs (full logs in the uploaded e2e-grpc-md-logs artifact) ==="
+          tail -n 200 e2e-logs/containers.log || true
+      - name: "Upload container logs on failure"
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4.6.2
+        with:
+          name: e2e-grpc-md-logs-shard-${{ matrix.shard }}
+          path: e2e-logs/
+          retention-days: 7
+          if-no-files-found: ignore
 
   e2e-vitess-matrix:
     name: "E2E Vitess Matrix"
@@ -379,10 +401,21 @@ jobs:
         run: |
           echo "Vitess e2e shard ${{ matrix.shard }}: ${{ matrix.run_filter }}"
           make test-e2e-local RUN="${{ matrix.run_filter }}" E2E_TEST_TIMEOUT=8m E2E_TEST_FLAGS=-v
-      - name: "Container logs on failure"
+      - name: "Capture container logs on failure"
         if: failure()
         run: |
-          docker compose -f deploy/e2e/docker-compose.yml logs --tail=300 schemabot localscale 2>/dev/null || true
+          mkdir -p e2e-logs
+          docker compose -f deploy/e2e/docker-compose.yml logs --no-color --timestamps > e2e-logs/containers.log 2>&1 || true
+          echo "=== tail of container logs (full logs in the uploaded e2e-vitess-logs artifact) ==="
+          tail -n 200 e2e-logs/containers.log || true
+      - name: "Upload container logs on failure"
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4.6.2
+        with:
+          name: e2e-vitess-logs-shard-${{ matrix.shard }}
+          path: e2e-logs/
+          retention-days: 7
+          if-no-files-found: ignore
   e2e-k8s:
     name: "E2E K8s Tests"
     needs: changes

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ deploy/aws-multi-env/*/config.yaml
 # Lint logs
 lint-error.logs
 
+# E2E container logs captured on failure
+e2e-logs/
+
 # Logs
 /logs
 *.log

--- a/Makefile
+++ b/Makefile
@@ -401,6 +401,11 @@ test-e2e-grpc: build ## Run gRPC e2e tests in isolated environment
 	E2E_TERN_PRODUCTION_MYSQL_DSN="root:testpassword@tcp(localhost:15373)/testapp" \
 	$(GOTEST) -count=1 -v -tags=e2e -timeout=10m ./e2e/grpc/... ; \
 	TEST_EXIT_CODE=$$?; \
+	if [ $$TEST_EXIT_CODE -ne 0 ]; then \
+		echo "Capturing gRPC e2e container logs before teardown..."; \
+		mkdir -p e2e-logs; \
+		$(E2E_GRPC_ENV) docker compose -p schemabot-e2e-grpc -f deploy/local/docker-compose.grpc.yml logs --no-color --timestamps > e2e-logs/grpc-containers.log 2>&1 || true; \
+	fi; \
 	echo "Tearing down gRPC e2e environment..."; \
 	$(E2E_GRPC_ENV) docker compose -p schemabot-e2e-grpc -f deploy/local/docker-compose.grpc.yml down -v; \
 	exit $$TEST_EXIT_CODE
@@ -453,6 +458,11 @@ test-e2e-grpc-multideploy: build ## Run multi-deployment fan-out gRPC e2e fixtur
 	E2E_TERN_US_MYSQL_DSN="root:testpassword@tcp(localhost:15373)/testapp" \
 	$(GOTEST) -count=1 -v -tags=e2e -timeout=10m -run '$(E2E_GRPC_MD_RUN)' ./e2e/grpc/... ; \
 	TEST_EXIT_CODE=$$?; \
+	if [ $$TEST_EXIT_CODE -ne 0 ]; then \
+		echo "Capturing multi-deployment gRPC e2e container logs before teardown..."; \
+		mkdir -p e2e-logs; \
+		$(E2E_GRPC_MD_ENV) docker compose -p schemabot-e2e-grpc-md -f deploy/local/docker-compose.grpc-multideploy.yml logs --no-color --timestamps > e2e-logs/grpc-multideploy-containers.log 2>&1 || true; \
+	fi; \
 	echo "Tearing down multi-deployment gRPC e2e environment..."; \
 	$(E2E_GRPC_MD_ENV) docker compose -p schemabot-e2e-grpc-md -f deploy/local/docker-compose.grpc-multideploy.yml down -v; \
 	exit $$TEST_EXIT_CODE

--- a/pkg/api/operator_stuck_applies.go
+++ b/pkg/api/operator_stuck_applies.go
@@ -1,0 +1,143 @@
+package api
+
+import (
+	"context"
+	"time"
+
+	"github.com/block/schemabot/pkg/metrics"
+)
+
+const (
+	// OperatorStuckPendingApplyThreshold is how long a pending apply may carry
+	// its claimable child rows before the monitor treats it as stuck. Apply
+	// creation rejects a second active apply for the same target rather than
+	// queuing it, so a pending apply is never waiting its turn; once a driver
+	// claims it, it leaves the pending state. A pending apply unclaimed this long
+	// therefore means no driver reached it — a saturated, operator-less, or
+	// wedged driver pool. It is set well above the claim cadence so ordinary
+	// claim latency never trips it.
+	OperatorStuckPendingApplyThreshold = 15 * time.Minute
+
+	// OperatorStuckPendingScanInterval is how often the monitor scans for stuck
+	// pending applies. It is coarse relative to the threshold: the scan only
+	// answers "has an unclaimed pending apply aged past the threshold", which
+	// does not need sub-minute resolution.
+	OperatorStuckPendingScanInterval = time.Minute
+
+	// OperatorStuckPendingScanTimeout bounds a single scan so a slow or
+	// contended database cannot stall the monitor loop.
+	OperatorStuckPendingScanTimeout = 5 * time.Second
+
+	// operatorStuckPendingSampleLimit caps how many stuck rows a single scan
+	// pulls back. The gauge counts what the scan returns, so a value at the cap
+	// means "at least this many"; the cap keeps a pathological backlog from
+	// loading an unbounded result set into memory every scan.
+	operatorStuckPendingSampleLimit = 500
+)
+
+// StartOperatorStuckPendingMonitor starts a background loop that periodically
+// scans for pending applies a driver should have claimed and emits the
+// stuck-pending gauge. It is a no-op when storage is unavailable (nothing to
+// observe).
+func (s *Service) StartOperatorStuckPendingMonitor(ctx context.Context) {
+	if s.storage == nil {
+		s.logger.Debug("operator stuck-pending monitor not started because storage is unavailable")
+		return
+	}
+
+	s.stuckPendingMu.Lock()
+	if s.stuckPendingCancel != nil {
+		s.stuckPendingMu.Unlock()
+		s.logger.Info("operator stuck-pending monitor already running")
+		return
+	}
+	monitorCtx, cancel := context.WithCancel(ctx)
+	s.stuckPendingCancel = cancel
+	s.stuckPendingMu.Unlock()
+
+	s.stuckPendingWg.Go(func() {
+		s.operatorStuckPendingMonitor(monitorCtx, OperatorStuckPendingScanInterval)
+	})
+	s.logger.Info("operator stuck-pending monitor started",
+		"interval", OperatorStuckPendingScanInterval,
+		"threshold", OperatorStuckPendingApplyThreshold,
+		"timeout", OperatorStuckPendingScanTimeout)
+}
+
+// StopOperatorStuckPendingMonitor stops the background stuck-pending monitor.
+// Safe to call multiple times.
+func (s *Service) StopOperatorStuckPendingMonitor() {
+	s.stuckPendingMu.Lock()
+	cancel := s.stuckPendingCancel
+	if cancel == nil {
+		s.stuckPendingMu.Unlock()
+		return
+	}
+	s.stuckPendingCancel = nil
+	s.stuckPendingMu.Unlock()
+
+	cancel()
+	s.stuckPendingWg.Wait()
+}
+
+func (s *Service) operatorStuckPendingMonitor(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	s.CollectOperatorStuckPendingMetrics(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.logger.Debug("operator stuck-pending monitor stopping", "error", ctx.Err())
+			return
+		case <-ticker.C:
+			s.CollectOperatorStuckPendingMetrics(ctx)
+		}
+	}
+}
+
+// CollectOperatorStuckPendingMetrics scans once for stuck pending applies and
+// records the gauge. It is exported so tests and diagnostics can run a single
+// synchronous collection without starting the background monitor.
+func (s *Service) CollectOperatorStuckPendingMetrics(ctx context.Context) {
+	if err := ctx.Err(); err != nil {
+		s.logger.Debug("operator stuck-pending scan skipped because context is done", "error", err)
+		return
+	}
+	if s.storage == nil || s.storage.Applies() == nil {
+		s.logger.Debug("operator stuck-pending scan skipped because apply storage is unavailable")
+		return
+	}
+
+	scanCtx, cancel := context.WithTimeout(ctx, OperatorStuckPendingScanTimeout)
+	defer cancel()
+
+	stuck, err := s.storage.Applies().FindStuckPendingApplies(scanCtx, OperatorStuckPendingApplyThreshold, operatorStuckPendingSampleLimit)
+	if err != nil {
+		// The gauge is a last-value instrument: leaving it untouched here
+		// re-exports the last-good value with a fresh timestamp, which reads as a
+		// healthy operator. The failure counter is the liveness signal that tells
+		// operators the gauge is stale.
+		metrics.RecordOperatorStuckPendingScanFailure(ctx)
+		s.logger.Warn("operator stuck-pending scan failed", "error", err)
+		return
+	}
+
+	metrics.RecordOperatorStuckPendingApplies(ctx, int64(len(stuck)))
+
+	if len(stuck) == 0 {
+		return
+	}
+
+	// stuck is ordered oldest first, so the first row is the longest-waiting one
+	// and the most useful triage handle. A driver should already have claimed
+	// these; log the count and the oldest so an operator can start there.
+	oldest := stuck[0]
+	oldestAge := s.clock.Now().Sub(oldest.CreatedAt)
+	s.logger.Warn("operator has pending applies a driver should have claimed; check driver pool liveness and saturation",
+		append(oldest.LogAttrs(),
+			"stuck_pending", len(stuck),
+			"threshold", OperatorStuckPendingApplyThreshold,
+			"oldest_pending_age", oldestAge)...)
+}

--- a/pkg/api/operator_stuck_applies_test.go
+++ b/pkg/api/operator_stuck_applies_test.go
@@ -1,0 +1,156 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/block/schemabot/pkg/storage"
+)
+
+// fakeStuckApplyStore serves a fixed FindStuckPendingApplies result; every other
+// ApplyStore method is unused by the stuck-pending monitor.
+type fakeStuckApplyStore struct {
+	storage.ApplyStore
+	stuck []*storage.Apply
+	err   error
+	calls int
+}
+
+func (f *fakeStuckApplyStore) FindStuckPendingApplies(context.Context, time.Duration, int) ([]*storage.Apply, error) {
+	f.calls++
+	return f.stuck, f.err
+}
+
+// stuckPendingMockStorage wires a fake ApplyStore into the mock storage so the
+// monitor can read it.
+type stuckPendingMockStorage struct {
+	mockStorage
+	applies storage.ApplyStore
+}
+
+func (m *stuckPendingMockStorage) Applies() storage.ApplyStore { return m.applies }
+
+func newStuckPendingTestService(t *testing.T, applies storage.ApplyStore) *Service {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	return New(&stuckPendingMockStorage{applies: applies}, &ServerConfig{}, nil, logger)
+}
+
+func newStuckPendingMetricReader(t *testing.T) sdkmetric.Reader {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prevMP := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	t.Cleanup(func() {
+		otel.SetMeterProvider(prevMP)
+		// Cleanup runs after the test's context is cancelled; strip the
+		// cancellation so the shutdown call gets a live context.
+		require.NoError(t, mp.Shutdown(context.WithoutCancel(t.Context())))
+	})
+	return reader
+}
+
+// gaugeValue returns the single data point value for a gauge metric, or -1 when
+// the metric was not emitted.
+func gaugeValue(t *testing.T, reader sdkmetric.Reader, name string) int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			gauge, ok := m.Data.(metricdata.Gauge[int64])
+			require.True(t, ok)
+			require.Len(t, gauge.DataPoints, 1)
+			return gauge.DataPoints[0].Value
+		}
+	}
+	return -1
+}
+
+func metricNames(t *testing.T, reader sdkmetric.Reader) map[string]bool {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	names := map[string]bool{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			names[m.Name] = true
+		}
+	}
+	return names
+}
+
+// A driver should already have claimed every pending apply the scan returns, so
+// the monitor records their count as the stuck-pending gauge for an operator to
+// alert on.
+func TestCollectOperatorStuckPendingMetricsRecordsGauge(t *testing.T) {
+	reader := newStuckPendingMetricReader(t)
+
+	store := &fakeStuckApplyStore{stuck: []*storage.Apply{
+		{ApplyIdentifier: "apply_oldest", Database: "db1", Environment: "staging", CreatedAt: time.Now().Add(-40 * time.Minute)},
+		{ApplyIdentifier: "apply_old", Database: "db2", Environment: "staging", CreatedAt: time.Now().Add(-20 * time.Minute)},
+	}}
+	svc := newStuckPendingTestService(t, store)
+
+	svc.CollectOperatorStuckPendingMetrics(t.Context())
+
+	assert.Equal(t, int64(2), gaugeValue(t, reader, "schemabot.operator.stuck_pending_applies"))
+	assert.Equal(t, 1, store.calls)
+	assert.NotContains(t, metricNames(t, reader), "schemabot.operator.stuck_pending_scan_failures",
+		"a successful scan must not increment the failure counter")
+}
+
+// With nothing stuck the gauge must still be recorded as 0: it is a last-value
+// instrument, so skipping the record when the backlog clears would freeze it at
+// its last nonzero value and show a phantom stuck population forever.
+func TestCollectOperatorStuckPendingMetricsRecordsZeroWhenHealthy(t *testing.T) {
+	reader := newStuckPendingMetricReader(t)
+
+	svc := newStuckPendingTestService(t, &fakeStuckApplyStore{stuck: nil})
+
+	svc.CollectOperatorStuckPendingMetrics(t.Context())
+
+	assert.Equal(t, int64(0), gaugeValue(t, reader, "schemabot.operator.stuck_pending_applies"))
+}
+
+// A scan failure must not emit the gauge: it is a last-value instrument, so
+// leaving it untouched re-exports the last-good value and reads as a healthy
+// operator. Instead it increments the scan-failure counter — the liveness signal
+// that the gauge is stale — and must not panic the monitor loop.
+func TestCollectOperatorStuckPendingMetricsCountsFailureOnStoreError(t *testing.T) {
+	reader := newStuckPendingMetricReader(t)
+
+	svc := newStuckPendingTestService(t, &fakeStuckApplyStore{err: errors.New("db down")})
+
+	svc.CollectOperatorStuckPendingMetrics(t.Context())
+
+	names := metricNames(t, reader)
+	assert.NotContains(t, names, "schemabot.operator.stuck_pending_applies", "the gauge must not be re-emitted on error")
+	assert.Contains(t, names, "schemabot.operator.stuck_pending_scan_failures", "a failed scan must increment the failure counter")
+}
+
+// The monitor is a no-op when apply storage is unavailable: there is nothing to
+// scan, so it must neither emit the gauge nor panic.
+func TestCollectOperatorStuckPendingMetricsNoOpWhenStorageUnavailable(t *testing.T) {
+	reader := newStuckPendingMetricReader(t)
+
+	svc := newStuckPendingTestService(t, nil)
+
+	svc.CollectOperatorStuckPendingMetrics(t.Context())
+
+	assert.NotContains(t, metricNames(t, reader), "schemabot.operator.stuck_pending_applies")
+}

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -160,6 +160,11 @@ type Service struct {
 	webhookInboxWg       sync.WaitGroup
 	webhookInboxInterval time.Duration
 
+	// Operator stuck-pending apply monitor loop management.
+	stuckPendingMu     sync.Mutex
+	stuckPendingCancel context.CancelFunc
+	stuckPendingWg     sync.WaitGroup
+
 	// Pending drops cleaner loop management.
 	pendingDropsMu     sync.Mutex
 	pendingDropsCancel context.CancelFunc
@@ -755,6 +760,7 @@ func (s *Service) Close() error {
 	s.StopOperator()
 	s.StopRemoteDeploymentHealthMonitor()
 	s.StopWebhookInboxMonitor()
+	s.StopOperatorStuckPendingMonitor()
 
 	s.ternMu.Lock()
 	var errs []error

--- a/pkg/metrics/README.md
+++ b/pkg/metrics/README.md
@@ -37,7 +37,7 @@ available, such as `repository`, `github_app`, and `installation_id`.
 | `schemabot.operator.resume_failures_total` | Counter | database, environment, reason | Operator resume attempts that failed |
 | `schemabot.operator.claim_failures_total` | Counter | environment, reason | Operator claim attempts that failed |
 | `schemabot.operator.claim_duration_seconds` | Histogram | database, environment, previous_state | Operator claim and resume duration |
-| `schemabot.operator.stuck_pending_applies` | Gauge | environment | Pending applies past the stuck threshold that a driver should have claimed |
+| `schemabot.operator.stuck_pending_applies` | Gauge | environment | Pending applies past the stuck threshold that a driver should have claimed (sampled; capped at 500, so a value of 500 means "at least 500") |
 | `schemabot.operator.stuck_pending_scan_failures` | Counter | environment | Failed stuck-pending apply scans (liveness signal for the gauge above) |
 | `schemabot.pending_drops.tables_moved_total` | Counter | database, environment | Dropped tables quarantined into the pending drops database |
 | `schemabot.pending_drops.cleanup_dropped_total` | Counter | database, environment | Expired quarantined tables permanently dropped by the cleaner |

--- a/pkg/metrics/README.md
+++ b/pkg/metrics/README.md
@@ -37,6 +37,8 @@ available, such as `repository`, `github_app`, and `installation_id`.
 | `schemabot.operator.resume_failures_total` | Counter | database, environment, reason | Operator resume attempts that failed |
 | `schemabot.operator.claim_failures_total` | Counter | environment, reason | Operator claim attempts that failed |
 | `schemabot.operator.claim_duration_seconds` | Histogram | database, environment, previous_state | Operator claim and resume duration |
+| `schemabot.operator.stuck_pending_applies` | Gauge | environment | Pending applies past the stuck threshold that a driver should have claimed |
+| `schemabot.operator.stuck_pending_scan_failures` | Counter | environment | Failed stuck-pending apply scans (liveness signal for the gauge above) |
 | `schemabot.pending_drops.tables_moved_total` | Counter | database, environment | Dropped tables quarantined into the pending drops database |
 | `schemabot.pending_drops.cleanup_dropped_total` | Counter | database, environment | Expired quarantined tables permanently dropped by the cleaner |
 | `schemabot.pending_drops.cleanup_skipped_total` | Counter | database, environment | Quarantined tables skipped by the cleaner due to unparseable names |

--- a/pkg/metrics/README.md
+++ b/pkg/metrics/README.md
@@ -47,6 +47,8 @@ available, such as `repository`, `github_app`, and `installation_id`.
 
 > **Deprecated aliases:** the `schemabot.scheduler.*` series (`resumed_total`, `resume_failures_total`, `claim_failures_total`, `claim_duration_seconds`) is still emitted alongside the `schemabot.operator.*` series for one release so dashboards and alerts can migrate. The scheduler-named series will be removed afterward.
 
+> **`stuck_pending_applies` is per-pod, not fleet-wide:** every pod running the server runs the stuck-pending monitor (there is no leader election, matching the inbox-depth and health monitors), so each pod reports the same DB-wide count as its own series. Aggregate with `max()`/`avg()`, not `sum()`, and expect the paired WARN log to fire from every pod each scan while anything is stuck.
+
 ### Attribute Values
 
 **status** (plans): `success`, `error`

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -789,6 +789,33 @@ func RecordOperatorClaimFailure(ctx context.Context, reason string) {
 	)
 }
 
+// RecordOperatorStuckPendingApplies records how many pending applies are older
+// than the stuck threshold while still carrying the child rows that make them
+// claimable — work a driver should already have picked up. Apply creation
+// rejects a concurrent apply for the same target rather than queuing it, so a
+// nonzero value is not normal backpressure: it means the operator driver pool is
+// not claiming (all drivers saturated on long-running applies, an
+// operator-less/crash-looping deployment, or a wedged claim path). The expected
+// operator action is to check driver liveness and claim-failure metrics/logs.
+func RecordOperatorStuckPendingApplies(ctx context.Context, count int64) {
+	recordGauge(ctx, "schemabot.operator.stuck_pending_applies", count,
+		"Number of pending applies past the stuck threshold that a driver should have claimed", "{apply}",
+		EnvironmentAttribute(""),
+	)
+}
+
+// RecordOperatorStuckPendingScanFailure counts failed stuck-pending scans. The
+// stuck-pending gauge is a last-value instrument, so a failed scan leaves it
+// frozen at its last-good value — indistinguishable from a healthy operator.
+// This counter is the liveness signal for the gauge: a nonzero rate means the
+// stuck-pending value is stale and must not be trusted.
+func RecordOperatorStuckPendingScanFailure(ctx context.Context) {
+	addCounter(ctx, "schemabot.operator.stuck_pending_scan_failures",
+		"Total number of failed operator stuck-pending apply scans", "{failure}",
+		EnvironmentAttribute(""),
+	)
+}
+
 var knownOperatorTerminalSummaryFailureReasons = map[string]bool{
 	"reload_apply_error":           true,
 	"apply_missing":                true,

--- a/pkg/serve/serve.go
+++ b/pkg/serve/serve.go
@@ -543,6 +543,7 @@ func (s *Server) Start(ctx context.Context) {
 	s.svc.StartOperator(ctx)
 	s.svc.StartRemoteDeploymentHealthMonitor(ctx)
 	s.svc.StartWebhookInboxMonitor(ctx)
+	s.svc.StartOperatorStuckPendingMonitor(ctx)
 	s.svc.StartPendingDropsCleaner(ctx)
 }
 

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -1097,6 +1097,41 @@ func (s *applyStore) GetInProgress(ctx context.Context) ([]*storage.Apply, error
 	return scanApplies(rows)
 }
 
+// FindStuckPendingApplies returns pending applies older than olderThan that
+// carry child rows — the same claimable-pending predicate FindNextApply uses, so
+// every row returned is one a driver should already have claimed. It is a
+// read-only diagnostic (no lease, no FOR UPDATE): apply creation rejects a
+// second active apply for the same target instead of queuing it, so a pending
+// apply this old is never legitimately waiting its turn. Ordered oldest first
+// and capped at limit; a non-positive limit means no cap.
+func (s *applyStore) FindStuckPendingApplies(ctx context.Context, olderThan time.Duration, limit int) ([]*storage.Apply, error) {
+	cutoffMicros := max(olderThan.Microseconds(), 0)
+	cutoff := s.dialect.RelativeTime(TimestampPrecisionDefault, BeforeCurrentTime, LiteralIntervalAmount(uint64(cutoffMicros)), IntervalMicrosecond)
+
+	query := fmt.Sprintf(`
+		SELECT `+applyColumnsForApplyAlias+`
+		FROM applies a
+		WHERE a.state = ?
+			AND a.created_at < %s
+			AND (
+				EXISTS (SELECT 1 FROM tasks t WHERE t.apply_id = a.id)
+				OR EXISTS (SELECT 1 FROM apply_operations ao WHERE ao.apply_id = a.id)
+			)
+		ORDER BY a.created_at
+	`, cutoff)
+	if limit > 0 {
+		query += fmt.Sprintf("LIMIT %d\n", limit)
+	}
+
+	rows, err := s.db.QueryContext(ctx, query, state.Apply.Pending)
+	if err != nil {
+		return nil, fmt.Errorf("query stuck pending applies older than %s: %w", olderThan, err)
+	}
+	defer utils.CloseAndLog(rows)
+
+	return scanApplies(rows)
+}
+
 // GetRecent returns the most recent applies across all databases, ordered by creation time desc.
 func (s *applyStore) GetRecent(ctx context.Context, filter storage.RecentAppliesFilter) ([]*storage.Apply, error) {
 	query := `

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -1098,29 +1098,32 @@ func (s *applyStore) GetInProgress(ctx context.Context) ([]*storage.Apply, error
 }
 
 // FindStuckPendingApplies returns pending applies older than olderThan that
-// carry child rows — the same claimable-pending predicate FindNextApply uses, so
+// carry child rows — the child-rows arm of FindNextApply's pending predicate, so
 // every row returned is one a driver should already have claimed. It is a
 // read-only diagnostic (no lease, no FOR UPDATE): apply creation rejects a
 // second active apply for the same target instead of queuing it, so a pending
 // apply this old is never legitimately waiting its turn. Ordered oldest first
-// and capped at limit; a non-positive limit means no cap.
+// (with an id tiebreak so same-second rows are stable) and capped at limit; a
+// non-positive limit means no cap.
 func (s *applyStore) FindStuckPendingApplies(ctx context.Context, olderThan time.Duration, limit int) ([]*storage.Apply, error) {
 	cutoffMicros := max(olderThan.Microseconds(), 0)
 	cutoff := s.dialect.RelativeTime(TimestampPrecisionDefault, BeforeCurrentTime, LiteralIntervalAmount(uint64(cutoffMicros)), IntervalMicrosecond)
 
-	query := fmt.Sprintf(`
-		SELECT `+applyColumnsForApplyAlias+`
+	// The column list and cutoff are trusted internal fragments; concatenate
+	// them directly rather than through a format string so a stray % can never
+	// corrupt the SQL.
+	query := `
+		SELECT ` + applyColumnsForApplyAlias + `
 		FROM applies a
 		WHERE a.state = ?
-			AND a.created_at < %s
+			AND a.created_at < ` + cutoff + `
 			AND (
 				EXISTS (SELECT 1 FROM tasks t WHERE t.apply_id = a.id)
 				OR EXISTS (SELECT 1 FROM apply_operations ao WHERE ao.apply_id = a.id)
 			)
-		ORDER BY a.created_at
-	`, cutoff)
+		ORDER BY a.created_at, a.id`
 	if limit > 0 {
-		query += fmt.Sprintf("LIMIT %d\n", limit)
+		query += fmt.Sprintf("\n\t\tLIMIT %d", limit)
 	}
 
 	rows, err := s.db.QueryContext(ctx, query, state.Apply.Pending)

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -2342,6 +2342,23 @@ func TestApplyStore_FindStuckPendingApplies(t *testing.T) {
 		}
 		return apply
 	}
+	// A VSchema-only apply carries an apply_operations row but no tasks; that
+	// operation row alone makes it claimable, so the stuck scan must surface it.
+	seedPendingVSchemaOnly := func(t *testing.T, applyID string, planID int64) *storage.Apply {
+		t.Helper()
+		lock := createTestLock(t, store, "db_"+applyID, storage.DatabaseTypeVitess, "staging")
+		apply := createTestApplyWithStateAndEnv(t, store, lock, applyID, planID, state.Apply.Pending, "staging")
+		now := time.Now()
+		_, err := store.ApplyOperations().Insert(ctx, &storage.ApplyOperation{
+			ApplyID:    apply.ID,
+			Deployment: apply.Database,
+			State:      state.ApplyOperation.Pending,
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		})
+		require.NoError(t, err)
+		return apply
+	}
 	backdate := func(t *testing.T, id int64, age time.Duration) {
 		t.Helper()
 		_, err := testDB.ExecContext(ctx,
@@ -2350,9 +2367,12 @@ func TestApplyStore_FindStuckPendingApplies(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Old claimable pending applies (have a task) → stuck, oldest first.
+	// Old claimable pending applies → stuck, oldest first. The tasks arm and the
+	// apply_operations arm are both claimable, so both must be surfaced.
 	oldest := seedPending(t, "apply_oldest_claimable", 9001, true)
 	backdate(t, oldest.ID, 40*time.Minute)
+	vschemaOnly := seedPendingVSchemaOnly(t, "apply_vschema_only", 9006)
+	backdate(t, vschemaOnly.ID, 30*time.Minute)
 	older := seedPending(t, "apply_old_claimable", 9002, true)
 	backdate(t, older.ID, 20*time.Minute)
 
@@ -2373,9 +2393,11 @@ func TestApplyStore_FindStuckPendingApplies(t *testing.T) {
 	t.Run("returns aged claimable pending applies oldest first", func(t *testing.T) {
 		stuck, err := store.Applies().FindStuckPendingApplies(ctx, threshold, 0)
 		require.NoError(t, err)
-		require.Len(t, stuck, 2)
+		require.Len(t, stuck, 3)
 		assert.Equal(t, oldest.ApplyIdentifier, stuck[0].ApplyIdentifier)
-		assert.Equal(t, older.ApplyIdentifier, stuck[1].ApplyIdentifier)
+		assert.Equal(t, vschemaOnly.ApplyIdentifier, stuck[1].ApplyIdentifier,
+			"a task-less pending apply with an apply_operations row must be surfaced")
+		assert.Equal(t, older.ApplyIdentifier, stuck[2].ApplyIdentifier)
 		assert.Equal(t, state.Apply.Pending, stuck[0].State)
 	})
 

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -5,6 +5,7 @@ package mysqlstore
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"strconv"
 	"strings"
 	"sync"
@@ -2299,6 +2300,97 @@ func TestApplyStore_FindNextApplyRequiresTasksForPendingApply(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, persisted)
 	assert.Equal(t, state.Apply.Running, persisted.State)
+}
+
+// FindStuckPendingApplies is the operator's stuck-pending observability probe.
+// It surfaces pending applies a driver should already have claimed — pending
+// with child rows, the same claimability predicate FindNextApply uses — that
+// have aged past the threshold, so an operator can tell a wedged or saturated
+// driver pool from a healthy one. It must never surface a young pending apply
+// (still within normal claim latency), a pending apply with no child rows (not
+// yet claimable), or a terminal apply.
+func TestApplyStore_FindStuckPendingApplies(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	// Each pending apply needs a distinct target: apply creation rejects a
+	// second active apply for the same database/type/environment, and pending is
+	// an active state.
+	seedPending := func(t *testing.T, applyID string, planID int64, withTask bool) *storage.Apply {
+		t.Helper()
+		lock := createTestLock(t, store, "db_"+applyID, storage.DatabaseTypeMySQL, "staging")
+		apply := createTestApplyWithStateAndEnv(t, store, lock, applyID, planID, state.Apply.Pending, "staging")
+		if withTask {
+			now := time.Now()
+			_, err := store.Tasks().Create(ctx, &storage.Task{
+				TaskIdentifier: "task_" + applyID,
+				ApplyID:        apply.ID,
+				PlanID:         apply.PlanID,
+				Database:       apply.Database,
+				DatabaseType:   apply.DatabaseType,
+				Engine:         storage.EngineSpirit,
+				Environment:    apply.Environment,
+				State:          state.Task.Pending,
+				TableName:      "users",
+				DDL:            "CREATE TABLE users (id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY)",
+				DDLAction:      "CREATE",
+				CreatedAt:      now,
+				UpdatedAt:      now,
+			})
+			require.NoError(t, err)
+		}
+		return apply
+	}
+	backdate := func(t *testing.T, id int64, age time.Duration) {
+		t.Helper()
+		_, err := testDB.ExecContext(ctx,
+			fmt.Sprintf(`UPDATE applies SET created_at = NOW() - INTERVAL %d SECOND WHERE id = ?`, int(age.Seconds())),
+			id)
+		require.NoError(t, err)
+	}
+
+	// Old claimable pending applies (have a task) → stuck, oldest first.
+	oldest := seedPending(t, "apply_oldest_claimable", 9001, true)
+	backdate(t, oldest.ID, 40*time.Minute)
+	older := seedPending(t, "apply_old_claimable", 9002, true)
+	backdate(t, older.ID, 20*time.Minute)
+
+	// Young claimable pending apply (created now) → below threshold, not stuck.
+	seedPending(t, "apply_young_claimable", 9003, true)
+
+	// Old pending apply with no child rows → not yet claimable, excluded.
+	noChildren := seedPending(t, "apply_old_no_children", 9004, false)
+	backdate(t, noChildren.ID, 40*time.Minute)
+
+	// Old terminal apply → not pending, excluded.
+	completedLock := createTestLock(t, store, "db_completed", storage.DatabaseTypeMySQL, "staging")
+	completed := createTestApplyWithStateAndEnv(t, store, completedLock, "apply_old_completed", 9005, state.Apply.Completed, "staging")
+	backdate(t, completed.ID, 40*time.Minute)
+
+	threshold := 10 * time.Minute
+
+	t.Run("returns aged claimable pending applies oldest first", func(t *testing.T) {
+		stuck, err := store.Applies().FindStuckPendingApplies(ctx, threshold, 0)
+		require.NoError(t, err)
+		require.Len(t, stuck, 2)
+		assert.Equal(t, oldest.ApplyIdentifier, stuck[0].ApplyIdentifier)
+		assert.Equal(t, older.ApplyIdentifier, stuck[1].ApplyIdentifier)
+		assert.Equal(t, state.Apply.Pending, stuck[0].State)
+	})
+
+	t.Run("limit caps the result to the oldest rows", func(t *testing.T) {
+		stuck, err := store.Applies().FindStuckPendingApplies(ctx, threshold, 1)
+		require.NoError(t, err)
+		require.Len(t, stuck, 1)
+		assert.Equal(t, oldest.ApplyIdentifier, stuck[0].ApplyIdentifier)
+	})
+
+	t.Run("a threshold above every age surfaces nothing", func(t *testing.T) {
+		stuck, err := store.Applies().FindStuckPendingApplies(ctx, time.Hour, 0)
+		require.NoError(t, err)
+		assert.Empty(t, stuck)
+	})
 }
 
 // A VSchema-only apply carries an apply_operations row but no tasks — the

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -400,6 +400,17 @@ type ApplyStore interface {
 	// Note: For recovery, use FindNextApply which handles locking.
 	GetInProgress(ctx context.Context) ([]*Apply, error)
 
+	// FindStuckPendingApplies returns pending applies that FindNextApply should
+	// already have claimed — pending with child rows (the same claimable-pending
+	// predicate FindNextApply uses) — but whose created_at is older than
+	// olderThan, ordered oldest first and capped at limit. It is a read-only
+	// diagnostic: apply creation rejects a second active apply for the same
+	// target rather than queuing it, so a pending apply this old is not waiting
+	// its turn — either no driver is claiming (a starved or crash-looping
+	// operator pool) or the claim path is wedged. Returns an empty slice when
+	// nothing is stuck. A non-positive limit means no cap.
+	FindStuckPendingApplies(ctx context.Context, olderThan time.Duration, limit int) ([]*Apply, error)
+
 	// FindNextApply atomically claims the next apply that needs attention.
 	// A claim selects one apply that needs work and refreshes its heartbeat in
 	// the same transaction. The owner is stored with a freshly generated lease

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -401,8 +401,8 @@ type ApplyStore interface {
 	GetInProgress(ctx context.Context) ([]*Apply, error)
 
 	// FindStuckPendingApplies returns pending applies that FindNextApply should
-	// already have claimed — pending with child rows (the same claimable-pending
-	// predicate FindNextApply uses) — but whose created_at is older than
+	// already have claimed — pending with child rows (the child-rows arm of
+	// FindNextApply's pending predicate) — but whose created_at is older than
 	// olderThan, ordered oldest first and capped at limit. It is a read-only
 	// diagnostic: apply creation rejects a second active apply for the same
 	// target rather than queuing it, so a pending apply this old is not waiting


### PR DESCRIPTION
## Summary

Adds two diagnostics for the intermittent apply-pending stall (an apply that stays `pending` while sibling applies claim and complete). Part A is a durable production signal for the failure class; Part B makes the CI occurrence diagnosable instead of scrolling the failure window out of a 300-line log tail.

## What

- **A — operator stuck-pending monitor.** A single-owner background monitor scans every 60s for pending applies a driver should already have claimed — the same claimable-pending predicate `FindNextApply` uses (`state=pending AND (has tasks OR has apply_operations)`) — that are older than a 15m threshold. Emits `schemabot.operator.stuck_pending_applies` (gauge), a WARN naming the oldest apply, and `schemabot.operator.stuck_pending_scan_failures` (liveness counter, since the gauge is last-value). New read-only `ApplyStore.FindStuckPendingApplies`, backed by the existing `idx_state_created_id` index.
- **B — E2E log capture.** The three docker-compose failure steps now write full `--no-color --timestamps` logs and upload them as per-shard artifacts (7-day retention) instead of a `--tail=300` console dump. E2E already runs at debug level, so the next occurrence preserves the operator's claim-decision logs.

## Why

Apply creation rejects a second active apply for the same target rather than queuing it, so a pending apply that stays pending is never waiting its turn — it means a saturated, operator-less, or wedged driver pool. Nothing surfaced that today, and the CI failure window was truncated out of the captured logs. The 15m threshold is deliberately conservative so ordinary claim latency never trips the gauge; Part B carries the fast (sub-30s) CI diagnosis.

## Before / after
```
Before
pending apply never claimed ─► (no signal)         ► silent stall
E2E job fails               ─► logs --tail=300      ► window lost

After
pending apply > 15m unclaimed ─► gauge + WARN + counter
E2E job fails                 ─► full timestamped logs ► uploaded artifact
```
## Follow-up (out of scope)

This is the 5th near-verbatim ticker-monitor in `pkg/api`; extracting a shared `periodicMonitor` helper is a separate cleanup.
