### PR TITLE
feat(cli): tail semantics for logs — newest N entries, plus --follow

### DIFF
--- a/pkg/cmd/commands/logs.go
+++ b/pkg/cmd/commands/logs.go
@@ -1,7 +1,9 @@
 package commands
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -11,20 +13,30 @@ import (
 	webhooktemplates "github.com/block/schemabot/pkg/webhook/templates"
 )
 
+// followInterval is how often --follow polls the logs endpoint for new entries.
+const followInterval = 5 * time.Second
+
+// followFetchLimit bounds each follow poll's read. A poll fetches the newest
+// followFetchLimit entries (per data-plane source, for deployment tails) and
+// prints the ones not yet shown; an apply that writes more than this within
+// one poll interval produces more output than a terminal tail can usefully
+// render anyway.
+const followFetchLimit = 500
+
 // LogsCmd views apply logs for a database or specific apply.
 type LogsCmd struct {
 	ApplyIDArg  string `arg:"" optional:"" help:"Apply ID (positional)" name:"apply_id"`
 	Database    string `short:"d" help:"Database name (required unless apply_id provided)"`
 	Environment string `short:"e" help:"Target environment (required unless apply_id provided)"`
 	ApplyID     string `short:"a" help:"Apply ID (e.g., apply_abc123)" name:"apply-id"`
-	Limit       int    `short:"n" help:"Number of log entries to show" default:"50"`
-	Follow      bool   `short:"f" help:"Follow logs in real-time"`
+	Limit       int    `short:"n" help:"Show the newest N log entries" default:"50"`
+	Follow      bool   `short:"f" help:"Print the newest N entries, then poll for new ones until interrupted"`
 	Deployment  string `help:"Read logs from the selected data-plane deployment"`
 	JSON        bool   `help:"Output as JSON"`
 }
 
 // Run executes the logs command.
