### PR TITLE
fix(github): clear a removed database's stale change summary when cleanup marks its check successful

### DIFF
--- a/pkg/storage/mysqlstore/checks.go
+++ b/pkg/storage/mysqlstore/checks.go
@@ -219,8 +219,9 @@ func successfulNoOpPlanResult(check *storage.Check) bool {
 // claimed the row after stale cleanup read it keeps blocking: a row that is
 // in_progress or owns an apply ID is left untouched, because a passing check must
 // never be derived from cleanup alone while an apply may have reached the live
-// database. The change summary is written as given — including empty — because
-// the stored summary describes the superseded plan and must not survive onto a
+// database. The change summary is overwritten with the caller's value;
+// an empty summary clears the stored one (persisted as NULL), because the
+// stored summary describes the superseded plan and must not survive onto a
 // head that no longer touches the database. Returns true when the row is in the
 // plan-only successful state after this call (whether this call wrote it or it
 // already was), and false only when a started apply still owns it.

--- a/pkg/storage/mysqlstore/checks.go
+++ b/pkg/storage/mysqlstore/checks.go
@@ -219,9 +219,11 @@ func successfulNoOpPlanResult(check *storage.Check) bool {
 // claimed the row after stale cleanup read it keeps blocking: a row that is
 // in_progress or owns an apply ID is left untouched, because a passing check must
 // never be derived from cleanup alone while an apply may have reached the live
-// database. Returns true when the row is in the plan-only successful state after
-// this call (whether this call wrote it or it already was), and false only when a
-// started apply still owns it.
+// database. The change summary is written as given — including empty — because
+// the stored summary describes the superseded plan and must not survive onto a
+// head that no longer touches the database. Returns true when the row is in the
+// plan-only successful state after this call (whether this call wrote it or it
+// already was), and false only when a started apply still owns it.
 //
 // This deliberately clears a review-time deployment drift block too: once a later
 // commit removes the database from the PR and no apply has started, the reviewed
@@ -243,11 +245,11 @@ func (s *checkStore) MarkStalePlanSuccessful(ctx context.Context, check *storage
 		    conclusion = ?,
 		    blocking_reason = ?,
 		    error_message = ?,
-		    change_summary = COALESCE(NULLIF(?, ''), change_summary)
+		    change_summary = ?
 		WHERE repository = ? AND pull_request = ?
 		  AND environment = ? AND database_type = ? AND database_name = ?
 		  AND status != ? AND apply_id IS NULL
-	`, check.HeadSHA, checkRunID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage, check.ChangeSummary,
+	`, check.HeadSHA, checkRunID, check.HasChanges, check.Status, check.Conclusion, check.BlockingReason, check.ErrorMessage, nullString(check.ChangeSummary),
 		check.Repository, check.PullRequest, check.Environment, check.DatabaseType, check.DatabaseName,
 		checkStatusInProgress)
 	if err != nil {

--- a/pkg/storage/mysqlstore/checks_test.go
+++ b/pkg/storage/mysqlstore/checks_test.go
@@ -666,7 +666,9 @@ func TestCheckStore_RecoverApplyOwnedCheckWithNoOpPlanRequiresNoOpSuccess(t *tes
 
 // When a database drops out of a PR and its stored check state is a plan-only
 // result with no started apply, stale cleanup marks it successful so the PR is
-// no longer blocked by a database it no longer touches.
+// no longer blocked by a database it no longer touches. The superseded plan's
+// change summary is cleared with it, so the aggregate renders the database as
+// having no pending schema change instead of repeating the old plan's counts.
 func TestCheckStore_MarkStalePlanSuccessfulMarksPlanOnlyCheck(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
@@ -684,6 +686,7 @@ func TestCheckStore_MarkStalePlanSuccessfulMarksPlanOnlyCheck(t *testing.T) {
 		Conclusion:     "action_required",
 		BlockingReason: "schema_change_pending",
 		ErrorMessage:   "schema change pending apply",
+		ChangeSummary:  "1 alter",
 	}))
 
 	marked, err := store.Checks().MarkStalePlanSuccessful(ctx, &storage.Check{
@@ -710,6 +713,7 @@ func TestCheckStore_MarkStalePlanSuccessfulMarksPlanOnlyCheck(t *testing.T) {
 	require.Equal(t, int64(0), retrieved.ApplyID)
 	require.Empty(t, retrieved.BlockingReason)
 	require.Empty(t, retrieved.ErrorMessage)
+	require.Empty(t, retrieved.ChangeSummary)
 }
 
 // A database can drop out of a PR at the same moment an apply for it begins. If
@@ -724,17 +728,18 @@ func TestCheckStore_MarkStalePlanSuccessfulLeavesInProgressApplyBlocking(t *test
 
 	apply := createCheckStoreApply(t, store, "apply-claimed-after-cleanup-read", state.Apply.Running)
 	require.NoError(t, store.Checks().Upsert(ctx, &storage.Check{
-		Repository:   "org/repo",
-		PullRequest:  123,
-		HeadSHA:      "oldsha",
-		Environment:  "staging",
-		DatabaseType: "mysql",
-		DatabaseName: "testdb",
-		CheckRunID:   100,
-		ApplyID:      apply.ID,
-		HasChanges:   true,
-		Status:       "in_progress",
-		Conclusion:   "",
+		Repository:    "org/repo",
+		PullRequest:   123,
+		HeadSHA:       "oldsha",
+		Environment:   "staging",
+		DatabaseType:  "mysql",
+		DatabaseName:  "testdb",
+		CheckRunID:    100,
+		ApplyID:       apply.ID,
+		HasChanges:    true,
+		Status:        "in_progress",
+		Conclusion:    "",
+		ChangeSummary: "1 alter",
 	}))
 
 	marked, err := store.Checks().MarkStalePlanSuccessful(ctx, &storage.Check{
@@ -759,6 +764,8 @@ func TestCheckStore_MarkStalePlanSuccessfulLeavesInProgressApplyBlocking(t *test
 	require.Empty(t, retrieved.Conclusion)
 	require.True(t, retrieved.HasChanges)
 	require.Equal(t, apply.ID, retrieved.ApplyID)
+	require.Equal(t, "1 alter", retrieved.ChangeSummary,
+		"apply-owned row keeps its change summary — the apply's schema change is still what the row describes")
 }
 
 // A terminal apply-owned row (apply ID still set after the apply finished) keeps
@@ -830,6 +837,7 @@ func TestCheckStore_MarkStalePlanSuccessfulIsIdempotentUnderChangedRows(t *testi
 		Conclusion:     "action_required",
 		BlockingReason: "schema_change_pending",
 		ErrorMessage:   "schema change pending apply",
+		ChangeSummary:  "1 alter",
 	}))
 
 	successCheck := &storage.Check{
@@ -864,6 +872,7 @@ func TestCheckStore_MarkStalePlanSuccessfulIsIdempotentUnderChangedRows(t *testi
 	require.Equal(t, int64(0), retrieved.ApplyID)
 	require.Empty(t, retrieved.BlockingReason)
 	require.Empty(t, retrieved.ErrorMessage)
+	require.Empty(t, retrieved.ChangeSummary)
 }
 
 // Under changed-rows semantics, a row claimed by a started apply between the

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -133,9 +133,10 @@ type CheckStore interface {
 	// the database it covers is no longer in the PR. It fails closed: the update
 	// is skipped when the row is in_progress or owns an apply ID, so a started
 	// apply that began after stale cleanup read the row keeps blocking the PR.
-	// The change summary is written as given — including empty — so the
-	// superseded plan's summary does not survive onto a head that no longer
-	// touches the database. Returns true when the row was marked successful.
+	// The change summary is overwritten with the caller's value; an empty
+	// summary clears the stored one (persisted as NULL), so the superseded
+	// plan's summary does not survive onto a head that no longer touches the
+	// database. Returns true when the row was marked successful.
 	MarkStalePlanSuccessful(ctx context.Context, check *Check) (bool, error)
 
 	// ClearAggregateBlock clears the blocking reason on stored aggregate check

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -133,7 +133,9 @@ type CheckStore interface {
 	// the database it covers is no longer in the PR. It fails closed: the update
 	// is skipped when the row is in_progress or owns an apply ID, so a started
 	// apply that began after stale cleanup read the row keeps blocking the PR.
-	// Returns true when the row was marked successful.
+	// The change summary is written as given — including empty — so the
+	// superseded plan's summary does not survive onto a head that no longer
+	// touches the database. Returns true when the row was marked successful.
 	MarkStalePlanSuccessful(ctx context.Context, check *Check) (bool, error)
 
 	// ClearAggregateBlock clears the blocking reason on stored aggregate check

--- a/pkg/webhook/aggregate_check_integration_test.go
+++ b/pkg/webhook/aggregate_check_integration_test.go
@@ -93,7 +93,9 @@ func TestE2EAggregateCheck(t *testing.T) {
 // TestE2EAggregateCheckStaleCleanup verifies that when a new commit removes all schema
 // changes from a PR, the stale per-database checks and aggregate check are re-created
 // on the new HEAD SHA with "success" conclusion. This reproduces the scenario where a
-// user pushes a commit that reverts their schema change.
+// user pushes a commit that reverts their schema change. The superseded plan's change
+// summary is cleared with the cleanup, so the aggregate table renders the databases as
+// having no pending schema change instead of repeating the old plan's counts.
 func TestE2EAggregateCheckStaleCleanup(t *testing.T) {
 	dbName := "webhook_aggregate_stale"
 	svc := setupE2EServiceMultiEnv(t, dbName)
@@ -102,16 +104,17 @@ func TestE2EAggregateCheckStaleCleanup(t *testing.T) {
 	// Seed per-database checks and aggregate as if a plan already ran on the first commit.
 	for _, env := range []string{"staging", "production"} {
 		check := &storage.Check{
-			Repository:   "octocat/hello-world",
-			PullRequest:  1,
-			HeadSHA:      "oldsha111",
-			Environment:  env,
-			DatabaseType: "mysql",
-			DatabaseName: dbName,
-			CheckRunID:   100,
-			HasChanges:   true,
-			Status:       checkStatusCompleted,
-			Conclusion:   checkConclusionActionRequired,
+			Repository:    "octocat/hello-world",
+			PullRequest:   1,
+			HeadSHA:       "oldsha111",
+			Environment:   env,
+			DatabaseType:  "mysql",
+			DatabaseName:  dbName,
+			CheckRunID:    100,
+			HasChanges:    true,
+			Status:        checkStatusCompleted,
+			Conclusion:    checkConclusionActionRequired,
+			ChangeSummary: "1 alter",
 		}
 		require.NoError(t, svc.Storage().Checks().Upsert(ctx, check))
 	}
@@ -215,6 +218,14 @@ func TestE2EAggregateCheckStaleCleanup(t *testing.T) {
 		assert.Equal(t, aggregateCheckName, cr.Name)
 		assert.Equal(t, checkConclusionSuccess, cr.Conclusion)
 		assert.False(t, prematurePassingAggregate.Load(), "passing aggregate was published before stale per-database records were cleaned")
+
+		// The cleaned rows render as databases with no pending schema change:
+		// an em dash in the Change column, not the superseded plan's counts.
+		require.NotNil(t, cr.Output)
+		assert.Equal(t, "Schema up to date", cr.Output.Title)
+		assert.Contains(t, cr.Output.Summary, fmt.Sprintf("| `%s` | staging | mysql | — | Up to date |", dbName))
+		assert.Contains(t, cr.Output.Summary, fmt.Sprintf("| `%s` | production | mysql | — | Up to date |", dbName))
+		assert.NotContains(t, cr.Output.Summary, "1 alter", "the aggregate must not repeat the superseded plan's change summary on a head with no schema changes")
 	case <-time.After(10 * time.Second):
 		t.Fatal("timed out waiting for aggregate check run")
 	}
@@ -228,6 +239,7 @@ func TestE2EAggregateCheckStaleCleanup(t *testing.T) {
 				assert.Equal(t, checkConclusionSuccess, check.Conclusion)
 				assert.False(t, check.HasChanges)
 				assert.Empty(t, check.BlockingReason)
+				assert.Empty(t, check.ChangeSummary)
 				break
 			}
 			select {

--- a/pkg/webhook/check_aggregate_test.go
+++ b/pkg/webhook/check_aggregate_test.go
@@ -189,6 +189,18 @@ func TestRenderDatabaseSection_EnvironmentColumn(t *testing.T) {
 	})
 }
 
+// A row with no recorded change summary — a database the current head does not
+// change, whether it was never touched or a later commit removed its schema
+// change — renders an em dash in the Change column, so both cases present
+// identically as "no pending schema change".
+func TestRenderDatabaseSection_NoPendingChangeRendersEmDash(t *testing.T) {
+	checks := []*storage.Check{
+		{DatabaseName: "orders", DatabaseType: "mysql", Environment: "production", Status: checkStatusCompleted, Conclusion: checkConclusionSuccess, HasChanges: false},
+	}
+	section := renderDatabaseSection(checks, maxCheckRunTextLength)
+	assert.Contains(t, section, "| `orders` | mysql | — | Up to date |")
+}
+
 // When the leader gates on participant deployments, their folded outcomes render
 // in a separate "Tenant deployments" section, keyed by tenant, distinct from the
 // leader's own per-database rows.

--- a/pkg/webhook/check_cleanup_integration_test.go
+++ b/pkg/webhook/check_cleanup_integration_test.go
@@ -139,16 +139,17 @@ func TestE2EStaleCheckCleanup(t *testing.T) {
 
 	// Seed a check for a database that WON'T be in the next auto-plan
 	err := svc.Storage().Checks().Upsert(t.Context(), &storage.Check{
-		Repository:   "octocat/hello-world",
-		PullRequest:  1,
-		HeadSHA:      "old-sha",
-		Environment:  "staging",
-		DatabaseType: "mysql",
-		DatabaseName: "removed_database",
-		CheckRunID:   42,
-		HasChanges:   true,
-		Status:       "completed",
-		Conclusion:   "action_required",
+		Repository:    "octocat/hello-world",
+		PullRequest:   1,
+		HeadSHA:       "old-sha",
+		Environment:   "staging",
+		DatabaseType:  "mysql",
+		DatabaseName:  "removed_database",
+		CheckRunID:    42,
+		HasChanges:    true,
+		Status:        "completed",
+		Conclusion:    "action_required",
+		ChangeSummary: "1 alter",
 	})
 	require.NoError(t, err)
 
@@ -190,14 +191,20 @@ func TestE2EStaleCheckCleanup(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rr.Code)
 
-	// The stale check (removed_database) should be updated to success
+	// The stale check (removed_database) should be updated to success, with the
+	// superseded plan's change summary cleared so the aggregate renders the
+	// database as having no pending schema change.
+	var staleCheck *storage.Check
 	require.Eventually(t, func() bool {
 		check, err := svc.Storage().Checks().Get(t.Context(), "octocat/hello-world", 1, "staging", "mysql", "removed_database")
 		if err != nil || check == nil {
 			return false
 		}
+		staleCheck = check
 		return check.Conclusion == "success"
 	}, 10*time.Second, 200*time.Millisecond, "stale check should be updated to success")
+	assert.False(t, staleCheck.HasChanges)
+	assert.Empty(t, staleCheck.ChangeSummary)
 
 	// The active check (dbName) should still exist (may be updated by auto-plan)
 	check, err := svc.Storage().Checks().Get(t.Context(), "octocat/hello-world", 1, "staging", "mysql", dbName)

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -877,6 +877,10 @@ func (h *Handler) markStalePlanOnlyCheckStateSuccessful(ctx context.Context, rep
 	check.ApplyID = 0
 	check.BlockingReason = ""
 	check.ErrorMessage = ""
+	// The stored summary describes the superseded plan; the current head no
+	// longer touches this database, so the aggregate row must render as a
+	// database with no pending schema change, not repeat the old plan's counts.
+	check.ChangeSummary = ""
 
 	// The success write is guarded against in-flight apply-owned rows: an apply
 	// that started after this cleanup read the row must keep blocking the PR.


### PR DESCRIPTION
## Why this matters

When a new commit removes a database's schema change from the PR, stale-check cleanup marks that database's stored check successful — but it kept the *previous* head's change summary. The aggregate Check Run then showed a row like "1 alter" against a database the PR no longer touches. An operator reading the check before merge sees a pending schema change that does not exist, and has to open the diff to discover the row is stale text, not a real change.

## What it does

Two layers, so the stored record and the rendered check agree:

- The cleanup path resets the stored check's change summary before marking it successful: the current head no longer touches this database, so the aggregate row must render as a database with no pending schema change.
- `MarkStalePlanSuccessful` now writes the change summary verbatim — including empty — instead of coalescing an empty summary back to the previous value. The stored record is what the caller said, not a blend of two heads.

A cleaned-up database's aggregate row now renders an em dash in the summary column. The "No managed schema changes" title still appears only when the PR has zero stored rows, and apply-owned rows are untouched — a database with an in-flight or finished apply keeps its summary, and cleanup still cannot flip it (started applies remain authoritative).

## How it moves us toward the northstar

The Check Run is the merge gate operators trust; every cell in it must describe the PR as it is now. Removing the last place where a stale head's text could leak into the current head's check keeps that trust cheap: read the check, believe the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
