### PR TITLE
refactor(webhook): give apply gates a retryable-vs-terminal disposition

### DIFF
--- a/pkg/webhook/apply_execute.go
+++ b/pkg/webhook/apply_execute.go
@@ -74,7 +74,10 @@ func (h *Handler) executeApply(
 		h.releaseApplyLockIfIntentUnchanged(ctx, repo, pr, database, dbType, environment, expectedPendingPlanID, "final stale-schema rejection")
 		return
 	}
-	if rejected := h.assertBaseSchemaStillCurrent(ctx, client, repo, pr, installationID, schemaResult, freshPRInfo, environment, requestedBy, actionName); rejected {
+	// executeApply is void; a base-schema evaluation failure only matters to a
+	// durable driver, so the error is discarded here (the gate has already
+	// logged it and posted user guidance) and any rejection releases the lock.
+	if rejected, _ := h.assertBaseSchemaStillCurrent(ctx, client, repo, pr, installationID, schemaResult, freshPRInfo, environment, requestedBy, actionName); rejected {
 		h.releaseApplyLockIfIntentUnchanged(ctx, repo, pr, database, dbType, environment, expectedPendingPlanID, "final base-schema freshness rejection")
 		return
 	}

--- a/pkg/webhook/apply_gating.go
+++ b/pkg/webhook/apply_gating.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/block/schemabot/pkg/api"
@@ -25,24 +26,32 @@ import (
 // This is a safety re-check, so it bypasses the request-scoped PR-info cache:
 // discovery earlier in the same delivery may have cached the PR as open, and a
 // close landing between discovery and this gate must still block the apply.
-func (h *Handler) enforceOpenPR(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, installationID int64, commandName, environment, requestedBy string) (blocked bool) {
-	prInfo, err := client.FetchPullRequestNoCache(ctx, repo, pr)
-	if err != nil {
+//
+// Returns follow the apply-gate disposition contract (see applyCommandCore):
+//   - (true, err) — the gate could not evaluate its inputs (a GitHub read
+//     failed). It fails closed and posts retry guidance, but the returned
+//     error marks the block as an evaluation failure a durable driver should
+//     re-drive.
+//   - (true, nil) — blocked on merits (the PR is closed). Terminal.
+//   - (false, nil) — the PR is open; the command may proceed.
+func (h *Handler) enforceOpenPR(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, installationID int64, commandName, environment, requestedBy string) (blocked bool, err error) {
+	prInfo, fetchErr := client.FetchPullRequestNoCache(ctx, repo, pr)
+	if fetchErr != nil {
 		h.logger.Error("failed to fetch PR state for the closed-PR apply gate; blocking the command",
-			"repo", repo, "pr", pr, "environment", environment, "command", commandName, "error", err)
+			"repo", repo, "pr", pr, "environment", environment, "command", commandName, "error", fetchErr)
 		// The raw error can carry internal detail (hosts, headers, newlines)
 		// that must not render in PR markdown; operators triage from the log
 		// line above.
 		h.postCommandError(repo, pr, installationID, commandName, environment, requestedBy, "Could not verify the pull request state, so the command was blocked. Retry, and see server logs if it persists.")
-		return true
+		return true, fmt.Errorf("fetch PR state for closed-PR gate %s#%d: %w", repo, pr, fetchErr)
 	}
 	if !prInfo.IsClosed() {
-		return false
+		return false, nil
 	}
 	h.logger.Info("apply command rejected: PR is closed",
 		"repo", repo, "pr", pr, "environment", environment, "command", commandName, "requested_by", requestedBy, "merged", prInfo.Merged)
 	h.postComment(repo, pr, installationID, templates.RenderApplyBlockedClosedPR(environment, requestedBy, prInfo.Merged))
-	return true
+	return true, nil
 }
 
 // isAggregateCheckName reports whether a check name matches this deployment's
@@ -100,14 +109,21 @@ func isPassingCheckConclusion(conclusion string) bool {
 }
 
 // enforcePassingChecks verifies that all non-SchemaBot PR checks are passing.
-// Returns true if apply was blocked (caller should return), false if it may proceed.
 // Blocks on both non-passing completed checks and in-progress checks with
 // distinct messages.
-func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, installationID int64, headSHA, environment string) bool {
+//
+// Returns follow the apply-gate disposition contract (see applyCommandCore):
+//   - (true, err) — the check statuses could not be read from GitHub. It fails
+//     closed and posts an error comment, but the returned error marks the block
+//     as an evaluation failure a durable driver should re-drive.
+//   - (true, nil) — blocked on merits (a required check is failing, in
+//     progress, or not yet reported). Terminal.
+//   - (false, nil) — all required checks pass; the command may proceed.
+func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, installationID int64, headSHA, environment string) (blocked bool, err error) {
 	config := h.service.Config()
 	if !config.ShouldRequirePassingChecks() {
 		h.logger.Debug("passing checks gate disabled", "repo", repo, "pr", pr)
-		return false
+		return false, nil
 	}
 
 	statuses, err := client.GetPRCheckStatuses(ctx, repo, headSHA, config.RequiredChecks)
@@ -140,7 +156,7 @@ func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.Ins
 			"error", err)
 		h.postComment(repo, pr, installationID,
 			templates.RenderApplyBlockedByCheckStatusError(environment, err, details))
-		return true
+		return true, fmt.Errorf("read PR check statuses %s#%d: %w", repo, pr, err)
 	}
 
 	notPassing := filterNonPassingNonSchemaBotChecks(statuses, config)
@@ -154,7 +170,7 @@ func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.Ins
 			"not_passing_count", len(notPassing))
 		h.postComment(repo, pr, installationID,
 			templates.RenderApplyBlockedByNonPassingChecks(environment, notPassing))
-		return true
+		return true, nil
 	}
 
 	if len(inProgress) > 0 || len(notReported) > 0 {
@@ -165,10 +181,10 @@ func (h *Handler) enforcePassingChecks(ctx context.Context, client *ghclient.Ins
 			"missing_required_checks", blockingCheckNames(notReported))
 		h.postComment(repo, pr, installationID,
 			templates.RenderApplyBlockedByInProgressChecks(environment, inProgress, notReported))
-		return true
+		return true, nil
 	}
 
-	return false
+	return false, nil
 }
 
 // blockingCheckNames extracts the check names from a slice of blocking checks

--- a/pkg/webhook/apply_gating_test.go
+++ b/pkg/webhook/apply_gating_test.go
@@ -558,7 +558,8 @@ func TestEnforcePassingChecks(t *testing.T) {
 		}
 
 		ctx := t.Context()
