### PR TITLE
refactor(webhook): give the actor-authorization gate a retryable-vs-terminal disposition

### DIFF
--- a/pkg/webhook/actor_authorization.go
+++ b/pkg/webhook/actor_authorization.go
@@ -45,6 +45,17 @@ func (h *Handler) actorAuthorizationClient(
 	return client, false
 }
 
+// enforcePRCommandActorAuthorization gates a PR command on the actor's
+// authorization and reports a retryable-vs-terminal disposition:
+//
+//   - (false, nil) — the actor is authorized, or authorization is disabled.
+//   - (true, nil) — a terminal merit block: the actor is not authorized, or the
+//     database is not configured on this instance. Retrying will not change the
+//     outcome, so a durable driver should stop.
+//   - (true, err) — the authorization decision could not be evaluated (a GitHub
+//     team-membership lookup or config read failed). It fails closed and posts
+//     an authorization-unavailable comment, but the returned error marks the
+//     block as an evaluation failure a durable driver should retry.
 func (h *Handler) enforcePRCommandActorAuthorization(
 	ctx context.Context,
 	client *ghclient.InstallationClient,
@@ -56,7 +67,7 @@ func (h *Handler) enforcePRCommandActorAuthorization(
 	databaseType string,
 	environment string,
 	commandName string,
-) bool {
+) (blocked bool, err error) {
 	result, err := h.authorizePRCommandActor(ctx, client, requestedBy, repo, database)
 	status := actorAuthorizationMetricStatus(result, err)
 	metrics.RecordPRCommandActorAuthorization(ctx, metricActionKey(commandName), database, environment, repo, status, result.Reason)
@@ -73,7 +84,7 @@ func (h *Handler) enforcePRCommandActorAuthorization(
 			Database:    database,
 			Environment: environment,
 		}))
-		return true
+		return true, fmt.Errorf("actor authorization %s#%d: %w", repo, pr, err)
 	}
 	if !result.Allowed {
 		// A missing database config is operationally distinct from an actor who
@@ -91,7 +102,7 @@ func (h *Handler) enforcePRCommandActorAuthorization(
 				Database:    database,
 				Environment: environment,
 			}))
-			return true
+			return true, nil
 		}
 		h.logger.Warn("PR command blocked by actor authorization",
 			"repo", repo, "pr", pr, "database", database,
@@ -105,14 +116,14 @@ func (h *Handler) enforcePRCommandActorAuthorization(
 			Environment:          environment,
 			AuthorizedPrincipals: h.service.Config().PRCommandAuthorizedPrincipals(repo, database),
 		}))
-		return true
+		return true, nil
 	}
 	if result.Reason == api.ActorAuthReasonDisabled {
 		h.logger.Debug("skipping PR command actor authorization because it is disabled",
 			"repo", repo, "pr", pr, "database", database,
 			"database_type", databaseType, "environment", environment,
 			"command", commandName, "requested_by", requestedBy)
-		return false
+		return false, nil
 	}
 	// Rollback, rollback-confirm, and unlock execute DDL or force-release locks,
 	// so the allow decision is audit-relevant. Log it at Info with the same
@@ -123,7 +134,7 @@ func (h *Handler) enforcePRCommandActorAuthorization(
 		"database_type", databaseType, "environment", environment,
 		"command", commandName, "requested_by", requestedBy,
 		"reason", result.Reason, "matched_principal", result.MatchedPrincipal)
-	return false
+	return false, nil
 }
 
 func (h *Handler) authorizePRCommandActor(

--- a/pkg/webhook/actor_authorization_test.go
+++ b/pkg/webhook/actor_authorization_test.go
@@ -343,8 +343,9 @@ func TestEnforcePRCommandActorAuthorizationComments(t *testing.T) {
 	})
 	h := actorAuthTestHandler(cfg, installClient)
 
-	blocked := h.enforcePRCommandActorAuthorization(t.Context(), installClient, "octocat/hello-world", 1, 12345, "mona", "orders", storage.DatabaseTypeMySQL, "staging", action.Apply)
+	blocked, err := h.enforcePRCommandActorAuthorization(t.Context(), installClient, "octocat/hello-world", 1, 12345, "mona", "orders", storage.DatabaseTypeMySQL, "staging", action.Apply)
 	assert.True(t, blocked)
