### PR TITLE
fix(serve): raise storage pool MaxIdleConns to curb connection churn

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -320,6 +320,37 @@ process has no target DSN and cannot clean that target. Cleanup runs only if the
 remote deployment is also a SchemaBot server with the target configured as
 local-mode MySQL and `cleanup_enabled: true`.
 
+## Storage Connection Pool
+
+SchemaBot tunes the `database/sql` pool for its internal storage database with
+defaults that suit a typical single-pod deployment. Override any of them under
+`storage.pool` when a deployment needs different sizing or timeouts. Every field
+is optional; omit `storage.pool` entirely to keep the defaults.
+
+```yaml
+storage:
+  dsn: "env:SCHEMABOT_DSN"
+  pool:
+    max_idle_conns: 10        # default: 10
+    max_open_conns: 0         # default: 0 (unbounded)
+    conn_max_lifetime: "5m"   # default: 5m
+    conn_max_idle_time: "3m"  # default: 3m
+    connect_timeout: "5s"     # default: unset (driver default)
+```
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `max_idle_conns` | `10` | Idle connections kept warm in the pool. Sized to cover the per-pod background concurrency (durable webhook drivers, operator drivers, and monitors) so idle connections are not closed and reopened every poll tick. |
+| `max_open_conns` | `0` (unbounded) | Maximum total open connections (the max pool size). Set a positive value to cap concurrent connections against the storage database. |
+| `conn_max_lifetime` | `5m` | Maximum age of a pooled connection before it is retired, keeping connections well under MySQL's `wait_timeout`. |
+| `conn_max_idle_time` | `3m` | Maximum time a connection may sit idle before it is retired. |
+| `connect_timeout` | unset | Bounds a single connection attempt (TCP dial plus handshake) via the driver's `timeout` DSN parameter. Does not bound query execution. |
+
+Durations are Go duration strings (for example `30s`, `5m`). When set, each
+duration must be positive, and `max_idle_conns` must not exceed a positive
+`max_open_conns`; SchemaBot rejects violations at config load rather than
+silently reverting to a default.
+
 ## Storage Schema Changes
 
 SchemaBot's internal storage schema is self-bootstrapping: on every startup,

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -383,6 +383,148 @@ type StorageConfig struct {
 	// columns, after every running pod is on a binary whose embedded schema no
 	// longer declares them.
 	AllowDestructiveSchemaChanges bool `yaml:"allow_destructive_schema_changes,omitempty"`
+
+	// Pool tunes SchemaBot's internal storage connection pool. Every field is
+	// optional; each falls back to a built-in default that preserves the prior
+	// hardcoded behavior when left unset.
+	Pool StoragePoolConfig `yaml:"pool,omitempty"`
+}
+
+// Storage connection-pool defaults. These reproduce the values that were
+// previously hardcoded in the server build path, so an unset pool config
+// behaves exactly as before.
+const (
+	// DefaultStorageMaxIdleConns sizes the idle pool to cover the per-pod
+	// background concurrency so idle connections stay pooled instead of being
+	// closed and reopened every poll tick. Go's driver default of 2 is smaller
+	// than that concurrency, so idle connections returned by the durable
+	// webhook drivers (4 × 1 s poll), operator drivers (4 × 10 s poll), and
+	// background monitors were closed and reopened on nearly every tick,
+	// producing constant CONNECT/DISCONNECT churn (visible as paired entries in
+	// the MySQL audit log). 10 keeps those connections warm.
+	DefaultStorageMaxIdleConns = 10
+
+	// DefaultStorageConnMaxLifetime proactively retires connections before
+	// MySQL's wait_timeout (default 28800s) to avoid "invalid connection"
+	// errors when the pool hands out a stale connection.
+	DefaultStorageConnMaxLifetime = 5 * time.Minute
+
+	// DefaultStorageConnMaxIdleTime discards connections that have sat idle
+	// this long, complementing the lifetime cap for connections that are
+	// rarely reused.
+	DefaultStorageConnMaxIdleTime = 3 * time.Minute
+)
+
+// StoragePoolConfig tunes the database/sql connection pool and driver dial
+// timeout for SchemaBot's internal storage database. Durations are Go duration
+// strings (e.g. "5m", "30s"). Zero/empty fields fall back to defaults; an
+// unset MaxOpenConns leaves the pool unbounded (the database/sql default) and
+// an unset ConnectTimeout leaves the driver's own dial behavior unchanged.
+type StoragePoolConfig struct {
+	// MaxIdleConns caps the number of idle connections kept in the pool.
+	// Unset (0) uses DefaultStorageMaxIdleConns.
+	MaxIdleConns int `yaml:"max_idle_conns,omitempty"`
+
+	// MaxOpenConns caps the total number of open connections (the max pool
+	// size). Unset (0) leaves the pool unbounded, matching database/sql's
+	// default.
+	MaxOpenConns int `yaml:"max_open_conns,omitempty"`
+
+	// ConnMaxLifetime is the maximum age of a pooled connection before it is
+	// retired. Unset uses DefaultStorageConnMaxLifetime.
+	ConnMaxLifetime string `yaml:"conn_max_lifetime,omitempty"`
+
+	// ConnMaxIdleTime is the maximum time a connection may sit idle before it
+	// is retired. Unset uses DefaultStorageConnMaxIdleTime.
+	ConnMaxIdleTime string `yaml:"conn_max_idle_time,omitempty"`
+
+	// ConnectTimeout bounds how long a single connection attempt (the TCP dial
+	// plus handshake) may take. It maps to the go-sql-driver `timeout` DSN
+	// parameter and does not bound query execution. Unset leaves the driver
+	// default (no explicit dial timeout).
+	ConnectTimeout string `yaml:"connect_timeout,omitempty"`
+}
+
+// MaxIdleConnsOrDefault returns the configured idle-pool cap or the default
+// when unset.
+func (p StoragePoolConfig) MaxIdleConnsOrDefault() int {
+	if p.MaxIdleConns > 0 {
+		return p.MaxIdleConns
+	}
+	return DefaultStorageMaxIdleConns
+}
+
+// ConnMaxLifetimeOrDefault returns the configured connection lifetime or the
+// default when unset. It assumes the value has already passed validation.
+func (p StoragePoolConfig) ConnMaxLifetimeOrDefault() time.Duration {
+	return parseDurationOrDefault(p.ConnMaxLifetime, DefaultStorageConnMaxLifetime)
+}
+
+// ConnMaxIdleTimeOrDefault returns the configured idle timeout or the default
+// when unset. It assumes the value has already passed validation.
+func (p StoragePoolConfig) ConnMaxIdleTimeOrDefault() time.Duration {
+	return parseDurationOrDefault(p.ConnMaxIdleTime, DefaultStorageConnMaxIdleTime)
+}
+
+// ConnectTimeoutOrZero returns the configured dial timeout, or zero when unset,
+// meaning "leave the driver default". It assumes the value has already passed
+// validation.
+func (p StoragePoolConfig) ConnectTimeoutOrZero() time.Duration {
+	return parseDurationOrDefault(p.ConnectTimeout, 0)
+}
+
+// parseDurationOrDefault parses a Go duration string, returning def when the
+// string is empty or unparseable. Callers validate values at config load, so a
+// parse failure here only happens on an already-rejected config.
+func parseDurationOrDefault(s string, def time.Duration) time.Duration {
+	if s == "" {
+		return def
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return def
+	}
+	return d
+}
+
+// Validate rejects out-of-range or malformed pool settings at config load so a
+// typo fails fast instead of silently reverting to a default at runtime.
+func (p StoragePoolConfig) Validate(context string) error {
+	if p.MaxIdleConns < 0 {
+		return fmt.Errorf("%s pool.max_idle_conns %d must not be negative", context, p.MaxIdleConns)
+	}
+	if p.MaxOpenConns < 0 {
+		return fmt.Errorf("%s pool.max_open_conns %d must not be negative", context, p.MaxOpenConns)
+	}
+	if p.MaxOpenConns > 0 && p.MaxIdleConns > 0 && p.MaxIdleConns > p.MaxOpenConns {
+		return fmt.Errorf("%s pool.max_idle_conns %d must not exceed pool.max_open_conns %d", context, p.MaxIdleConns, p.MaxOpenConns)
+	}
+	if err := validatePositiveDuration(context, "pool.conn_max_lifetime", p.ConnMaxLifetime); err != nil {
+		return err
+	}
+	if err := validatePositiveDuration(context, "pool.conn_max_idle_time", p.ConnMaxIdleTime); err != nil {
+		return err
+	}
+	if err := validatePositiveDuration(context, "pool.connect_timeout", p.ConnectTimeout); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validatePositiveDuration accepts an empty value (meaning "use the default")
+// and otherwise requires a parseable, strictly positive Go duration.
+func validatePositiveDuration(context, field, value string) error {
+	if value == "" {
+		return nil
+	}
+	d, err := time.ParseDuration(value)
+	if err != nil {
+		return fmt.Errorf("%s %s %q is not a valid duration: %w", context, field, value, err)
+	}
+	if d <= 0 {
+		return fmt.Errorf("%s %s %q must be positive (omit it to use the default)", context, field, value)
+	}
+	return nil
 }
 
 // DSNFromConfig configures a MySQL DSN assembled from separate secret values.
@@ -1992,9 +2134,11 @@ func (c StorageConfig) validateLocalDSNConfig(context string) error {
 		return fmt.Errorf("%s cannot configure both dsn and dsn_from", context)
 	}
 	if c.DSNFrom != nil {
-		return c.DSNFrom.Validate(context)
+		if err := c.DSNFrom.Validate(context); err != nil {
+			return err
+		}
 	}
-	return nil
+	return c.Pool.Validate(context)
 }
 
 // HasLocalDSN returns true when the environment should use a local database connection.

