### PR TITLE
fix(cli): treat 202 Accepted control responses as success

### DIFF
--- a/pkg/cmd/client/request.go
+++ b/pkg/cmd/client/request.go
@@ -163,7 +163,7 @@ func doSendBody(endpoint, method, path string, body any) error {
 }
 
 // doPostInto sends a JSON POST to endpoint+path and unmarshals the JSON response into result.
-// Returns an *APIError for non-200 responses (use IsNotFound to check for 404).
+// Returns an *APIError for error responses (use IsNotFound to check for 404).
 func doPostInto(endpoint, path string, body any, result any) error {
 	return doPostIntoWithClient(context.Background(), httpClient, endpoint, path, body, result)
 }
@@ -202,7 +202,10 @@ func doPostIntoWithClient(ctx context.Context, client *http.Client, endpoint, pa
 		return fmt.Errorf("read response: %w", err)
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	// Control endpoints answer 202 Accepted when the request is durably
+	// recorded and the apply owner completes it asynchronously; the body
+	// carries the same JSON shape as a 200 and is equally a success.
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
 		return parseAPIError(resp.StatusCode, respBody)
 	}
 

--- a/pkg/cmd/client/request_test.go
+++ b/pkg/cmd/client/request_test.go
@@ -45,8 +45,9 @@ func sendThroughTransport(t *testing.T, rawURL string, presetAuth string) (*http
 	return httpClient.Do(req)
 }
 
-// controlStatusServer returns a test server that answers every POST with the
-// given status code and JSON body, for exercising the client's status handling.
+// controlStatusServer returns a test server that answers every request with
+// the given status code and JSON body, for exercising the client's status
+// handling.
 func controlStatusServer(t *testing.T, statusCode int, body string) *httptest.Server {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/cmd/client/request_test.go
+++ b/pkg/cmd/client/request_test.go
@@ -45,6 +45,62 @@ func sendThroughTransport(t *testing.T, rawURL string, presetAuth string) (*http
 	return httpClient.Do(req)
 }
 
+// controlStatusServer returns a test server that answers every POST with the
+// given status code and JSON body, for exercising the client's status handling.
+func controlStatusServer(t *testing.T, statusCode int, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// A 202 Accepted from a control endpoint means the request was durably
+// recorded and the apply owner completes it asynchronously — the operator's
+// command succeeded. The client must decode the response body as a success,
+// not surface the status code as an error.
+func TestDoPostIntoAcceptsAccepted(t *testing.T) {
+	srv := controlStatusServer(t, http.StatusAccepted, `{"accepted": true, "status": "already_requested"}`)
+
+	var result struct {
+		Accepted bool   `json:"accepted"`
+		Status   string `json:"status"`
+	}
+	err := doPostInto(srv.URL, "/api/skip-revert", map[string]string{"apply_id": "apply-abc"}, &result)
+
+	require.NoError(t, err)
+	assert.True(t, result.Accepted)
+	assert.Equal(t, "already_requested", result.Status)
+}
+
+func TestDoPostIntoAcceptsOK(t *testing.T) {
+	srv := controlStatusServer(t, http.StatusOK, `{"accepted": true}`)
+
+	var result struct {
+		Accepted bool `json:"accepted"`
+	}
+	err := doPostInto(srv.URL, "/api/skip-revert", map[string]string{"apply_id": "apply-abc"}, &result)
+
+	require.NoError(t, err)
+	assert.True(t, result.Accepted)
+}
+
+func TestDoPostIntoErrorStatusReturnsAPIError(t *testing.T) {
+	srv := controlStatusServer(t, http.StatusConflict, `{"error": "schema change is not in its revert window", "error_code": "conflict"}`)
+
+	var result struct{}
+	err := doPostInto(srv.URL, "/api/skip-revert", map[string]string{"apply_id": "apply-abc"}, &result)
+
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusConflict, apiErr.Status)
+	assert.Equal(t, "conflict", apiErr.ErrorCode)
+	assert.Contains(t, apiErr.Message, "not in its revert window")
+}
+
 func TestAuthTokenAttachedAsBearer(t *testing.T) {
 	var gotAuth string
 	srv := captureAuthServer(t, &gotAuth)


### PR DESCRIPTION
## Why this matters

Control endpoints answer **202 Accepted** when a request is durably recorded and completed asynchronously by the apply owner — for example a `skip-revert` whose immediate engine call failed but whose durable control request remains pending, or a repeated `revert` that is already queued. The CLI client treated any non-200 response as an error, so a command the server had accepted surfaced to the operator as a failure like `HTTP 202: {"accepted":true}` — exactly wrong at the moment an operator is closing a revert window and needs to trust the tool.

## What it does

- `doPostInto` now decodes 202 response bodies as successes (they carry the same JSON shape as a 200), so `revert`, `skip-revert`, `release`, and retry paths report what actually happened: accepted, completing asynchronously.
- Every other status still returns an `*APIError` as before.
- Tests cover 202-with-body decoding, the 200 baseline, and an error status still producing a typed `APIError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
