### PR TITLE
feat(cli): filter schemabot status by --state

### DIFF
--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -3725,6 +3725,71 @@ func TestHandleStatusLastWindowBoundsFilter(t *testing.T) {
 	require.Len(t, applies.filters, 1, "an invalid window must not reach storage")
 }
 
+// TestHandleStatusStateFilter verifies that the `state` query parameter
+// normalizes to the canonical apply state and restricts the storage filter,
+// that a typo'd state is rejected rather than returning a silently empty
+// list, and that `state` cannot be combined with `failed`.
+func TestHandleStatusStateFilter(t *testing.T) {
+	now := time.Now().UTC()
+	applies := &recentApplyStore{
+		applies: []*storage.Apply{
+			{
+				ApplyIdentifier: "apply-running",
+				Database:        "orders",
+				Environment:     "staging",
+				Engine:          storage.EngineSpirit,
+				State:           state.Apply.Running,
+				Caller:          "cli",
+				CreatedAt:       now,
+				UpdatedAt:       now,
+			},
+			{
+				ApplyIdentifier: "apply-completed",
+				Database:        "payments",
+				Environment:     "staging",
+				Engine:          storage.EngineSpirit,
+				State:           state.Apply.Completed,
+				Caller:          "cli",
+				CreatedAt:       now.Add(-time.Minute),
+				UpdatedAt:       now.Add(-time.Minute),
+			},
+		},
+	}
+	stor := &mockStorageWithApplyStores{applies: applies}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := New(stor, testServerConfig(), nil, logger)
+	mux := http.NewServeMux()
+	svc.ConfigureRoutes(mux)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status?state=RUNNING", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var resp apitypes.StatusResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, state.Apply.Running, resp.State, "the state filter echoes in canonical form")
+	require.Len(t, resp.Applies, 1)
+	assert.Equal(t, "apply-running", resp.Applies[0].ApplyID)
+	assert.Equal(t, map[string]int{state.Apply.Running: 1}, resp.StateCounts)
+	require.Len(t, applies.filters, 1)
+	assert.Equal(t, []string{state.Apply.Running}, applies.filters[0].States)
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status?state=comleted", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "unknown state")
+	require.Len(t, applies.filters, 1, "an unknown state must not reach storage")
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/status?state=running&failed=true", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "state cannot be combined with failed")
+	require.Len(t, applies.filters, 1, "conflicting filters must not reach storage")
+}
+
 func TestParseStatusFailuresOnly(t *testing.T) {
 	for _, tt := range []struct {
 		name      string

--- a/pkg/api/progress_handlers.go
+++ b/pkg/api/progress_handlers.go
@@ -768,6 +768,11 @@ func (s *Service) handleStatus(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	stateFilter, err := parseStatusState(r, failuresOnly)
+	if err != nil {
+		s.writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 
 	filter := storage.RecentAppliesFilter{
 		Limit:       limit + 1,
@@ -776,6 +781,9 @@ func (s *Service) handleStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	if failuresOnly {
 		filter.States = []string{state.Apply.Failed, state.Apply.FailedRetryable}
+	}
+	if stateFilter != "" {
+		filter.States = []string{stateFilter}
 	}
 	if last > 0 {
 		filter.UpdatedSince = time.Now().Add(-last)
@@ -808,6 +816,7 @@ func (s *Service) handleStatus(w http.ResponseWriter, r *http.Request) {
 	if last > 0 {
 		resp.Last = last.String()
 	}
+	resp.State = stateFilter
 	operationsByApply := map[int64][]*storage.ApplyOperation{}
 	if filter.Deployment != "" {
 		applyIDs := make([]int64, 0, len(applies))
@@ -977,6 +986,26 @@ func parseStatusFailuresOnly(r *http.Request) (bool, error) {
 		return false, fmt.Errorf("failed must be a boolean")
 	}
 	return failed, nil
+}
+
+// parseStatusState parses the optional `state` query parameter restricting the
+// status list to one apply state. The value is normalized to canonical
+// lowercase and must name a known apply state, so a typo returns an error
+// instead of a silently empty list. It cannot be combined with `failed`, which
+// is its own state filter.
+func parseStatusState(r *http.Request, failuresOnly bool) (string, error) {
+	raw := r.URL.Query().Get("state")
+	if raw == "" {
+		return "", nil
+	}
+	if failuresOnly {
+		return "", fmt.Errorf("state cannot be combined with failed")
+	}
+	normalized := state.NormalizeState(raw)
+	if _, ok := state.LookupApply(normalized); !ok {
+		return "", fmt.Errorf("unknown state %q", raw)
+	}
+	return normalized, nil
 }
 
 // progressFromLocalStorage builds a ProgressResponse from local apply + task

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -821,6 +821,9 @@ type StatusResponse struct {
 	// Last echoes the window bounding the list to applies updated within it;
 	// empty means the list is bounded by limit alone.
 	Last string `json:"last,omitempty"`
+	// State echoes the canonical form of the state filter restricting the
+	// list; empty means no state filter.
+	State string `json:"state,omitempty"`
 	// StateCounts tallies every apply matching the request's filters by state,
 	// unbounded by limit — the applies list may be a truncated page, but these
 	// counts never are.

--- a/pkg/cmd/client/client.go
+++ b/pkg/cmd/client/client.go
@@ -572,7 +572,9 @@ type StatusOptions struct {
 	Limit       int
 	Environment string
 	Deployment  string
-	Failed      bool
+	// State restricts the list to one apply state; empty means all states.
+	State  string
+	Failed bool
 	// Last bounds the list to applies updated within this window; zero means
 	// unbounded.
 	Last time.Duration
@@ -592,6 +594,9 @@ func GetStatus(endpoint string, opts ...StatusOptions) (*apitypes.StatusResponse
 		}
 		if opts[0].Deployment != "" {
 			values.Set("deployment", opts[0].Deployment)
+		}
+		if opts[0].State != "" {
+			values.Set("state", opts[0].State)
 		}
 		if opts[0].Failed {
 			values.Set("failed", "true")

--- a/pkg/cmd/client/client_test.go
+++ b/pkg/cmd/client/client_test.go
@@ -123,12 +123,13 @@ func TestListDatabases(t *testing.T) {
 }
 
 func TestGetStatusWithOptions(t *testing.T) {
-	var gotLimit, gotEnvironment, gotFailed, gotLast string
+	var gotLimit, gotEnvironment, gotFailed, gotLast, gotState string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotLimit = r.URL.Query().Get("limit")
 		gotEnvironment = r.URL.Query().Get("environment")
 		gotFailed = r.URL.Query().Get("failed")
 		gotLast = r.URL.Query().Get("last")
+		gotState = r.URL.Query().Get("state")
 		w.Header().Set("Content-Type", "application/json")
 		_, err := w.Write([]byte(`{"active_count":0,"limit":50,"applies":[]}`))
 		require.NoError(t, err)
@@ -147,7 +148,13 @@ func TestGetStatusWithOptions(t *testing.T) {
 	assert.Equal(t, "staging", gotEnvironment)
 	assert.Equal(t, "true", gotFailed)
 	assert.Equal(t, "24h0m0s", gotLast)
+	assert.Empty(t, gotState)
 	assert.Equal(t, 50, result.Limit)
+
+	_, err = GetStatus(server.URL, StatusOptions{State: "running"})
+	require.NoError(t, err)
+	assert.Equal(t, "running", gotState)
+	assert.Empty(t, gotFailed)
 }
 
 func TestReadSchemaFiles_RegularDirectories(t *testing.T) {

--- a/pkg/cmd/commands/status.go
+++ b/pkg/cmd/commands/status.go
@@ -17,6 +17,7 @@ type StatusCmd struct {
 	Environment string `short:"e" help:"Environment filter"`
 	Deployment  string `help:"Deployment filter"`
 	Last        string `help:"Only show applies updated within this window, for example 6h or 2d; by default the list is bounded by --limit alone"`
+	State       string `help:"Only show applies in this state, for example running, completed, or failed_retryable; cannot be combined with --failed"`
 	Limit       int    `short:"n" help:"Maximum recent applies to show (default 20, max 1000)"`
 	Failed      bool   `help:"Show only failed recent applies" name:"failed"`
 	ExternalID  bool   `help:"Show external engine apply IDs" name:"external-id"`
@@ -41,6 +42,9 @@ func (cmd *StatusCmd) Run(g *Globals) error {
 	}
 
 	// Mode 3: List recent applies
+	if cmd.State != "" && cmd.Failed {
+		return fmt.Errorf("--state cannot be combined with --failed")
+	}
 	var last time.Duration
 	if cmd.Last != "" {
 		window, err := parseOperatorDuration(cmd.Last)
@@ -56,6 +60,7 @@ func (cmd *StatusCmd) Run(g *Globals) error {
 			Limit:       cmd.Limit,
 			Environment: cmd.Environment,
 			Deployment:  cmd.Deployment,
+			State:       cmd.State,
 			Failed:      cmd.Failed,
 			Last:        last,
 		})
@@ -82,6 +87,7 @@ func (cmd *StatusCmd) Run(g *Globals) error {
 		HasMore:        result.HasMore,
 		FailuresOnly:   result.FailuresOnly,
 		Last:           cmd.Last,
+		StateFilter:    result.State,
 		StateCounts:    result.StateCounts,
 		ShowExternalID: cmd.ExternalID,
 		Deployment:     cmd.Deployment,

--- a/pkg/cmd/commands/status_test.go
+++ b/pkg/cmd/commands/status_test.go
@@ -1,0 +1,16 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatusCmdStateAndFailedAreMutuallyExclusive(t *testing.T) {
+	cmd := &StatusCmd{State: "running", Failed: true}
+	err := cmd.Run(&Globals{Endpoint: "http://localhost:1"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--state cannot be combined with --failed")
+}

--- a/pkg/cmd/internal/templates/progress.go
+++ b/pkg/cmd/internal/templates/progress.go
@@ -855,19 +855,34 @@ type StatusListData struct {
 	HasMore        bool
 	FailuresOnly   bool
 	Last           string
+	StateFilter    string
 	StateCounts    map[string]int
 	ShowExternalID bool
 	Deployment     string
 	Applies        []ActiveApplyData
 }
 
-// statusWindowSuffix renders the --last window as a header suffix, or empty
-// when the list is unbounded.
+// statusWindowSuffix renders the active list filters (--state, --last) as a
+// header suffix, or empty when the list is unfiltered.
 func statusWindowSuffix(data StatusListData) string {
-	if data.Last == "" {
+	parts := statusFilterPhrases(data)
+	if len(parts) == 0 {
 		return ""
 	}
-	return fmt.Sprintf(" %s(updated in the last %s)%s", ANSIDim, data.Last, ANSIReset)
+	return fmt.Sprintf(" %s(%s)%s", ANSIDim, strings.Join(parts, ", "), ANSIReset)
+}
+
+// statusFilterPhrases returns one human-readable phrase per active list
+// filter, shared by the header suffix and the empty-state message.
+func statusFilterPhrases(data StatusListData) []string {
+	var parts []string
+	if data.StateFilter != "" {
+		parts = append(parts, fmt.Sprintf("in state %s", state.Label(data.StateFilter)))
+	}
+	if data.Last != "" {
+		parts = append(parts, fmt.Sprintf("updated in the last %s", data.Last))
+	}
+	return parts
 }
 
 // writeStatusStateSummary renders one line tallying every apply matching the
@@ -901,14 +916,14 @@ func writeStatusStateSummary(counts map[string]int) {
 // WriteStatusList writes the status list output.
 func WriteStatusList(data StatusListData) {
 	if len(data.Applies) == 0 {
-		window := ""
-		if data.Last != "" {
-			window = fmt.Sprintf(" updated in the last %s", data.Last)
+		filters := ""
+		if parts := statusFilterPhrases(data); len(parts) > 0 {
+			filters = " " + strings.Join(parts, ", ")
 		}
 		if data.FailuresOnly {
-			fmt.Printf("%sNo recent failed schema changes%s%s\n", ANSIDim, window, ANSIReset)
+			fmt.Printf("%sNo recent failed schema changes%s%s\n", ANSIDim, filters, ANSIReset)
 		} else {
-			fmt.Printf("%sNo recent schema changes%s%s\n", ANSIDim, window, ANSIReset)
+			fmt.Printf("%sNo recent schema changes%s%s\n", ANSIDim, filters, ANSIReset)
 		}
 		return
 	}

--- a/pkg/cmd/internal/templates/progress_states_test.go
+++ b/pkg/cmd/internal/templates/progress_states_test.go
@@ -114,6 +114,40 @@ func TestWriteStatusListStateSummary(t *testing.T) {
 	assert.Contains(t, output, "15 total: 12 Completed · 2 Failed · 1 Running")
 }
 
+func TestWriteStatusListStateFilterSuffix(t *testing.T) {
+	output := captureStdout(t, func() {
+		WriteStatusList(StatusListData{
+			ActiveCount: 0,
+			Limit:       20,
+			StateFilter: state.Apply.FailedRetryable,
+			Last:        "6h",
+			Applies: []ActiveApplyData{
+				{
+					ApplyID:     "apply-example",
+					Database:    "orders",
+					Environment: "staging",
+					State:       state.Apply.FailedRetryable,
+					StartedAt:   "2026-05-28T12:00:00Z",
+					Caller:      "cli",
+				},
+			},
+		})
+	})
+
+	assert.Contains(t, output, "(in state Retrying, updated in the last 6h)")
+}
+
+func TestWriteStatusListEmptyWithStateFilter(t *testing.T) {
+	output := captureStdout(t, func() {
+		WriteStatusList(StatusListData{
+			Limit:       20,
+			StateFilter: state.Apply.Running,
+		})
+	})
+
+	assert.Contains(t, output, "No recent schema changes in state Running")
+}
+
 func TestWriteStatusListNoStateSummaryWhenEmpty(t *testing.T) {
 	output := captureStdout(t, func() {
 		WriteStatusList(StatusListData{


### PR DESCRIPTION
## Why this matters

`--failed` is the only state lens `schemabot status` has, and it hard-codes one pair of states. Operators also need "what is running right now?", "what is waiting on a revert window?", or "what is retrying?" — any single state, without grepping the full list.

## What it does

- Adds `--state <state>` to `schemabot status` (e.g. `--state running`, `--state failed_retryable`), applied server-side as a filter on the recent-applies list.
- The value is normalized and validated against the known apply states, so a typo returns an error instead of a silently empty list.
- Mutually exclusive with `--failed` (rejected on both the CLI and the API), which stays as the two-state failure shorthand.
- The header and empty states echo the active filter, e.g. `(in state Retrying, updated in the last 6h)`, and the response echoes the canonical state back.

## Example

```console
$ schemabot status --state failed_retryable --last 6h
Recent schema changes (in state Retrying, updated in the last 6h)
2 total: 2 Retrying

  APPLY ID      DATABASE  ENV         STATE     STARTED      CALLER
  apply_a1b2c3  orders    production  Retrying  2 hours ago  octocat
  apply_d4e5f6  users     production  Retrying  4 hours ago  hubot
```

With `--json` (or `GET /api/status?state=failed_retryable&last=6h`) — the response echoes the canonical state:

```json
{
  "active_count": 0,
  "limit": 10,
  "last": "6h0m0s",
  "state": "failed_retryable",
  "state_counts": {
    "failed_retryable": 2
  },
  "applies": [ "…2 items…" ]
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