--- a/pkg/api/storage_pool_test.go
+++ b/pkg/api/storage_pool_test.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStoragePoolConfig_Defaults verifies that an unset pool config resolves to
+// the values that were previously hardcoded in the server build path, so
+// omitting storage.pool preserves the prior behavior exactly.
+func TestStoragePoolConfig_Defaults(t *testing.T) {
+	var p StoragePoolConfig
+
+	assert.Equal(t, DefaultStorageMaxIdleConns, p.MaxIdleConnsOrDefault())
+	assert.Equal(t, DefaultStorageConnMaxLifetime, p.ConnMaxLifetimeOrDefault())
+	assert.Equal(t, DefaultStorageConnMaxIdleTime, p.ConnMaxIdleTimeOrDefault())
+	// An unset connect timeout means "leave the driver default".
+	assert.Equal(t, time.Duration(0), p.ConnectTimeoutOrZero())
+	// MaxOpenConns is applied by the caller only when > 0; unset stays 0.
+	assert.Equal(t, 0, p.MaxOpenConns)
+}
+
+// TestStoragePoolConfig_Overrides verifies that configured values win over the
+// defaults.
+func TestStoragePoolConfig_Overrides(t *testing.T) {
+	p := StoragePoolConfig{
+		MaxIdleConns:    25,
+		MaxOpenConns:    50,
+		ConnMaxLifetime: "10m",
+		ConnMaxIdleTime: "90s",
+		ConnectTimeout:  "3s",
+	}
+
+	assert.Equal(t, 25, p.MaxIdleConnsOrDefault())
+	assert.Equal(t, 10*time.Minute, p.ConnMaxLifetimeOrDefault())
+	assert.Equal(t, 90*time.Second, p.ConnMaxIdleTimeOrDefault())
+	assert.Equal(t, 3*time.Second, p.ConnectTimeoutOrZero())
+}
+
+// TestStoragePoolConfig_Validate exercises the config-load guardrails.
+func TestStoragePoolConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name       string
+		pool       StoragePoolConfig
+		wantErrSub string
+	}{
+		{
+			name: "empty is valid",
+			pool: StoragePoolConfig{},
+		},
+		{
+			name: "fully specified is valid",
+			pool: StoragePoolConfig{
+				MaxIdleConns:    10,
+				MaxOpenConns:    20,
+				ConnMaxLifetime: "5m",
+				ConnMaxIdleTime: "3m",
+				ConnectTimeout:  "5s",
+			},
+		},
+		{
+			name:       "negative max_idle_conns rejected",
+			pool:       StoragePoolConfig{MaxIdleConns: -1},
+			wantErrSub: "max_idle_conns",
+		},
+		{
+			name:       "negative max_open_conns rejected",
+			pool:       StoragePoolConfig{MaxOpenConns: -1},
+			wantErrSub: "max_open_conns",
+		},
+		{
+			name:       "idle exceeding open rejected",
+			pool:       StoragePoolConfig{MaxIdleConns: 30, MaxOpenConns: 10},
+			wantErrSub: "must not exceed",
+		},
+		{
+			name:       "unparseable lifetime rejected",
+			pool:       StoragePoolConfig{ConnMaxLifetime: "nope"},
+			wantErrSub: "conn_max_lifetime",
+		},
+		{
+			name:       "non-positive idle time rejected",
+			pool:       StoragePoolConfig{ConnMaxIdleTime: "0s"},
+			wantErrSub: "must be positive",
+		},
+		{
+			name:       "unparseable connect timeout rejected",
+			pool:       StoragePoolConfig{ConnectTimeout: "5"},
+			wantErrSub: "connect_timeout",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.pool.Validate("storage")
+			if tt.wantErrSub == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErrSub)
+		})
+	}
+}
+
+// TestStorageConfig_ValidatePropagatesPoolErrors ensures a bad pool config is
+// surfaced through the storage config's validation entry point (so it fails at
+// config load rather than silently at runtime).
+func TestStorageConfig_ValidatePropagatesPoolErrors(t *testing.T) {
+	c := StorageConfig{
+		DSN:  "root:secret@tcp(localhost:3306)/app",
+		Pool: StoragePoolConfig{ConnMaxLifetime: "bogus"},
+	}
+	err := c.validateLocalDSNConfig("storage")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conn_max_lifetime")
+}