+	assert.NoError(t, err)
 
 	body := requireComment(t, comments, "authorization comment")
 	assert.Contains(t, body, "SchemaBot Command Not Authorized")
@@ -366,8 +367,9 @@ func TestEnforcePRCommandActorAuthorizationUnconfiguredDatabaseComment(t *testin
 	})
 	h := actorAuthTestHandler(cfg, installClient)
 
-	blocked := h.enforcePRCommandActorAuthorization(t.Context(), installClient, "octocat/hello-world", 1, 12345, "mona", "payments", storage.DatabaseTypeMySQL, "", action.Unlock)
+	blocked, err := h.enforcePRCommandActorAuthorization(t.Context(), installClient, "octocat/hello-world", 1, 12345, "mona", "payments", storage.DatabaseTypeMySQL, "", action.Unlock)
 	assert.True(t, blocked)
+	assert.NoError(t, err)
 
 	body := requireComment(t, comments, "unconfigured-database authorization comment")
 	assert.Contains(t, body, "database `payments` is not configured on this SchemaBot instance")
@@ -385,8 +387,9 @@ func TestEnforcePRCommandActorAuthorizationTeamLookupErrorComment(t *testing.T) 
 	})
 	h := actorAuthTestHandler(cfg, installClient)
 
-	blocked := h.enforcePRCommandActorAuthorization(t.Context(), installClient, "octocat/hello-world", 1, 12345, "mona", "orders", storage.DatabaseTypeMySQL, "staging", action.Apply)
+	blocked, err := h.enforcePRCommandActorAuthorization(t.Context(), installClient, "octocat/hello-world", 1, 12345, "mona", "orders", storage.DatabaseTypeMySQL, "staging", action.Apply)
 	assert.True(t, blocked)
+	require.Error(t, err, "an unverifiable authorization decision must surface a retryable error")
 
 	body := requireComment(t, comments, "authorization failure comment")
 	assert.Contains(t, body, "SchemaBot Authorization Check Failed")

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -100,7 +100,9 @@ func (h *Handler) applyCommandCore(repo string, pr int, environment, databaseNam
 		return false, nil
 	}
 
-	if blocked := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, schemaResult.Database, schemaResult.Type, environment, action.Apply); blocked {
+	if blocked, err := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, schemaResult.Database, schemaResult.Type, environment, action.Apply); err != nil {
+		return true, fmt.Errorf("apply command actor authorization %s#%d: %w", repo, pr, err)
+	} else if blocked {
 		return false, nil
 	}
 
@@ -434,7 +436,9 @@ func (h *Handler) applyConfirmCommandCore(repo string, pr int, environment, data
 		return false, nil
 	}
 
-	if blocked := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, schemaResult.Database, schemaResult.Type, environment, action.ApplyConfirm); blocked {
+	if blocked, err := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, schemaResult.Database, schemaResult.Type, environment, action.ApplyConfirm); err != nil {
+		return true, fmt.Errorf("apply-confirm command actor authorization %s#%d: %w", repo, pr, err)
+	} else if blocked {
 		return false, nil
 	}
 
@@ -616,7 +620,9 @@ func (h *Handler) handleUnlockCommand(repo string, pr int, installationID int64,
 		return
 	}
 	for _, lock := range locks {
-		if blocked := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, lock.DatabaseName, lock.DatabaseType, "", action.Unlock); blocked {
+		// Evaluation errors are logged in the gate; this synchronous path treats
+		// any block as terminal, so the retryable disposition is not consumed here.
+		if blocked, _ := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, lock.DatabaseName, lock.DatabaseType, "", action.Unlock); blocked {
 			return
 		}
 	}

--- a/pkg/webhook/control.go
+++ b/pkg/webhook/control.go
@@ -150,7 +150,9 @@ func runControlCommand[R any](
 	if blocked {
 		return nil
 	}
-	if blocked := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, apply.Database, apply.DatabaseType, result.Environment, actionName); blocked {
+	// Evaluation errors are logged in the gate; this synchronous path treats any
+	// block as terminal, so the retryable disposition is not consumed here.
+	if blocked, _ := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, apply.Database, apply.DatabaseType, result.Environment, actionName); blocked {
 		return nil
 	}
 