-func (cmd *LogsCmd) Run(g *Globals) error {
+func (cmd *LogsCmd) Run(ctx context.Context, g *Globals) error {
 	// Merge positional apply_id into flag
 	if cmd.ApplyIDArg != "" && cmd.ApplyID == "" {
 		cmd.ApplyID = cmd.ApplyIDArg
@@ -42,8 +54,8 @@ func (cmd *LogsCmd) Run(g *Globals) error {
 	if cmd.Deployment != "" && cmd.ApplyID == "" {
 		return fmt.Errorf("--deployment requires an explicit apply_id")
 	}
-	if cmd.Deployment != "" && cmd.Follow {
-		return fmt.Errorf("--deployment is incompatible with --follow")
+	if cmd.JSON && cmd.Follow {
+		return fmt.Errorf("--json is incompatible with --follow: the tail renders human-readable lines; run without --follow for a JSON snapshot")
 	}
 
 	ep, err := resolveEndpoint(g.Endpoint, g.Profile)
@@ -51,14 +63,16 @@ func (cmd *LogsCmd) Run(g *Globals) error {
 		return err
 	}
 
-	if cmd.Follow {
-		return followLogs(ep, cmd.Database, cmd.Environment, cmd.ApplyID)
-	}
-	if cmd.Deployment != "" {
+	switch {
+	case cmd.Follow && cmd.Deployment != "":
+		return followDeploymentLogs(ctx, ep, cmd.ApplyID, cmd.Deployment, cmd.Limit)
+	case cmd.Follow:
+		return followLogs(ctx, ep, cmd.Database, cmd.Environment, cmd.ApplyID, cmd.Limit)
+	case cmd.Deployment != "":
 		return showDeploymentLogs(ep, cmd.ApplyID, cmd.Deployment, cmd.Limit, cmd.JSON)
+	default:
+		return showLogs(ep, cmd.Database, cmd.Environment, cmd.ApplyID, cmd.Limit, cmd.JSON)
 	}
-
-	return showLogs(ep, cmd.Database, cmd.Environment, cmd.ApplyID, cmd.Limit, cmd.JSON)
 }
 
 func showDeploymentLogs(endpoint, applyID, deployment string, limit int, outputJSON bool) error {
@@ -134,8 +148,9 @@ func showLogs(endpoint, database, environment, applyID string, limit int, output
 	return nil
 }
 
-// followLogs continuously polls for new logs.
-func followLogs(endpoint, database, environment, applyID string) error {
+// followLogs prints the newest initialLimit entries, then polls for new ones
+// until the command context is cancelled (Ctrl+C).
+func followLogs(ctx context.Context, endpoint, database, environment, applyID string, initialLimit int) error {
 	switch {
 	case applyID != "" && database == "":
 		fmt.Printf("Following logs for %s... (Ctrl+C to stop)\n\n", applyID)
@@ -145,31 +160,182 @@ func followLogs(endpoint, database, environment, applyID string) error {
 		fmt.Printf("Following logs for %s/%s... (Ctrl+C to stop)\n\n", database, environment)
 	}
 
-	var lastID int64
-	for {
-		logs, err := client.GetLogs(endpoint, database, environment, applyID, 100)
-		if err != nil {
-			fmt.Printf("Error fetching logs: %v\n", err)
-			time.Sleep(2 * time.Second)
+	state := &followState{}
+	fetch := func(limit int) ([]*client.LogEntry, error) {
+		return client.GetLogs(endpoint, database, environment, applyID, limit)
+	}
+	emit := func(logs []*client.LogEntry) {
+		printLogs(state.advance(logs))
+	}
+	return runFollowLoop(ctx, fetch, emit, initialLimit, followInterval)
+}
+
+// followDeploymentLogs tails data-plane logs: it prints the newest
+// initialLimit entries from every remote source, then polls for new ones
+// until the command context is cancelled (Ctrl+C).
+func followDeploymentLogs(ctx context.Context, endpoint, applyID, deployment string, initialLimit int) error {
+	fmt.Printf("Following data-plane logs for %s on %s... (Ctrl+C to stop)\n\n", applyID, deployment)
+
+	state := newDeploymentFollowState()
+	fetch := func(limit int) (*apitypes.DeploymentLogsResponse, error) {
+		return client.GetDeploymentLogs(endpoint, applyID, deployment, limit)
+	}
+	emit := func(result *apitypes.DeploymentLogsResponse) {
+		batches, warnings := state.advance(result)
+		for _, batch := range batches {
+			if batch.label != "" {
+				fmt.Printf("%s%s%s\n", templates.ANSIDim, batch.label, templates.ANSIReset)
+			}
+			printLogs(batch.logs)
+		}
+		for _, warning := range warnings {
+			fmt.Fprintf(os.Stderr, "Warning: %s\n", warning)
+		}
+	}
+	return runFollowLoop(ctx, fetch, emit, initialLimit, followInterval)
+}
+
+// followState tracks the newest log entry already printed so each poll prints
+// only entries that arrived since. Entries are deduplicated on the log id —
+// the write-ordered key — not on timestamps, which collide at second
+// precision.
+type followState struct {
+	lastID int64
+}
+
+// advance returns the entries newer than the last printed one, in the
+// chronological order the server delivered them, and records the newest as
+// printed.
+func (s *followState) advance(logs []*client.LogEntry) []*client.LogEntry {
+	var fresh []*client.LogEntry
+	for _, log := range logs {
+		if log.ID > s.lastID {
+			fresh = append(fresh, log)
+			s.lastID = log.ID
+		}
+	}
+	return fresh
+}
+
+// deploymentFollowState tracks, per data-plane source, the newest log entry
+// already printed. A source is one remote apply on one target; its log ids
+// are that data plane's write-ordered keys, monotonic within the source but
+// unrelated across sources, so each source dedupes independently on its own
+// followState.
+type deploymentFollowState struct {
+	bySource map[string]*followState
+	// seen holds every source key ever observed, including sources that have
+	// only ever failed, so the labeling decision reflects the apply's real
+	// fan-out rather than which sources happened to be readable this poll.
+	seen map[string]bool
+	// lastWarned records, per failing source, the failure already reported so
+	// an unchanged failure is not repeated on every poll. A source that
+	// recovers is cleared, so a relapse warns again.
+	lastWarned map[string]string
+}
+
+func newDeploymentFollowState() *deploymentFollowState {
+	return &deploymentFollowState{bySource: make(map[string]*followState), seen: make(map[string]bool), lastWarned: make(map[string]string)}
+}
+
+// deploymentFollowBatch is one source's not-yet-printed entries from a poll.
+// The label identifies the source and is empty while only one source has been
+// observed, matching the unadorned single-source one-shot view.
+type deploymentFollowBatch struct {
+	label string
+	logs  []*client.LogEntry
+}
+
+// deploymentFollowSourceKey identifies a data-plane log source (one remote
+// apply on one target) across polls, for both successful sources and per-source
+// read errors.
+func deploymentFollowSourceKey(target string, operations []*apitypes.LogOperationProvenance, externalID string) string {
+	if target == "" && len(operations) > 0 {
+		target = operations[0].Target
+	}
+	return target + "\x00" + externalID
+}
+
+// advance returns each source's entries newer than the last printed ones, in
+// the chronological order the server delivered them, plus the warnings to
+// surface for sources that could not be read this poll.
+func (s *deploymentFollowState) advance(result *apitypes.DeploymentLogsResponse) ([]deploymentFollowBatch, []string) {
+	for _, source := range result.Sources {
+		key := deploymentFollowSourceKey("", source.Operations, source.ExternalID)
+		s.seen[key] = true
+		if s.bySource[key] == nil {
+			s.bySource[key] = &followState{}
+		}
+		// A successful read clears the source's warning suppression so a
+		// relapse after recovery is reported again.
+		delete(s.lastWarned, key)
+	}
+	for _, sourceErr := range result.Errors {
+		s.seen[deploymentFollowSourceKey(sourceErr.Target, sourceErr.Operations, sourceErr.ExternalID)] = true
+	}
+
+	// Label batches once more than one source exists, so interleaved tails
+	// stay attributable; a single-source tail stays unadorned.
+	labelSources := len(s.seen) > 1
+
+	var batches []deploymentFollowBatch
+	for _, source := range result.Sources {
+		key := deploymentFollowSourceKey("", source.Operations, source.ExternalID)
+		fresh := s.bySource[key].advance(source.Logs)
+		if len(fresh) == 0 {
+			// Nothing new for this source since the last poll.
 			continue
 		}
-
-		// Find new logs (those with ID > lastID)
-		var newLogs []*client.LogEntry
-		for _, log := range logs {
-			if log.ID > lastID {
-				newLogs = append(newLogs, log)
-				if log.ID > lastID {
-					lastID = log.ID
-				}
-			}
+		batch := deploymentFollowBatch{logs: fresh}
+		if labelSources {
+			batch.label = deploymentLogSourceLabel("", source.Operations, source.ExternalID)
 		}
+		batches = append(batches, batch)
+	}
 
-		if len(newLogs) > 0 {
-			printLogs(newLogs)
+	var warnings []string
+	for _, sourceErr := range result.Errors {
+		key := deploymentFollowSourceKey(sourceErr.Target, sourceErr.Operations, sourceErr.ExternalID)
+		warning := fmt.Sprintf("%s: %s", deploymentLogSourceLabel(sourceErr.Target, sourceErr.Operations, sourceErr.ExternalID), sourceErr.Message)
+		if s.lastWarned[key] == warning {
+			// This exact failure was already reported; repeating it on every
+			// poll would drown the tail.
+			continue
 		}
+		s.lastWarned[key] = warning
+		warnings = append(warnings, warning)
+	}
+	return batches, warnings
+}
 
-		time.Sleep(1 * time.Second)
+// runFollowLoop fetches the newest initialLimit entries and hands them to
+// emit, then polls fetch on every interval tick until ctx is cancelled. emit
+// owns dedupe and printing, so each log mode decides how to track what was
+// already shown. The initial fetch must succeed — a broken endpoint should
+// fail the command, not tail nothing. Later polls warn and retry on the next
+// tick instead: a tail during an incident must survive transient server blips.
+func runFollowLoop[T any](ctx context.Context, fetch func(limit int) (T, error), emit func(T), initialLimit int, interval time.Duration) error {
+	result, err := fetch(initialLimit)
+	if err != nil {
+		return fmt.Errorf("fetch initial log window: %w", err)
+	}
+	emit(result)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			// Interrupting a tail is its normal exit, not a failure.
+			return nil
+		case <-ticker.C:
+		}
+		result, err := fetch(followFetchLimit)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to fetch logs, retrying next poll: %v\n", err)
+			continue
+		}
+		emit(result)
 	}
 }
 

--- a/pkg/cmd/commands/logs_test.go
+++ b/pkg/cmd/commands/logs_test.go
@@ -1,15 +1,265 @@
 package commands
 
 import (
+	"context"
+	"fmt"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/block/schemabot/pkg/apitypes"
+	"github.com/block/schemabot/pkg/cmd/client"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestLogsCommandDeploymentValidation(t *testing.T) {
-	err := (&LogsCmd{Deployment: "data-plane", Database: "orders", Environment: "production"}).Run(&Globals{})
+// followTestDeadline bounds every wait in the follow-loop tests so a stuck
+// loop fails fast instead of hanging the suite.
+const followTestDeadline = 10 * time.Second
+
+func TestLogsCommandFlagValidation(t *testing.T) {
+	err := (&LogsCmd{Deployment: "data-plane", Database: "orders", Environment: "production"}).Run(t.Context(), &Globals{})
 	require.EqualError(t, err, "--deployment requires an explicit apply_id")
 
-	err = (&LogsCmd{Deployment: "data-plane", ApplyID: "apply-a", Follow: true}).Run(&Globals{})
-	require.EqualError(t, err, "--deployment is incompatible with --follow")
+	err = (&LogsCmd{ApplyID: "apply-a", Follow: true, JSON: true}).Run(t.Context(), &Globals{})
+	require.ErrorContains(t, err, "--json is incompatible with --follow")
+
+	err = (&LogsCmd{Deployment: "data-plane", ApplyID: "apply-a", Follow: true, JSON: true}).Run(t.Context(), &Globals{})
+	require.ErrorContains(t, err, "--json is incompatible with --follow")
+}
+
+func followLogEntry(id int64) *client.LogEntry {
+	return &client.LogEntry{ID: id, Message: fmt.Sprintf("entry %d", id)}
+}
+
+// TestFollowStateAdvance verifies the follow dedupe: overlapping poll windows
+// only surface entries whose id is newer than the last printed one, in the
+// order delivered, so an operator tailing an apply never sees a line twice.
+func TestFollowStateAdvance(t *testing.T) {
+	state := &followState{}
+
+	first := state.advance([]*client.LogEntry{followLogEntry(1), followLogEntry(2), followLogEntry(3)})
+	require.Len(t, first, 3)
+	assert.Equal(t, int64(1), first[0].ID)
+	assert.Equal(t, int64(3), first[2].ID)
+
+	// A window that fully overlaps what was printed surfaces nothing.
+	assert.Empty(t, state.advance([]*client.LogEntry{followLogEntry(2), followLogEntry(3)}))
+
+	// A window with overlap plus new entries surfaces only the new ones.
+	fresh := state.advance([]*client.LogEntry{followLogEntry(3), followLogEntry(4), followLogEntry(5)})
+	require.Len(t, fresh, 2)
+	assert.Equal(t, "entry 4", fresh[0].Message)
+	assert.Equal(t, "entry 5", fresh[1].Message)
+
+	assert.Empty(t, state.advance(nil))
+}
+
+type followFetchResult struct {
+	logs []*client.LogEntry
+	err  error
+}
+
+// scriptedFetch returns each result in script in turn, repeating the final
+// result once the script is exhausted, and records the limit of every call.
+func scriptedFetch(script []followFetchResult) (fetch func(limit int) ([]*client.LogEntry, error), limits func() []int) {
+	var mu sync.Mutex
+	var seen []int
+	calls := 0
+	fetch = func(limit int) ([]*client.LogEntry, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		seen = append(seen, limit)
+		result := script[min(calls, len(script)-1)]
+		calls++
+		return result.logs, result.err
+	}
+	limits = func() []int {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]int(nil), seen...)
+	}
+	return fetch, limits
+}
+
+// TestRunFollowLoop verifies the follow loop end to end: the initial poll
+// prints the newest-N window, later polls print only entries newer than the
+// last printed id, a transient fetch failure is retried on the next tick
+// without killing the tail, and cancellation exits cleanly.
+func TestRunFollowLoop(t *testing.T) {
+	script := []followFetchResult{
+		{logs: []*client.LogEntry{followLogEntry(1), followLogEntry(2), followLogEntry(3)}},
+		{logs: []*client.LogEntry{followLogEntry(2), followLogEntry(3)}},
+		{err: fmt.Errorf("transient poll failure")},
+		{logs: []*client.LogEntry{followLogEntry(3), followLogEntry(4), followLogEntry(5)}},
+	}
+	fetch, limits := scriptedFetch(script)
+
+	printed := make(chan *client.LogEntry, 64)
+	state := &followState{}
+	emit := func(logs []*client.LogEntry) {
+		for _, log := range state.advance(logs) {
+			printed <- log
+		}
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- runFollowLoop(ctx, fetch, emit, 3, time.Millisecond)
+	}()
+
+	var got []*client.LogEntry
+	for len(got) < 5 {
+		select {
+		case entry := <-printed:
+			got = append(got, entry)
+		case <-time.After(followTestDeadline):
+			t.Fatalf("timed out waiting for followed entries, got %d of 5", len(got))
+		}
+	}
+	for i, entry := range got {
+		assert.Equal(t, int64(i+1), entry.ID)
+		assert.Equal(t, fmt.Sprintf("entry %d", i+1), entry.Message)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(followTestDeadline):
+		t.Fatal("follow loop did not exit after cancellation")
+	}
+
+	// The steady-state script repeats a fully-printed window, so nothing
+	// beyond the five expected entries is ever re-printed.
+	select {
+	case entry := <-printed:
+		t.Fatalf("unexpected duplicate entry printed: id=%d", entry.ID)
+	default:
+	}
+
+	seen := limits()
+	require.NotEmpty(t, seen)
+	assert.Equal(t, 3, seen[0], "initial poll uses the -n window")
+	for _, limit := range seen[1:] {
+		assert.Equal(t, followFetchLimit, limit, "follow polls use the bounded fetch window")
+	}
+}
+
+// TestRunFollowLoopInitialFetchFails verifies that a broken endpoint fails the
+// command immediately rather than tailing nothing.
+func TestRunFollowLoopInitialFetchFails(t *testing.T) {
+	fetch, _ := scriptedFetch([]followFetchResult{{err: fmt.Errorf("endpoint unreachable")}})
+	err := runFollowLoop(t.Context(), fetch, func([]*client.LogEntry) {}, 3, time.Millisecond)
+	require.ErrorContains(t, err, "fetch initial log window")
+	require.ErrorContains(t, err, "endpoint unreachable")
+}
+
+func deploymentFollowSource(target, externalID string, ids ...int64) *apitypes.DeploymentLogSource {
+	source := &apitypes.DeploymentLogSource{
+		ExternalID: externalID,
+		Operations: []*apitypes.LogOperationProvenance{{OperationKey: target + "-op", Target: target, OperationKind: "spirit"}},
+	}
+	for _, id := range ids {
+		source.Logs = append(source.Logs, followLogEntry(id))
+	}
+	return source
+}
+
+func deploymentFollowError(target, externalID, message string) *apitypes.DeploymentLogError {
+	return &apitypes.DeploymentLogError{
+		ExternalID: externalID,
+		Target:     target,
+		Operations: []*apitypes.LogOperationProvenance{{OperationKey: target + "-op", Target: target, OperationKind: "spirit"}},
+		Code:       "RemoteLogReadFailed",
+		Reason:     "remote_log_read_failed",
+		Message:    message,
+	}
+}
+
+// TestDeploymentFollowStateAdvance verifies the per-source dedupe of a
+// data-plane tail: each source's log ids are only comparable within that
+// source, so overlapping ids across sources still all print, while an
+// overlapping window from the same source prints only the new entries.
+// Batches carry a source label only once the apply fans out to more than one
+// source, so a single-source tail reads like the plain apply-log tail.
+func TestDeploymentFollowStateAdvance(t *testing.T) {
+	state := newDeploymentFollowState()
+
+	batches, warnings := state.advance(&apitypes.DeploymentLogsResponse{
+		Sources: []*apitypes.DeploymentLogSource{deploymentFollowSource("target-a", "remote-1", 1, 2)},
+	})
+	require.Len(t, batches, 1)
+	assert.Empty(t, batches[0].label, "a single-source tail is unadorned")
+	require.Len(t, batches[0].logs, 2)
+	assert.Equal(t, int64(1), batches[0].logs[0].ID)
+	assert.Equal(t, int64(2), batches[0].logs[1].ID)
+	assert.Empty(t, warnings)
+
+	// A second source appears with ids overlapping the first source's: its
+	// entries are all new (independent id sequence), and batches become
+	// labeled. The first source's overlapping window dedupes as usual.
+	batches, warnings = state.advance(&apitypes.DeploymentLogsResponse{
+		Sources: []*apitypes.DeploymentLogSource{
+			deploymentFollowSource("target-a", "remote-1", 2, 3),
+			deploymentFollowSource("target-b", "remote-2", 1, 2),
+		},
+	})
+	require.Len(t, batches, 2)
+	assert.Equal(t, "target-a / spirit (remote-1)", batches[0].label)
+	require.Len(t, batches[0].logs, 1)
+	assert.Equal(t, int64(3), batches[0].logs[0].ID)
+	assert.Equal(t, "target-b / spirit (remote-2)", batches[1].label)
+	require.Len(t, batches[1].logs, 2)
+	assert.Equal(t, int64(1), batches[1].logs[0].ID)
+	assert.Equal(t, int64(2), batches[1].logs[1].ID)
+	assert.Empty(t, warnings)
+
+	// A fully-overlapping poll surfaces nothing for either source.
+	batches, warnings = state.advance(&apitypes.DeploymentLogsResponse{
+		Sources: []*apitypes.DeploymentLogSource{
+			deploymentFollowSource("target-a", "remote-1", 3),
+			deploymentFollowSource("target-b", "remote-2", 2),
+		},
+	})
+	assert.Empty(t, batches)
+	assert.Empty(t, warnings)
+}
+
+// TestDeploymentFollowStateWarnings verifies that a persistently failing
+// source is reported once rather than on every poll, and that a source which
+// recovers and then fails again is reported again — the operator needs to see
+// the relapse, not assume the old warning still applies.
+func TestDeploymentFollowStateWarnings(t *testing.T) {
+	state := newDeploymentFollowState()
+
+	failing := &apitypes.DeploymentLogsResponse{
+		Sources: []*apitypes.DeploymentLogSource{deploymentFollowSource("target-a", "remote-1", 1)},
+		Errors:  []*apitypes.DeploymentLogError{deploymentFollowError("target-b", "remote-2", "Data-plane logs could not be read; check server logs and retry.")},
+	}
+
+	batches, warnings := state.advance(failing)
+	require.Len(t, batches, 1)
+	assert.Equal(t, "target-a / spirit (remote-1)", batches[0].label, "a failing source still counts toward the fan-out, so the readable one is labeled")
+	require.Len(t, warnings, 1)
+	assert.Equal(t, "target-b / spirit (remote-2): Data-plane logs could not be read; check server logs and retry.", warnings[0])
+
+	// The same failure on the next poll is not repeated.
+	_, warnings = state.advance(failing)
+	assert.Empty(t, warnings)
+
+	// The source recovers, then fails again: the relapse is reported.
+	_, warnings = state.advance(&apitypes.DeploymentLogsResponse{
+		Sources: []*apitypes.DeploymentLogSource{
+			deploymentFollowSource("target-a", "remote-1"),
+			deploymentFollowSource("target-b", "remote-2", 5),
+		},
+	})
+	assert.Empty(t, warnings)
+
+	_, warnings = state.advance(failing)
+	require.Len(t, warnings, 1)
+	assert.Equal(t, "target-b / spirit (remote-2): Data-plane logs could not be read; check server logs and retry.", warnings[0])
 }

--- a/pkg/storage/mysqlstore/apply_logs.go
+++ b/pkg/storage/mysqlstore/apply_logs.go
@@ -118,7 +118,11 @@ func (s *applyLogStore) GetRecentByApply(ctx context.Context, applyID int64, lim
 	return logs, nil
 }
 
-// List returns logs matching the filter criteria, ordered by created_at.
+// List returns the newest Limit logs matching the filter criteria, ordered by
+// created_at ascending so the result reads chronologically. Ties on created_at
+// (second precision) are broken by id so entries keep their insertion order.
+// Callers rendering a bounded tail (like the CLI logs command) need the newest
+// entries — a long-running apply accumulates far more log rows than the window.
 func (s *applyLogStore) List(ctx context.Context, filter storage.ApplyLogFilter) ([]*storage.ApplyLog, error) {
 	// Build query with filters
 	query := `
@@ -141,7 +145,7 @@ func (s *applyLogStore) List(ctx context.Context, filter storage.ApplyLogFilter)
 		args = append(args, filter.EventType)
 	}
 
-	query += " ORDER BY created_at ASC"
+	query += " ORDER BY created_at DESC, id DESC"
 
 	limit := filter.Limit
 	if limit <= 0 {
@@ -156,7 +160,12 @@ func (s *applyLogStore) List(ctx context.Context, filter storage.ApplyLogFilter)
 	}
 	defer utils.CloseAndLog(rows)
 
-	return scanApplyLogs(rows)
+	logs, err := scanApplyLogs(rows)
+	if err != nil {
+		return nil, err
+	}
+	slices.Reverse(logs)
+	return logs, nil
 }
 
 // scanApplyLogs scans multiple apply log rows.

--- a/pkg/storage/mysqlstore/apply_logs_test.go
+++ b/pkg/storage/mysqlstore/apply_logs_test.go
@@ -53,3 +53,52 @@ func TestApplyLogStore_GetRecentByApply(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, none)
 }
+
+// TestApplyLogStore_List_ReturnsNewestWindow verifies the bounded read behind
+// the logs API: when an apply has more entries than the requested limit, the
+// window is the newest limit entries in chronological order — an operator
+// tailing a busy apply sees the latest activity, not a stale head. Ties on
+// created_at (second precision) are broken by id so insertion order holds.
+func TestApplyLogStore_List_ReturnsNewestWindow(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "list_logs_db", storage.DatabaseTypeMySQL, "staging")
+	apply := createTestApplyWithStateAndEnv(t, store, lock, "apply_list_logs", 602, state.Apply.Running, "staging")
+
+	const seeded = 6
+	for i := 1; i <= seeded; i++ {
+		level := storage.LogLevelInfo
+		if i%2 == 0 {
+			level = storage.LogLevelWarn
+		}
+		require.NoError(t, store.ApplyLogs().Append(ctx, &storage.ApplyLog{
+			ApplyID:   apply.ID,
+			Level:     level,
+			EventType: storage.LogEventInfo,
+			Source:    storage.LogSourceSchemaBot,
+			Message:   fmt.Sprintf("entry %d", i),
+		}))
+	}
+
+	window, err := store.ApplyLogs().List(ctx, storage.ApplyLogFilter{ApplyID: apply.ID, Limit: 3})
+	require.NoError(t, err)
+	require.Len(t, window, 3)
+	assert.Equal(t, "entry 4", window[0].Message)
+	assert.Equal(t, "entry 5", window[1].Message)
+	assert.Equal(t, "entry 6", window[2].Message)
+
+	all, err := store.ApplyLogs().List(ctx, storage.ApplyLogFilter{ApplyID: apply.ID, Limit: seeded * 2})
+	require.NoError(t, err)
+	require.Len(t, all, seeded)
+	for i, entry := range all {
+		assert.Equal(t, fmt.Sprintf("entry %d", i+1), entry.Message)
+	}
+
+	warns, err := store.ApplyLogs().List(ctx, storage.ApplyLogFilter{ApplyID: apply.ID, Level: storage.LogLevelWarn, Limit: 2})
+	require.NoError(t, err)
+	require.Len(t, warns, 2)
+	assert.Equal(t, "entry 4", warns[0].Message)
+	assert.Equal(t, "entry 6", warns[1].Message)
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -807,7 +807,8 @@ type ApplyLogStore interface {
 	// caller rendering a tail needs.
 	GetRecentByApply(ctx context.Context, applyID int64, limit int) ([]*ApplyLog, error)
 
-	// List returns logs matching the filter criteria, ordered by created_at.
+	// List returns the newest Limit logs matching the filter criteria,
+	// ordered by created_at ascending so the result reads chronologically.
 	List(ctx context.Context, filter ApplyLogFilter) ([]*ApplyLog, error)
 }
 


### PR DESCRIPTION
## Why this matters

`schemabot logs -n 50` claimed to show recent logs but actually returned the *oldest* 50 entries: the storage read ordered ascending and applied the limit there. For any apply with more than N log lines — exactly the applies an operator is triaging — the command silently showed the beginning of the story and none of the current state. The newest entries, the ones that answer "what is it doing right now", were unreachable no matter what `-n` you passed.

## What it does

`logs -n` now returns the newest N entries, still printed oldest-first within the window (standard tail semantics). The storage read selects the newest window (`ORDER BY created_at DESC, id DESC` with the limit, then reversed for delivery), with the write-ordered id as tie-break so same-second entries cannot shuffle. The remote data-plane read path already had these semantics; this aligns the control-plane path with it.

It also adds `--follow` for apply and deployment logs (folded in from #821): after printing the initial window, the command polls for new entries and streams them as they land, so an operator can watch a live apply instead of re-running the command.

## How it moves us toward the northstar

`logs` is the first tool an operator reaches for when an apply looks stuck. It has to answer "what happened most recently" by default — a log window that ends where the incident begins is worse than no window at all — and `--follow` keeps answering it as the apply progresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
