### PR TITLE
fix(github): minimize stale plan comments for databases a new head no longer touches

### DIFF
--- a/pkg/storage/mysqlstore/plan_comments.go
+++ b/pkg/storage/mysqlstore/plan_comments.go
@@ -60,6 +60,31 @@ func (s *planCommentStore) ListUnminimizedForSlot(ctx context.Context, repo stri
 	return comments, rows.Err()
 }
 
+// ListUnminimizedForPR returns the not-yet-minimized comments across every
+// database slot on a pull request, ordered by id ascending.
+func (s *planCommentStore) ListUnminimizedForPR(ctx context.Context, repo string, pr int) ([]*storage.PlanComment, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT `+planCommentColumns+`
+		FROM plan_comments
+		WHERE repository = ? AND pull_request = ? AND minimized_at IS NULL
+		ORDER BY id
+	`, repo, pr)
+	if err != nil {
+		return nil, fmt.Errorf("query unminimized plan comments for %s#%d: %w", repo, pr, err)
+	}
+	defer utils.CloseAndLog(rows)
+
+	var comments []*storage.PlanComment
+	for rows.Next() {
+		comment, err := scanPlanComment(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan plan comment for %s#%d: %w", repo, pr, err)
+		}
+		comments = append(comments, comment)
+	}
+	return comments, rows.Err()
+}
+
 // MarkMinimized stamps minimized_at after the GitHub minimize call succeeded.
 // An already-minimized row is not an error.
 func (s *planCommentStore) MarkMinimized(ctx context.Context, id int64) error {

--- a/pkg/storage/mysqlstore/plan_comments_test.go
+++ b/pkg/storage/mysqlstore/plan_comments_test.go
@@ -67,6 +67,37 @@ func TestPlanCommentStore_InsertAndListUnminimizedForSlot(t *testing.T) {
 	assert.Empty(t, comments)
 }
 
+func TestPlanCommentStore_ListUnminimizedForPR(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	// Two database slots on the target PR, one already-minimized row on the
+	// same PR, and one row on a different PR.
+	first := insertTestPlanComment(t, store, "org/repo", 42, "orders", "mysql", "staging", "sha1", 100)
+	second := insertTestPlanComment(t, store, "org/repo", 42, "billing", "mysql", "staging", "sha1", 200)
+	minimized := insertTestPlanComment(t, store, "org/repo", 42, "orders", "mysql", "staging", "sha2", 300)
+	require.NoError(t, store.PlanComments().MarkMinimized(ctx, minimized.ID))
+	insertTestPlanComment(t, store, "org/repo", 7, "orders", "mysql", "staging", "sha1", 400)
+
+	comments, err := store.PlanComments().ListUnminimizedForPR(ctx, "org/repo", 42)
+	require.NoError(t, err)
+	require.Len(t, comments, 2, "every unminimized slot on the PR is listed, other PRs and minimized rows are not")
+
+	assert.Equal(t, first.ID, comments[0].ID, "ordered by id ascending")
+	assert.Equal(t, "orders", comments[0].DatabaseName)
+	assert.Equal(t, second.ID, comments[1].ID)
+	assert.Equal(t, "billing", comments[1].DatabaseName)
+	assert.Equal(t, "mysql", comments[1].DatabaseType)
+	assert.Equal(t, "sha1", comments[1].HeadSHA)
+	assert.Equal(t, "IC_node200", comments[1].GitHubNodeID)
+
+	// A PR with no rows lists as empty, not an error.
+	comments, err = store.PlanComments().ListUnminimizedForPR(ctx, "org/repo", 999)
+	require.NoError(t, err)
+	assert.Empty(t, comments)
+}
+
 func TestPlanCommentStore_MarkMinimized(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()
@@ -174,6 +205,16 @@ func TestPlanCommentStore_ListUnminimizedForSlot_DBError(t *testing.T) {
 
 	store := New(db)
 	_, err = store.PlanComments().ListUnminimizedForSlot(t.Context(), "org/repo", 1, "db", "mysql")
+	require.Error(t, err)
+}
+
+func TestPlanCommentStore_ListUnminimizedForPR_DBError(t *testing.T) {
+	db, err := sql.Open("mysql", testDSN)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	store := New(db)
+	_, err = store.PlanComments().ListUnminimizedForPR(t.Context(), "org/repo", 1)
 	require.Error(t, err)
 }
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -670,6 +670,12 @@ type PlanCommentStore interface {
 	// caller decides which of them a newly posted comment supersedes.
 	ListUnminimizedForSlot(ctx context.Context, repo string, pr int, database, databaseType string) ([]*PlanComment, error)
 
+	// ListUnminimizedForPR returns the not-yet-minimized comments across every
+	// database slot on a pull request, ordered by id ascending. Callers use it
+	// to find slots whose database no longer resolves a schema config in the
+	// PR diff, since no per-slot plan outcome sweeps those.
+	ListUnminimizedForPR(ctx context.Context, repo string, pr int) ([]*PlanComment, error)
+
 	// MarkMinimized stamps minimized_at after the GitHub minimize call
 	// succeeded. An already-minimized row is not an error.
 	MarkMinimized(ctx context.Context, id int64) error

--- a/pkg/webhook/auto_plan_integration_test.go
+++ b/pkg/webhook/auto_plan_integration_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/block/schemabot/pkg/api"
 	ghclient "github.com/block/schemabot/pkg/github"
+	"github.com/block/schemabot/pkg/state"
 	"github.com/block/schemabot/pkg/storage"
 )
 
@@ -798,6 +799,142 @@ func TestE2EAutoPlanNoSchemaFiles(t *testing.T) {
 	select {
 	case body := <-comments:
 		t.Fatalf("expected no plan comment for no-schema auto-plan, got: %s", body)
+	case <-time.After(250 * time.Millisecond):
+	}
+}
+
+// TestE2EAutoPlanSynchronizeSchemaRevertedSweepsStalePlanComment exercises the
+// reverted-schema-change UX through the full webhook path: a PR that
+// previously planned a schema change receives a synchronize whose net diff no
+// longer touches any schema file — a revert commit removed the change. No
+// plan runs for the database, so the sweep collapses the prior head's plan
+// comment (its pending DDL and apply prompt no longer match the branch), while
+// a plan comment whose head produced an apply stays expanded as the
+// operational record of what ran.
+func TestE2EAutoPlanSynchronizeSchemaRevertedSweepsStalePlanComment(t *testing.T) {
+	dbName := "webhook_autoplan_schema_reverted"
+	svc := setupE2EService(t, dbName)
+	ctx := t.Context()
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(gh.PullRequest{
+			State: new("open"),
+			Head:  &gh.PullRequestBranch{Ref: new("feature-branch"), SHA: new("newsha")},
+			Base:  &gh.PullRequestBranch{Ref: new("main"), SHA: new("basesha")},
+			User:  &gh.User{Login: new("testuser")},
+		})
+	})
+	// The net diff after the revert touches no schema files.
+	mux.HandleFunc("GET /repos/octocat/hello-world/pulls/1/files", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]*gh.CommitFile{
+			{Filename: new("app/service.go"), Status: new("modified")},
+		})
+	})
+	mux.HandleFunc("POST /repos/octocat/hello-world/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	})
+	comments := make(chan string, 1)
+	mux.HandleFunc("POST /repos/octocat/hello-world/issues/1/comments", commentRecorder(t, comments))
+	minimized := make(chan string, 4)
+	mux.HandleFunc("POST /graphql", func(w http.ResponseWriter, r *http.Request) {
+		var gql struct {
+			Variables map[string]string `json:"variables"`
+		}
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&gql))
+		minimized <- gql.Variables["id"]
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"minimizeComment": map[string]any{
+					"minimizedComment": map[string]any{"isMinimized": true},
+				},
+			},
+		})
+	})
+
+	// Two of the database's plan comments are still expanded on the PR: one
+	// from a plan that never applied, one whose plan became an apply.
+	insertPlanCommentRow(t, svc.Storage(), "octocat/hello-world", 1, dbName, "staging", "priorsha", 9001, "IC_reverted_prior")
+	insertPlanCommentRow(t, svc.Storage(), "octocat/hello-world", 1, dbName, "staging", "ownedsha", 9002, "IC_reverted_owned")
+
+	planID, err := svc.Storage().Plans().Create(ctx, &storage.Plan{
+		PlanIdentifier: "plan_reverted_owned",
+		Database:       dbName,
+		DatabaseType:   "mysql",
+		Repository:     "octocat/hello-world",
+		PullRequest:    1,
+		Environment:    "staging",
+		HeadSHA:        "ownedsha",
+		CreatedAt:      time.Now(),
+	})
+	require.NoError(t, err)
+	lock := &storage.Lock{
+		DatabaseName: dbName,
+		DatabaseType: "mysql",
+		Repository:   "octocat/hello-world",
+		PullRequest:  1,
+		Owner:        "octocat/hello-world#1",
+	}
+	require.NoError(t, svc.Storage().Locks().Acquire(ctx, lock))
+	lock, err = svc.Storage().Locks().Get(ctx, dbName, "mysql")
+	require.NoError(t, err)
+	_, err = svc.Storage().Applies().Create(ctx, &storage.Apply{
+		ApplyIdentifier: "apply_reverted_owned",
+		LockID:          lock.ID,
+		PlanID:          planID,
+		Database:        dbName,
+		DatabaseType:    "mysql",
+		Repository:      "octocat/hello-world",
+		PullRequest:     1,
+		Environment:     "staging",
+		Engine:          "spirit",
+		State:           state.Apply.Completed,
+	})
+	require.NoError(t, err)
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	installClient := ghclient.NewInstallationClient(client, logger)
+	h := NewHandler(svc, &fakeClientFactory{client: installClient}, nil, logger)
+
+	req := buildPRWebhookRequest(t, prWebhookPayloadOpts{
+		action:    "synchronize",
+		beforeSHA: "priorsha",
+		headSHA:   "newsha",
+		headRef:   "feature-branch",
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// The never-applied prior head's plan comment collapses even though no plan
+	// ran and no new comment replaces it.
+	select {
+	case node := <-minimized:
+		assert.Equal(t, "IC_reverted_prior", node)
+	case <-time.After(webhookIntegrationPollDeadline):
+		t.Fatal("timed out waiting for the reverted schema change's stale plan comment to be minimized")
+	}
+	require.Eventually(t, func() bool {
+		heads := unminimizedHeads(t, svc.Storage(), "octocat/hello-world", 1, dbName, "mysql")
+		return len(heads) == 1 && heads[0] == "ownedsha"
+	}, webhookIntegrationCheckRunDeadline, 100*time.Millisecond,
+		"the swept comment must be recorded minimized and the apply-owned comment must stay expanded")
+
+	// The apply-owned comment must not receive a late minimize, and the sweep
+	// never posts a comment of its own.
+	select {
+	case node := <-minimized:
+		t.Fatalf("expected no further minimize after the sweep, but %q was minimized", node)
+	case body := <-comments:
+		t.Fatalf("expected no plan comment after the schema change was reverted, got: %s", body)
 	case <-time.After(250 * time.Millisecond):
 	}
 }

--- a/pkg/webhook/check_runs_test.go
+++ b/pkg/webhook/check_runs_test.go
@@ -36,6 +36,18 @@ func (s *emptyStorage) Locks() storage.LockStore {
 	return &emptyLockStore{}
 }
 
+func (s *emptyStorage) PlanComments() storage.PlanCommentStore {
+	return &emptyPlanCommentStore{}
+}
+
+type emptyPlanCommentStore struct {
+	storage.PlanCommentStore
+}
+
+func (s *emptyPlanCommentStore) ListUnminimizedForPR(ctx context.Context, repo string, pr int) ([]*storage.PlanComment, error) {
+	return nil, nil
+}
+
 type emptyLockStore struct {
 	storage.LockStore
 }

--- a/pkg/webhook/plan_comment_minimize.go
+++ b/pkg/webhook/plan_comment_minimize.go
@@ -137,6 +137,63 @@ func (h *Handler) minimizeStalePlanComments(ctx context.Context, client *ghclien
 	h.minimizePlanCommentsForSlot(ctx, client, repo, pr, database, databaseType, headSHA, nil)
 }
 
+// sweepStalePlanCommentsForRemovedDatabases collapses the stale plan comments
+// of databases that no longer resolve a schema config in the PR diff — for
+// example a later commit reverted the schema change, so the schema file
+// dropped out of the net diff. No plan runs for such a database, so no
+// per-slot plan outcome supersedes its comments; without this sweep a prior
+// head's plan comment would keep advertising pending DDL and an apply prompt
+// that no longer match the branch. Each slot goes through
+// minimizeStalePlanComments, so the fresh-head verification and the
+// apply-owned hold apply unchanged. affectedDatabases holds the databases the
+// current delivery still plans; their slots are left to their own plan
+// outcomes.
+func (h *Handler) sweepStalePlanCommentsForRemovedDatabases(repo string, pr int, headSHA string, installationID int64, affectedDatabases map[string]bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	comments, err := h.service.Storage().PlanComments().ListUnminimizedForPR(ctx, repo, pr)
+	if err != nil {
+		h.logger.Error("failed to list plan comments for removed-database sweep; plan comments for databases no longer in the PR stay expanded until the next push",
+			"repo", repo, "pr", pr, "head_sha", headSHA, "error", err)
+		return
+	}
+
+	type databaseSlot struct {
+		database     string
+		databaseType string
+	}
+	slots := map[databaseSlot]bool{}
+	for _, comment := range comments {
+		if affectedDatabases[comment.DatabaseName] {
+			h.logger.Debug("keeping plan comment slot out of the removed-database sweep because its database is still in the PR; its own plan outcome supersedes the slot",
+				"repo", repo, "pr", pr, "database", comment.DatabaseName,
+				"database_type", comment.DatabaseType, "head_sha", headSHA)
+			continue
+		}
+		slots[databaseSlot{database: comment.DatabaseName, databaseType: comment.DatabaseType}] = true
+	}
+	if len(slots) == 0 {
+		h.logger.Debug("no plan comment slots for databases removed from the PR; nothing to sweep",
+			"repo", repo, "pr", pr, "head_sha", headSHA)
+		return
+	}
+
+	client, err := h.clientForRepo(repo, installationID)
+	if err != nil {
+		h.logger.Error("failed to create GitHub client for removed-database plan comment sweep; plan comments for databases no longer in the PR stay expanded until the next push",
+			"repo", repo, "pr", pr, "head_sha", headSHA, "installation_id", installationID, "error", err)
+		return
+	}
+
+	for slot := range slots {
+		h.logger.Info("minimizing stale plan comments for database no longer in the PR",
+			"repo", repo, "pr", pr, "database", slot.database,
+			"database_type", slot.databaseType, "head_sha", headSHA)
+		h.minimizeStalePlanComments(ctx, client, repo, pr, slot.database, slot.databaseType, headSHA)
+	}
+}
+
 // minimizePlanCommentsForSlot sweeps the slot's unminimized plan comments and
 // collapses the superseded ones. posted is the newly posted comment when the
 // sweep follows a post: its own row is skipped and supersession follows

--- a/pkg/webhook/plan_comment_minimize_integration_test.go
+++ b/pkg/webhook/plan_comment_minimize_integration_test.go
@@ -436,6 +436,34 @@ func TestStalePlanCommentSweepSkipsWhenHeadMoved(t *testing.T) {
 		"every comment stays expanded until the current head's own sweep")
 }
 
+// TestRemovedDatabaseSweepMinimizesOnlyRemovedSlots exercises the sweep that
+// runs when a database's schema files drop out of the PR's net diff — for
+// example a revert commit removed the schema change, so no plan runs for that
+// database and no per-slot plan outcome would otherwise touch its comments.
+// The removed database's stale comments collapse; a slot whose database is
+// still planned by the delivery is left to its own plan outcome, and a
+// removed-database comment already rendered at the current head stays
+// expanded.
+func TestRemovedDatabaseSweepMinimizesOnlyRemovedSlots(t *testing.T) {
+	const repo = "org/plan-min-removed-db-sweep"
+	h, st, fake := setupPlanCommentHandler(t, repo)
+
+	insertPlanCommentRow(t, st, repo, 42, "orders", "staging", "shaA", 9001, "IC_removed_shaA")
+	insertPlanCommentRow(t, st, repo, 42, "orders", "staging", "shaB", 9002, "IC_removed_shaB")
+	insertPlanCommentRow(t, st, repo, 42, "billing", "staging", "shaA", 9003, "IC_planned_shaA")
+	fake.setCurrentHead("shaB")
+
+	h.sweepStalePlanCommentsForRemovedDatabases(repo, 42, "shaB", 12345, map[string]bool{"billing": true})
+
+	assert.Equal(t, []string{"IC_removed_shaA"}, fake.minimizedNodes(),
+		"only the removed database's prior-head comment is minimized")
+	assert.Equal(t, []string{"shaB"}, unminimizedHeads(t, st, repo, 42, "orders", "mysql"),
+		"the removed database's current-head comment stays expanded")
+	assert.Equal(t, []string{"shaA"}, unminimizedHeads(t, st, repo, 42, "billing", "mysql"),
+		"a slot the delivery still plans is left to its own plan outcome")
+	assert.Equal(t, 0, fake.createCount(), "the sweep posts no comment")
+}
+
 // TestStalePlanCommentSweepKeepsApplyOwnedHeadExpanded covers the safety hold
 // on the no-new-comment sweep: once an apply exists for the head a plan
 // comment was rendered at, that comment is the operational record of what ran.

--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -374,6 +374,13 @@ func (h *Handler) runAutoPlanForPR(ctx context.Context, client *ghclient.Install
 		h.cleanupStaleChecks(repo, pr, headSHA, installationID, affectedDatabases)
 	})
 
+	// Plan comments for databases no longer in the PR have no plan outcome
+	// left to supersede them, so sweep their slots alongside the stale-check
+	// cleanup.
+	h.goSafe(repo, pr, installationID, func() {
+		h.sweepStalePlanCommentsForRemovedDatabases(repo, pr, headSHA, installationID, affectedDatabases)
+	})
+
 	if len(configs) == 0 {
 		h.logger.Info("no schema files in PR, skipping auto-plan", "repo", repo, "pr", pr, "head_sha", headSHA, "source", source, "delivery_id", deliveryID)
 		// An aggregate participant does not own the required check for the repo —

--- a/pkg/webhook/webhook_integration_test.go
+++ b/pkg/webhook/webhook_integration_test.go
@@ -194,6 +194,7 @@ func setupE2EServiceWithStorage(t *testing.T, appDBName string, wrapStorage func
 	// returns nil.
 	_, _ = schemabotDB.ExecContext(ctx, "DELETE ao FROM apply_operations ao JOIN applies a ON a.id = ao.apply_id WHERE a.repository = 'octocat/hello-world' AND a.pull_request = 1")
 	_, _ = schemabotDB.ExecContext(ctx, "DELETE FROM applies WHERE repository = 'octocat/hello-world' AND pull_request = 1")
+	_, _ = schemabotDB.ExecContext(ctx, "DELETE FROM plan_comments WHERE repository = 'octocat/hello-world' AND pull_request = 1")
 	_, _ = schemabotDB.ExecContext(ctx, "DELETE FROM plans WHERE database_name = ?", appDBName)
 
 	localClient, err := tern.NewLocalClient(tern.LocalConfig{


### PR DESCRIPTION
## Why this matters

When a new commit removes a database's schema change from the PR, the stored check state is cleaned up — but that database's plan comment stayed fully expanded on the PR timeline. The PR then shows a prominent plan for a change that no longer exists. Reviewers read plan comments to understand what will run; an expanded plan for a removed change is actively misleading, and today the only fix is a human manually minimizing it.

## What it does

Auto-plan now sweeps stale plan comments for databases the new head no longer touches:

```
push (synchronize) ──► auto-plan discovers configs for new head
                            │
                            ├─► per-database plan comments (touched DBs)
                            │
                            └─► background sweep (same trigger as stale-check cleanup):
                                  tracked, unminimized plan comments on this PR
                                  whose database is NOT touched by the new head
                                      │  fresh-head verify + apply-owned guard
                                      ▼
                                  minimized as outdated
```

- The sweep keys off the same signal as stale-check cleanup (`affectedDatabases`), so comment state and check state converge on the same answer for "does this head still touch that database" — including the head-changed-again and apply-owned cases, where the sweep leaves the comment alone.
- Deliberately broader than the zero-configs case: a head that drops one database while keeping another sweeps only the removed database's comments.
- Fail direction: a failed sweep leaves a stale comment expanded (noise), never minimizes a live one (hiding). Every skip is logged with the database and PR identifiers.

New storage listing (`ListUnminimizedForPR`) backs the sweep; minimization itself reuses the existing stale-plan minimizer and its guards.

## How it moves us toward the northstar

PR surfaces must describe the PR as it is now, without a human janitor. This closes the gap where check state moved on but the comment timeline didn't — one less place where reviewers can act on stale information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