--- a/pkg/webhook/plan.go
+++ b/pkg/webhook/plan.go
@@ -201,7 +201,10 @@ func (h *Handler) planForResolvedDatabaseBlocked(ctx context.Context, repo strin
 			"repo", repo, "pr", pr, "database", databaseName, "requested_by", requestedBy)
 		return false
 	}
-	return h.enforcePRCommandActorAuthorization(ctx, authzClient, repo, pr, installationID, requestedBy, databaseName, dbConfig.Type, environment, action.Plan)
+	// Evaluation errors are logged in the gate; this synchronous path treats any
+	// block as terminal, so the retryable disposition is not consumed here.
+	blocked, _ = h.enforcePRCommandActorAuthorization(ctx, authzClient, repo, pr, installationID, requestedBy, databaseName, dbConfig.Type, environment, action.Plan)
+	return blocked
 }
 
 // handleMultiEnvPlan runs plan for all configured environments and posts a single combined comment.

--- a/pkg/webhook/rollback.go
+++ b/pkg/webhook/rollback.go
@@ -94,7 +94,9 @@ func (h *Handler) handleRollbackCommand(repo string, pr int, installationID int6
 	if blocked {
 		return
 	}
-	if blocked := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, database, dbType, environment, action.Rollback); blocked {
+	// Evaluation errors are logged in the gate; this synchronous path treats any
+	// block as terminal, so the retryable disposition is not consumed here.
+	if blocked, _ := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, database, dbType, environment, action.Rollback); blocked {
 		return
 	}
 
@@ -332,7 +334,9 @@ func (h *Handler) handleRollbackConfirmCommand(repo string, pr int, environment 
 	// must be an authorized admin/operator before any lock is released or acted
 	// on. The database comes from the lock-pinned rollback plan instead of
 	// current PR files so confirmation follows the reviewed rollback artifact.
-	if blocked := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, database, dbType, environment, action.RollbackConfirm); blocked {
+	// Evaluation errors are logged in the gate; this synchronous path treats any
+	// block as terminal, so the retryable disposition is not consumed here.
+	if blocked, _ := h.enforcePRCommandActorAuthorization(ctx, client, repo, pr, installationID, requestedBy, database, dbType, environment, action.RollbackConfirm); blocked {
 		return
 	}
 


### PR DESCRIPTION
## Summary
Folds the shared PR-command actor-authorization gate into the same retryable-vs-terminal contract the apply/confirm gates already use, so a durable driver retries on a transient authorization-lookup failure instead of permanently dropping the command.

## What
`enforcePRCommandActorAuthorization` now returns `(blocked bool, err error)`:

| Outcome | Return | Meaning |
|---|---|---|
| team-membership / config read failure | `(true, err)` | retryable — fails closed, posts an authorization-unavailable comment |
| not authorized / unconfigured database | `(true, nil)` | terminal merit block |
| authorized / disabled | `(false, nil)` | passes |

The two already-error-bearing cores (`applyCommandCore`, `applyConfirmCommandCore`) wire the returned error into their retry disposition. The five synchronous callers (plan, control, rollback, rollback-confirm, unlock) explicitly discard the disposition and keep their existing fail-closed terminal-block behavior; the gate logs evaluation errors itself.

## Why
Previously a GitHub team-membership blip was folded into the boolean "blocked" result, so a durable apply driver would classify it terminal and permanently drop the apply — even though the `FetchPullRequest` call beside it correctly treats the same blip as retryable.
```
before:  authz lookup fails ──► return true (blocked)
│
applyCommandCore ───────────┴──► terminal ──► apply dropped

after:   authz lookup fails ──► return (true, err)
│
applyCommandCore ───────────┴──► retryable ──► driver retries
```
This is WH-9c-2a. WH-9c-2b will plumb the disposition through the five synchronous caller signatures once those paths go durable.
