### PR TITLE
fix(planetscale): treat missing branch VSchema as empty in keyspace diff

### DIFF
--- a/pkg/engine/planetscale/branch.go
+++ b/pkg/engine/planetscale/branch.go
@@ -258,7 +258,17 @@ func (e *Engine) diffKeyspace(ctx context.Context, client psclient.PSClient, org
 			Keyspace:     ks,
 		})
 		if fetchErr != nil {
-			return nil, false, "", fmt.Errorf("fetch VSchema for keyspace %s: %w", ks, fetchErr)
+			var psErr *ps.Error
+			if !errors.As(fetchErr, &psErr) || psErr.Code != ps.ErrNotFound {
+				return nil, false, "", fmt.Errorf("fetch VSchema for keyspace %s: %w", ks, fetchErr)
+			}
+			// Keyspace has no VSchema on this branch yet — either it has
+			// never had one, or the API has not converged after a recent
+			// write. Treat as empty so the desired VSchema appears as a
+			// change; validation callers absorb convergence lag through
+			// the VSchema staleness retry.
+			e.logger.Info("VSchema not found for keyspace, treating as empty",
+				"keyspace", ks, "branch", branch)
 		}
 		if currentVSchema != nil {
 			currentVSchemaRaw = currentVSchema.Raw

--- a/pkg/engine/planetscale/branch.go
+++ b/pkg/engine/planetscale/branch.go
@@ -267,7 +267,7 @@ func (e *Engine) diffKeyspace(ctx context.Context, client psclient.PSClient, org
 			// write. Treat as empty so the desired VSchema appears as a
 			// change; validation callers absorb convergence lag through
 			// the VSchema staleness retry.
-			e.logger.Info("VSchema not found for keyspace, treating as empty",
+			e.logger.Warn("VSchema not found for keyspace, treating as empty",
 				"keyspace", ks, "branch", branch)
 		}
 		if currentVSchema != nil {

--- a/pkg/engine/planetscale/branch_test.go
+++ b/pkg/engine/planetscale/branch_test.go
@@ -2,6 +2,7 @@ package planetscale
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"testing"
@@ -90,6 +91,68 @@ func TestDiffKeyspace_DetectsSchemaChanges(t *testing.T) {
 		require.Len(t, changes, 1, "should detect CREATE TABLE")
 		assert.Equal(t, "users", changes[0].Table)
 		assert.Equal(t, statement.StatementCreateTable, changes[0].Operation)
+	})
+}
+
+// vschemaFetchStubClient serves a fixed response for keyspace VSchema reads so
+// tests can drive the VSchema half of diffKeyspace without a live API.
+type vschemaFetchStubClient struct {
+	psclient.PSClient
+	vschema *ps.VSchema
+	err     error
+}
+
+func (c *vschemaFetchStubClient) GetKeyspaceVSchema(_ context.Context, _ *ps.GetKeyspaceVSchemaRequest) (*ps.VSchema, error) {
+	return c.vschema, c.err
+}
+
+// A NotFound on the keyspace VSchema read means the keyspace has no VSchema on
+// the branch yet — first-time VSchema creation, or the API lagging a recent
+// write. The diff must treat that as an empty current VSchema so the desired
+// VSchema surfaces as a change (plan reports it will be created; post-apply
+// validation reports a difference that the staleness retry re-polls) instead
+// of failing the operation. Any other fetch error must still fail the diff.
+func TestDiffKeyspace_VSchemaFetchErrors(t *testing.T) {
+	e := &Engine{
+		linter: lint.New(),
+		logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
+	}
+	desiredVSchema := `{"sharded": false, "tables": {"users_seq": {"type": "sequence"}}}`
+	desired := &schema.Namespace{
+		Files: map[string]string{
+			"vschema.json": desiredVSchema,
+		},
+	}
+	currentSchema := map[string][]table.TableSchema{"myapp": {}}
+
+	t.Run("NotFound treated as empty current VSchema", func(t *testing.T) {
+		client := &vschemaFetchStubClient{err: &ps.Error{Code: ps.ErrNotFound}}
+		changes, vschemaChanged, currentRaw, err := e.diffKeyspace(t.Context(), client, "org", "mydb", "schemabot-mydb-abc", "myapp", desired, currentSchema)
+		require.NoError(t, err)
+		assert.Empty(t, changes)
+		assert.True(t, vschemaChanged, "desired VSchema must surface as a change against a missing one")
+		assert.Empty(t, currentRaw)
+	})
+
+	t.Run("non-NotFound API error fails the diff", func(t *testing.T) {
+		client := &vschemaFetchStubClient{err: &ps.Error{Code: ps.ErrInternal}}
+		_, _, _, err := e.diffKeyspace(t.Context(), client, "org", "mydb", "schemabot-mydb-abc", "myapp", desired, currentSchema)
+		require.ErrorContains(t, err, "fetch VSchema for keyspace myapp")
+	})
+
+	t.Run("non-API error fails the diff", func(t *testing.T) {
+		client := &vschemaFetchStubClient{err: errors.New("dial tcp: connection refused")}
+		_, _, _, err := e.diffKeyspace(t.Context(), client, "org", "mydb", "schemabot-mydb-abc", "myapp", desired, currentSchema)
+		require.ErrorContains(t, err, "fetch VSchema for keyspace myapp")
+	})
+
+	t.Run("matching VSchema reports no change", func(t *testing.T) {
+		client := &vschemaFetchStubClient{vschema: &ps.VSchema{Raw: desiredVSchema}}
+		changes, vschemaChanged, currentRaw, err := e.diffKeyspace(t.Context(), client, "org", "mydb", "schemabot-mydb-abc", "myapp", desired, currentSchema)
+		require.NoError(t, err)
+		assert.Empty(t, changes)
+		assert.False(t, vschemaChanged)
+		assert.Equal(t, desiredVSchema, currentRaw)
 	})
 }
 


### PR DESCRIPTION
## Why this matters

Applying a keyspace's first-ever VSchema fails at post-apply validation. The engine writes the VSchema to the branch successfully, applies the DDL, then re-reads the VSchema to validate — and the PlanetScale API can return `Not Found` for a short window after the write (eventual consistency, most visible when the keyspace never had a VSchema before). `diffKeyspace` treated any fetch error as fatal, so the apply hard-failed even though everything had landed correctly. The same fatal 404 also blocked planning a first VSchema when the API had no record of one yet.

## What it does

- `diffKeyspace` now treats `ErrNotFound` from `GetKeyspaceVSchema` as an empty current VSchema, mirroring how the DDL schema fetch already handles a missing keyspace. The desired VSchema then surfaces as a change: plan reports it will be created, and post-apply validation reports a difference that the existing VSchema staleness retry re-polls (5s × 18) until the API converges. Never converging still fails closed with the mismatch error.
- All other fetch errors (auth, network, 5xx) still fail the diff immediately.
- Unit tests cover the NotFound-as-empty path, both non-NotFound error shapes staying fatal, and the matching-VSchema no-change baseline.

```
before: write VSchema ─ apply DDL ─ validate ─ GET vschema → 404 → apply FAILED
after:  write VSchema ─ apply DDL ─ validate ─ GET vschema → 404 → "difference"
                                        ▲                              │
                                        └────── retry (≤90s) ──────────┘
                                                → converges → validated ✓
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)