### PR TITLE
feat(cli): summarize schemabot status by state

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -257,6 +257,25 @@ func (s *recentApplyStore) GetRecent(_ context.Context, filter storage.RecentApp
 	if s.err != nil {
 		return nil, s.err
 	}
+	applies := s.matching(filter)
+	if filter.Limit > 0 && len(applies) > filter.Limit {
+		return applies[:filter.Limit], nil
+	}
+	return applies, nil
+}
+
+func (s *recentApplyStore) CountRecentByState(_ context.Context, filter storage.RecentAppliesFilter) (map[string]int, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	counts := map[string]int{}
+	for _, apply := range s.matching(filter) {
+		counts[apply.State]++
+	}
+	return counts, nil
+}
+
+func (s *recentApplyStore) matching(filter storage.RecentAppliesFilter) []*storage.Apply {
 	applies := make([]*storage.Apply, 0, len(s.applies))
 	for _, apply := range s.applies {
 		if filter.Environment != "" && apply.Environment != filter.Environment {
@@ -270,10 +289,7 @@ func (s *recentApplyStore) GetRecent(_ context.Context, filter storage.RecentApp
 		}
 		applies = append(applies, apply)
 	}
-	if filter.Limit > 0 && len(applies) > filter.Limit {
-		return applies[:filter.Limit], nil
-	}
-	return applies, nil
+	return applies
 }
 
 type memoryControlRequestStore struct {
@@ -3430,6 +3446,11 @@ func TestHandleStatusLimitAndEnvironment(t *testing.T) {
 	assert.True(t, resp.HasMore)
 	assert.False(t, resp.FailuresOnly)
 	assert.Equal(t, 1, resp.ActiveCount)
+	assert.Equal(t, map[string]int{
+		state.Apply.Completed: 2,
+		state.Apply.Running:   1,
+		state.Apply.Failed:    1,
+	}, resp.StateCounts, "state counts cover every matching apply, not just the truncated page")
 	require.Len(t, resp.Applies, 2)
 	assert.Equal(t, "apply-one", resp.Applies[0].ApplyID)
 	assert.Equal(t, "external-one", resp.Applies[0].ExternalID)

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -790,12 +790,19 @@ func (s *Service) handleStatus(w http.ResponseWriter, r *http.Request) {
 	if hasMore {
 		applies = applies[:limit]
 	}
+	stateCounts, err := s.storage.Applies().CountRecentByState(r.Context(), filter)
+	if err != nil {
+		s.logger.Error("count recent applies by state failed", "error", err)
+		s.writeError(w, http.StatusInternalServerError, "failed to count recent applies by state")
+		return
+	}
 
 	resp := &apitypes.StatusResponse{
 		Limit:        limit,
 		MaxLimit:     maxStatusLimit,
 		HasMore:      hasMore,
 		FailuresOnly: failuresOnly,
+		StateCounts:  stateCounts,
 		Applies:      make([]*apitypes.ActiveApplyResponse, 0, len(applies)),
 	}
 	if last > 0 {

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -820,6 +820,10 @@ type StatusResponse struct {
 	FailuresOnly bool `json:"failures_only,omitempty"`
 	// Last echoes the window bounding the list to applies updated within it;
 	// empty means the list is bounded by limit alone.
-	Last    string                 `json:"last,omitempty"`
-	Applies []*ActiveApplyResponse `json:"applies"`
+	Last string `json:"last,omitempty"`
+	// StateCounts tallies every apply matching the request's filters by state,
+	// unbounded by limit — the applies list may be a truncated page, but these
+	// counts never are.
+	StateCounts map[string]int         `json:"state_counts,omitempty"`
+	Applies     []*ActiveApplyResponse `json:"applies"`
 }

--- a/pkg/cmd/commands/status.go
+++ b/pkg/cmd/commands/status.go
@@ -82,6 +82,7 @@ func (cmd *StatusCmd) Run(g *Globals) error {
 		HasMore:        result.HasMore,
 		FailuresOnly:   result.FailuresOnly,
 		Last:           cmd.Last,
+		StateCounts:    result.StateCounts,
 		ShowExternalID: cmd.ExternalID,
 		Deployment:     cmd.Deployment,
 		Applies:        applies,

--- a/pkg/cmd/internal/templates/progress.go
+++ b/pkg/cmd/internal/templates/progress.go
@@ -855,6 +855,7 @@ type StatusListData struct {
 	HasMore        bool
 	FailuresOnly   bool
 	Last           string
+	StateCounts    map[string]int
 	ShowExternalID bool
 	Deployment     string
 	Applies        []ActiveApplyData
@@ -867,6 +868,34 @@ func statusWindowSuffix(data StatusListData) string {
 		return ""
 	}
 	return fmt.Sprintf(" %s(updated in the last %s)%s", ANSIDim, data.Last, ANSIReset)
+}
+
+// writeStatusStateSummary renders one line tallying every apply matching the
+// request's filters by state. The counts come from the server unbounded by
+// limit, so the line stays truthful when the table below it is a truncated
+// page. Ordered by count descending (ties by state name) so the dominant
+// outcome reads first.
+func writeStatusStateSummary(counts map[string]int) {
+	if len(counts) == 0 {
+		return
+	}
+	states := make([]string, 0, len(counts))
+	total := 0
+	for s, n := range counts {
+		states = append(states, s)
+		total += n
+	}
+	sort.Slice(states, func(i, j int) bool {
+		if counts[states[i]] != counts[states[j]] {
+			return counts[states[i]] > counts[states[j]]
+		}
+		return states[i] < states[j]
+	})
+	parts := make([]string, 0, len(states))
+	for _, s := range states {
+		parts = append(parts, fmt.Sprintf("%d %s", counts[s], state.Label(s)))
+	}
+	fmt.Printf("%s%d total: %s%s\n", ANSIDim, total, strings.Join(parts, " · "), ANSIReset)
 }
 
 // WriteStatusList writes the status list output.
@@ -898,6 +927,7 @@ func WriteStatusList(data StatusListData) {
 	} else {
 		fmt.Printf("%sRecent schema changes%s%s\n", ANSIBold, ANSIReset, statusWindowSuffix(data))
 	}
+	writeStatusStateSummary(data.StateCounts)
 	fmt.Println()
 
 	// Calculate column widths from data
@@ -1042,6 +1072,7 @@ func writeStatusListFooter(data StatusListData) {
 
 func writeFailedStatusList(data StatusListData) {
 	fmt.Printf("%sRecent failed schema changes%s%s\n", ANSIBold, ANSIReset, statusWindowSuffix(data))
+	writeStatusStateSummary(data.StateCounts)
 	fmt.Println()
 
 	for i, a := range data.Applies {

--- a/pkg/cmd/internal/templates/progress_states_test.go
+++ b/pkg/cmd/internal/templates/progress_states_test.go
@@ -88,6 +88,54 @@ func TestWriteStatusListHasMoreFooterAtMaxLimit(t *testing.T) {
 	assert.NotContains(t, output, "Use --limit N to show more.")
 }
 
+func TestWriteStatusListStateSummary(t *testing.T) {
+	output := captureStdout(t, func() {
+		WriteStatusList(StatusListData{
+			ActiveCount: 1,
+			Limit:       20,
+			StateCounts: map[string]int{
+				state.Apply.Completed: 12,
+				state.Apply.Failed:    2,
+				state.Apply.Running:   1,
+			},
+			Applies: []ActiveApplyData{
+				{
+					ApplyID:     "apply-example",
+					Database:    "orders",
+					Environment: "staging",
+					State:       state.Apply.Running,
+					StartedAt:   "2026-05-28T12:00:00Z",
+					Caller:      "cli",
+				},
+			},
+		})
+	})
+
+	assert.Contains(t, output, "15 total: 12 Completed · 2 Failed · 1 Running")
+}
+
+func TestWriteStatusListNoStateSummaryWhenEmpty(t *testing.T) {
+	output := captureStdout(t, func() {
+		WriteStatusList(StatusListData{
+			ActiveCount: 0,
+			Limit:       20,
+			Applies: []ActiveApplyData{
+				{
+					ApplyID:     "apply-example",
+					Database:    "orders",
+					Environment: "staging",
+					State:       state.Apply.Completed,
+					StartedAt:   "2026-05-28T12:00:00Z",
+					CompletedAt: "2026-05-28T12:00:02Z",
+					Caller:      "cli",
+				},
+			},
+		})
+	})
+
+	assert.NotContains(t, output, "total:")
+}
+
 func TestWriteStatusListExternalID(t *testing.T) {
 	output := captureStdout(t, func() {
 		WriteStatusList(StatusListData{

--- a/pkg/storage/mysqlstore/applies.go
+++ b/pkg/storage/mysqlstore/applies.go
@@ -1111,14 +1111,12 @@ func (s *applyStore) GetInProgress(ctx context.Context) ([]*storage.Apply, error
 	return scanApplies(rows)
 }
 
-// GetRecent returns the most recent applies across all databases, ordered by creation time desc.
-func (s *applyStore) GetRecent(ctx context.Context, filter storage.RecentAppliesFilter) ([]*storage.Apply, error) {
-	query := `
-		SELECT ` + applyColumns + `
-		FROM applies
-	`
-	var args []any
+// recentAppliesWhere builds the WHERE predicates and args shared by the
+// recent-apply list and count queries, so both views agree on which applies a
+// filter selects.
+func recentAppliesWhere(filter storage.RecentAppliesFilter) ([]string, []any) {
 	var where []string
+	var args []any
 	if filter.Environment != "" {
 		where = append(where, "environment = ?")
 		args = append(args, filter.Environment)
@@ -1139,6 +1137,16 @@ func (s *applyStore) GetRecent(ctx context.Context, filter storage.RecentApplies
 		where = append(where, "updated_at >= ?")
 		args = append(args, filter.UpdatedSince)
 	}
+	return where, args
+}
+
+// GetRecent returns the most recent applies across all databases, ordered by creation time desc.
+func (s *applyStore) GetRecent(ctx context.Context, filter storage.RecentAppliesFilter) ([]*storage.Apply, error) {
+	query := `
+		SELECT ` + applyColumns + `
+		FROM applies
+	`
+	where, args := recentAppliesWhere(filter)
 	if len(where) > 0 {
 		query += " WHERE " + strings.Join(where, " AND ")
 	}
@@ -1152,6 +1160,38 @@ func (s *applyStore) GetRecent(ctx context.Context, filter storage.RecentApplies
 	defer utils.CloseAndLog(rows)
 
 	return scanApplies(rows)
+}
+
+// CountRecentByState returns how many applies match the filter, grouped by
+// state. The filter's Limit is ignored: counts cover every matching row, so a
+// summary over a window is not truncated by list pagination.
+func (s *applyStore) CountRecentByState(ctx context.Context, filter storage.RecentAppliesFilter) (map[string]int, error) {
+	query := "SELECT state, COUNT(*) FROM applies"
+	where, args := recentAppliesWhere(filter)
+	if len(where) > 0 {
+		query += " WHERE " + strings.Join(where, " AND ")
+	}
+	query += " GROUP BY state"
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("count recent applies by state: %w", err)
+	}
+	defer utils.CloseAndLog(rows)
+
+	counts := map[string]int{}
+	for rows.Next() {
+		var applyState string
+		var count int
+		if err := rows.Scan(&applyState, &count); err != nil {
+			return nil, fmt.Errorf("scan recent apply state count: %w", err)
+		}
+		counts[applyState] = count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate recent apply state counts: %w", err)
+	}
+	return counts, nil
 }
 
 // FindNextApply atomically claims the next apply that needs attention.

--- a/pkg/storage/mysqlstore/applies_test.go
+++ b/pkg/storage/mysqlstore/applies_test.go
@@ -1425,6 +1425,47 @@ func TestApplyStore_GetRecentUpdatedSince(t *testing.T) {
 	require.Len(t, applies, 2)
 }
 
+// A status summary must tally every apply matching the filters — unbounded by
+// the list limit, scoped by environment, and windowed by UpdatedSince — so an
+// operator reading a truncated status page still sees truthful totals.
+func TestApplyStore_CountRecentByState(t *testing.T) {
+	clearTables(t)
+	ctx := t.Context()
+	store := New(testDB)
+
+	lock := createTestLock(t, store, "countdb", "mysql", "staging")
+	createTestApplyWithStateAndEnv(t, store, lock, "apply_count_completed_one", 230, state.Apply.Completed, "staging")
+	createTestApplyWithStateAndEnv(t, store, lock, "apply_count_completed_two", 231, state.Apply.Completed, "staging")
+	createTestApplyWithStateAndEnv(t, store, lock, "apply_count_failed", 232, state.Apply.Failed, "staging")
+	createTestApplyWithStateAndEnv(t, store, lock, "apply_count_other_env", 233, state.Apply.Completed, "production")
+
+	counts, err := store.Applies().CountRecentByState(ctx, storage.RecentAppliesFilter{
+		Limit:       1,
+		Environment: "staging",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]int{
+		state.Apply.Completed: 2,
+		state.Apply.Failed:    1,
+	}, counts, "counts cover every matching row even when the list limit is 1")
+
+	_, err = testDB.ExecContext(ctx,
+		"UPDATE `applies` SET updated_at = ? WHERE apply_identifier = ?",
+		time.Now().Add(-2*time.Hour), "apply_count_completed_one")
+	require.NoError(t, err)
+
+	counts, err = store.Applies().CountRecentByState(ctx, storage.RecentAppliesFilter{
+		Limit:        10,
+		Environment:  "staging",
+		UpdatedSince: time.Now().Add(-time.Hour),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]int{
+		state.Apply.Completed: 1,
+		state.Apply.Failed:    1,
+	}, counts)
+}
+
 func TestApplyStore_GetRecentDeploymentFilterMatchesParentAndOperation(t *testing.T) {
 	clearTables(t)
 	ctx := t.Context()

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -396,6 +396,11 @@ type ApplyStore interface {
 	// Used by `schemabot status` (no args) to show recent activity.
 	GetRecent(ctx context.Context, filter RecentAppliesFilter) ([]*Apply, error)
 
+	// CountRecentByState returns how many applies match the filter, grouped by
+	// state. The filter's Limit is ignored: counts cover every matching row, so
+	// a status summary is not truncated by list pagination.
+	CountRecentByState(ctx context.Context, filter RecentAppliesFilter) (map[string]int, error)
+
 	// GetInProgress returns all applies in non-terminal states.
 	// Note: For recovery, use FindNextApply which handles locking.
 	GetInProgress(ctx context.Context) ([]*Apply, error)


### PR DESCRIPTION
## Why this matters

`schemabot status` shows a page of recent applies bounded by `--limit`, so the totals an operator infers from the visible rows are wrong whenever the window holds more applies than the page. A sweep that asks "how many failed in the last 6h?" needs truthful counts, not a truncated list.

## What it does

- Adds a `state_counts` tally to the status response, computed server-side with a `GROUP BY state` over every apply matching the request's filters (environment, `--failed`, `--last`) — deliberately unbounded by `--limit`, so pagination never skews the totals.
- The CLI renders it as a one-line summary under the header, e.g. `15 total: 12 Completed · 2 Failed · 1 Running`, ordered by count.
- The count query shares its predicates with the list query, so the summary and the rows always describe the same window.

## Example

```console
$ schemabot status --last 6h --limit 2
Recent schema changes (updated in the last 6h)
15 total: 12 Completed · 2 Failed · 1 Running

  APPLY ID      DATABASE  ENV         STATE    STARTED         CALLER
  apply_a1b2c3  orders    production  Running  10 minutes ago  octocat
  apply_d4e5f6  users     staging     Failed   2 hours ago     hubot
```

With `--json` — the counts cover all 15 matching applies even though the page holds 2:

```json
{
  "active_count": 1,
  "limit": 2,
  "has_more": true,
  "last": "6h0m0s",
  "state_counts": {
    "completed": 12,
    "failed": 2,
    "running": 1
  },
  "applies": [ "…2 items…" ]
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
