### PR TITLE
test(ddl): pin engine refusal predicate to Spirit's statement-scope checks

### DIFF
--- a/pkg/ddl/verdict.go
+++ b/pkg/ddl/verdict.go
@@ -37,12 +37,16 @@ const (
 // but that depends on live table state, not the statement text, so it cannot
 // be claimed here — it surfaces as an apply-time failure instead.
 //
-// Statements a preflight check would refuse but that can complete through the
-// engine's instant-DDL fast path are not reported here — the verdict must
-// never claim an apply will fail when it can succeed. The fast path is only
-// guaranteed for single-ALTER applies: when the engine batches several ALTERs
-// into one run it may skip the fast path and refuse such a statement anyway.
-// That is a tolerated false negative — the verdict errs toward silence.
+// The engine tags its statement-scope preflight checks with
+// check.ScopeStatement, but that set is broader than what this function may
+// claim: the engine attempts MySQL's native DDL (ALGORITHM=INSTANT, then a
+// safe-INPLACE subset) before running preflight checks, so a statement those
+// checks would refuse can still complete through that fast path — for example
+// dropping and re-adding a column of the same name, or renaming a column.
+// The verdict must never claim an apply will fail when it can succeed, so
+// only checks no fast path can bypass are mirrored here; the rest err toward
+// silence, a tolerated false negative that surfaces as an apply-time failure
+// at worst. Agreement with the engine's own checks is enforced by test.
 // Only ALTER TABLE statements can be refused; everything else returns false.
 func EngineRefusalReason(stmt string) (string, bool, error) {
 	stmts, err := statement.New(stmt)

--- a/pkg/ddl/verdict_test.go
+++ b/pkg/ddl/verdict_test.go
@@ -1,8 +1,11 @@
 package ddl
 
 import (
+	"log/slog"
 	"testing"
 
+	"github.com/block/spirit/pkg/migration/check"
+	"github.com/block/spirit/pkg/statement"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -93,6 +96,68 @@ func TestEngineRefusalReason(t *testing.T) {
 			} else {
 				assert.Empty(t, reason)
 			}
+		})
+	}
+}
+
+// runEngineStatementChecks runs the engine's own statement-scope preflight
+// checks against a single statement, returning the engine's refusal error
+// (nil when the checks accept the statement).
+func runEngineStatementChecks(t *testing.T, stmt string) error {
+	t.Helper()
+	stmts, err := statement.New(stmt)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+	resources := check.Resources{Statement: stmts[0]}
+	return check.RunChecks(t.Context(), resources, slog.New(slog.DiscardHandler), check.ScopeStatement)
+}
+
+// TestEngineRefusalReasonAgreesWithEngineChecks pins the refusal predicate to
+// the engine: every statement this package refuses must also be refused by
+// the engine's statement-scope preflight checks, with the same reason. If the
+// engine relaxes or rewords one of these checks, this test fails and the
+// predicate must be revisited — a refusal claimed here that the engine no
+// longer enforces would wrongly block an apply that can succeed.
+func TestEngineRefusalReasonAgreesWithEngineChecks(t *testing.T) {
+	refused := []string{
+		"ALTER TABLE `users` DROP PRIMARY KEY",
+		"ALTER TABLE `users` DROP PRIMARY KEY, ADD PRIMARY KEY (`id`, `tenant_id`)",
+		"ALTER TABLE `users` ADD COLUMN `email` VARCHAR(255), ALGORITHM=INPLACE",
+		"ALTER TABLE `users` ADD COLUMN `email` VARCHAR(255), LOCK=NONE",
+		"ALTER TABLE `orders` ADD CONSTRAINT `fk_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)",
+		"ALTER TABLE `orders` ADD FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)",
+	}
+	for _, stmt := range refused {
+		t.Run(stmt, func(t *testing.T) {
+			reason, isRefused, err := EngineRefusalReason(stmt)
+			require.NoError(t, err)
+			require.True(t, isRefused)
+			checkErr := runEngineStatementChecks(t, stmt)
+			require.Error(t, checkErr, "engine statement-scope checks accept a statement this package refuses")
+			assert.Equal(t, reason, checkErr.Error())
+		})
+	}
+}
+
+// TestEngineRefusalReasonToleratesFastPathStatements documents the deliberate
+// gap between this package's refusals and the engine's statement-scope
+// checks: these statements fail a statement-scope check, but the engine
+// attempts MySQL's native DDL fast path before preflight checks and the fast
+// path can complete them, so the verdict must stay silent rather than claim
+// an apply will fail.
+func TestEngineRefusalReasonToleratesFastPathStatements(t *testing.T) {
+	fastPath := []string{
+		"ALTER TABLE `users` DROP COLUMN `email`, ADD COLUMN `email` VARCHAR(255)",
+		"ALTER TABLE `users` RENAME COLUMN `email` TO `contact_email`, ADD COLUMN `email` VARCHAR(255)",
+	}
+	for _, stmt := range fastPath {
+		t.Run(stmt, func(t *testing.T) {
+			reason, isRefused, err := EngineRefusalReason(stmt)
+			require.NoError(t, err)
+			assert.False(t, isRefused)
+			assert.Empty(t, reason)
+			require.Error(t, runEngineStatementChecks(t, stmt),
+				"engine statement-scope checks accept this statement, so it no longer documents a tolerated gap — remove it from this corpus")
 		})
 	}
 }


### PR DESCRIPTION
## Why this matters

`ddl.EngineRefusalReason` mirrors the engine refusals Spirit enforces on a statement's text — the verdict behind the plan-time ⛔ blocked rendering and the apply-start gate. A mirror can drift: if Spirit relaxes or rewords one of these checks, SchemaBot would keep claiming "blocked" for a statement the engine happily runs, and the apply gate would wrongly reject an apply that can succeed. Until now nothing tied the mirror to the engine's actual behavior.

Spirit now tags its statement-pure preflight checks with `check.ScopeStatement`, runnable from a parsed statement alone. Replacing the mirror's internals with that set outright would overclaim, though: Spirit's runner attempts MySQL's native DDL fast path (`ALGORITHM=INSTANT`, then a safe-INPLACE subset) *before* preflight checks, so statements failing the drop-and-re-add or column-rename checks can still complete natively. The mirror deliberately covers only the checks no fast path can bypass — the verdict must never claim an apply will fail when it can succeed.

## What it does

- Uses `check.RunChecks(ScopeStatement)` as a test oracle: every statement `EngineRefusalReason` refuses must also be refused by Spirit's own statement-scope checks, with byte-identical reason text. Drift in either behavior or wording now fails the test.
- Documents the tolerated divergence with explicit test cases (drop-and-re-add of a column, rename overlapping an added column): the engine's statement-scope checks refuse them, the verdict stays silent because the fast path can complete them.
- States the fast-path certainty boundary in the `EngineRefusalReason` doc comment.

```
plan verdict claims "blocked"  ⊆  Spirit ScopeStatement refusals
        (fail-closed gate)          (broader: fast path may still succeed)
```

## How it moves us toward the northstar

Keeps the execution-mode verdict (and the apply-start gate built on it) trustworthy as Spirit evolves: the safety claim "this apply cannot succeed" is now continuously verified against the engine that enforces it, instead of resting on a hand-maintained mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)