### PR TITLE
feat(cli): filter schemabot databases by --name

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -2483,6 +2483,46 @@ func TestDatabaseListSanitizesConfigAndReportsTopology(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	assert.Empty(t, resp.Databases)
 
+	// A name filter is a case-insensitive substring match, so a family
+	// prefix selects every shard-style database that contains it.
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/databases?name=ORD", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Databases, 1)
+	assert.Equal(t, "orders", resp.Databases[0].Database)
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/databases?name=count", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Databases, 1)
+	assert.Equal(t, "accounts", resp.Databases[0].Database)
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/databases?type=mysql&name=accounts", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Databases)
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/databases?type=mysql&name=orders", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Databases, 1)
+	assert.Equal(t, "orders", resp.Databases[0].Database)
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/databases?name=nomatch", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Databases)
+
 	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/databases?type=cockroach", nil)
 	w = httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
@@ -2500,7 +2540,7 @@ func TestDatabaseListRejectsInvalidDeploymentTopology(t *testing.T) {
 				},
 			},
 		},
-	}, "")
+	}, "", "")
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `database "orders" environment "production" deployments map is empty`)

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/block/spirit/pkg/statement"
@@ -649,7 +650,8 @@ func (s *Service) handleDatabaseList(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	resp, err := databaseListResponse(s.config, databaseType)
+	name := strings.TrimSpace(r.URL.Query().Get("name"))
+	resp, err := databaseListResponse(s.config, databaseType, name)
 	if err != nil {
 		s.logger.Error("database list failed", "error", err)
 		s.writeError(w, http.StatusInternalServerError, "failed to list databases: "+err.Error())
@@ -668,13 +670,21 @@ func parseDatabaseListTypeFilter(r *http.Request) (string, error) {
 	}
 }
 
-func databaseListResponse(config *ServerConfig, databaseType string) (*apitypes.DatabaseListResponse, error) {
+// databaseListResponse builds the sanitized database list, keeping only
+// databases matching the optional type and name filters. The name filter is a
+// case-insensitive substring match so one query covers a sharded family
+// (omnibus matches omnibus_001, omnibus_002, ...).
+func databaseListResponse(config *ServerConfig, databaseType, name string) (*apitypes.DatabaseListResponse, error) {
 	if config == nil {
 		return nil, fmt.Errorf("server config is nil")
 	}
+	nameFilter := strings.ToLower(name)
 	databaseNames := make([]string, 0, len(config.Databases))
 	for database, dbConfig := range config.Databases {
 		if databaseType != "" && dbConfig.Type != databaseType {
+			continue
+		}
+		if nameFilter != "" && !strings.Contains(strings.ToLower(database), nameFilter) {
 			continue
 		}
 		databaseNames = append(databaseNames, database)

--- a/pkg/cmd/client/client.go
+++ b/pkg/cmd/client/client.go
@@ -55,15 +55,22 @@ func GetEnvironments(endpoint, database string) ([]string, error) {
 // ListDatabasesOptions controls database list request fields.
 type ListDatabasesOptions struct {
 	Type string
+	// Name keeps only databases whose name contains it, case-insensitively.
+	Name string
 }
 
 // ListDatabases fetches the configured databases known to the server.
 func ListDatabases(endpoint string, opts ListDatabasesOptions) (*apitypes.DatabaseListResponse, error) {
 	requestPath := "/api/databases"
+	values := url.Values{}
 	if opts.Type != "" {
-		values := url.Values{}
 		values.Set("type", opts.Type)
-		requestPath += "?" + values.Encode()
+	}
+	if opts.Name != "" {
+		values.Set("name", opts.Name)
+	}
+	if encoded := values.Encode(); encoded != "" {
+		requestPath += "?" + encoded
 	}
 	var result apitypes.DatabaseListResponse
 	if err := doGetInto(endpoint, requestPath, &result); err != nil {

--- a/pkg/cmd/client/client_test.go
+++ b/pkg/cmd/client/client_test.go
@@ -88,11 +88,12 @@ func TestCallPullSchemaAPIError(t *testing.T) {
 }
 
 func TestListDatabases(t *testing.T) {
-	var gotType string
+	var gotType, gotName string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/api/databases", r.URL.Path)
 		gotType = r.URL.Query().Get("type")
+		gotName = r.URL.Query().Get("name")
 		w.Header().Set("Content-Type", "application/json")
 		require.NoError(t, json.NewEncoder(w).Encode(apitypes.DatabaseListResponse{
 			Databases: []*apitypes.DatabaseResponse{
@@ -108,10 +109,11 @@ func TestListDatabases(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	result, err := ListDatabases(server.URL, ListDatabasesOptions{Type: "mysql"})
+	result, err := ListDatabases(server.URL, ListDatabasesOptions{Type: "mysql", Name: "ord"})
 	require.NoError(t, err)
 
 	assert.Equal(t, "mysql", gotType)
+	assert.Equal(t, "ord", gotName)
 	require.NotNil(t, result)
 	require.Len(t, result.Databases, 1)
 	assert.Equal(t, "orders", result.Databases[0].Database)

--- a/pkg/cmd/commands/databases.go
+++ b/pkg/cmd/commands/databases.go
@@ -15,7 +15,7 @@ import (
 
 // DatabasesCmd lists databases configured on the SchemaBot server.
 type DatabasesCmd struct {
-	Type string `help:"Database type filter (mysql, vitess, or strata)"`
+	Type string `help:"Database type filter (mysql, vitess, strata, or postgres)"`
 	Name string `help:"Only show databases whose name contains this string, case-insensitively; a family prefix like omnibus matches every shard"`
 	JSON bool   `help:"Output as JSON"`
 }
@@ -29,11 +29,15 @@ func (cmd *DatabasesCmd) Run(g *Globals) error {
 	if err := validateDatabaseListType(cmd.Type); err != nil {
 		return err
 	}
+	// The server treats a whitespace-only name filter as absent; trim here so
+	// the rendered headers and empty-state message agree with what the server
+	// actually filtered on.
+	name := strings.TrimSpace(cmd.Name)
 
 	var resp *apitypes.DatabaseListResponse
 	err = withLoading("Loading databases...", !cmd.JSON, func() error {
 		var loadErr error
-		resp, loadErr = client.ListDatabases(ep, client.ListDatabasesOptions{Type: cmd.Type, Name: cmd.Name})
+		resp, loadErr = client.ListDatabases(ep, client.ListDatabasesOptions{Type: cmd.Type, Name: name})
 		return loadErr
 	})
 	if err != nil {
@@ -42,7 +46,7 @@ func (cmd *DatabasesCmd) Run(g *Globals) error {
 	if cmd.JSON {
 		return writeJSON(resp)
 	}
-	return writeDatabaseList(os.Stdout, resp, cmd.Name)
+	return writeDatabaseList(os.Stdout, resp, name)
 }
 
 func validateDatabaseListType(databaseType string) error {

--- a/pkg/cmd/commands/databases.go
+++ b/pkg/cmd/commands/databases.go
@@ -16,6 +16,7 @@ import (
 // DatabasesCmd lists databases configured on the SchemaBot server.
 type DatabasesCmd struct {
 	Type string `help:"Database type filter (mysql, vitess, or strata)"`
+	Name string `help:"Only show databases whose name contains this string, case-insensitively; a family prefix like omnibus matches every shard"`
 	JSON bool   `help:"Output as JSON"`
 }
 
@@ -32,7 +33,7 @@ func (cmd *DatabasesCmd) Run(g *Globals) error {
 	var resp *apitypes.DatabaseListResponse
 	err = withLoading("Loading databases...", !cmd.JSON, func() error {
 		var loadErr error
-		resp, loadErr = client.ListDatabases(ep, client.ListDatabasesOptions{Type: cmd.Type})
+		resp, loadErr = client.ListDatabases(ep, client.ListDatabasesOptions{Type: cmd.Type, Name: cmd.Name})
 		return loadErr
 	})
 	if err != nil {
@@ -41,7 +42,7 @@ func (cmd *DatabasesCmd) Run(g *Globals) error {
 	if cmd.JSON {
 		return writeJSON(resp)
 	}
-	return writeDatabaseList(os.Stdout, resp)
+	return writeDatabaseList(os.Stdout, resp, cmd.Name)
 }
 
 func validateDatabaseListType(databaseType string) error {
@@ -53,8 +54,14 @@ func validateDatabaseListType(databaseType string) error {
 	}
 }
 
-func writeDatabaseList(w io.Writer, resp *apitypes.DatabaseListResponse) error {
+func writeDatabaseList(w io.Writer, resp *apitypes.DatabaseListResponse, nameFilter string) error {
 	if resp == nil || len(resp.Databases) == 0 {
+		// An empty filtered list means no match, not an unconfigured server —
+		// say so, or operators misread the deployment as empty.
+		if nameFilter != "" {
+			_, err := fmt.Fprintf(w, "No databases match --name %q.\n", nameFilter)
+			return err
+		}
 		_, err := fmt.Fprintln(w, "No databases configured.")
 		return err
 	}

--- a/pkg/cmd/commands/databases_test.go
+++ b/pkg/cmd/commands/databases_test.go
@@ -33,7 +33,7 @@ func TestWriteDatabaseList(t *testing.T) {
 				},
 			},
 		},
-	})
+	}, "")
 
 	require.NoError(t, err)
 	output := out.String()
@@ -51,11 +51,12 @@ func TestWriteDatabaseList(t *testing.T) {
 }
 
 func TestDatabasesCommandRunFetchesAndRendersDatabases(t *testing.T) {
-	var gotType string
+	var gotType, gotName string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/api/databases", r.URL.Path)
 		gotType = r.URL.Query().Get("type")
+		gotName = r.URL.Query().Get("name")
 		w.Header().Set("Content-Type", "application/json")
 		require.NoError(t, json.NewEncoder(w).Encode(apitypes.DatabaseListResponse{
 			Databases: []*apitypes.DatabaseResponse{
@@ -71,7 +72,7 @@ func TestDatabasesCommandRunFetchesAndRendersDatabases(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	cmd := &DatabasesCmd{Type: "mysql"}
+	cmd := &DatabasesCmd{Type: "mysql", Name: "ord"}
 	var runErr error
 	output := captureStdout(func() {
 		runErr = cmd.Run(&Globals{Endpoint: server.URL})
@@ -79,6 +80,7 @@ func TestDatabasesCommandRunFetchesAndRendersDatabases(t *testing.T) {
 
 	require.NoError(t, runErr)
 	assert.Equal(t, "mysql", gotType)
+	assert.Equal(t, "ord", gotName)
 	assert.Contains(t, output, "DATABASE")
 	assert.Contains(t, output, "orders")
 	assert.Contains(t, output, "mysql")
@@ -88,10 +90,18 @@ func TestDatabasesCommandRunFetchesAndRendersDatabases(t *testing.T) {
 
 func TestWriteDatabaseListEmpty(t *testing.T) {
 	var out bytes.Buffer
-	err := writeDatabaseList(&out, &apitypes.DatabaseListResponse{})
+	err := writeDatabaseList(&out, &apitypes.DatabaseListResponse{}, "")
 
 	require.NoError(t, err)
 	assert.Equal(t, "No databases configured.\n", out.String())
+}
+
+func TestWriteDatabaseListEmptyWithNameFilter(t *testing.T) {
+	var out bytes.Buffer
+	err := writeDatabaseList(&out, &apitypes.DatabaseListResponse{}, "omnibus")
+
+	require.NoError(t, err)
+	assert.Equal(t, "No databases match --name \"omnibus\".\n", out.String())
 }
 
 func TestValidateDatabaseListType(t *testing.T) {

--- a/pkg/cmd/commands/databases_test.go
+++ b/pkg/cmd/commands/databases_test.go
@@ -72,7 +72,7 @@ func TestDatabasesCommandRunFetchesAndRendersDatabases(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	cmd := &DatabasesCmd{Type: "mysql", Name: "ord"}
+	cmd := &DatabasesCmd{Type: "mysql", Name: " ord "}
 	var runErr error
 	output := captureStdout(func() {
 		runErr = cmd.Run(&Globals{Endpoint: server.URL})
@@ -80,7 +80,7 @@ func TestDatabasesCommandRunFetchesAndRendersDatabases(t *testing.T) {
 
 	require.NoError(t, runErr)
 	assert.Equal(t, "mysql", gotType)
-	assert.Equal(t, "ord", gotName)
+	assert.Equal(t, "ord", gotName, "the name filter is trimmed before it reaches the server")
 	assert.Contains(t, output, "DATABASE")
 	assert.Contains(t, output, "orders")
 	assert.Contains(t, output, "mysql")


### PR DESCRIPTION
## Why this matters

`schemabot databases` prints every configured database. As servers grow — especially once sharded families land, where one logical app fans out into `<app>_001`, `<app>_002`, … — the unfiltered list stops being scannable.

## What it does

- Adds `--name <substring>` to `schemabot databases`, applied server-side (`?name=`) as a case-insensitive substring match, so a family prefix selects every shard in one query.
- Composes with the existing `--type` filter.
- An empty filtered result says `No databases match --name "<value>".` instead of `No databases configured.`, so operators don't misread a miss as an unconfigured server.

## Example

```console
$ schemabot databases --name ord
DATABASE  TYPE   ENVIRONMENTS         DEPLOYMENTS
orders    mysql  production, staging  production: orders-primary

$ schemabot databases --name omnibus
No databases match --name "omnibus".
```

With `--json` (or `GET /api/databases?name=ord`):

```json
{
  "databases": [
    {
      "database": "orders",
      "type": "mysql",
      "environments": [
        {"environment": "production", "deployments": ["orders-primary"]},
        {"environment": "staging"}
      ]
    }
  ]
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
