### PR TITLE
feat(github): reject applies whose plan contains engine-blocked changes

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -97,6 +97,35 @@ schemabot apply -e staging
 </details>
 
 <details>
+<summary><a name="apply-rejected-engineblocked-changes"></a><strong>Apply Rejected (Engine-blocked Changes)</strong></summary>
+
+
+## Schema Change Plan — Staging
+
+**Database**: `testapp` | **Type**: `MySQL` | **Schema Name**: `testapp`
+
+*Requested by @jackjackbits at 2026-01-01 00:00:00 UTC · planned from [`abcdef1`](https://github.com/block/schemabot/commit/abcdef1234567890abcdef1234567890abcdef12)*
+
+```sql
+ALTER TABLE `users`
+    DROP PRIMARY KEY,
+    ADD PRIMARY KEY(`id`, `tenant_id`);
+
+ALTER TABLE `orders` ADD COLUMN `notes` text;
+```
+
+📋 **Plan**: **2** tables to alter
+
+---
+
+**⛔ Apply rejected**: **1** planned change not supported by the schema-change engine
+- `users`: dropping primary key is not supported
+
+Rewrite these statements as a supported schema change, or contact your SchemaBot operators for help.
+
+</details>
+
+<details>
 <summary><a name="mysql-plan-tenant-target"></a><strong>MySQL Plan (Tenant Target)</strong></summary>
 
 

--- a/pkg/apitypes/apitypes.go
+++ b/pkg/apitypes/apitypes.go
@@ -496,6 +496,32 @@ func (r *PlanResponse) UnsafeChanges() []UnsafeChange {
 	return result
 }
 
+// HasBlockedChanges reports whether any planned change carries the blocked
+// execution-mode verdict, across namespace-level and per-shard changes. A
+// blocked change guarantees the apply fails, so gates use this to reject the
+// apply before it starts.
+func (r *PlanResponse) HasBlockedChanges() bool {
+	if r == nil {
+		return false
+	}
+	for _, t := range r.FlatTables() {
+		if t.EngineBlocked() {
+			return true
+		}
+	}
+	for _, sp := range r.Shards {
+		if sp == nil {
+			continue
+		}
+		for _, t := range sp.Changes {
+			if t.EngineBlocked() {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // LintWarnings returns lint results with warning severity.
 func (r *PlanResponse) LintWarnings() []LintViolationResponse {
 	var result []LintViolationResponse
@@ -584,8 +610,19 @@ type TableChangeResponse struct {
 	ModeReason    string `json:"mode_reason,omitempty"`
 }
 
+// executionModeBlocked is the execution-mode verdict a planner records on a
+// table change the engine refuses. It mirrors the engine-side constant
+// (pkg/ddl); apitypes keeps its own copy so this package stays dependency-free.
+const executionModeBlocked = "blocked"
+
 // GetTableName implements ddl.TableWithName for filtering Spirit internal tables.
 func (t *TableChangeResponse) GetTableName() string { return t.TableName }
+
+// EngineBlocked reports whether the planner's execution-mode verdict says the
+// engine deterministically refuses this change: an apply will fail on it.
+func (t *TableChangeResponse) EngineBlocked() bool {
+	return t != nil && strings.EqualFold(t.ExecutionMode, executionModeBlocked)
+}
 
 // UnsafeChange returns the unsafe-change view for table changes that require
 // explicit operator opt-in. Engines should mark unsafe table changes directly;

--- a/pkg/apitypes/apitypes_test.go
+++ b/pkg/apitypes/apitypes_test.go
@@ -195,3 +195,62 @@ func TestPlanResponse_HasChanges(t *testing.T) {
 		})
 	}
 }
+
+// A blocked verdict anywhere in the plan — namespace-level or per-shard —
+// marks the plan as containing blocked changes, so apply gates reject it
+// before the apply starts.
+func TestPlanResponse_HasBlockedChanges(t *testing.T) {
+	tests := []struct {
+		name string
+		resp *PlanResponse
+		want bool
+	}{
+		{
+			name: "namespace-level blocked change",
+			resp: &PlanResponse{
+				Changes: []*SchemaChangeResponse{{
+					Namespace: "testdb",
+					TableChanges: []*TableChangeResponse{
+						{TableName: "users", ExecutionMode: "blocked", ModeReason: "dropping primary key is not supported"},
+					},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "per-shard blocked change only",
+			resp: &PlanResponse{
+				Shards: []*ShardPlanResponse{{
+					Shard: "-40",
+					Changes: []*TableChangeResponse{
+						{TableName: "users", ExecutionMode: "blocked"},
+					},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "direct and default modes are not blocked",
+			resp: &PlanResponse{
+				Changes: []*SchemaChangeResponse{{
+					Namespace: "testdb",
+					TableChanges: []*TableChangeResponse{
+						{TableName: "users", ExecutionMode: "direct"},
+						{TableName: "orders"},
+					},
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "nil plan",
+			resp: nil,
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.resp.HasBlockedChanges())
+		})
+	}
+}

--- a/pkg/cmd/commands/preview.go
+++ b/pkg/cmd/commands/preview.go
@@ -71,6 +71,7 @@ func (cmd *PreviewCmd) Run(g *Globals) error {
 		templates.PreviewCLIOutput(previewType)
 	// Comment template types
 	case templates.PreviewCommentPlan, templates.PreviewCommentPlanBlocked,
+		templates.PreviewCommentApplyBlockedRejected,
 		templates.PreviewCommentPlanTenant,
 		templates.PreviewCommentPlanEmpty,
 		templates.PreviewCommentNoManagedSchema,
@@ -245,6 +246,7 @@ Interactive TUI:
 Comment Templates (GitHub PR comments):
   comment_plan                  Plan comment with DDL changes + lint violations
   comment_plan_blocked          Plan with a statement the engine refuses (blocked verdict)
+  comment_apply_blocked_rejected Apply rejected: plan contains engine-blocked statements
   comment_plan_tenant           Tenant-targeted plan comment
   comment_plan_empty            Plan comment with no changes
   comment_no_managed_schema     No managed schema changes in current PR

--- a/pkg/cmd/internal/templates/preview.go
+++ b/pkg/cmd/internal/templates/preview.go
@@ -112,6 +112,7 @@ const (
 	// Comment template previews (GitHub PR comments)
 	PreviewCommentPlan                         PreviewType = "comment_plan"                            // Plan comment with DDL changes + lint violations
 	PreviewCommentPlanBlocked                  PreviewType = "comment_plan_blocked"                    // Plan with a statement the engine refuses (blocked verdict)
+	PreviewCommentApplyBlockedRejected         PreviewType = "comment_apply_blocked_rejected"          // Apply rejected: plan contains engine-blocked statements
 	PreviewCommentPlanTenant                   PreviewType = "comment_plan_tenant"                     // Tenant-targeted plan comment
 	PreviewCommentPlanEmpty                    PreviewType = "comment_plan_empty"                      // Plan comment with no changes
 	PreviewCommentNoManagedSchema              PreviewType = "comment_no_managed_schema"               // No managed schema changes in current PR

--- a/pkg/cmd/internal/templates/preview_comment.go
+++ b/pkg/cmd/internal/templates/preview_comment.go
@@ -41,6 +41,7 @@ func previewCommentAllOutput() {
 	}{
 		{"PLAN COMMENT", func() { fmt.Print(webhooktemplates.PreviewCommentPlan()) }},
 		{"PLAN COMMENT (ENGINE-BLOCKED CHANGE)", func() { fmt.Print(webhooktemplates.PreviewCommentPlanBlocked()) }},
+		{"APPLY REJECTED (ENGINE-BLOCKED CHANGES)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedRejected()) }},
 		{"PLAN COMMENT (TENANT TARGET)", func() { fmt.Print(webhooktemplates.PreviewCommentPlanTenant()) }},
 		{"PLAN COMMENT (NO CHANGES)", func() { fmt.Print(webhooktemplates.PreviewCommentPlanNoChanges()) }},
 		{"NO MANAGED SCHEMA CHANGES", func() { fmt.Print(webhooktemplates.PreviewCommentNoManagedSchemaChanges()) }},
@@ -127,6 +128,7 @@ func previewCommentPlanAllOutput() {
 	}{
 		{"MYSQL PLAN", func() { fmt.Print(webhooktemplates.PreviewCommentPlan()) }},
 		{"MYSQL PLAN (ENGINE-BLOCKED CHANGE)", func() { fmt.Print(webhooktemplates.PreviewCommentPlanBlocked()) }},
+		{"APPLY REJECTED (ENGINE-BLOCKED CHANGES)", func() { fmt.Print(webhooktemplates.PreviewCommentApplyBlockedRejected()) }},
 		{"MYSQL PLAN (TENANT TARGET)", func() { fmt.Print(webhooktemplates.PreviewCommentPlanTenant()) }},
 		{"MYSQL PLAN (NO CHANGES)", func() { fmt.Print(webhooktemplates.PreviewCommentPlanNoChanges()) }},
 		{"NO MANAGED SCHEMA CHANGES", func() { fmt.Print(webhooktemplates.PreviewCommentNoManagedSchemaChanges()) }},

--- a/pkg/cmd/internal/templates/preview_dispatch.go
+++ b/pkg/cmd/internal/templates/preview_dispatch.go
@@ -118,6 +118,8 @@ func PreviewCLIOutput(previewType PreviewType) {
 		fmt.Print(webhooktemplates.PreviewCommentPlan())
 	case PreviewCommentPlanBlocked:
 		fmt.Print(webhooktemplates.PreviewCommentPlanBlocked())
+	case PreviewCommentApplyBlockedRejected:
+		fmt.Print(webhooktemplates.PreviewCommentApplyBlockedRejected())
 	case PreviewCommentPlanTenant:
 		fmt.Print(webhooktemplates.PreviewCommentPlanTenant())
 	case PreviewCommentPlanEmpty:

--- a/pkg/webhook/apply_execute.go
+++ b/pkg/webhook/apply_execute.go
@@ -98,6 +98,20 @@ func (h *Handler) executeApply(
 		return
 	}
 
+	// Engine-blocked changes reject the apply outright — the re-plan may have
+	// resolved a change to blocked even if the reviewed plan had none (e.g.
+	// the direct execution policy changed, or the table grew past its bound).
+	// Release the lock: no retry of this command can succeed, so holding it
+	// would only force a manual unlock after the schema is rewritten.
+	if planResp.HasBlockedChanges() {
+		commentData := buildPlanCommentData(schemaResult, planResp, environment, result.Tenant, requestedBy)
+		h.logger.Info("apply rejected: re-plan contains engine-blocked changes",
+			"repo", repo, "pr", pr, "database", database, "environment", environment, "action", actionName)
+		h.postComment(repo, pr, installationID, templates.RenderBlockedChangesApplyRejected(commentData))
+		h.releaseApplyLockIfIntentUnchanged(ctx, repo, pr, database, dbType, environment, expectedPendingPlanID, "engine-blocked changes rejection")
+		return
+	}
+
 	// Automatic apply DDL drift check: if the re-plan DDL differs from the stored auto-plan,
 	// downgrade to manual confirmation so the user reviews the new plan.
 	if storedPlan != nil && !ddlMatchesStoredPlan(planResp, storedPlan) {

--- a/pkg/webhook/apply_handlers.go
+++ b/pkg/webhook/apply_handlers.go
@@ -251,6 +251,18 @@ func (h *Handler) applyCommandCore(repo string, pr int, environment, databaseNam
 		return false, nil
 	}
 
+	// Engine-blocked changes reject the apply before the unsafe gate: no flag
+	// lets a refused statement through, so the user must never be coached
+	// toward --allow-unsafe for a guaranteed failure. No lock is held yet, so
+	// the rejection needs no release.
+	if planResp.HasBlockedChanges() {
+		commentData := buildPlanCommentData(schemaResult, planResp, environment, result.Tenant, requestedBy)
+		h.logger.Info("apply rejected: plan contains engine-blocked changes",
+			"repo", repo, "pr", pr, "database", database, "environment", environment)
+		h.postComment(repo, pr, installationID, templates.RenderBlockedChangesApplyRejected(commentData))
+		return false, nil
+	}
+
 	// Block unsafe changes unless --allow-unsafe was specified
 	if len(planResp.UnsafeChanges()) > 0 && !result.AllowUnsafe {
 		commentData := buildPlanCommentData(schemaResult, planResp, environment, result.Tenant, requestedBy)

--- a/pkg/webhook/blocked_gate_integration_test.go
+++ b/pkg/webhook/blocked_gate_integration_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strings"
 	"testing"
 	"time"
 
@@ -30,8 +29,7 @@ const pkSwapSchema = "CREATE TABLE `users` (\n" +
 // database so the plan produces the refused primary-key reshape.
 func seedPKSwapTargetTable(t *testing.T, dbName string) {
 	t.Helper()
-	appDSN := strings.Replace(e2eTargetDSN, "/target_test", "/"+dbName, 1)
-	db, err := sql.Open("mysql", appDSN)
+	db, err := sql.Open("mysql", driftDSN(t, dbName))
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 	_, err = db.ExecContext(t.Context(), "CREATE TABLE `users` (\n"+

--- a/pkg/webhook/blocked_gate_integration_test.go
+++ b/pkg/webhook/blocked_gate_integration_test.go
@@ -1,0 +1,87 @@
+//go:build integration
+
+package webhook
+
+import (
+	"database/sql"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	gh "github.com/google/go-github/v86/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pkSwapSchema is a schema file declaring a composite primary key on a table
+// the target holds with a single-column key, so the plan diff is exactly the
+// primary-key reshape the schema-change engine refuses.
+const pkSwapSchema = "CREATE TABLE `users` (\n" +
+	"  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n" +
+	"  `tenant_id` bigint unsigned NOT NULL,\n" +
+	"  PRIMARY KEY (`id`,`tenant_id`)\n" +
+	") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;"
+
+// seedPKSwapTargetTable creates the pre-change `users` table on the app
+// database so the plan produces the refused primary-key reshape.
+func seedPKSwapTargetTable(t *testing.T, dbName string) {
+	t.Helper()
+	appDSN := strings.Replace(e2eTargetDSN, "/target_test", "/"+dbName, 1)
+	db, err := sql.Open("mysql", appDSN)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	_, err = db.ExecContext(t.Context(), "CREATE TABLE `users` (\n"+
+		"  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n"+
+		"  `tenant_id` bigint unsigned NOT NULL,\n"+
+		"  PRIMARY KEY (`id`)\n"+
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci")
+	require.NoError(t, err, "seed pre-change users table")
+}
+
+// An apply on a plan containing an engine-blocked change is rejected before
+// any lock is taken: the PR gets a ⛔ rejection comment naming the table and
+// the refusal, with no retry or --allow-unsafe coaching, and the database
+// lock stays free.
+func TestE2EApplyRejectedOnBlockedPlan(t *testing.T) {
+	dbName := "webhook_blocked_gate"
+	svc := setupE2EService(t, dbName)
+	seedPKSwapTargetTable(t, dbName)
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := gh.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	schemabotConfig := fmt.Sprintf("database: %s\ntype: mysql\n", dbName)
+	result := setupFakeGitHubForPlan(t, mux, map[string]string{"users.sql": pkSwapSchema}, schemabotConfig, dbName)
+
+	h := newE2EHandler(t, svc, client)
+	req := buildWebhookRequest(t, webhookPayloadOpts{
+		comment: "schemabot apply -e staging",
+		isPR:    true,
+	}, nil)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	select {
+	case body := <-result.comments:
+		assert.Contains(t, body, "⛔ Apply rejected")
+		assert.Contains(t, body, "not supported by the schema-change engine")
+		assert.Contains(t, body, "`users`")
+		assert.NotContains(t, body, "--allow-unsafe", "a guaranteed failure must not coach an unsafe override")
+	case <-time.After(webhookIntegrationPollDeadline):
+		t.Fatal("timed out waiting for the apply rejection comment")
+	}
+
+	lock, err := svc.Storage().Locks().Get(t.Context(), dbName, "mysql")
+	require.NoError(t, err)
+	assert.Nil(t, lock, "a rejected apply must not leave the database locked")
+}

--- a/pkg/webhook/templates/apply_commands.go
+++ b/pkg/webhook/templates/apply_commands.go
@@ -151,6 +151,48 @@ func RenderUnsafeChangesBlocked(data PlanCommentData) string {
 	return sb.String()
 }
 
+// RenderBlockedChangesApplyRejected renders the rejection comment for an
+// apply whose plan contains statements the schema-change engine refuses.
+// Unlike unsafe changes there is no opt-in flag that lets a refused statement
+// through, so the comment carries no retry instructions — the guidance is to
+// rewrite the change or contact the operators.
+func RenderBlockedChangesApplyRejected(data PlanCommentData) string {
+	var sb strings.Builder
+
+	// Render the full plan first (DDL, summary) so the user can see what was
+	// planned — but without a lock or confirm footer.
+	writeEnvironmentTitle(&sb, "Schema Change Plan", data.Environment)
+
+	writePlanMetadata(&sb, data)
+	writePlanAttribution(&sb, data)
+	sb.WriteString("\n")
+
+	totalStatements, keyspacesWithVSchema := countChanges(data.Changes)
+	if totalStatements+keyspacesWithVSchema > 0 {
+		writeKeyspaceChanges(&sb, data)
+	}
+
+	writePlanSummary(&sb, data, totalStatements, keyspacesWithVSchema)
+
+	sb.WriteString("---\n\n")
+	n := len(data.BlockedChanges)
+	fmt.Fprintf(&sb, "**⛔ Apply rejected**: **%d** planned %s not supported by the schema-change engine\n", n, pluralize("change", n))
+	for _, c := range data.BlockedChanges {
+		table := "`" + c.Table + "`"
+		if len(c.Shards) > 0 {
+			table = fmt.Sprintf("%s (%s)", table, planShardList(c.Shards))
+		}
+		if c.Reason != "" {
+			fmt.Fprintf(&sb, "- %s: %s\n", table, c.Reason)
+		} else {
+			fmt.Fprintf(&sb, "- %s\n", table)
+		}
+	}
+	sb.WriteString("\nRewrite these statements as a supported schema change, or contact your SchemaBot operators for help.\n")
+
+	return sb.String()
+}
+
 // RenderApplyStarted renders the initial body of the live progress comment when
 // an apply begins. It uses the same stable status title as the in-place status
 // comment the observer later edits this into, so the headline does not jump from

--- a/pkg/webhook/templates/preview.go
+++ b/pkg/webhook/templates/preview.go
@@ -80,6 +80,32 @@ func PreviewCommentPlanBlocked() string {
 	})
 }
 
+// PreviewCommentApplyBlockedRejected renders a sample apply rejection for a
+// plan containing statements the engine refuses.
+func PreviewCommentApplyBlockedRejected() string {
+	return RenderBlockedChangesApplyRejected(PlanCommentData{
+		Database:    "testapp",
+		SchemaName:  "testapp",
+		Environment: "staging",
+		HeadSHA:     previewHeadSHA,
+		Repository:  previewRepository,
+		RequestedBy: previewRequestedBy,
+		IsMySQL:     true,
+		Changes: []KeyspaceChangeData{
+			{
+				Keyspace: "testapp",
+				Statements: []string{
+					"ALTER TABLE `users` DROP PRIMARY KEY, ADD PRIMARY KEY (`id`, `tenant_id`)",
+					"ALTER TABLE `orders` ADD COLUMN `notes` TEXT",
+				},
+			},
+		},
+		BlockedChanges: []BlockedChangeData{
+			{Table: "users", Reason: "dropping primary key is not supported"},
+		},
+	})
+}
+
 // PreviewCommentPlanTenant renders a tenant-targeted plan comment.
 func PreviewCommentPlanTenant() string {
 	return RenderPlanComment(PlanCommentData{


### PR DESCRIPTION
**Why this matters:** #798 made engine-blocked changes *visible*: the plan comment renders a ⛔ section when a statement carries the blocked execution-mode verdict (primary key reshapes, `ADD FOREIGN KEY`). But nothing yet *enforces* the verdict — an apply on such a plan still starts, takes the database lock, fails in under a second, and the failure copy coaches retries and `--allow-unsafe` even though no flag can make a refused statement succeed.

**What it does:** Turns the verdict into a gate. An apply whose plan contains engine-blocked changes is rejected before it starts, with a comment naming each table and refusal reason and no retry coaching:

```
before (#798):  plan shows ⛔  →  apply starts  →  lock taken  →  fails <1s  →  "retry with --allow-unsafe"
after  (#838):  plan shows ⛔  →  apply rejected up front  →  no lock, no doomed apply
```

The gate runs in both places an apply can begin: pre-lock on the apply command (nothing to release), and on the pre-execution re-plan (releasing the lock, since a retry of the same command cannot succeed). Covered by an integration test driving the webhook flow end to end.

First of three stacked PRs; the follow-ups add policy-gated direct execution for refused statements and its PR disclosure flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
