### PR TITLE
refactor(webhook): use slices.Backward to find the latest plan comment

### DIFF
--- a/pkg/webhook/pull_request.go
+++ b/pkg/webhook/pull_request.go
@@ -271,9 +271,9 @@ func (h *Handler) shouldPostAutoPlanComment(ctx context.Context, client *ghclien
 			return true
 		}
 		var prior *storage.PlanComment
-		for i := len(comments) - 1; i >= 0; i-- {
-			if comments[i].EnvironmentScope == expectedScope {
-				prior = comments[i]
+		for _, v := range slices.Backward(comments) {
+			if v.EnvironmentScope == expectedScope {
+				prior = v
 				break
 			}
 		}


### PR DESCRIPTION
## Summary

Replace the manual reverse-index loop in `shouldPostAutoPlanComment` with
`slices.Backward`, preserving the existing newest-first lookup for the
latest matching plan comment. Behavior-preserving; no functional change.

## What

One loop rewrite in `pkg/webhook/pull_request.go`.

## Why

The stdlib iterator states the intent (walk newest→oldest) directly and
removes index arithmetic.
