### PR TITLE
feat(cli): exit nonzero when checks backfill leaves work needing attention

### DIFF
--- a/docs/check-runs.md
+++ b/docs/check-runs.md
@@ -656,6 +656,15 @@ on expected participants that have not reported. A missing participant check
 is repaired by running the backfill on that participant's deployment — never
 by the leader.
 
+**The exit code means "nothing needs an operator after this run."** A run
+that leaves work behind exits nonzero with a one-line count summary, after
+printing the full report, so a scheduled sweep can alert on the exit code
+without parsing the output. A `--dry-run` acts on nothing, so any finding —
+missing, held, or stuck — fails the run. Outside `--dry-run`, successfully
+recreated checks are resolved and do not fail the run; held PRs, failed
+recreations, and stuck Check Runs do, because the backfill never acts on
+those and an operator still has to.
+
 [github-create-check-run]: https://docs.github.com/en/rest/checks/runs#create-a-check-run
 [github-check-runs]: https://docs.github.com/en/rest/checks/runs
 [github-protected-branches]: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches

--- a/pkg/cmd/commands/checks_backfill.go
+++ b/pkg/cmd/commands/checks_backfill.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/block/schemabot/pkg/apitypes"
 	cmdclient "github.com/block/schemabot/pkg/cmd/client"
+	"github.com/block/schemabot/pkg/ui"
 )
 
 // ChecksCmd groups SchemaBot Check Run operator commands.
@@ -286,7 +287,61 @@ scanning:
 		}
 	}
 	stopProgress()
-	return cmd.write(report)
+	if err := cmd.write(report); err != nil {
+		return err
+	}
+	return attentionExitError(report)
+}
+
+// attentionExitError makes the exit code mean "nothing needs an operator
+// after this run": it converts anything the run left unresolved into a
+// nonzero exit, so scheduled sweeps can alert on the exit code instead of
+// parsing the output. In a dry-run nothing was acted on, so every finding
+// remains. After an act phase, successfully recreated checks are resolved;
+// held PRs, failed recreations, and stuck Check Runs remain — the backfill
+// never acts on those. It fires only after the full report has been printed;
+// the report itself is unchanged. A run that leaves nothing behind returns
+// nil.
+func attentionExitError(report *checksBackfillReport) error {
+	var parts []string
+	if report.DryRun {
+		if n := len(report.Actions); n > 0 {
+			part := fmt.Sprintf("%d %s with missing Check Runs", n, ui.Pluralize("PR", n))
+			held := 0
+			for _, action := range report.Actions {
+				if action.Held {
+					held++
+				}
+			}
+			if held > 0 {
+				part += fmt.Sprintf(" (%d held)", held)
+			}
+			parts = append(parts, part)
+		}
+	} else {
+		held, failed := 0, 0
+		for _, action := range report.Actions {
+			switch {
+			case action.Held:
+				held++
+			case action.Error != "":
+				failed++
+			}
+		}
+		if held > 0 {
+			parts = append(parts, fmt.Sprintf("%d held %s", held, ui.Pluralize("PR", held)))
+		}
+		if failed > 0 {
+			parts = append(parts, fmt.Sprintf("%d failed Check Run %s", failed, ui.Pluralize("recreation", failed)))
+		}
+	}
+	if n := len(report.Stuck); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d stuck %s", n, ui.Pluralize("Check Run", n)))
+	}
+	if len(parts) == 0 {
+		return nil
+	}
+	return fmt.Errorf("checks backfill left %s needing attention", strings.Join(parts, " and "))
 }
 
 // checksScanProgressLine renders one scan progress update. The denominator is

--- a/pkg/cmd/commands/checks_backfill_test.go
+++ b/pkg/cmd/commands/checks_backfill_test.go
@@ -223,6 +223,110 @@ func TestChecksBackfillRunSkipsNamedDisabledRepo(t *testing.T) {
 	assert.Empty(t, report.Actions)
 }
 