-		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		blocked, err := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		require.Error(t, err, "an unreadable check gate must surface a retryable error")
 		assert.True(t, blocked, "should block on permission error")
 
 		select {
@@ -602,7 +603,8 @@ func TestEnforcePassingChecks(t *testing.T) {
 		}
 
 		ctx := t.Context()
-		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		blocked, err := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		require.Error(t, err, "an unreadable check gate must surface a retryable error")
 		assert.True(t, blocked, "should block when API fails")
 
 		select {
@@ -644,7 +646,8 @@ func TestEnforcePassingChecks(t *testing.T) {
 		}
 
 		ctx := t.Context()
-		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		blocked, err := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		require.NoError(t, err)
 		assert.True(t, blocked, "should block when checks are failing")
 
 		select {
@@ -689,7 +692,8 @@ func TestEnforcePassingChecks(t *testing.T) {
 		}
 
 		ctx := t.Context()
-		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		blocked, err := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		require.NoError(t, err)
 		assert.True(t, blocked, "should block when a check was cancelled")
 
 		select {
@@ -720,7 +724,8 @@ func TestEnforcePassingChecks(t *testing.T) {
 		}
 
 		ctx := t.Context()
-		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		blocked, err := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		require.NoError(t, err)
 		assert.False(t, blocked, "should allow when configured checks pass")
 	})
 
@@ -750,7 +755,8 @@ func TestEnforcePassingChecks(t *testing.T) {
 		}
 
 		ctx := t.Context()
-		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		blocked, err := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		require.NoError(t, err)
 		assert.False(t, blocked, "status-only required gate should pass without reading check runs")
 		assert.False(t, checkRunsCalled, "unrelated check runs should not be fetched once required statuses are found")
 	})
@@ -784,7 +790,8 @@ func TestEnforcePassingChecks(t *testing.T) {
 		}
 
 		ctx := t.Context()
-		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		blocked, err := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		require.NoError(t, err)
 		assert.True(t, blocked, "should block on all checks when configured checks are absent")
 
 		select {
@@ -829,7 +836,8 @@ func TestEnforcePassingChecks(t *testing.T) {
 		}
 
 		ctx := t.Context()
-		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		blocked, err := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		require.NoError(t, err)
 		assert.True(t, blocked, "should block when a required check has not reported")
 
 		select {
@@ -878,7 +886,8 @@ func TestEnforcePassingChecks(t *testing.T) {
 		}
 
 		ctx := t.Context()
-		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		blocked, err := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		require.NoError(t, err)
 		assert.True(t, blocked, "should block when no required check has reported")
 
 		select {
@@ -921,7 +930,8 @@ func TestEnforcePassingChecks(t *testing.T) {
 		}
 
 		ctx := t.Context()
-		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		blocked, err := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		require.NoError(t, err)
 		assert.True(t, blocked, "should block when a required check has not reported")
 
 		logs := logBuf.String()
@@ -966,7 +976,8 @@ func TestEnforcePassingChecks(t *testing.T) {
 		}
 
 		ctx := t.Context()
-		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		blocked, err := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		require.NoError(t, err)
 		assert.True(t, blocked, "should block when a required check is running and another has not reported")
 
 		select {
@@ -1005,7 +1016,8 @@ func TestEnforcePassingChecks(t *testing.T) {
 		}
 
 		ctx := t.Context()
-		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		blocked, err := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		require.NoError(t, err)
 		assert.False(t, blocked, "should allow when all required checks reported and passed")
 	})
 
@@ -1028,7 +1040,8 @@ func TestEnforcePassingChecks(t *testing.T) {
 		}
 
 		ctx := t.Context()
-		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		blocked, err := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		require.NoError(t, err)
 		assert.False(t, blocked, "should allow when all non-SchemaBot checks pass")
 	})
 
@@ -1061,7 +1074,8 @@ func TestEnforcePassingChecks(t *testing.T) {
 		}
 
 		ctx := t.Context()
-		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		blocked, err := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		require.NoError(t, err)
 		assert.True(t, blocked, "should block when checks are in-progress")
 
 		select {
@@ -1091,7 +1105,8 @@ func TestEnforcePassingChecks(t *testing.T) {
 		}
 
 		ctx := t.Context()
-		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		blocked, err := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		require.NoError(t, err)
 		assert.False(t, blocked, "should not block on own failed check with variant slug")
 	})
 
@@ -1107,7 +1122,8 @@ func TestEnforcePassingChecks(t *testing.T) {
 		}
 
 		ctx := t.Context()