--- a/pkg/mysqlconn/mysqlconn.go
+++ b/pkg/mysqlconn/mysqlconn.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/block/spirit/pkg/dbconn"
 	dsndriver "github.com/go-mysql/hotswap-dsn-driver"
@@ -13,14 +14,33 @@ import (
 
 var openSQL = sql.Open
 
+// Option customizes the parsed MySQL config before the DSN is reassembled.
+// Options are applied in ConnectionDSN, so they flow through Open,
+// OpenReloadable, and the credential-reload path alike.
+type Option func(*mysql.Config)
+
+// WithConnectTimeout bounds a single connection attempt (TCP dial plus
+// handshake) by setting the driver's `timeout` DSN parameter. A non-positive
+// duration is ignored, leaving the driver default in place. It does not bound
+// query execution — use context deadlines for that.
+func WithConnectTimeout(d time.Duration) Option {
+	return func(cfg *mysql.Config) {
+		if d > 0 {
+			cfg.Timeout = d
+		}
+	}
+}
+
 // hotswapDriverName is Daniel Nichter's (https://github.com/daniel-nichter)
 // hot-swap DSN driver, a drop-in replacement for github.com/go-sql-driver/mysql
 // that re-reads credentials on an access-denied error. See OpenReloadable.
 const hotswapDriverName = "mysql-hotswap-dsn"
 
-// Open returns a MySQL connection using the same target-DSN normalization as Spirit.
-func Open(dsn string) (*sql.DB, error) {
-	connectionDSN, err := ConnectionDSN(dsn)
+// Open returns a MySQL connection using the same target-DSN normalization as
+// Spirit. Options customize the DSN (for example WithConnectTimeout) before the
+// pool is opened.
+func Open(dsn string, opts ...Option) (*sql.DB, error) {
+	connectionDSN, err := ConnectionDSN(dsn, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -54,13 +74,13 @@ func Open(dsn string) (*sql.DB, error) {
 // driver, so reserve it for the single long-lived storage pool. Target-database
 // connections use Open, whose credentials come from the apply request rather
 // than the storage secret.
-func OpenReloadable(dsn string, reload func() (string, error)) (*sql.DB, error) {
-	connectionDSN, err := ConnectionDSN(dsn)
+func OpenReloadable(dsn string, reload func() (string, error), opts ...Option) (*sql.DB, error) {
+	connectionDSN, err := ConnectionDSN(dsn, opts...)
 	if err != nil {
 		return nil, err
 	}
 	dsndriver.SetHotswapFunc(func(_ context.Context, _ string) string {
-		return reloadConnectionDSN(reload)
+		return reloadConnectionDSN(reload, opts...)
 	})
 	db, err := openSQL(hotswapDriverName, connectionDSN)
 	if err != nil {
@@ -73,13 +93,13 @@ func OpenReloadable(dsn string, reload func() (string, error)) (*sql.DB, error) 
 // the hot-swap driver. It returns "" — meaning "keep the current DSN" — when the
 // reload or transport step fails, so a transient error cannot wedge the pool
 // with an empty DSN.
-func reloadConnectionDSN(reload func() (string, error)) string {
+func reloadConnectionDSN(reload func() (string, error), opts ...Option) string {
 	rawDSN, err := reload()
 	if err != nil {
 		slog.Error("reload storage DSN after access-denied failed; keeping current credentials", "error", err)
 		return ""
 	}
-	reloadedDSN, err := ConnectionDSN(rawDSN)
+	reloadedDSN, err := ConnectionDSN(rawDSN, opts...)
 	if err != nil {
 		slog.Error("apply transport settings to reloaded storage DSN failed; keeping current credentials", "error", err)
 		return ""
@@ -88,18 +108,23 @@ func reloadConnectionDSN(reload func() (string, error)) string {
 	return reloadedDSN
 }
 
-// ConnectionDSN returns a MySQL DSN with required transport settings applied.
-func ConnectionDSN(dsn string) (string, error) {
+// ConnectionDSN returns a MySQL DSN with required transport settings applied,
+// plus any caller-supplied options (for example WithConnectTimeout). Options
+// are applied on every return path so they take effect regardless of whether
+// the DSN also needs RDS TLS enhancement.
+func ConnectionDSN(dsn string, opts ...Option) (string, error) {
 	cfg, err := mysql.ParseDSN(dsn)
 	if err != nil {
 		return "", fmt.Errorf("parse DSN: %w", err)
 	}
+	// An explicit TLS config or a non-RDS host needs no TLS enhancement; apply
+	// options directly to the parsed config and reassemble.
 	if cfg.TLSConfig != "" {
-		return dsn, nil
+		return applyOptions(dsn, cfg, opts...), nil
 	}
 	tlsMode, ok := tlsModeForHost(cfg.Addr)
 	if !ok {
-		return dsn, nil
+		return applyOptions(dsn, cfg, opts...), nil
 	}
 	dbConfig := dbconn.NewDBConfig()
 	dbConfig.TLSMode = tlsMode
@@ -107,7 +132,29 @@ func ConnectionDSN(dsn string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("enhance RDS DSN with TLS: %w", err)
 	}
-	return connectionDSN, nil
+	if len(opts) == 0 {
+		return connectionDSN, nil
+	}
+	// Re-parse the enhanced DSN so options layer on top of the injected TLS
+	// settings rather than discarding them.
+	enhanced, err := mysql.ParseDSN(connectionDSN)
+	if err != nil {
+		return "", fmt.Errorf("parse enhanced DSN: %w", err)
+	}
+	return applyOptions(connectionDSN, enhanced, opts...), nil
+}
+
+// applyOptions runs each option against cfg and returns the reassembled DSN.
+// When no options are supplied it returns raw unchanged, preserving the
+// original DSN string exactly (FormatDSN may otherwise reorder parameters).
+func applyOptions(raw string, cfg *mysql.Config, opts ...Option) string {
+	if len(opts) == 0 {
+		return raw
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	return cfg.FormatDSN()
 }
 
 func tlsModeForHost(addr string) (string, bool) {

--- a/pkg/mysqlconn/mysqlconn_test.go
+++ b/pkg/mysqlconn/mysqlconn_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
@@ -73,6 +74,48 @@ func TestConnectionDSN(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestConnectionDSN_WithConnectTimeout(t *testing.T) {
+	t.Run("sets timeout on a plain DSN", func(t *testing.T) {
+		got, err := ConnectionDSN(
+			"root:secret@tcp(localhost:3306)/app?parseTime=true",
+			WithConnectTimeout(4*time.Second),
+		)
+		require.NoError(t, err)
+
+		cfg, err := mysql.ParseDSN(got)
+		require.NoError(t, err)
+		assert.Equal(t, 4*time.Second, cfg.Timeout)
+		// Existing params survive.
+		assert.True(t, cfg.ParseTime)
+	})
+
+	t.Run("layers timeout on top of injected RDS TLS", func(t *testing.T) {
+		got, err := ConnectionDSN(
+			"spirit:secret@tcp(database.cluster-abc123.us-west-2.rds.amazonaws.com:3306)/app?parseTime=true",
+			WithConnectTimeout(7*time.Second),
+		)
+		require.NoError(t, err)
+
+		cfg, err := mysql.ParseDSN(got)
+		require.NoError(t, err)
+		assert.Equal(t, 7*time.Second, cfg.Timeout)
+		// RDS TLS enhancement is preserved alongside the timeout.
+		assert.Equal(t, "rds", cfg.TLSConfig)
+	})
+
+	t.Run("non-positive timeout leaves the driver default", func(t *testing.T) {
+		got, err := ConnectionDSN(
+			"root:secret@tcp(localhost:3306)/app?parseTime=true",
+			WithConnectTimeout(0),
+		)
+		require.NoError(t, err)
+
+		cfg, err := mysql.ParseDSN(got)
+		require.NoError(t, err)
+		assert.Equal(t, time.Duration(0), cfg.Timeout)
+	})
 }
 
 func TestOpenNormalizesRDSDSNBeforeOpening(t *testing.T) {

--- a/pkg/serve/serve.go
+++ b/pkg/serve/serve.go
@@ -305,18 +305,17 @@ func Build(ctx context.Context, cfg *api.ServerConfig, opts ...Option) (*Server,
 		}
 	}()
 
-	// Proactively discard idle connections before MySQL's wait_timeout (default 28800s)
-	// to avoid "invalid connection" errors when the pool hands out stale connections.
-	db.SetConnMaxLifetime(5 * time.Minute)
-	db.SetConnMaxIdleTime(3 * time.Minute)
-
-	// Size the idle pool to cover the per-pod background concurrency so idle
-	// connections stay pooled instead of being closed and reopened every tick.
-	// Without this, Go's default MaxIdleConns=2 causes constant TCP churn
-	// (CONNECT/DISCONNECT pairs in the MySQL audit log) because the durable
-	// webhook drivers (4 × 1 s poll), operator drivers (4 × 10 s poll), and
-	// background monitors all return connections that exceed the idle limit.
-	db.SetMaxIdleConns(10)
+	// Apply the storage connection-pool settings. Each knob is configurable via
+	// storage.pool; the *OrDefault helpers supply the defaults (and their
+	// rationale) from the api package. MaxOpenConns is left unset when zero so
+	// the pool stays unbounded, matching database/sql's default.
+	pool := cfg.Storage.Pool
+	db.SetConnMaxLifetime(pool.ConnMaxLifetimeOrDefault())
+	db.SetConnMaxIdleTime(pool.ConnMaxIdleTimeOrDefault())
+	db.SetMaxIdleConns(pool.MaxIdleConnsOrDefault())
+	if pool.MaxOpenConns > 0 {
+		db.SetMaxOpenConns(pool.MaxOpenConns)
+	}
 
 	// Log config summary for debugging
 	logger.Info("config loaded",
@@ -462,7 +461,8 @@ func connectStorage(ctx context.Context, cfg *api.ServerConfig, logger *slog.Log
 	if err := api.EnsureSchema(dsn, logger, api.WithAllowDestructiveSchemaChanges(cfg.Storage.AllowDestructiveSchemaChanges)); err != nil {
 		return nil, fmt.Errorf("ensure storage schema: %w", err)
 	}
-	db, err := mysqlconn.OpenReloadable(dsn, cfg.StorageDSN)
+	db, err := mysqlconn.OpenReloadable(dsn, cfg.StorageDSN,
+		mysqlconn.WithConnectTimeout(cfg.Storage.Pool.ConnectTimeoutOrZero()))
 	if err != nil {
 		return nil, fmt.Errorf("open storage database: %w", err)
 	}

--- a/pkg/serve/serve.go
+++ b/pkg/serve/serve.go
@@ -310,6 +310,14 @@ func Build(ctx context.Context, cfg *api.ServerConfig, opts ...Option) (*Server,
 	db.SetConnMaxLifetime(5 * time.Minute)
 	db.SetConnMaxIdleTime(3 * time.Minute)
 
+	// Size the idle pool to cover the per-pod background concurrency so idle
+	// connections stay pooled instead of being closed and reopened every tick.
+	// Without this, Go's default MaxIdleConns=2 causes constant TCP churn
+	// (CONNECT/DISCONNECT pairs in the MySQL audit log) because the durable
+	// webhook drivers (4 × 1 s poll), operator drivers (4 × 10 s poll), and
+	// background monitors all return connections that exceed the idle limit.
+	db.SetMaxIdleConns(10)
+
 	// Log config summary for debugging
 	logger.Info("config loaded",
 		"databases", len(cfg.Databases),


### PR DESCRIPTION
Go's default MaxIdleConns of 2 was smaller than the per-pod background concurrency, so idle connections returned by the webhook drivers, operator drivers, and background monitors were closed and reopened on nearly every poll tick. Size the idle pool to 10 to keep those connections warm and eliminate the constant CONNECT/DISCONNECT churn visible in the MySQL audit log.