### PR TITLE
feat(cli): bound schemabot status to a --last window

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -3606,6 +3606,64 @@ func TestParseStatusLimit(t *testing.T) {
 	}
 }
 
+func TestParseStatusLast(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		target    string
+		want      time.Duration
+		wantError bool
+	}{
+		{name: "default", target: "/api/status"},
+		{name: "hours", target: "/api/status?last=24h", want: 24 * time.Hour},
+		{name: "minutes", target: "/api/status?last=30m", want: 30 * time.Minute},
+		{name: "zero", target: "/api/status?last=0s", wantError: true},
+		{name: "negative", target: "/api/status?last=-1h", wantError: true},
+		{name: "not a duration", target: "/api/status?last=yesterday", wantError: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, tt.target, nil)
+			got, err := parseStatusLast(req)
+			if tt.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestHandleStatusLastWindowBoundsFilter verifies that the `last` query
+// parameter becomes an UpdatedSince bound on the storage filter and is echoed
+// back in the response, and that an invalid window is rejected rather than
+// silently ignored.
+func TestHandleStatusLastWindowBoundsFilter(t *testing.T) {
+	applies := &recentApplyStore{}
+	stor := &mockStorageWithApplyStores{applies: applies}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(stor, testServerConfig(), nil, logger)
+	mux := http.NewServeMux()
+	svc.ConfigureRoutes(mux)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status?last=24h", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp apitypes.StatusResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "24h0m0s", resp.Last)
+
+	require.Len(t, applies.filters, 1)
+	assert.WithinDuration(t, time.Now().Add(-24*time.Hour), applies.filters[0].UpdatedSince, time.Minute)
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status?last=yesterday", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	require.Len(t, applies.filters, 1, "an invalid window must not reach storage")
+}
+
 func TestParseStatusFailuresOnly(t *testing.T) {
 	for _, tt := range []struct {
 		name      string

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -753,6 +753,11 @@ func (s *Service) handleStatus(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	last, err := parseStatusLast(r)
+	if err != nil {
+		s.writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 
 	filter := storage.RecentAppliesFilter{
 		Limit:       limit + 1,
@@ -761,6 +766,9 @@ func (s *Service) handleStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	if failuresOnly {
 		filter.States = []string{state.Apply.Failed, state.Apply.FailedRetryable}
+	}
+	if last > 0 {
+		filter.UpdatedSince = time.Now().Add(-last)
 	}
 	applies, err := s.storage.Applies().GetRecent(r.Context(), filter)
 	if err != nil {
@@ -779,6 +787,9 @@ func (s *Service) handleStatus(w http.ResponseWriter, r *http.Request) {
 		HasMore:      hasMore,
 		FailuresOnly: failuresOnly,
 		Applies:      make([]*apitypes.ActiveApplyResponse, 0, len(applies)),
+	}
+	if last > 0 {
+		resp.Last = last.String()
 	}
 	operationsByApply := map[int64][]*storage.ApplyOperation{}
 	if filter.Deployment != "" {
@@ -923,6 +934,20 @@ func parseStatusLimit(r *http.Request) (int, error) {
 		return maxStatusLimit, nil
 	}
 	return limit, nil
+}
+
+// parseStatusLast parses the optional `last` query parameter bounding the
+// status list to applies updated within the window. Zero means unbounded.
+func parseStatusLast(r *http.Request) (time.Duration, error) {
+	raw := r.URL.Query().Get("last")
+	if raw == "" {
+		return 0, nil
+	}
+	last, err := time.ParseDuration(raw)
+	if err != nil || last <= 0 {
+		return 0, fmt.Errorf("last must be a positive duration such as 30m or 24h")
+	}
+	return last, nil
 }
 
 func parseStatusFailuresOnly(r *http.Request) (bool, error) {

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -813,10 +813,13 @@ type ActiveApplyResponse struct {
 
 // StatusResponse is the HTTP response for GET /api/status.
 type StatusResponse struct {
-	ActiveCount  int                    `json:"active_count"`
-	Limit        int                    `json:"limit,omitempty"`
-	MaxLimit     int                    `json:"max_limit,omitempty"`
-	HasMore      bool                   `json:"has_more,omitempty"`
-	FailuresOnly bool                   `json:"failures_only,omitempty"`
-	Applies      []*ActiveApplyResponse `json:"applies"`
+	ActiveCount  int  `json:"active_count"`
+	Limit        int  `json:"limit,omitempty"`
+	MaxLimit     int  `json:"max_limit,omitempty"`
+	HasMore      bool `json:"has_more,omitempty"`
+	FailuresOnly bool `json:"failures_only,omitempty"`
+	// Last echoes the window bounding the list to applies updated within it;
+	// empty means the list is bounded by limit alone.
+	Last    string                 `json:"last,omitempty"`
+	Applies []*ActiveApplyResponse `json:"applies"`
 }

--- a/pkg/cmd/client/client.go
+++ b/pkg/cmd/client/client.go
@@ -566,6 +566,9 @@ type StatusOptions struct {
 	Environment string
 	Deployment  string
 	Failed      bool
+	// Last bounds the list to applies updated within this window; zero means
+	// unbounded.
+	Last time.Duration
 }
 
 // GetStatus fetches recent schema changes.
@@ -585,6 +588,9 @@ func GetStatus(endpoint string, opts ...StatusOptions) (*apitypes.StatusResponse
 		}
 		if opts[0].Failed {
 			values.Set("failed", "true")
+		}
+		if opts[0].Last > 0 {
+			values.Set("last", opts[0].Last.String())
 		}
 		if encoded := values.Encode(); encoded != "" {
 			requestPath += "?" + encoded

--- a/pkg/cmd/client/client_test.go
+++ b/pkg/cmd/client/client_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -120,11 +121,12 @@ func TestListDatabases(t *testing.T) {
 }
 
 func TestGetStatusWithOptions(t *testing.T) {
-	var gotLimit, gotEnvironment, gotFailed string
+	var gotLimit, gotEnvironment, gotFailed, gotLast string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotLimit = r.URL.Query().Get("limit")
 		gotEnvironment = r.URL.Query().Get("environment")
 		gotFailed = r.URL.Query().Get("failed")
+		gotLast = r.URL.Query().Get("last")
 		w.Header().Set("Content-Type", "application/json")
 		_, err := w.Write([]byte(`{"active_count":0,"limit":50,"applies":[]}`))
 		require.NoError(t, err)
@@ -135,12 +137,14 @@ func TestGetStatusWithOptions(t *testing.T) {
 		Limit:       50,
 		Environment: "staging",
 		Failed:      true,
+		Last:        24 * time.Hour,
 	})
 	require.NoError(t, err)
 
 	assert.Equal(t, "50", gotLimit)
 	assert.Equal(t, "staging", gotEnvironment)
 	assert.Equal(t, "true", gotFailed)
+	assert.Equal(t, "24h0m0s", gotLast)
 	assert.Equal(t, 50, result.Limit)
 }
 

--- a/pkg/cmd/commands/status.go
+++ b/pkg/cmd/commands/status.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/block/schemabot/pkg/apitypes"
 	"github.com/block/schemabot/pkg/cmd/client"
@@ -15,6 +16,7 @@ type StatusCmd struct {
 	Database    string `short:"d" help:"Database name (show apply history)"`
 	Environment string `short:"e" help:"Environment filter"`
 	Deployment  string `help:"Deployment filter"`
+	Last        string `help:"Only show applies updated within this window, for example 6h or 2d; by default the list is bounded by --limit alone"`
 	Limit       int    `short:"n" help:"Maximum recent applies to show (default 20, max 1000)"`
 	Failed      bool   `help:"Show only failed recent applies" name:"failed"`
 	ExternalID  bool   `help:"Show external engine apply IDs" name:"external-id"`
@@ -39,6 +41,14 @@ func (cmd *StatusCmd) Run(g *Globals) error {
 	}
 
 	// Mode 3: List recent applies
+	var last time.Duration
+	if cmd.Last != "" {
+		window, err := parseOperatorDuration(cmd.Last)
+		if err != nil {
+			return fmt.Errorf("parse --last: %w", err)
+		}
+		last = window
+	}
 	var result *apitypes.StatusResponse
 	err = withLoading("Loading schema change status...", !cmd.JSON, func() error {
 		var loadErr error
@@ -47,6 +57,7 @@ func (cmd *StatusCmd) Run(g *Globals) error {
 			Environment: cmd.Environment,
 			Deployment:  cmd.Deployment,
 			Failed:      cmd.Failed,
+			Last:        last,
 		})
 		return loadErr
 	})
@@ -70,6 +81,7 @@ func (cmd *StatusCmd) Run(g *Globals) error {
 		MaxLimit:       result.MaxLimit,
 		HasMore:        result.HasMore,
 		FailuresOnly:   result.FailuresOnly,
+		Last:           cmd.Last,
 		ShowExternalID: cmd.ExternalID,
 		Deployment:     cmd.Deployment,
 		Applies:        applies,

--- a/pkg/cmd/internal/templates/progress.go
+++ b/pkg/cmd/internal/templates/progress.go
@@ -854,18 +854,32 @@ type StatusListData struct {
 	MaxLimit       int
 	HasMore        bool
 	FailuresOnly   bool
+	Last           string
 	ShowExternalID bool
 	Deployment     string
 	Applies        []ActiveApplyData
 }
 
+// statusWindowSuffix renders the --last window as a header suffix, or empty
+// when the list is unbounded.
+func statusWindowSuffix(data StatusListData) string {
+	if data.Last == "" {
+		return ""
+	}
+	return fmt.Sprintf(" %s(updated in the last %s)%s", ANSIDim, data.Last, ANSIReset)
+}
+
 // WriteStatusList writes the status list output.
 func WriteStatusList(data StatusListData) {
 	if len(data.Applies) == 0 {
+		window := ""
+		if data.Last != "" {
+			window = fmt.Sprintf(" updated in the last %s", data.Last)
+		}
 		if data.FailuresOnly {
-			fmt.Printf("%sNo recent failed schema changes%s\n", ANSIDim, ANSIReset)
+			fmt.Printf("%sNo recent failed schema changes%s%s\n", ANSIDim, window, ANSIReset)
 		} else {
-			fmt.Printf("%sNo recent schema changes%s\n", ANSIDim, ANSIReset)
+			fmt.Printf("%sNo recent schema changes%s%s\n", ANSIDim, window, ANSIReset)
 		}
 		return
 	}
@@ -877,12 +891,12 @@ func WriteStatusList(data StatusListData) {
 	// Header
 	if data.ActiveCount > 0 {
 		if data.ActiveCount == 1 {
-			fmt.Printf("%s1 active schema change%s\n", ANSIBold, ANSIReset)
+			fmt.Printf("%s1 active schema change%s%s\n", ANSIBold, ANSIReset, statusWindowSuffix(data))
 		} else {
-			fmt.Printf("%s%d active schema changes%s\n", ANSIBold, data.ActiveCount, ANSIReset)
+			fmt.Printf("%s%d active schema changes%s%s\n", ANSIBold, data.ActiveCount, ANSIReset, statusWindowSuffix(data))
 		}
 	} else {
-		fmt.Printf("%sRecent schema changes%s\n", ANSIBold, ANSIReset)
+		fmt.Printf("%sRecent schema changes%s%s\n", ANSIBold, ANSIReset, statusWindowSuffix(data))
 	}
 	fmt.Println()
 
@@ -1027,7 +1041,7 @@ func writeStatusListFooter(data StatusListData) {
 }
 
 func writeFailedStatusList(data StatusListData) {
-	fmt.Printf("%sRecent failed schema changes%s\n", ANSIBold, ANSIReset)
+	fmt.Printf("%sRecent failed schema changes%s%s\n", ANSIBold, ANSIReset, statusWindowSuffix(data))
 	fmt.Println()
 
 	for i, a := range data.Applies {

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -1135,6 +1135,10 @@ func (s *applyStore) GetRecent(ctx context.Context, filter storage.RecentApplies
 		where = append(where, fmt.Sprintf("state IN (%s)", placeholders(len(filter.States))))
 		args = append(args, stringArgs(filter.States)...)
 	}
+	if !filter.UpdatedSince.IsZero() {
+		where = append(where, "updated_at >= ?")
+		args = append(args, filter.UpdatedSince)
+	}
 	if len(where) > 0 {
 		query += " WHERE " + strings.Join(where, " AND ")
 	}

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -1389,6 +1389,42 @@ func TestApplyStore_GetRecentLimitAndEnvironment(t *testing.T) {
 	assert.Equal(t, "apply_recent_staging_failed", applies[0].ApplyIdentifier)
 }
 
+// TestApplyStore_GetRecentUpdatedSince verifies the status window bound: only
+// applies whose updated_at falls at or after the bound are returned, so an
+// apply that last changed before the window drops out while fresh activity
+// stays visible.
+func TestApplyStore_GetRecentUpdatedSince(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "windowdb", "mysql", "staging")
+	createTestApplyWithStateAndEnv(t, store, lock, "apply_window_stale", 220, state.Apply.Completed, "staging")
+	createTestApplyWithStateAndEnv(t, store, lock, "apply_window_fresh", 221, state.Apply.Completed, "staging")
+
+	_, err := testDB.ExecContext(ctx,
+		"UPDATE `applies` SET updated_at = ? WHERE apply_identifier = ?",
+		time.Now().Add(-2*time.Hour), "apply_window_stale")
+	require.NoError(t, err)
+
+	applies, err := store.Applies().GetRecent(ctx, storage.RecentAppliesFilter{
+		Limit:        10,
+		Environment:  "staging",
+		UpdatedSince: time.Now().Add(-time.Hour),
+	})
+	require.NoError(t, err)
+	require.Len(t, applies, 1)
+	assert.Equal(t, "apply_window_fresh", applies[0].ApplyIdentifier)
+
+	applies, err = store.Applies().GetRecent(ctx, storage.RecentAppliesFilter{
+		Limit:        10,
+		Environment:  "staging",
+		UpdatedSince: time.Now().Add(-3 * time.Hour),
+	})
+	require.NoError(t, err)
+	require.Len(t, applies, 2)
+}
+
 func TestApplyStore_GetRecentDeploymentFilterMatchesParentAndOperation(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -506,6 +506,12 @@ type RecentAppliesFilter struct {
 	Environment string
 	Deployment  string
 	States      []string
+	// UpdatedSince, when set, restricts results to applies whose updated_at
+	// falls at or after this instant. Filtering on updated_at rather than
+	// started_at keeps two kinds of applies visible in a window: those that
+	// reached a terminal state within it, and those started earlier but
+	// still active (progress keeps touching updated_at).
+	UpdatedSince time.Time
 }
 
 // RetryableExpirationReason identifies why operator retry recovery stopped.


### PR DESCRIPTION
## Why this matters

`schemabot status` always returns the N most recent applies, so answering "what ran in the last hour?" means eyeballing timestamps — and on a busy server the window you care about scrolls past the limit. Periodic monitoring (hourly sweeps, daily digests) needs a first-class time bound.

## What it does

- Adds `--last <window>` to `schemabot status` (e.g. `--last 6h`, `--last 2d`), threaded through the client, API (`?last=`), and storage as an `updated_at >= now - window` filter.
- Filters on `updated_at` rather than `started_at`, so long-running applies that are still active stay visible alongside applies that reached a terminal state inside the window.
- The CLI headers and empty states echo the window (e.g. `(updated in the last 6h)`), and the response echoes the parsed window back.
- Composes with the existing `--limit`, `-e`, and `--failed` filters.

## Example

```console
$ schemabot status --last 6h
Recent schema changes (updated in the last 6h)

  APPLY ID      DATABASE  ENV         STATE      STARTED      CALLER
  apply_a1b2c3  orders    production  Completed  2 hours ago  octocat
  apply_d4e5f6  users     staging     Failed     5 hours ago  hubot
```

With `--json` (or `GET /api/status?last=6h`) — the response echoes the parsed window:

```json
{
  "active_count": 0,
  "limit": 10,
  "last": "6h0m0s",
  "applies": [
    {
      "apply_id": "apply_a1b2c3",
      "database": "orders",
      "environment": "production",
      "state": "completed",
      "engine": "spirit",
      "caller": "octocat",
      "started_at": "2026-07-24T14:02:11Z",
      "completed_at": "2026-07-24T14:09:48Z",
      "updated_at": "2026-07-24T14:09:48Z"
    }
  ]
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