-		blocked := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		blocked, err := h.enforcePassingChecks(ctx, installClient, "octocat/hello-world", 1, 12345, "abc123", "staging")
+		require.NoError(t, err)
 		assert.False(t, blocked, "should not block when disabled")
 	})
 }

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -38,11 +38,14 @@ func (h *Handler) handleApplyCommand(repo string, pr int, environment, databaseN
 //     user-facing rejection; an unexpected failure there (for example a
 //     transient GitHub config read) stays retryable.
 //
-// Gate blocks are terminal even when the gate blocked because it could not
-// evaluate its own inputs (for example a GitHub read inside the gate failed):
-// gates fail closed and post their own retry guidance, so the block is the
-// command's answer and recovery is the user re-issuing the command, not a
-// driver re-driving the delivery.
+// Apply gates return a (blocked, err) disposition of their own: a merit block
+// (PR closed, review missing, checks failing, prior environment not clean,
+// stale base schema) is terminal, while an evaluation failure inside the gate
+// (a GitHub or storage read the gate needs) surfaces as a non-nil error and is
+// retryable. Gates always fail closed and post their own guidance, so the
+// synchronous wrapper can ignore the error; the durable disposition here maps a
+// gate's evaluation-failure error to retry=true and a merit block to the
+// terminal answer.
 //
 // A posted PR comment does not imply a terminal disposition: retryable sites
 // post best-effort error comments too, so a durable driver re-driving one may
@@ -91,7 +94,9 @@ func (h *Handler) applyCommandCore(repo string, pr int, environment, databaseNam
 		h.acknowledgeCommandActPoint(repo, pr, installationID, result)
 	}
 
-	if blocked := h.enforceOpenPR(ctx, client, repo, pr, installationID, action.Apply, environment, requestedBy); blocked {
+	if blocked, err := h.enforceOpenPR(ctx, client, repo, pr, installationID, action.Apply, environment, requestedBy); err != nil {
+		return true, fmt.Errorf("apply command open-PR gate %s#%d: %w", repo, pr, err)
+	} else if blocked {
 		return false, nil
 	}
 
@@ -108,7 +113,9 @@ func (h *Handler) applyCommandCore(repo string, pr int, environment, databaseNam
 	}
 
 	// Tier 1: review gate (server-owned review policy for this database)
-	if blocked := h.enforceReviewGate(ctx, client, repo, pr, installationID, schemaResult, environment, requestedBy, action.Apply); blocked {
+	if blocked, err := h.enforceReviewGate(ctx, client, repo, pr, installationID, schemaResult, environment, requestedBy, action.Apply); err != nil {
+		return true, fmt.Errorf("apply command review gate %s#%d: %w", repo, pr, err)
+	} else if blocked {
 		h.logger.Info("apply blocked by review gate", "repo", repo, "pr", pr, "environment", environment, "requested_by", requestedBy)
 		return false, nil
 	}
@@ -120,7 +127,9 @@ func (h *Handler) applyCommandCore(repo string, pr int, environment, databaseNam
 		h.postCommandError(repo, pr, installationID, action.Apply, environment, requestedBy, "Failed to fetch PR info: "+err.Error())
 		return true, fmt.Errorf("apply command fetch PR for checks gate %s#%d: %w", repo, pr, err)
 	}
-	if blocked := h.enforcePassingChecks(ctx, client, repo, pr, installationID, prInfo.HeadSHA, environment); blocked {
+	if blocked, err := h.enforcePassingChecks(ctx, client, repo, pr, installationID, prInfo.HeadSHA, environment); err != nil {
+		return true, fmt.Errorf("apply command checks gate %s#%d: %w", repo, pr, err)
+	} else if blocked {
 		return false, nil
 	}
 
@@ -129,7 +138,9 @@ func (h *Handler) applyCommandCore(repo string, pr int, environment, databaseNam
 	lockOwner := fmt.Sprintf("%s#%d", repo, pr)
 
 	// Environment ordering enforcement: prior server-configured environments must be clean before applying.
-	if blocked := h.checkPriorEnvironments(ctx, repo, pr, database, dbType, environment, schemaResult.Environments, installationID); blocked {
+	if blocked, err := h.checkPriorEnvironments(ctx, repo, pr, database, dbType, environment, schemaResult.Environments, installationID); err != nil {
+		return true, fmt.Errorf("apply command prior-environments gate %s#%d: %w", repo, pr, err)
+	} else if blocked {
 		h.logger.Info("apply blocked by environment ordering", "repo", repo, "pr", pr, "database", database, "environment", environment)
 		return false, nil
 	}
@@ -210,7 +221,9 @@ func (h *Handler) applyCommandCore(repo string, pr int, environment, databaseNam
 	if rejected := h.assertSchemaStillCurrent(ctx, repo, pr, installationID, schemaResult, prInfo.HeadSHA, environment, requestedBy, action.Apply); rejected {
 		return false, nil
 	}
-	if rejected := h.assertBaseSchemaStillCurrent(ctx, client, repo, pr, installationID, schemaResult, prInfo, environment, requestedBy, action.Apply); rejected {
+	if rejected, err := h.assertBaseSchemaStillCurrent(ctx, client, repo, pr, installationID, schemaResult, prInfo, environment, requestedBy, action.Apply); err != nil {
+		return true, fmt.Errorf("apply command base-schema freshness %s#%d: %w", repo, pr, err)
+	} else if rejected {
 		return false, nil
 	}
 
@@ -303,7 +316,10 @@ func (h *Handler) applyCommandCore(repo string, pr int, environment, databaseNam
 	// once the checks recover, without a manual unlock. The release is keyed
 	// on the (owner, pending plan) intent acquired above, so a lock that has
 	// since changed hands or been re-pinned is preserved.
-	if blocked := h.enforcePassingChecks(ctx, client, repo, pr, installationID, prInfo.HeadSHA, environment); blocked {
+	if blocked, err := h.enforcePassingChecks(ctx, client, repo, pr, installationID, prInfo.HeadSHA, environment); err != nil {
+		h.releaseApplyLockIfIntentUnchanged(ctx, repo, pr, database, dbType, environment, planResp.PlanID, "fresh-HEAD checks gate evaluation failure")
+		return true, fmt.Errorf("apply command fresh-HEAD checks gate %s#%d: %w", repo, pr, err)
+	} else if blocked {
 		h.releaseApplyLockIfIntentUnchanged(ctx, repo, pr, database, dbType, environment, planResp.PlanID, "fresh-HEAD checks gate block")
 		return false, nil
 	}
@@ -412,7 +428,9 @@ func (h *Handler) applyConfirmCommandCore(repo string, pr int, environment, data
 		return true, fmt.Errorf("apply-confirm command attach server environments %s#%d: %w", repo, pr, err)
 	}
 
-	if blocked := h.enforceOpenPR(ctx, client, repo, pr, installationID, action.ApplyConfirm, environment, requestedBy); blocked {
+	if blocked, err := h.enforceOpenPR(ctx, client, repo, pr, installationID, action.ApplyConfirm, environment, requestedBy); err != nil {
+		return true, fmt.Errorf("apply-confirm command open-PR gate %s#%d: %w", repo, pr, err)
+	} else if blocked {
 		return false, nil
 	}
 
@@ -421,7 +439,9 @@ func (h *Handler) applyConfirmCommandCore(repo string, pr int, environment, data
 	}
 
 	// Tier 1: review gate (re-check on confirm to prevent bypass)
-	if blocked := h.enforceReviewGate(ctx, client, repo, pr, installationID, schemaResult, environment, requestedBy, action.ApplyConfirm); blocked {
+	if blocked, err := h.enforceReviewGate(ctx, client, repo, pr, installationID, schemaResult, environment, requestedBy, action.ApplyConfirm); err != nil {
+		return true, fmt.Errorf("apply-confirm command review gate %s#%d: %w", repo, pr, err)
+	} else if blocked {
 		h.logger.Info("apply-confirm blocked by review gate", "repo", repo, "pr", pr, "environment", environment, "requested_by", requestedBy)
 		return false, nil
 	}
@@ -440,7 +460,9 @@ func (h *Handler) applyConfirmCommandCore(repo string, pr int, environment, data
 		return true, fmt.Errorf("apply-confirm command fetch PR for checks gate %s#%d: %w", repo, pr, err)
 	}
 
-	if blocked := h.enforcePassingChecks(ctx, client, repo, pr, installationID, confirmPRInfo.HeadSHA, environment); blocked {
+	if blocked, err := h.enforcePassingChecks(ctx, client, repo, pr, installationID, confirmPRInfo.HeadSHA, environment); err != nil {
+		return true, fmt.Errorf("apply-confirm command checks gate %s#%d: %w", repo, pr, err)
+	} else if blocked {
 		return false, nil
 	}
 
@@ -494,7 +516,10 @@ func (h *Handler) applyConfirmCommandCore(repo string, pr int, environment, data
 		releaseObservedApplyIntent("stale-schema rejection")
 		return false, nil
 	}
-	if rejected := h.assertBaseSchemaStillCurrent(ctx, client, repo, pr, installationID, schemaResult, confirmPRInfo, environment, requestedBy, action.ApplyConfirm); rejected {
+	if rejected, err := h.assertBaseSchemaStillCurrent(ctx, client, repo, pr, installationID, schemaResult, confirmPRInfo, environment, requestedBy, action.ApplyConfirm); err != nil {
+		releaseObservedApplyIntent("base-schema freshness evaluation failure")
+		return true, fmt.Errorf("apply-confirm command base-schema freshness %s#%d: %w", repo, pr, err)
+	} else if rejected {
 		releaseObservedApplyIntent("base-schema freshness rejection")
 		return false, nil
 	}

--- a/pkg/webhook/apply_integration_test.go
+++ b/pkg/webhook/apply_integration_test.go
@@ -2809,8 +2809,9 @@ func TestE2EApplyThreeEnvEnforcement(t *testing.T) {
 	// Case 1: production blocked when sandbox is action_required
 	seedCheck(t, svc, dbName, "sandbox", "action_required")
 
-	blocked := h.checkPriorEnvironments(t.Context(), "octocat/hello-world", 1,
+	blocked, err := h.checkPriorEnvironments(t.Context(), "octocat/hello-world", 1,
 		dbName, "mysql", "production", envs, 1)
+	require.NoError(t, err)
 	assert.True(t, blocked, "production should be blocked when sandbox is action_required")
 
 	select {
@@ -2824,8 +2825,9 @@ func TestE2EApplyThreeEnvEnforcement(t *testing.T) {
 	seedCheck(t, svc, dbName, "sandbox", "success")
 	seedCheck(t, svc, dbName, "staging", "action_required")
 
-	blocked = h.checkPriorEnvironments(t.Context(), "octocat/hello-world", 1,
+	blocked, err = h.checkPriorEnvironments(t.Context(), "octocat/hello-world", 1,
 		dbName, "mysql", "production", envs, 1)
+	require.NoError(t, err)
 	assert.True(t, blocked, "production should be blocked when staging is action_required")
 
 	select {
@@ -2838,20 +2840,23 @@ func TestE2EApplyThreeEnvEnforcement(t *testing.T) {
 	// Case 3: production allowed when both sandbox and staging are success
 	seedCheck(t, svc, dbName, "staging", "success")
 
-	blocked = h.checkPriorEnvironments(t.Context(), "octocat/hello-world", 1,
+	blocked, err = h.checkPriorEnvironments(t.Context(), "octocat/hello-world", 1,
 		dbName, "mysql", "production", envs, 1)
+	require.NoError(t, err)
 	assert.False(t, blocked, "production should not be blocked when all prior envs are success")
 
 	// Case 4: staging only requires sandbox (not production)
 	seedCheck(t, svc, dbName, "sandbox", "action_required")
 
-	blocked = h.checkPriorEnvironments(t.Context(), "octocat/hello-world", 1,
+	blocked, err = h.checkPriorEnvironments(t.Context(), "octocat/hello-world", 1,
 		dbName, "mysql", "staging", envs, 1)
+	require.NoError(t, err)
 	assert.True(t, blocked, "staging should be blocked when sandbox is action_required")
 
 	// Case 5: sandbox (first env) is never blocked
-	blocked = h.checkPriorEnvironments(t.Context(), "octocat/hello-world", 1,
+	blocked, err = h.checkPriorEnvironments(t.Context(), "octocat/hello-world", 1,
 		dbName, "mysql", "sandbox", envs, 1)
+	require.NoError(t, err)
 	assert.False(t, blocked, "sandbox (first env) should never be blocked")
 }
 

--- a/pkg/webhook/check_prior_env.go
+++ b/pkg/webhook/check_prior_env.go
@@ -16,7 +16,6 @@ import (
 // checkPriorEnvironments enforces server-owned environment ordering: all enabled
 // environments before the current one in the server promotion order must have a
 // successful SchemaBot check.
-// Returns true if the apply is blocked (caller should return).
 //
 // For environments: [sandbox, staging, production]
 //   - applying to sandbox: no prior envs, always allowed
@@ -28,12 +27,22 @@ import (
 // environments. For prior environments owned by this instance, local storage is
 // checked. For prior environments owned by another instance, the GitHub Checks
 // API is queried for the per-environment aggregate check run.
+//
+// Returns follow the apply-gate disposition contract (see applyCommandCore):
+//   - (true, err) — a prior-environment check could not be evaluated (a storage
+//     or GitHub read failed). It fails closed and posts an error comment, but
+//     the returned error marks the block as an evaluation failure a durable
+//     driver should re-drive.
+//   - (true, nil) — blocked on merits (a prior environment is not applied, is
+//     still in progress, failed, or its check is missing/untrusted; or the
+//     target is absent from the configured promotion order). Terminal.
+//   - (false, nil) — all prior environments are clean; the apply may proceed.
 func (h *Handler) checkPriorEnvironments(
 	ctx context.Context, repo string, pr int,
 	database, dbType, environment string,
 	environments []string,
 	installationID int64,
-) bool {
+) (blocked bool, err error) {
 	config := h.service.Config()
 
 	// On a scoped instance the server-configured promotion order is the only
@@ -52,7 +61,7 @@ func (h *Handler) checkPriorEnvironments(
 		metrics.RecordPromotionConfigErrorBlock(ctx, repo, database, environment)
 		h.postComment(repo, pr, installationID,
 			templates.RenderApplyBlockedByUnlistedEnvironment(environment, order))
-		return true
+		return true, nil
 	}
 
 	environments = promotionGateEnvironments(config, environment, environments)
@@ -68,7 +77,7 @@ func (h *Handler) checkPriorEnvironments(
 
 	// First environment or not in list — no prior environments to check
 	if currentIdx <= 0 {
-		return false
+		return false, nil
 	}
 
 	// Check all prior environments
@@ -77,18 +86,22 @@ func (h *Handler) checkPriorEnvironments(
 
 		if config.IsEnvironmentAllowed(priorEnv) {
 			// This instance owns the prior environment — check local database
-			if blocked := h.checkPriorEnvViaLocal(ctx, repo, pr, database, dbType, environment, priorEnv, installationID); blocked {
-				return true
+			if blocked, err := h.checkPriorEnvViaLocal(ctx, repo, pr, database, dbType, environment, priorEnv, installationID); err != nil {
+				return true, err
+			} else if blocked {
+				return true, nil
 			}
 		} else {
 			// Another instance owns this environment — check GitHub Checks API
-			if blocked := h.checkPriorEnvViaGitHub(ctx, repo, pr, database, environment, priorEnv, installationID); blocked {
-				return true
+			if blocked, err := h.checkPriorEnvViaGitHub(ctx, repo, pr, database, environment, priorEnv, installationID); err != nil {
+				return true, err
+			} else if blocked {
+				return true, nil
 			}
 		}
 	}
 
-	return false
+	return false, nil
 }
 
 // scopedTargetMissingFromPromotionOrder reports whether this instance is scoped
@@ -116,12 +129,16 @@ func promotionGateEnvironments(config *api.ServerConfig, environment string, env
 	return config.OrderedEnvironments(environments)
 }
 
-// checkPriorEnvViaLocal checks the prior environment status using the local database.
+// checkPriorEnvViaLocal checks the prior environment status using the local
+// database. Returns follow the same disposition contract as
+// checkPriorEnvironments: (true, err) on a storage read failure (retryable),
+// (true, nil) on a merit block, and (false, nil) when the prior environment
+// is clean.
 func (h *Handler) checkPriorEnvViaLocal(
 	ctx context.Context, repo string, pr int,
 	database, dbType, environment, priorEnv string,
 	installationID int64,
-) bool {
+) (blocked bool, err error) {
 	check, err := h.waitForLocalPriorEnvCheck(ctx, repo, pr, database, dbType, environment, priorEnv)
 	if err != nil {
 		h.logger.Error("failed to look up prior environment check",
@@ -131,7 +148,7 @@ func (h *Handler) checkPriorEnvViaLocal(
 			"error", err)
 		h.postComment(repo, pr, installationID,
 			templates.RenderApplyBlockedByPriorEnvCheckError(priorEnv, "read SchemaBot storage", err))
-		return true
+		return true, fmt.Errorf("read prior-environment check %s#%d prior=%s: %w", repo, pr, priorEnv, err)
 	}
 
 	if check == nil {
@@ -142,7 +159,7 @@ func (h *Handler) checkPriorEnvViaLocal(
 			"attempts", h.priorEnvCheckMaxAttemptCount())
 		h.postComment(repo, pr, installationID,
 			templates.RenderApplyBlockedByMissingPriorEnvCheck(priorEnv))
-		return true
+		return true, nil
 	}
 
 	switch {
@@ -152,7 +169,7 @@ func (h *Handler) checkPriorEnvViaLocal(
 			"database", database, "database_type", dbType,
 			"environment", environment, "prior_environment", priorEnv,
 			"check_status", check.Status, "check_conclusion", check.Conclusion)
-		return false
+		return false, nil
 	case check.Status == checkStatusInProgress:
 		h.logger.Warn("prior environment check is still in progress after retries, blocking apply",
 			"repo", repo, "pr", pr,
@@ -162,7 +179,7 @@ func (h *Handler) checkPriorEnvViaLocal(
 			"attempts", h.priorEnvCheckMaxAttemptCount())
 		h.postComment(repo, pr, installationID,
 			templates.RenderApplyBlockedByPriorEnvInProgress(database, environment, priorEnv))
-		return true
+		return true, nil
 	default:
 		status := "has pending changes"
 		action := fmt.Sprintf("Apply %s first", priorEnv)
@@ -172,7 +189,7 @@ func (h *Handler) checkPriorEnvViaLocal(
 		}
 		h.postComment(repo, pr, installationID,
 			templates.RenderApplyBlockedByPriorEnv(database, environment, priorEnv, status, action))
-		return true
+		return true, nil
 	}
 }
 
@@ -235,18 +252,21 @@ func storedPriorEnvCheckStatus(check *storage.Check) string {
 // (github.trusted-check-app-slugs). A same-named check run from any other app
 // (e.g. a GitHub Actions job) cannot satisfy the gate, and when ownership
 // cannot be verified the gate blocks the apply.
+// Returns follow the same disposition contract as checkPriorEnvironments:
+// (true, err) on a GitHub read failure (retryable), (true, nil) on a merit
+// block, and (false, nil) when the prior environment is verified clean.
 func (h *Handler) checkPriorEnvViaGitHub(
 	ctx context.Context, repo string, pr int,
 	database, environment, priorEnv string,
 	installationID int64,
-) bool {
+) (blocked bool, err error) {
 	client, err := h.clientForRepo(repo, installationID)
 	if err != nil {
 		h.logger.Error("failed to create GitHub client for prior env check, blocking apply",
 			"prior_env", priorEnv, "error", err)
 		h.postComment(repo, pr, installationID,
 			templates.RenderApplyBlockedByPriorEnvCheckError(priorEnv, "create GitHub client", err))
-		return true
+		return true, fmt.Errorf("create GitHub client for prior-environment check %s#%d prior=%s: %w", repo, pr, priorEnv, err)
 	}
 
 	prInfo, err := client.FetchPullRequest(ctx, repo, pr)
@@ -255,7 +275,7 @@ func (h *Handler) checkPriorEnvViaGitHub(
 			"prior_env", priorEnv, "error", err)
 		h.postComment(repo, pr, installationID,
 			templates.RenderApplyBlockedByPriorEnvCheckError(priorEnv, "fetch PR details", err))
-		return true
+		return true, fmt.Errorf("fetch PR for prior-environment check %s#%d prior=%s: %w", repo, pr, priorEnv, err)
 	}
 
 	checkName := aggregateCheckNameForEnv(h.aggregateCheckNameForRepo(repo), priorEnv)
@@ -269,7 +289,7 @@ func (h *Handler) checkPriorEnvViaGitHub(
 			"check_name", checkName, "error", err)
 		h.postComment(repo, pr, installationID,
 			templates.RenderApplyBlockedByPriorEnvCheckError(priorEnv, "query check runs", err))
-		return true
+		return true, fmt.Errorf("query GitHub check for prior-environment %s#%d prior=%s: %w", repo, pr, priorEnv, err)
 	}
 
 	if checkResult == nil && len(untrustedApps) > 0 {
@@ -289,7 +309,7 @@ func (h *Handler) checkPriorEnvViaGitHub(
 		}
 		h.postComment(repo, pr, installationID,
 			templates.RenderApplyBlockedByUntrustedPriorEnvCheck(priorEnv, checkName, untrustedApps))
-		return true
+		return true, nil
 	}
 
 	if checkResult == nil {
@@ -301,7 +321,7 @@ func (h *Handler) checkPriorEnvViaGitHub(
 			"attempts", h.priorEnvCheckMaxAttemptCount())
 		h.postComment(repo, pr, installationID,
 			templates.RenderApplyBlockedByMissingPriorEnvCheck(priorEnv))
-		return true
+		return true, nil
 	}
 
 	switch {
@@ -311,7 +331,7 @@ func (h *Handler) checkPriorEnvViaGitHub(
 			"database", database,
 			"environment", environment, "prior_environment", priorEnv,
 			"check_name", checkName, "conclusion", checkResult.Conclusion)
-		return false
+		return false, nil
 	case checkResult.Status == checkStatusInProgress || checkResult.Status == checkStatusQueued:
 		h.logger.Warn("prior environment GitHub check is still non-terminal after retries, blocking apply",
 			"repo", repo, "pr", pr,
@@ -322,7 +342,7 @@ func (h *Handler) checkPriorEnvViaGitHub(
 			"attempts", h.priorEnvCheckMaxAttemptCount())
 		h.postComment(repo, pr, installationID,
 			templates.RenderApplyBlockedByPriorEnvInProgress(database, environment, priorEnv))
-		return true
+		return true, nil
 	default:
 		status := "has pending changes"
 		action := fmt.Sprintf("Apply %s first", priorEnv)
@@ -332,7 +352,7 @@ func (h *Handler) checkPriorEnvViaGitHub(
 		}
 		h.postComment(repo, pr, installationID,
 			templates.RenderApplyBlockedByPriorEnv(database, environment, priorEnv, status, action))
-		return true
+		return true, nil
 	}
 }
 

--- a/pkg/webhook/check_prior_env_test.go
+++ b/pkg/webhook/check_prior_env_test.go
@@ -50,7 +50,8 @@ func TestCheckPriorEnvViaLocalFailsClosedOnStorageError(t *testing.T) {
 		priorEnvCheckRetryInterval: time.Nanosecond,
 	}
 
-	blocked := h.checkPriorEnvViaLocal(t.Context(), repo, pr, "orders", "mysql", "production", "staging", 12345)
+	blocked, err := h.checkPriorEnvViaLocal(t.Context(), repo, pr, "orders", "mysql", "production", "staging", 12345)
+	require.Error(t, err, "an unreadable prior-environment gate must surface a retryable error")
 	assert.True(t, blocked, "storage read failure should block apply")
 
 	select {
@@ -98,7 +99,8 @@ func TestCheckPriorEnvViaLocalMissingCheckBlocksWithActionableGuidance(t *testin
 		priorEnvCheckRetryInterval: time.Nanosecond,
 	}
 
-	blocked := h.checkPriorEnvViaLocal(t.Context(), repo, pr, "orders", "mysql", "production", "staging", 12345)
+	blocked, err := h.checkPriorEnvViaLocal(t.Context(), repo, pr, "orders", "mysql", "production", "staging", 12345)
+	require.NoError(t, err)
 	assert.True(t, blocked, "missing prior check should block apply")
 
 	select {
@@ -152,7 +154,8 @@ func TestCheckPriorEnvViaLocalRetriesBeforeFailClosed(t *testing.T) {
 		priorEnvCheckRetryInterval: time.Nanosecond,
 	}
 
-	blocked := h.checkPriorEnvViaLocal(t.Context(), repo, pr, "orders", "mysql", "production", "staging", 12345)
+	blocked, err := h.checkPriorEnvViaLocal(t.Context(), repo, pr, "orders", "mysql", "production", "staging", 12345)
+	require.NoError(t, err)
 	assert.False(t, blocked, "retry should observe the prior environment success and allow apply")
 	assert.Equal(t, 2, checks.calls)
 
@@ -223,8 +226,9 @@ func TestCheckPriorEnvironmentsWithProductionOnlyServerConfigChecksStaging(t *te
 		priorEnvCheckRetryInterval: time.Nanosecond,
 	}
 
-	blocked := h.checkPriorEnvironments(t.Context(), repo, pr,
+	blocked, err := h.checkPriorEnvironments(t.Context(), repo, pr,
 		"orders", "mysql", "production", []string{"staging", "production"}, 12345)
+	require.NoError(t, err)
 	assert.True(t, blocked, "production blocks when the environment list includes staging before production")
 
 	select {
@@ -243,8 +247,9 @@ func TestCheckPriorEnvironmentsWithProductionOnlyServerConfigChecksStaging(t *te
 	require.NoError(t, h.attachServerEnvironments(schemaResult, "production"))
 	assert.Equal(t, []string{"production"}, schemaResult.Environments)
 
-	blocked = h.checkPriorEnvironments(t.Context(), repo, pr,
+	blocked, err = h.checkPriorEnvironments(t.Context(), repo, pr,
 		"orders", "mysql", "production", schemaResult.Environments, 12345)
+	require.NoError(t, err)
 	assert.True(t, blocked, "production blocks on staging even when this server only has a production target for the database")
 
 	select {
@@ -342,9 +347,10 @@ func TestCheckPriorEnvironmentsCrossDeploymentAppTrust(t *testing.T) {
 		h, comments := setup(t, installClient)
 		registerGitHubEndpoints(t, mux, comments)
 
-		blocked := h.checkPriorEnvironments(t.Context(), repo, pr,
+		blocked, err := h.checkPriorEnvironments(t.Context(), repo, pr,
 			"orders", "mysql", "production", []string{"production"}, 12345)
 
+		require.NoError(t, err)
 		assert.False(t, blocked, "a passing staging aggregate check from the trusted staging deployment App must allow production apply")
 		select {
 		case body := <-comments:
@@ -359,9 +365,10 @@ func TestCheckPriorEnvironmentsCrossDeploymentAppTrust(t *testing.T) {
 		h, comments := setup(t, installClient)
 		registerGitHubEndpoints(t, mux, comments)
 
-		blocked := h.checkPriorEnvironments(t.Context(), repo, pr,
+		blocked, err := h.checkPriorEnvironments(t.Context(), repo, pr,
 			"orders", "mysql", "production", []string{"production"}, 12345)
 
+		require.NoError(t, err)
 		assert.True(t, blocked, "a staging aggregate check from an unconfigured App must not satisfy the promotion gate")
 		select {
 		case body := <-comments:
@@ -434,8 +441,9 @@ func TestCheckPriorEnvironmentsScopedTargetMissingFromOrderFailsClosed(t *testin
 		priorEnvCheckRetryInterval: time.Nanosecond,
 	}
 
-	blocked := h.checkPriorEnvironments(t.Context(), repo, pr,
+	blocked, err := h.checkPriorEnvironments(t.Context(), repo, pr,
 		"orders", "mysql", "canary", []string{"canary"}, 12345)
+	require.NoError(t, err)
 	assert.True(t, blocked, "scoped instance must fail closed when an allowed target environment is absent from the promotion order")
 
 	select {
@@ -551,8 +559,9 @@ func TestCheckPriorEnvironmentsScopedTargetInOrderAllowsApply(t *testing.T) {
 		priorEnvCheckRetryInterval: time.Nanosecond,
 	}
 
-	blocked := h.checkPriorEnvironments(t.Context(), repo, pr,
+	blocked, err := h.checkPriorEnvironments(t.Context(), repo, pr,
 		"orders", "mysql", "production", []string{"production"}, 12345)
+	require.NoError(t, err)
 	assert.False(t, blocked, "in-order target with a passing prior environment check should be allowed")
 
 	select {
@@ -627,7 +636,8 @@ func TestCheckPriorEnvViaGitHub(t *testing.T) {
 			{"id": 1, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "success", "app": map[string]any{"slug": "schemabot"}},
 		})
 
-		blocked := h.checkPriorEnvViaGitHub(t.Context(), repo, pr, "orders", "production", "staging", 12345)
+		blocked, err := h.checkPriorEnvViaGitHub(t.Context(), repo, pr, "orders", "production", "staging", 12345)
+		require.NoError(t, err)
 		assert.False(t, blocked)
 
 		select {
@@ -642,7 +652,8 @@ func TestCheckPriorEnvViaGitHub(t *testing.T) {
 			{"id": 1, "name": "SchemaBot X (staging)", "status": "completed", "conclusion": "success", "app": map[string]any{"slug": "schemabot"}},
 		}, &api.ServerConfig{GitHub: api.GitHubConfig{CheckName: "SchemaBot X"}})
 
-		blocked := h.checkPriorEnvViaGitHub(t.Context(), repo, pr, "orders", "production", "staging", 12345)
+		blocked, err := h.checkPriorEnvViaGitHub(t.Context(), repo, pr, "orders", "production", "staging", 12345)
+		require.NoError(t, err)
 		assert.False(t, blocked)
 
 		select {
@@ -657,14 +668,16 @@ func TestCheckPriorEnvViaGitHub(t *testing.T) {
 			{"id": 1, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "action_required", "app": map[string]any{"slug": "schemabot"}},
 		})
 
-		blocked := h.checkPriorEnvViaGitHub(t.Context(), repo, pr, "orders", "production", "staging", 12345)
+		blocked, err := h.checkPriorEnvViaGitHub(t.Context(), repo, pr, "orders", "production", "staging", 12345)
+		require.NoError(t, err)
 		assert.True(t, blocked)
 	})
 
 	t.Run("no staging check blocks apply", func(t *testing.T) {
 		h, comments := setupCheckRunServer(t, []map[string]any{})
 
-		blocked := h.checkPriorEnvViaGitHub(t.Context(), repo, pr, "orders", "production", "staging", 12345)
+		blocked, err := h.checkPriorEnvViaGitHub(t.Context(), repo, pr, "orders", "production", "staging", 12345)
+		require.NoError(t, err)
 		assert.True(t, blocked)
 
 		select {
@@ -683,7 +696,8 @@ func TestCheckPriorEnvViaGitHub(t *testing.T) {
 			{"id": 1, "name": "SchemaBot (staging)", "status": "in_progress", "conclusion": "", "app": map[string]any{"slug": "schemabot"}},
 		})
 
-		blocked := h.checkPriorEnvViaGitHub(t.Context(), repo, pr, "orders", "production", "staging", 12345)
+		blocked, err := h.checkPriorEnvViaGitHub(t.Context(), repo, pr, "orders", "production", "staging", 12345)
+		require.NoError(t, err)
 		assert.True(t, blocked)
 	})
 
@@ -698,7 +712,8 @@ func TestCheckPriorEnvViaGitHub(t *testing.T) {
 			{"id": 1, "name": "SchemaBot (staging)", "status": "completed", "conclusion": "success", "app": map[string]any{"slug": "github-actions"}},
 		})
 
-		blocked := h.checkPriorEnvViaGitHub(t.Context(), repo, pr, "orders", "production", "staging", 12345)
+		blocked, err := h.checkPriorEnvViaGitHub(t.Context(), repo, pr, "orders", "production", "staging", 12345)
+		require.NoError(t, err)
 		assert.True(t, blocked, "a foreign-app check run must not satisfy the promotion gate")
 
 		select {
@@ -756,7 +771,8 @@ func TestCheckPriorEnvViaGitHub(t *testing.T) {
 			priorEnvCheckRetryInterval: time.Nanosecond,
 		}
 
-		blocked := h.checkPriorEnvViaGitHub(t.Context(), repo, pr, "orders", "production", "staging", 12345)
+		blocked, err := h.checkPriorEnvViaGitHub(t.Context(), repo, pr, "orders", "production", "staging", 12345)
+		require.Error(t, err, "an unverifiable check-run ownership read must surface a retryable error")
 		assert.True(t, blocked, "unverifiable check run ownership must block the promotion gate")
 
 		select {
@@ -817,7 +833,8 @@ func TestCheckPriorEnvViaGitHub(t *testing.T) {
 			priorEnvCheckRetryInterval: time.Nanosecond,
 		}
 
-		blocked := h.checkPriorEnvViaGitHub(t.Context(), repo, pr, "orders", "production", "staging", 12345)
+		blocked, err := h.checkPriorEnvViaGitHub(t.Context(), repo, pr, "orders", "production", "staging", 12345)
+		require.NoError(t, err)
 		assert.False(t, blocked, "retry should observe the prior environment success and allow apply")
 		assert.Equal(t, 2, checkCalls)
 
@@ -866,7 +883,8 @@ func TestCheckPriorEnvViaGitHub(t *testing.T) {
 			priorEnvCheckRetryInterval: time.Nanosecond,
 		}
 
-		blocked := h.checkPriorEnvViaGitHub(t.Context(), repo, pr, "orders", "production", "staging", 12345)
+		blocked, err := h.checkPriorEnvViaGitHub(t.Context(), repo, pr, "orders", "production", "staging", 12345)
+		require.Error(t, err, "an unreadable prior-environment gate must surface a retryable error")
 		assert.True(t, blocked, "GitHub API failure should block apply")
 
 		select {

--- a/pkg/webhook/review_gate.go
+++ b/pkg/webhook/review_gate.go
@@ -20,13 +20,20 @@ type ReviewGateResult struct {
 }
 
 // enforceReviewGate runs the review gate check and posts the appropriate comment if blocked.
-// Returns true if the apply was blocked (caller should return), false if it may proceed.
-func (h *Handler) enforceReviewGate(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, installationID int64, schemaResult *ghclient.SchemaRequestResult, environment, requestedBy, commandName string) bool {
+//
+// Returns follow the apply-gate disposition contract (see applyCommandCore):
+//   - (true, err) — the review gate could not be evaluated (a GitHub or config
+//     read failed). It fails closed and posts an error comment, but the
+//     returned error marks the block as an evaluation failure a durable driver
+//     should re-drive.
+//   - (true, nil) — blocked on merits (required approval is missing). Terminal.
+//   - (false, nil) — the gate is disabled or satisfied; the command may proceed.
+func (h *Handler) enforceReviewGate(ctx context.Context, client *ghclient.InstallationClient, repo string, pr int, installationID int64, schemaResult *ghclient.SchemaRequestResult, environment, requestedBy, commandName string) (blocked bool, err error) {
 	gateResult, err := h.checkReviewGate(ctx, client, repo, pr, schemaResult.Database, schemaResult.SchemaPath)
 	if err != nil {
 		h.logger.Error("review gate check failed", "error", err)
 		h.postCommandError(repo, pr, installationID, commandName, environment, requestedBy, reviewGateErrorDetail(err))
-		return true
+		return true, fmt.Errorf("review gate %s#%d: %w", repo, pr, err)
 	}
 	if gateResult != nil && !gateResult.Approved {
 		h.postComment(repo, pr, installationID, templates.RenderReviewRequired(templates.ReviewGateData{
@@ -36,9 +43,9 @@ func (h *Handler) enforceReviewGate(ctx context.Context, client *ghclient.Instal
 			Reviewers:   gateResult.RequiredReviewers,
 			PRAuthor:    gateResult.PRAuthor,
 		}))
-		return true
+		return true, nil
 	}
-	return false
+	return false, nil
 }
 
 func reviewGateErrorDetail(err error) string {

--- a/pkg/webhook/schema_freshness.go
+++ b/pkg/webhook/schema_freshness.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	ghclient "github.com/block/schemabot/pkg/github"
@@ -83,6 +84,15 @@ func metricActionKey(action string) string {
 // base commits), so unrelated commits elsewhere in a monorepo never block an
 // apply. GitHub read uncertainty rejects the apply rather than silently
 // bypassing the guard.
+//
+// Returns follow the apply-gate disposition contract (see applyCommandCore):
+//   - (true, err) — the base schema freshness could not be verified (a GitHub
+//     read failed). It fails closed and posts a rejection comment, but the
+//     returned error marks the rejection as an evaluation failure a durable
+//     driver should re-drive.
+//   - (true, nil) — rejected on merits (the schema path changed on the base
+//     branch after the PR diverged). Terminal.
+//   - (false, nil) — the base schema is unchanged under the PR; apply may proceed.
 func (h *Handler) assertBaseSchemaStillCurrent(
 	ctx context.Context,
 	client *ghclient.InstallationClient,
@@ -94,7 +104,7 @@ func (h *Handler) assertBaseSchemaStillCurrent(
 	environment string,
 	requestedBy string,
 	action string,
-) bool {
+) (rejected bool, err error) {
 	schemaPaths := []string{schema.SchemaPath}
 	if schema.SchemaLinkPath != "" {
 		schemaPaths = append(schemaPaths, schema.SchemaLinkPath)
@@ -122,10 +132,10 @@ func (h *Handler) assertBaseSchemaStillCurrent(
 			SchemaPath:        schema.SchemaPath,
 			VerificationError: true,
 		}))
-		return true
+		return true, fmt.Errorf("verify base schema freshness %s#%d: %w", repo, pr, err)
 	}
 	if !changed {
-		return false
+		return false, nil
 	}
 
 	h.logger.Warn("apply rejected: schema path changed on base branch after PR divergence",
@@ -148,5 +158,5 @@ func (h *Handler) assertBaseSchemaStillCurrent(
 		Environment: environment,
 		SchemaPath:  schema.SchemaPath,
 	}))
-	return true
+	return true, nil
 }


### PR DESCRIPTION
## Summary

The apply command gates fold transient GitHub/storage read failures into their boolean "blocked" result. A durable driver consuming the apply disposition would therefore treat a transient blip inside a gate as a terminal block and permanently drop the apply — even though the direct PR fetches beside the gates correctly treat the same blip as retryable. This gives the five apply/confirm-scoped gates a three-state contract that separates a terminal merit-block from a retryable evaluation failure.

## What

Five gates return `(blocked bool, err error)` instead of a bare `bool`:
`enforceOpenPR`, `enforcePassingChecks`, `enforceReviewGate`,
`checkPriorEnvironments` (plus its local/GitHub helpers), and
`assertBaseSchemaStillCurrent`.

- evaluation failure (a GitHub/storage read the gate needs) → `(true, err)` — fails closed, posts guidance, and marks the block retryable
- blocked on merits → `(true, nil)` — terminal
- passed → `(false, nil)`

`applyCommandCore` maps a gate's `err` to `retry=true` and a merit block to the terminal answer. The synchronous handlers (`handleApplyConfirmCommand`, `executeApply`) are behavior-preserving: because an eval failure keeps `blocked=true`, they still stop on any block via `blocked, _ :=`.

`enforcePRCommandActorAuthorization` is intentionally **not** in this PR — it is the one gate also called from plan/rollback/control/unlock, so it is carved into a follow-up to keep this change scoped to the apply/confirm path.

## Why

This is the prerequisite for converting the durable webhook driver to consume the apply disposition: without it, a durable `issue_comment` apply would fail closed on a transient GitHub outage and never re-drive.

## Before / after
```
before: gate read fails ─▶ return true (blocked)
applyCommandCore ─▶ terminal ─▶ durable driver drops the apply
```

```
after:  gate read fails ─▶ return (true, err)
applyCommandCore ─▶ retry=true ─▶ durable driver re-drives
gate blocks on merits ─▶ (true, nil) ─▶ terminal (unchanged)
```