### PR TITLE
chore: move MySQL test and dev containers to mysql:8.4

### DIFF
--- a/deploy/e2e/docker-compose.yml
+++ b/deploy/e2e/docker-compose.yml
@@ -16,7 +16,7 @@ name: schemabot-e2e
 services:
   # SchemaBot's internal storage database
   mysql-schemabot:
-    image: mysql:8.0
+    image: mysql:8.4
     environment:
       MYSQL_ROOT_PASSWORD: testpassword
       MYSQL_DATABASE: schemabot
@@ -34,7 +34,7 @@ services:
 
   # Staging MySQL instance
   mysql-staging:
-    image: mysql:8.0
+    image: mysql:8.4
     environment:
       MYSQL_ROOT_PASSWORD: testpassword
       MYSQL_INITDB_SKIP_TZINFO: "1"
@@ -52,7 +52,7 @@ services:
 
   # Production MySQL instance
   mysql-production:
-    image: mysql:8.0
+    image: mysql:8.4
     environment:
       MYSQL_ROOT_PASSWORD: testpassword
       MYSQL_INITDB_SKIP_TZINFO: "1"

--- a/deploy/k8s/scripts/mysql-shell.sh
+++ b/deploy/k8s/scripts/mysql-shell.sh
@@ -83,7 +83,7 @@ OVERRIDES=$(jq -n \
         spec: {
             containers: [{
                 name: $name,
-                image: "mysql:8.0",
+                image: "mysql:8.4",
                 stdin: true,
                 tty: true,
                 command: ["sh", "-c", $cmd],
@@ -94,7 +94,7 @@ OVERRIDES=$(jq -n \
     }')
 
 "${KUBECTL[@]}" run "$POD_NAME" --rm -it \
-    --image=mysql:8.0 \
+    --image=mysql:8.4 \
     -n "$NAMESPACE" \
     --restart=Never \
     --overrides="$OVERRIDES"

--- a/deploy/local/docker-compose.grpc-multideploy.yml
+++ b/deploy/local/docker-compose.grpc-multideploy.yml
@@ -32,7 +32,7 @@ services:
   # Tern EU deployment (production environment)
   # =============================================================================
   tern-eu-mysql:
-    image: mysql:8.0
+    image: mysql:8.4
     environment:
       MYSQL_ROOT_PASSWORD: testpassword
       MYSQL_DATABASE: tern
@@ -79,7 +79,7 @@ services:
   # Tern US deployment (production environment)
   # =============================================================================
   tern-us-mysql:
-    image: mysql:8.0
+    image: mysql:8.4
     environment:
       MYSQL_ROOT_PASSWORD: testpassword
       MYSQL_DATABASE: tern
@@ -128,7 +128,7 @@ services:
   # SchemaBot's internal storage database
   # Note: Schema is applied by SchemaBot on startup (dogfooding)
   schemabot-mysql:
-    image: mysql:8.0
+    image: mysql:8.4
     environment:
       MYSQL_ROOT_PASSWORD: testpassword
       MYSQL_DATABASE: schemabot

--- a/deploy/local/docker-compose.grpc.yml
+++ b/deploy/local/docker-compose.grpc.yml
@@ -23,7 +23,7 @@ services:
   # Tern Staging
   # =============================================================================
   tern-staging-mysql:
-    image: mysql:8.0
+    image: mysql:8.4
     container_name: tern-staging-mysql
     environment:
       MYSQL_ROOT_PASSWORD: testpassword
@@ -72,7 +72,7 @@ services:
   # Tern Production
   # =============================================================================
   tern-production-mysql:
-    image: mysql:8.0
+    image: mysql:8.4
     container_name: tern-production-mysql
     environment:
       MYSQL_ROOT_PASSWORD: testpassword
@@ -123,7 +123,7 @@ services:
   # SchemaBot's internal storage database
   # Note: Schema is applied by SchemaBot on startup (dogfooding)
   schemabot-mysql:
-    image: mysql:8.0
+    image: mysql:8.4
     container_name: schemabot-mysql
     environment:
       MYSQL_ROOT_PASSWORD: testpassword

--- a/deploy/local/docker-compose.vitess.yml
+++ b/deploy/local/docker-compose.vitess.yml
@@ -28,7 +28,7 @@ services:
       start_period: 60s
 
   localscale-mysql:
-    image: mysql:8.0
+    image: mysql:8.4
     ports:
       - "${LOCALSCALE_MYSQL_PORT:-28004}:3306"
     environment:

--- a/deploy/local/docker-compose.yml
+++ b/deploy/local/docker-compose.yml
@@ -21,7 +21,7 @@ services:
   # SchemaBot's internal storage database
   # Note: Schema is applied by SchemaBot on startup via Spirit
   mysql-schemabot:
-    image: mysql:8.0
+    image: mysql:8.4
     environment:
       MYSQL_ROOT_PASSWORD: testpassword
       MYSQL_DATABASE: schemabot
@@ -40,7 +40,7 @@ services:
   # Staging MySQL instance (migration target)
   # Demonstrates separate MySQL instances for staging/production
   mysql-staging:
-    image: mysql:8.0
+    image: mysql:8.4
     environment:
       MYSQL_ROOT_PASSWORD: testpassword
       MYSQL_INITDB_SKIP_TZINFO: "1"
@@ -58,7 +58,7 @@ services:
 
   # Production MySQL instance (migration target)
   mysql-production:
-    image: mysql:8.0
+    image: mysql:8.4
     environment:
       MYSQL_ROOT_PASSWORD: testpassword
       MYSQL_INITDB_SKIP_TZINFO: "1"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   mysql:
-    image: mysql:8.0.44
+    image: mysql:8.4
     restart: unless-stopped
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=1

--- a/e2e/k8s/mysql.yaml
+++ b/e2e/k8s/mysql.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
         - name: mysql
-          image: mysql:8.0
+          image: mysql:8.4
           env:
             - name: MYSQL_ROOT_PASSWORD
               value: testpassword
@@ -80,7 +80,7 @@ spec:
     spec:
       containers:
         - name: mysql
-          image: mysql:8.0
+          image: mysql:8.4
           env:
             - name: MYSQL_ROOT_PASSWORD
               value: testpassword

--- a/integration/setup_test.go
+++ b/integration/setup_test.go
@@ -144,7 +144,7 @@ func TestMain(m *testing.M) {
 func startMySQLContainer(ctx context.Context, baseName, dbName string, schemaFS *embed.FS) (testcontainers.Container, error) {
 	req := testcontainers.ContainerRequest{
 		Name:         containerName(baseName),
-		Image:        "mysql:8.0",
+		Image:        "mysql:8.4",
 		ExposedPorts: []string{"3306/tcp"},
 		Env: map[string]string{
 			"MYSQL_ROOT_PASSWORD": "testpassword",

--- a/pkg/api/enqueue_authorized_apply_integration_test.go
+++ b/pkg/api/enqueue_authorized_apply_integration_test.go
@@ -36,7 +36,7 @@ func TestEnqueueAuthorizedApplyQueuesDurableApplyAgainstStorage(t *testing.T) {
 	ctx := t.Context()
 
 	container, err := mysql.Run(ctx,
-		"mysql:8.0",
+		"mysql:8.4",
 		mysql.WithDatabase("schemabot_test"),
 		mysql.WithUsername("root"),
 		mysql.WithPassword("test"),

--- a/pkg/api/ensure_schema_integration_test.go
+++ b/pkg/api/ensure_schema_integration_test.go
@@ -200,7 +200,7 @@ func startEnsureSchemaContainer(t *testing.T, ctx context.Context) (testcontaine
 
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "mysql:8.0",
+			Image:        "mysql:8.4",
 			ExposedPorts: []string{"3306/tcp"},
 			Env: map[string]string{
 				"MYSQL_ROOT_PASSWORD": "testpassword",

--- a/pkg/api/operator_multi_operation_integration_test.go
+++ b/pkg/api/operator_multi_operation_integration_test.go
@@ -411,7 +411,7 @@ func TestOperatorMultiOperationMatrix(t *testing.T) {
 func startMatrixContainer(t *testing.T, ctx context.Context) *sql.DB {
 	t.Helper()
 	container, err := mysql.Run(ctx,
-		"mysql:8.0",
+		"mysql:8.4",
 		mysql.WithDatabase("schemabot_test"),
 		mysql.WithUsername("root"),
 		mysql.WithPassword("test"),

--- a/pkg/api/pending_drops_cleaner_integration_test.go
+++ b/pkg/api/pending_drops_cleaner_integration_test.go
@@ -29,7 +29,7 @@ func TestStartPendingDropsCleanerDropsExpiredTable(t *testing.T) {
 	ctx := t.Context()
 
 	container, err := mysql.Run(ctx,
-		"mysql:8.0",
+		"mysql:8.4",
 		mysql.WithDatabase("schemabot_test"),
 		mysql.WithUsername("root"),
 		mysql.WithPassword("test"),

--- a/pkg/api/service_integration_test.go
+++ b/pkg/api/service_integration_test.go
@@ -23,7 +23,7 @@ func TestNew_Integration(t *testing.T) {
 	ctx := t.Context()
 
 	container, err := mysql.Run(ctx,
-		"mysql:8.0",
+		"mysql:8.4",
 		mysql.WithDatabase("schemabot_test"),
 		mysql.WithUsername("root"),
 		mysql.WithPassword("test"),

--- a/pkg/engine/spirit/spirit_integration_test.go
+++ b/pkg/engine/spirit/spirit_integration_test.go
@@ -41,7 +41,7 @@ func TestMain(m *testing.M) {
 
 	// Start shared MySQL container
 	req := testcontainers.ContainerRequest{
-		Image:        "mysql:8.0",
+		Image:        "mysql:8.4",
 		ExposedPorts: []string{"3306/tcp"},
 		Env: map[string]string{
 			"MYSQL_ROOT_PASSWORD": "testpassword",

--- a/pkg/pendingdrops/cleaner_integration_test.go
+++ b/pkg/pendingdrops/cleaner_integration_test.go
@@ -29,7 +29,7 @@ func TestMain(m *testing.M) {
 	ctx := context.Background()
 
 	req := testcontainers.ContainerRequest{
-		Image:        "mysql:8.0",
+		Image:        "mysql:8.4",
 		ExposedPorts: []string{"3306/tcp"},
 		Env: map[string]string{
 			"MYSQL_ROOT_PASSWORD": "testpassword",

--- a/pkg/storage/mysqlstore/mysql_test.go
+++ b/pkg/storage/mysqlstore/mysql_test.go
@@ -104,7 +104,7 @@ func applyTestSchema(db *sql.DB) error {
 
 func startMySQLContainer(ctx context.Context) (testcontainers.Container, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        "mysql:8.0",
+		Image:        "mysql:8.4",
 		ExposedPorts: []string{"3306/tcp"},
 		Env: map[string]string{
 			"MYSQL_ROOT_PASSWORD": "testpassword",

--- a/pkg/tern/local_client_integration_test.go
+++ b/pkg/tern/local_client_integration_test.go
@@ -46,7 +46,7 @@ func TestMain(m *testing.M) {
 	// Start shared MySQL container
 	var err error
 	sharedContainer, err = mysql.Run(ctx,
-		"mysql:8.0",
+		"mysql:8.4",
 		mysql.WithDatabase("testdb"),
 		mysql.WithUsername("root"),
 		mysql.WithPassword("test"),

--- a/pkg/webhook/webhook_integration_test.go
+++ b/pkg/webhook/webhook_integration_test.go
@@ -704,7 +704,7 @@ func setupE2EServiceMultiEnv(t *testing.T, appDBName string) *api.Service {
 func startE2EMySQLContainer(ctx context.Context, baseName, dbName string, schemaFS *embed.FS) (testcontainers.Container, error) {
 	req := testcontainers.ContainerRequest{
 		Name:         e2eContainerName(baseName),
-		Image:        "mysql:8.0",
+		Image:        "mysql:8.4",
 		ExposedPorts: []string{"3306/tcp"},
 		Env: map[string]string{
 			"MYSQL_ROOT_PASSWORD": "testpassword",


### PR DESCRIPTION
## Why this matters

The repo ran a mix of MySQL container versions: a few pkg/api integration tests and `run-spirit-fmt.sh` were already on `mysql:8.4`, while everything else — integration test containers, the docker-compose stacks, the e2e k8s manifests, and the mysql-shell debug pod — was on `mysql:8.0` (the root compose file pinned `8.0.44`). Standardizing on 8.4 keeps every layer testing against the same server version.

## What it does

Bumps every remaining `mysql:8.0` image reference to `mysql:8.4` (19 files, image tags only). All server options in use (`gtid_mode`, `enforce_gtid_consistency`, `log-bin`, `log_error_verbosity`, `default_time_zone`) are unchanged in 8.4, and none of the options MySQL 8.4 removed are used anywhere. The `pkg/namedlock` test moves to 8.4 separately in #835.

🤖 Generated with [Claude Code](https://claude.com/claude-code)