+// checksBackfillScanServer serves a single-page checks scan returning the
+// given missing and stuck PRs, the shape a dry-run sweep consumes.
+func checksBackfillScanServer(t *testing.T, missing []apitypes.MissingCheckPR, stuck []apitypes.StuckCheckPR) *httptest.Server {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/checks/scan", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(apitypes.ChecksScanResponse{
+			Repo:       "octo/repo",
+			CheckNames: []string{"SchemaBot (production)"},
+			Scanned:    5,
+			Missing:    missing,
+			Stuck:      stuck,
+		}))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// A dry-run scan that surfaces PRs needing attention — missing Check Runs
+// and stuck Check Runs — exits nonzero with a one-line error stating the
+// counts, after the full report has already been printed, so a scheduled
+// sweep can alert on $? without parsing the output.
+func TestChecksBackfillDryRunFindingsExitNonzero(t *testing.T) {
+	server := checksBackfillScanServer(t,
+		[]apitypes.MissingCheckPR{
+			{Number: 7, URL: "https://github.com/octo/repo/pull/7", Title: "missing", HeadSHA: "sha7", MissingNames: []string{"SchemaBot (production)"}},
+		},
+		[]apitypes.StuckCheckPR{
+			{
+				Number: 9, URL: "https://github.com/octo/repo/pull/9", Title: "stuck", HeadSHA: "sha9",
+				Checks: []apitypes.IncompleteCheckRun{{Name: "SchemaBot (production)", CheckRunID: 90, Status: "queued"}},
+			},
+		})
+
+	cmd := &ChecksBackfillCmd{Repo: "octo/repo", DryRun: true, StuckAfter: "1h", JSON: true}
+	var runErr error
+	output := captureStdout(func() {
+		runErr = cmd.Run(t.Context(), &Globals{Endpoint: server.URL})
+	})
+
+	require.Error(t, runErr)
+	assert.EqualError(t, runErr, "checks backfill left 1 PR with missing Check Runs and 1 stuck Check Run needing attention")
+
+	var report checksBackfillReport
+	require.NoError(t, json.Unmarshal([]byte(output), &report), "the full report is still printed before the exit-code error")
+	require.Len(t, report.Actions, 1)
+	assert.Equal(t, 7, report.Actions[0].PR)
+	require.Len(t, report.Stuck, 1)
+	assert.Equal(t, 9, report.Stuck[0].PR)
+}
+
+// A clean scan — nothing missing, nothing stuck — exits zero, so a scheduled
+// sweep alerts only when an operator has something to do.
+func TestChecksBackfillCleanScanExitsZero(t *testing.T) {
+	server := checksBackfillScanServer(t, nil, nil)
+
+	cmd := &ChecksBackfillCmd{Repo: "octo/repo", DryRun: true, StuckAfter: "1h", JSON: true}
+	var runErr error
+	output := captureStdout(func() {
+		runErr = cmd.Run(t.Context(), &Globals{Endpoint: server.URL})
+	})
+
+	require.NoError(t, runErr)
+	var report checksBackfillReport
+	require.NoError(t, json.Unmarshal([]byte(output), &report))
+	assert.Empty(t, report.Actions)
+	assert.Empty(t, report.Stuck)
+}
+
+// The exit code means "nothing needs an operator after this run". In a
+// dry-run every finding remains. After an act phase, a successfully
+// recreated check is resolved and does not fail the run, while held PRs,
+// failed recreations, and stuck Check Runs — which the backfill never acts
+// on — still do.
+func TestChecksBackfillAttentionExitError(t *testing.T) {
+	assert.NoError(t, attentionExitError(&checksBackfillReport{DryRun: true}))
+
+	err := attentionExitError(&checksBackfillReport{
+		DryRun:  true,
+		Actions: []checksBackfillAction{{PR: 1}, {PR: 2, Held: true}},
+	})
+	assert.EqualError(t, err, "checks backfill left 2 PRs with missing Check Runs (1 held) needing attention")
+
+	err = attentionExitError(&checksBackfillReport{
+		DryRun: true,
+		Stuck:  []checksStuckCheck{{PR: 3}, {PR: 4}},
+	})
+	assert.EqualError(t, err, "checks backfill left 2 stuck Check Runs needing attention")
+
+	assert.NoError(t, attentionExitError(&checksBackfillReport{
+		Actions: []checksBackfillAction{{PR: 1, Outcome: "created 1 Check Run"}},
+	}), "a recreated check is resolved, not left needing attention")
+
+	err = attentionExitError(&checksBackfillReport{
+		Actions: []checksBackfillAction{
+			{PR: 1, Outcome: "created 1 Check Run"},
+			{PR: 2, Held: true},
+			{PR: 3, Error: "boom"},
+		},
+		Stuck: []checksStuckCheck{{PR: 4}},
+	})
+	assert.EqualError(t, err, "checks backfill left 1 held PR and 1 failed Check Run recreation and 1 stuck Check Run needing attention")
+}
+
 // The pacing decision: pause only when the budget snapshot is below the floor
 // and a future reset exists to wait for. Missing snapshots, disabled pacing,
 // healthy budgets, and already-past resets all proceed without waiting.


### PR DESCRIPTION
## Why this matters

`schemabot checks backfill` is built for periodic sweeps, but a scheduled run can only signal "something needs attention" through its output. Cron jobs, CI steps, and monitoring wrappers alert on exit codes; they should not have to parse the report to know whether an operator has work to do.

## What it does

Makes the exit code mean **"nothing needs an operator after this run"** — no flag:

- A `--dry-run` acts on nothing, so any finding (missing, held, or stuck Check Runs) exits nonzero with a one-line count summary, e.g. `checks backfill left 2 PRs with missing Check Runs (1 held) and 1 stuck Check Run needing attention`.
- Outside `--dry-run`, successfully recreated checks are resolved and do not fail the run; held PRs, failed recreations, and stuck Check Runs still do, because the backfill never acts on those.
- The full report is always printed before the exit-code error, so the alert and the details travel together.

## Example

A dry-run that finds one PR with a missing Check Run and one stuck Check Run:

```console
$ schemabot checks backfill --all-repos --dry-run
Scanned 42 open PRs in acme/orders-service, acme/users-service for SchemaBot (production).

Stuck Check Runs — uncompleted for over 1h0m0s (backfill does not act on existing Check Runs; investigate the apply or plan that owns each):
PR                                            CHECK                   STATUS       AGE
https://github.com/acme/users-service/pull/87  SchemaBot (production)  in_progress  26h14m0s
PR                                              MISSING CHECKS          ACTION
https://github.com/acme/orders-service/pull/128  SchemaBot (production)  synthesize via auto-plan
Error: checks backfill left 1 PR with missing Check Runs and 1 stuck Check Run needing attention

$ echo $?
1
```

A run that leaves nothing behind exits zero:

```console
$ schemabot checks backfill --all-repos --dry-run
Scanned 42 open PRs in acme/orders-service, acme/users-service for SchemaBot (production).
No missing SchemaBot Check Runs found.

$ echo $?
0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
