### PR TITLE
test(namedlock): gate integration test on a real SQL handshake

### DIFF
--- a/pkg/namedlock/namedlock_integration_test.go
+++ b/pkg/namedlock/namedlock_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -26,17 +27,21 @@ var sharedDSN string
 func TestMain(m *testing.M) {
 	ctx := context.Background()
 
+	// The MySQL entrypoint runs a throwaway init server that also logs
+	// "ready for connections" and binds nothing on TCP, so log- and
+	// port-based waits can be satisfied before the final server accepts
+	// clients. Gate readiness on a real query through the mapped port
+	// instead — the same handshake the tests themselves perform.
 	req := testcontainers.ContainerRequest{
-		Image:        "mysql:8.0",
+		Image:        "mysql:8.4",
 		ExposedPorts: []string{"3306/tcp"},
 		Env: map[string]string{
 			"MYSQL_ROOT_PASSWORD": "testpassword",
 			"MYSQL_DATABASE":      "testdb",
 		},
-		WaitingFor: wait.ForAll(
-			wait.ForLog("ready for connections").WithOccurrence(2).WithStartupTimeout(30*time.Second),
-			wait.ForListeningPort("3306/tcp"),
-		),
+		WaitingFor: wait.ForSQL("3306/tcp", "mysql", func(host string, port nat.Port) string {
+			return fmt.Sprintf("root:testpassword@tcp(%s:%s)/testdb", host, port.Port())
+		}).WithStartupTimeout(30 * time.Second),
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{


### PR DESCRIPTION
## Why this matters

The `pkg/namedlock` integration tests were flaky in CI: both tests failed at 0.00s with `invalid connection` / `unexpected EOF` on the first ping because the MySQL container's wait strategy can be satisfied while the container is still initializing.

## What it does

The mysql image entrypoint runs a throwaway init server that also logs `ready for connections` twice (the X Plugin socket line and the `port: 0` line), so `ForLog(...).WithOccurrence(2)` matches before the final server exists. `ForListeningPort` doesn't close the gap: its external check passes through docker-proxy even when the container port is closed, and testcontainers downgrades to that external-only check when the in-container shell exec misbehaves under load. The first handshake then lands in the init-server teardown window.

This replaces the log/port wait with `wait.ForSQL`, which polls a real query through the mapped port with the Go MySQL driver — the same handshake the tests perform — and cannot succeed before the final server accepts clients. No timeouts were increased. Also moves the container to `mysql:8.4`.

Verified stable with `scripts/test-flaky.sh` (5/5 for both tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)