### PR TITLE
feat(engine): align Spirit run settings with production defaults and add a spirit config block

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -351,6 +351,51 @@ duration must be positive, and `max_idle_conns` must not exceed a positive
 `max_open_conns`; SchemaBot rejects violations at config load rather than
 silently reverting to a default.
 
+## Spirit Run Settings
+
+For MySQL databases this server drives directly, the Spirit engine runs every
+schema change with a set of production-proven defaults. The `spirit:` block
+exists only to *deviate* from them — leave it out entirely to run with the
+defaults below.
+
+```yaml
+spirit:
+  enable_experimental_autoscaling: true  # default: true
+  checkpoint_max_age: 72h                # default: 72h (3 days)
+  checksum_yield_timeout: 12h            # default: 12h
+```
+
+The defaults, and why they were chosen:
+
+- **Write threads are auto-sized and autoscaled** (not configurable as a fixed
+  count). Spirit starts write threads at a size appropriate for the target
+  instance and, with `enable_experimental_autoscaling` on, scales them
+  dynamically from throttler feedback. A fixed thread count is the classic
+  failure mode on large targets — throughput that made sense on one instance
+  class silently starves or overloads another. The operator control for copy
+  aggressiveness is the apply's `volume`, not a thread count. Set
+  `enable_experimental_autoscaling: false` only as an incident kill switch when
+  autoscaling misbehaves on a target fleet.
+- **`checkpoint_max_age: 72h`** — a checkpoint older than this is not resumed;
+  the copy restarts cleanly instead of replaying days of old binlogs, which on
+  a busy target is slower and riskier than starting over.
+- **`checksum_yield_timeout: 12h`** — each checksum read transaction yields its
+  `REPEATABLE READ` snapshot within this bound so a long checksum cannot pin
+  InnoDB purge and degrade the whole target instance.
+- **GTID change source is auto-detected** (no knob). Targets with
+  `gtid_mode=ON` and `enforce_gtid_consistency=ON` get Spirit's GTID-based
+  change source, which tracks replication position across binlog rotation and
+  failover more robustly than binlog file+position; every other target keeps
+  the universally supported file+position source.
+
+A database can override the server-level value by setting the same key
+(`enable_experimental_autoscaling`, `checkpoint_max_age`,
+`checksum_yield_timeout`) in its own metadata; the database's entry wins.
+
+These settings only apply where this server constructs the Spirit engine
+itself — local-mode MySQL databases. Databases routed to a remote deployment
+over gRPC run with that deployment's engine settings.
+
 ## Storage Schema Changes
 
 SchemaBot's internal storage schema is self-bootstrapping: on every startup,

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -15,6 +15,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/block/schemabot/pkg/engine/spirit"
 	"github.com/block/schemabot/pkg/inventory"
 	"github.com/block/schemabot/pkg/pendingdrops"
 	"github.com/block/schemabot/pkg/routing"
@@ -173,6 +174,14 @@ type ServerConfig struct {
 	// background cleaner can be run by this process or disabled so another
 	// deployment owns permanent cleanup after the retention period.
 	PendingDrops PendingDropsConfig `yaml:"pending_drops,omitempty"`
+
+	// Spirit overrides the Spirit engine's default run settings for every
+	// MySQL database this server drives directly. Unset fields keep the
+	// engine defaults (see pkg/engine/spirit), so the block is only needed
+	// to deviate — for example to disable write-thread autoscaling as an
+	// incident kill switch. A database's own metadata entry for the same
+	// key wins over this server-level value.
+	Spirit SpiritConfig `yaml:"spirit,omitempty"`
 }
 
 // PendingDropsConfig configures the pending drops quarantine for MySQL/Spirit
@@ -238,6 +247,66 @@ func (c *ServerConfig) PendingDropsRetention() (time.Duration, error) {
 		return 0, fmt.Errorf("pending_drops.retention must be positive, got %q", c.PendingDrops.Retention)
 	}
 	return d, nil
+}
+
+// SpiritConfig overrides the Spirit engine's default run settings. Each field
+// maps to an engine metadata key (see spirit.SettingsFromMetadata); values set
+// here are merged into every locally driven MySQL database's metadata unless
+// the database sets the same key itself.
+type SpiritConfig struct {
+	// EnableExperimentalAutoscaling controls whether Spirit scales write
+	// threads dynamically from throttler feedback. Defaults to true when not
+	// configured (nil = enabled); set false as the operator kill switch when
+	// autoscaling misbehaves on a target fleet.
+	EnableExperimentalAutoscaling *bool `yaml:"enable_experimental_autoscaling"`
+
+	// CheckpointMaxAge bounds how old a Spirit checkpoint may be and still be
+	// resumed, as a Go duration string (e.g. "72h"). Defaults to 3 days:
+	// a copy stalled that long restarts cleanly instead of replaying days of
+	// old binlogs.
+	CheckpointMaxAge string `yaml:"checkpoint_max_age,omitempty"`
+
+	// ChecksumYieldTimeout bounds each checksum read transaction before it
+	// yields its REPEATABLE READ snapshot, as a Go duration string (e.g.
+	// "12h"). Defaults to 12 hours so a long checksum cannot pin InnoDB purge
+	// on the target.
+	ChecksumYieldTimeout string `yaml:"checksum_yield_timeout,omitempty"`
+}
+
+// SpiritMetadata validates the configured Spirit overrides and returns them as
+// engine metadata entries, containing only the keys the config sets. Duration
+// values must parse and be positive; a misconfigured override fails server
+// construction instead of silently running applies with the defaults.
+func (c *ServerConfig) SpiritMetadata() (map[string]string, error) {
+	metadata := map[string]string{}
+	if c.Spirit.EnableExperimentalAutoscaling != nil {
+		metadata[spirit.MetadataEnableExperimentalAutoscaling] = strconv.FormatBool(*c.Spirit.EnableExperimentalAutoscaling)
+	}
+	if err := setSpiritDuration(metadata, spirit.MetadataCheckpointMaxAge, c.Spirit.CheckpointMaxAge); err != nil {
+		return nil, err
+	}
+	if err := setSpiritDuration(metadata, spirit.MetadataChecksumYieldTimeout, c.Spirit.ChecksumYieldTimeout); err != nil {
+		return nil, err
+	}
+	return metadata, nil
+}
+
+// setSpiritDuration validates an optional spirit duration override and records
+// it under the given metadata key. Empty values are skipped so the engine
+// default applies.
+func setSpiritDuration(metadata map[string]string, key, raw string) error {
+	if raw == "" {
+		return nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return fmt.Errorf("parse spirit.%s %q: %w", key, raw, err)
+	}
+	if d <= 0 {
+		return fmt.Errorf("spirit.%s must be positive, got %q", key, raw)
+	}
+	metadata[key] = raw
+	return nil
 }
 
 // GitHubConfig configures the GitHub App used for webhook-driven schema changes.

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
+	"github.com/block/schemabot/pkg/engine/spirit"
 	"github.com/block/schemabot/pkg/inventory"
 	"github.com/block/schemabot/pkg/pendingdrops"
 	"github.com/block/schemabot/pkg/routing"
@@ -3523,5 +3524,48 @@ func TestKnownEnvironments(t *testing.T) {
 		var cfg *ServerConfig
 		assert.Nil(t, cfg.KnownEnvironments())
 		assert.False(t, cfg.IsEnvironmentKnown("staging"))
+	})
+}
+
+// TestServerConfig_SpiritMetadata verifies that the spirit block translates
+// into engine metadata overrides: an absent block produces no entries (the
+// engine defaults apply), configured values carry through, and a
+// misconfigured duration fails instead of silently running applies with the
+// defaults.
+func TestServerConfig_SpiritMetadata(t *testing.T) {
+	t.Run("absent block produces no overrides", func(t *testing.T) {
+		var cfg ServerConfig
+		metadata, err := cfg.SpiritMetadata()
+		require.NoError(t, err)
+		assert.Empty(t, metadata)
+	})
+
+	t.Run("configured values translate to metadata keys", func(t *testing.T) {
+		var cfg ServerConfig
+		require.NoError(t, yaml.Unmarshal([]byte(`
+spirit:
+  enable_experimental_autoscaling: false
+  checkpoint_max_age: 24h
+  checksum_yield_timeout: 6h
+`), &cfg))
+		metadata, err := cfg.SpiritMetadata()
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{
+			spirit.MetadataEnableExperimentalAutoscaling: "false",
+			spirit.MetadataCheckpointMaxAge:              "24h",
+			spirit.MetadataChecksumYieldTimeout:          "6h",
+		}, metadata)
+	})
+
+	t.Run("invalid duration errors", func(t *testing.T) {
+		cfg := ServerConfig{Spirit: SpiritConfig{CheckpointMaxAge: "3 days"}}
+		_, err := cfg.SpiritMetadata()
+		require.ErrorContains(t, err, "checkpoint_max_age")
+	})
+
+	t.Run("non-positive duration errors", func(t *testing.T) {
+		cfg := ServerConfig{Spirit: SpiritConfig{ChecksumYieldTimeout: "-1h"}}
+		_, err := cfg.SpiritMetadata()
+		require.ErrorContains(t, err, "must be positive")
 	})
 }

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net/http"
 	"os"
 	"strings"
@@ -565,6 +566,11 @@ func (s *Service) newLocalTernClient(key, database, dbType string, envConfig Env
 	if !s.config.PendingDropsEnabled() {
 		metadata["pending_drops"] = "false"
 	}
+	spiritMetadata, err := s.config.SpiritMetadata()
+	if err != nil {
+		return nil, fmt.Errorf("resolve spirit config for %s: %w", key, err)
+	}
+	maps.Copy(metadata, spiritMetadata)
 	client, err := tern.NewLocalClient(tern.LocalConfig{
 		Database:        database,
 		Type:            dbType,

--- a/pkg/engine/spirit/execution.go
+++ b/pkg/engine/spirit/execution.go
@@ -6,14 +6,94 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	spiritmigration "github.com/block/spirit/pkg/migration"
 	"github.com/block/spirit/pkg/statement"
 	"github.com/block/spirit/pkg/utils"
+	"github.com/go-sql-driver/mysql"
 
 	"github.com/block/schemabot/pkg/ddl"
 	"github.com/block/schemabot/pkg/engine"
+	"github.com/block/schemabot/pkg/mysqlconn"
 )
+
+// maxCommitLatency is the commit-latency throttle threshold: the copy backs
+// off when the target's observed average commit latency exceeds it. It must
+// be set explicitly — Spirit treats a zero value as "throttler disabled", and
+// in redo-aware mode this throttler is also the backstop that lets the
+// write-thread autoscaler grow above its starting value.
+const maxCommitLatency = 100 * time.Millisecond
+
+// newMigration builds the Spirit migration for a statement against the
+// target with the engine's copy, durability, and throttling settings.
+// Callers layer statement-specific fields (DeferCutOver, RespectSentinel)
+// onto the result.
+//
+// Write threads start at the target-appropriate automatic size (on Aurora,
+// the instance vCPU count) and, when autoscaling is enabled, scale
+// dynamically from there on throttler feedback, so apply throughput tracks
+// the target instance rather than a fixed constant.
+func (e *Engine) newMigration(ctx context.Context, host, username, password, database, stmt string) *spiritmigration.Migration {
+	threads, chunkTime, lockTimeout := e.copySettings()
+	return &spiritmigration.Migration{
+		Host:                          host,
+		Username:                      username,
+		Password:                      &password,
+		Database:                      database,
+		Statement:                     stmt,
+		TargetChunkTime:               chunkTime,
+		Threads:                       threads,
+		WriteThreads:                  0, // auto-size for the target
+		LockWaitTimeout:               lockTimeout,
+		InterpolateParams:             true,
+		CheckpointMaxAge:              e.checkpointMaxAge,
+		ChecksumYieldTimeout:          e.checksumYieldTimeout,
+		MaxCommitLatency:              maxCommitLatency,
+		EnableExperimentalAutoscaling: e.autoscaling,
+		EnableExperimentalGTID:        e.gtidChangeSourceSupported(ctx, host, username, password, database),
+	}
+}
+
+// gtidChangeSourceSupported reports whether the target can serve Spirit's
+// GTID-based change source, which tracks replication position across binlog
+// rotation and failover more robustly than binlog file+position. Spirit
+// refuses to start when the GTID source is requested on a target without
+// gtid_mode=ON, so the source is chosen per target: GTID-capable targets get
+// the stronger source and every other target keeps the universally supported
+// binlog file+position source.
+func (e *Engine) gtidChangeSourceSupported(ctx context.Context, host, username, password, database string) bool {
+	cfg := mysql.NewConfig()
+	cfg.User = username
+	cfg.Passwd = password
+	cfg.Net = "tcp"
+	cfg.Addr = host
+	cfg.DBName = database
+	db, err := mysqlconn.Open(cfg.FormatDSN())
+	if err != nil {
+		e.logger.Warn("failed to probe target GTID support, using the binlog file+position change source",
+			"host", host, "database", database, "error", err)
+		return false
+	}
+	defer utils.CloseAndLog(db)
+
+	var gtidMode, enforceConsistency string
+	if err := db.QueryRowContext(ctx,
+		`SELECT @@global.gtid_mode, @@global.enforce_gtid_consistency`).Scan(&gtidMode, &enforceConsistency); err != nil {
+		e.logger.Warn("failed to probe target GTID support, using the binlog file+position change source",
+			"host", host, "database", database, "error", err)
+		return false
+	}
+	if gtidMode != "ON" || enforceConsistency != "ON" {
+		e.logger.Info("target does not support GTID, using the binlog file+position change source",
+			"host", host, "database", database,
+			"gtid_mode", gtidMode, "enforce_gtid_consistency", enforceConsistency)
+		return false
+	}
+	e.logger.Info("target supports GTID, using the GTID change source",
+		"host", host, "database", database)
+	return true
+}
 
 // executeSchemaChange runs the Spirit schema change synchronously.
 // All DDL statements (CREATE, DROP, ALTER, RENAME) are passed through Spirit.
@@ -262,18 +342,7 @@ func (e *Engine) executeSingleStatement(ctx context.Context, host, username, pas
 		"type", stmtType,
 	)
 
-	threads, chunkTime, lockTimeout := e.copySettings()
-	migration := &spiritmigration.Migration{
-		Host:              host,
-		Username:          username,
-		Password:          &password,
-		Database:          database,
-		Statement:         stmt,
-		TargetChunkTime:   chunkTime,
-		Threads:           threads,
-		LockWaitTimeout:   lockTimeout,
-		InterpolateParams: true,
-	}
+	migration := e.newMigration(ctx, host, username, password, database, stmt)
 
 	runner, err := spiritmigration.NewRunner(migration)
 	if err != nil {
@@ -307,20 +376,9 @@ func (e *Engine) executeSpiritMigration(ctx context.Context, host, username, pas
 		ddls = append(ddls, p.Statement)
 	}
 
-	threads, chunkTime, lockTimeout := e.copySettings()
-	migration := &spiritmigration.Migration{
-		Host:              host,
-		Username:          username,
-		Password:          &password,
-		Database:          database,
-		Statement:         combinedStatement,
-		TargetChunkTime:   chunkTime,
-		Threads:           threads,
-		LockWaitTimeout:   lockTimeout,
-		InterpolateParams: true,
-		DeferCutOver:      deferCutover,
-		RespectSentinel:   deferCutover, // Only wait for sentinel when deferring cutover
-	}
+	migration := e.newMigration(ctx, host, username, password, database, combinedStatement)
+	migration.DeferCutOver = deferCutover
+	migration.RespectSentinel = deferCutover // Only wait for sentinel when deferring cutover
 
 	runner, err := spiritmigration.NewRunner(migration)
 	if err != nil {

--- a/pkg/engine/spirit/execution.go
+++ b/pkg/engine/spirit/execution.go
@@ -25,7 +25,7 @@ import (
 // write-thread autoscaler grow above its starting value.
 const maxCommitLatency = 100 * time.Millisecond
 
-// newMigration builds the Spirit migration for a statement against the
+// newSpiritMigration builds the Spirit migration for a statement against the
 // target with the engine's copy, durability, and throttling settings.
 // Callers layer statement-specific fields (DeferCutOver, RespectSentinel)
 // onto the result.
@@ -34,7 +34,7 @@ const maxCommitLatency = 100 * time.Millisecond
 // the instance vCPU count) and, when autoscaling is enabled, scale
 // dynamically from there on throttler feedback, so apply throughput tracks
 // the target instance rather than a fixed constant.
-func (e *Engine) newMigration(ctx context.Context, host, username, password, database, stmt string) *spiritmigration.Migration {
+func (e *Engine) newSpiritMigration(ctx context.Context, host, username, password, database, stmt string) *spiritmigration.Migration {
 	threads, chunkTime, lockTimeout := e.copySettings()
 	return &spiritmigration.Migration{
 		Host:                          host,
@@ -76,6 +76,12 @@ func (e *Engine) gtidChangeSourceSupported(ctx context.Context, host, username, 
 		return false
 	}
 	defer utils.CloseAndLog(db)
+
+	if err := db.PingContext(ctx); err != nil {
+		e.logger.Warn("failed to connect to target for GTID support probe, using the binlog file+position change source",
+			"host", host, "database", database, "error", err)
+		return false
+	}
 
 	var gtidMode, enforceConsistency string
 	if err := db.QueryRowContext(ctx,
@@ -342,7 +348,7 @@ func (e *Engine) executeSingleStatement(ctx context.Context, host, username, pas
 		"type", stmtType,
 	)
 
-	migration := e.newMigration(ctx, host, username, password, database, stmt)
+	migration := e.newSpiritMigration(ctx, host, username, password, database, stmt)
 
 	runner, err := spiritmigration.NewRunner(migration)
 	if err != nil {
@@ -376,7 +382,7 @@ func (e *Engine) executeSpiritMigration(ctx context.Context, host, username, pas
 		ddls = append(ddls, p.Statement)
 	}
 
-	migration := e.newMigration(ctx, host, username, password, database, combinedStatement)
+	migration := e.newSpiritMigration(ctx, host, username, password, database, combinedStatement)
 	migration.DeferCutOver = deferCutover
 	migration.RespectSentinel = deferCutover // Only wait for sentinel when deferring cutover
 

--- a/pkg/engine/spirit/settings.go
+++ b/pkg/engine/spirit/settings.go
@@ -1,0 +1,95 @@
+// settings.go defines the tunable Spirit run settings and their fleet
+// defaults. The defaults are applied in New whenever a Settings field is left
+// at its zero value, so every embedder — the SchemaBot server, custom engine
+// factories, and external data planes that construct this engine directly —
+// runs with the same defaults unless it explicitly overrides one.
+package spirit
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// DefaultCheckpointMaxAge bounds how old a Spirit checkpoint may be and still
+// be resumed. A copy that has been stalled longer than this restarts cleanly
+// instead of replaying days of old binlogs, which on a busy target can be
+// slower and riskier than starting over.
+const DefaultCheckpointMaxAge = 3 * 24 * time.Hour
+
+// DefaultChecksumYieldTimeout bounds how long each checksum read transaction
+// may run before yielding. The checksum reads under a REPEATABLE READ
+// snapshot; without a yield bound a long checksum pins InnoDB purge and
+// history-list growth degrades the whole target instance.
+const DefaultChecksumYieldTimeout = 12 * time.Hour
+
+// Settings tunes the Spirit runs this engine starts. A zero value resolves to
+// the corresponding default in New; fields are set only to deviate from the
+// fleet defaults.
+type Settings struct {
+	// EnableExperimentalAutoscaling scales Spirit's write threads dynamically
+	// from throttler feedback so apply throughput tracks the target instance's
+	// capacity instead of a fixed constant. nil defaults to enabled; false is
+	// the operator kill switch when autoscaling misbehaves on a target fleet.
+	EnableExperimentalAutoscaling *bool
+
+	// CheckpointMaxAge bounds how old a checkpoint may be and still be
+	// resumed. Zero defaults to DefaultCheckpointMaxAge.
+	CheckpointMaxAge time.Duration
+
+	// ChecksumYieldTimeout bounds each checksum read transaction before it
+	// yields its snapshot. Zero defaults to DefaultChecksumYieldTimeout.
+	ChecksumYieldTimeout time.Duration
+}
+
+// Engine metadata keys read by SettingsFromMetadata. These are the
+// per-database override surface: the server config's spirit block is
+// translated into these keys, and a database's own metadata entry wins over
+// the server-level value.
+const (
+	MetadataEnableExperimentalAutoscaling = "enable_experimental_autoscaling"
+	MetadataCheckpointMaxAge              = "checkpoint_max_age"
+	MetadataChecksumYieldTimeout          = "checksum_yield_timeout"
+)
+
+// SettingsFromMetadata builds Settings from engine metadata key-value pairs.
+// Absent keys leave the corresponding field at its zero value so New resolves
+// the default; present keys must parse, because silently ignoring a
+// misconfigured override would run the apply with settings the operator
+// believes they changed.
+func SettingsFromMetadata(metadata map[string]string) (Settings, error) {
+	var settings Settings
+	if raw, ok := metadata[MetadataEnableExperimentalAutoscaling]; ok {
+		enabled, err := strconv.ParseBool(raw)
+		if err != nil {
+			return Settings{}, fmt.Errorf("parse %s %q: %w", MetadataEnableExperimentalAutoscaling, raw, err)
+		}
+		settings.EnableExperimentalAutoscaling = &enabled
+	}
+	var err error
+	if settings.CheckpointMaxAge, err = parsePositiveDuration(metadata, MetadataCheckpointMaxAge); err != nil {
+		return Settings{}, err
+	}
+	if settings.ChecksumYieldTimeout, err = parsePositiveDuration(metadata, MetadataChecksumYieldTimeout); err != nil {
+		return Settings{}, err
+	}
+	return settings, nil
+}
+
+// parsePositiveDuration parses an optional duration metadata value, requiring
+// it to be positive when present. Absent keys return zero so the engine
+// default applies.
+func parsePositiveDuration(metadata map[string]string, key string) (time.Duration, error) {
+	raw, ok := metadata[key]
+	if !ok {
+		return 0, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s %q: %w", key, raw, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("%s must be positive, got %q", key, raw)
+	}
+	return d, nil
+}

--- a/pkg/engine/spirit/settings_test.go
+++ b/pkg/engine/spirit/settings_test.go
@@ -1,0 +1,111 @@
+package spirit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSettingsFromMetadata(t *testing.T) {
+	boolPtr := func(v bool) *bool { return &v }
+
+	tests := []struct {
+		name     string
+		metadata map[string]string
+		want     Settings
+		wantErr  string
+	}{
+		{
+			name:     "nil metadata leaves all fields zero",
+			metadata: nil,
+			want:     Settings{},
+		},
+		{
+			name: "unrelated keys are ignored",
+			metadata: map[string]string{
+				"pending_drops": "false",
+				"organization":  "acme",
+			},
+			want: Settings{},
+		},
+		{
+			name: "all overrides parse",
+			metadata: map[string]string{
+				MetadataEnableExperimentalAutoscaling: "false",
+				MetadataCheckpointMaxAge:              "24h",
+				MetadataChecksumYieldTimeout:          "6h",
+			},
+			want: Settings{
+				EnableExperimentalAutoscaling: boolPtr(false),
+				CheckpointMaxAge:              24 * time.Hour,
+				ChecksumYieldTimeout:          6 * time.Hour,
+			},
+		},
+		{
+			name: "autoscaling true is preserved as an explicit value",
+			metadata: map[string]string{
+				MetadataEnableExperimentalAutoscaling: "true",
+			},
+			want: Settings{EnableExperimentalAutoscaling: boolPtr(true)},
+		},
+		{
+			name: "invalid autoscaling value errors",
+			metadata: map[string]string{
+				MetadataEnableExperimentalAutoscaling: "yep",
+			},
+			wantErr: MetadataEnableExperimentalAutoscaling,
+		},
+		{
+			name: "invalid checkpoint duration errors",
+			metadata: map[string]string{
+				MetadataCheckpointMaxAge: "3 days",
+			},
+			wantErr: MetadataCheckpointMaxAge,
+		},
+		{
+			name: "non-positive checksum yield errors",
+			metadata: map[string]string{
+				MetadataChecksumYieldTimeout: "0s",
+			},
+			wantErr: "must be positive",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SettingsFromMetadata(tt.metadata)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestNewResolvesSettings verifies that New resolves zero-value Settings
+// fields to the fleet defaults and preserves explicit overrides, so every
+// embedder that constructs the engine without configuration runs with the
+// documented defaults.
+func TestNewResolvesSettings(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		eng := New(Config{})
+		assert.Equal(t, DefaultCheckpointMaxAge, eng.checkpointMaxAge)
+		assert.Equal(t, DefaultChecksumYieldTimeout, eng.checksumYieldTimeout)
+		assert.True(t, eng.autoscaling)
+	})
+
+	t.Run("overrides", func(t *testing.T) {
+		autoscaling := false
+		eng := New(Config{Settings: Settings{
+			EnableExperimentalAutoscaling: &autoscaling,
+			CheckpointMaxAge:              24 * time.Hour,
+			ChecksumYieldTimeout:          6 * time.Hour,
+		}})
+		assert.Equal(t, 24*time.Hour, eng.checkpointMaxAge)
+		assert.Equal(t, 6*time.Hour, eng.checksumYieldTimeout)
+		assert.False(t, eng.autoscaling)
+	})
+}

--- a/pkg/engine/spirit/spirit.go
+++ b/pkg/engine/spirit/spirit.go
@@ -59,7 +59,13 @@ type Engine struct {
 	lockWaitTimeout     time.Duration
 	debugLogs           bool
 	disablePendingDrops bool
-	cpuHint             int // Inferred CPU count from innodb_buffer_pool_instances (0 = unknown); guarded by mu
+
+	// Resolved Settings applied to every Spirit run; immutable after New.
+	checkpointMaxAge     time.Duration
+	checksumYieldTimeout time.Duration
+	autoscaling          bool
+
+	cpuHint int // Inferred CPU count from innodb_buffer_pool_instances (0 = unknown); guarded by mu
 
 	// Log callback for routing Spirit logs to ApplyLogStore (with table context)
 	onLog func(level slog.Level, table, msg string)
@@ -122,6 +128,10 @@ type Config struct {
 	// default because it keeps dropped table data recoverable until the
 	// retention period expires.
 	DisablePendingDrops bool
+
+	// Settings tunes the Spirit runs the engine starts; zero-value fields
+	// resolve to the fleet defaults (see settings.go).
+	Settings Settings
 }
 
 // New creates a new Spirit engine.
@@ -146,14 +156,29 @@ func New(cfg Config) *Engine {
 		lockWaitTimeout = DefaultLockWaitTimeout
 	}
 
+	checkpointMaxAge := cfg.Settings.CheckpointMaxAge
+	if checkpointMaxAge == 0 {
+		checkpointMaxAge = DefaultCheckpointMaxAge
+	}
+
+	checksumYieldTimeout := cfg.Settings.ChecksumYieldTimeout
+	if checksumYieldTimeout == 0 {
+		checksumYieldTimeout = DefaultChecksumYieldTimeout
+	}
+
+	autoscaling := cfg.Settings.EnableExperimentalAutoscaling == nil || *cfg.Settings.EnableExperimentalAutoscaling
+
 	eng := &Engine{
-		logger:              logger,
-		linter:              lint.New(),
-		targetChunkTime:     targetChunkTime,
-		threads:             threads,
-		lockWaitTimeout:     lockWaitTimeout,
-		debugLogs:           cfg.DebugLogs,
-		disablePendingDrops: cfg.DisablePendingDrops,
+		logger:               logger,
+		linter:               lint.New(),
+		targetChunkTime:      targetChunkTime,
+		threads:              threads,
+		lockWaitTimeout:      lockWaitTimeout,
+		debugLogs:            cfg.DebugLogs,
+		disablePendingDrops:  cfg.DisablePendingDrops,
+		checkpointMaxAge:     checkpointMaxAge,
+		checksumYieldTimeout: checksumYieldTimeout,
+		autoscaling:          autoscaling,
 	}
 
 	// Create Spirit logger with filter that checks debugLogs at runtime

--- a/pkg/engine/spirit/spirit_integration_test.go
+++ b/pkg/engine/spirit/spirit_integration_test.go
@@ -2269,20 +2269,20 @@ func TestEngine_StatelessControlAddressesDSNSchema(t *testing.T) {
 	assert.False(t, exists, "signal is reported absent after the sentinel drop")
 }
 
-// TestNewMigrationRunSettings verifies the Spirit run settings applied to
+// TestNewSpiritMigrationRunSettings verifies the Spirit run settings applied to
 // every schema change this engine starts: the fleet defaults resolve when the
 // engine is built without overrides, metadata overrides carry through, and
 // the change source is selected per target capability — the shared test
 // container runs without gtid_mode=ON, so the universally supported binlog
 // file+position source is chosen instead of the GTID source Spirit would
 // refuse to start on this target.
-func TestNewMigrationRunSettings(t *testing.T) {
+func TestNewSpiritMigrationRunSettings(t *testing.T) {
 	dsn, _ := setupTestMySQL(t)
 	host, username, password, database, err := parseDSN(dsn)
 	require.NoError(t, err, "parseDSN")
 
 	eng := New(Config{})
-	m := eng.newMigration(t.Context(), host, username, password, database, "ALTER TABLE t1 ADD COLUMN c1 INT")
+	m := eng.newSpiritMigration(t.Context(), host, username, password, database, "ALTER TABLE t1 ADD COLUMN c1 INT")
 	assert.Equal(t, DefaultCheckpointMaxAge, m.CheckpointMaxAge)
 	assert.Equal(t, DefaultChecksumYieldTimeout, m.ChecksumYieldTimeout)
 	assert.True(t, m.EnableExperimentalAutoscaling, "autoscaling defaults to enabled")
@@ -2299,7 +2299,7 @@ func TestNewMigrationRunSettings(t *testing.T) {
 	})
 	require.NoError(t, err, "SettingsFromMetadata")
 	eng = New(Config{Settings: settings})
-	m = eng.newMigration(t.Context(), host, username, password, database, "ALTER TABLE t1 ADD COLUMN c1 INT")
+	m = eng.newSpiritMigration(t.Context(), host, username, password, database, "ALTER TABLE t1 ADD COLUMN c1 INT")
 	assert.Equal(t, 24*time.Hour, m.CheckpointMaxAge)
 	assert.Equal(t, 6*time.Hour, m.ChecksumYieldTimeout)
 	assert.False(t, m.EnableExperimentalAutoscaling, "autoscaling override disables it")

--- a/pkg/engine/spirit/spirit_integration_test.go
+++ b/pkg/engine/spirit/spirit_integration_test.go
@@ -2268,3 +2268,39 @@ func TestEngine_StatelessControlAddressesDSNSchema(t *testing.T) {
 	require.NoError(t, err, "deferred cutover signal lookup after cutover")
 	assert.False(t, exists, "signal is reported absent after the sentinel drop")
 }
+
+// TestNewMigrationRunSettings verifies the Spirit run settings applied to
+// every schema change this engine starts: the fleet defaults resolve when the
+// engine is built without overrides, metadata overrides carry through, and
+// the change source is selected per target capability — the shared test
+// container runs without gtid_mode=ON, so the universally supported binlog
+// file+position source is chosen instead of the GTID source Spirit would
+// refuse to start on this target.
+func TestNewMigrationRunSettings(t *testing.T) {
+	dsn, _ := setupTestMySQL(t)
+	host, username, password, database, err := parseDSN(dsn)
+	require.NoError(t, err, "parseDSN")
+
+	eng := New(Config{})
+	m := eng.newMigration(t.Context(), host, username, password, database, "ALTER TABLE t1 ADD COLUMN c1 INT")
+	assert.Equal(t, DefaultCheckpointMaxAge, m.CheckpointMaxAge)
+	assert.Equal(t, DefaultChecksumYieldTimeout, m.ChecksumYieldTimeout)
+	assert.True(t, m.EnableExperimentalAutoscaling, "autoscaling defaults to enabled")
+	assert.True(t, m.InterpolateParams)
+	assert.Zero(t, m.WriteThreads, "write threads auto-size for the target")
+	assert.Equal(t, maxCommitLatency, m.MaxCommitLatency,
+		"commit-latency throttle must be set explicitly; Spirit disables the throttler on zero")
+	assert.False(t, m.EnableExperimentalGTID, "GTID-off target keeps the binlog file+position change source")
+
+	settings, err := SettingsFromMetadata(map[string]string{
+		MetadataEnableExperimentalAutoscaling: "false",
+		MetadataCheckpointMaxAge:              "24h",
+		MetadataChecksumYieldTimeout:          "6h",
+	})
+	require.NoError(t, err, "SettingsFromMetadata")
+	eng = New(Config{Settings: settings})
+	m = eng.newMigration(t.Context(), host, username, password, database, "ALTER TABLE t1 ADD COLUMN c1 INT")
+	assert.Equal(t, 24*time.Hour, m.CheckpointMaxAge)
+	assert.Equal(t, 6*time.Hour, m.ChecksumYieldTimeout)
+	assert.False(t, m.EnableExperimentalAutoscaling, "autoscaling override disables it")
+}

--- a/pkg/serve/serve.go
+++ b/pkg/serve/serve.go
@@ -683,11 +683,24 @@ func buildGRPCTernClient(ctx context.Context, config *api.ServerConfig, st *mysq
 func grpcLocalClientFactory(config *api.ServerConfig, wakeOperator func(applyIdentifier, database, environment string), engineFactories map[string]tern.EngineFactory) tern.LocalClientFactory {
 	pendingDropsDisabled := !config.PendingDropsEnabled()
 	return func(cfg tern.LocalConfig, st storage.Storage, logger *slog.Logger) (tern.Client, error) {
-		if pendingDropsDisabled {
+		spiritMetadata, err := config.SpiritMetadata()
+		if err != nil {
+			return nil, fmt.Errorf("resolve spirit config for database %q: %w", cfg.Database, err)
+		}
+		if pendingDropsDisabled || len(spiritMetadata) > 0 {
 			if cfg.Metadata == nil {
 				cfg.Metadata = map[string]string{}
 			}
+		}
+		if pendingDropsDisabled {
 			cfg.Metadata["pending_drops"] = "false"
+		}
+		// Server-level spirit overrides are defaults; a database's own
+		// metadata entry for the same key wins.
+		for key, value := range spiritMetadata {
+			if _, ok := cfg.Metadata[key]; !ok {
+				cfg.Metadata[key] = value
+			}
 		}
 		if cfg.WakeOperator == nil {
 			cfg.WakeOperator = wakeOperator

--- a/pkg/tern/local_client.go
+++ b/pkg/tern/local_client.go
@@ -147,7 +147,10 @@ type LocalConfig struct {
 	// Keys used by PlanetScale: organization, token_name, token_value,
 	// tls_name, revert_window_duration, main_branch.
 	// Keys used by Spirit: pending_drops ("false" disables the pending drops
-	// quarantine so DROP TABLE executes directly).
+	// quarantine so DROP TABLE executes directly), plus the run-settings
+	// overrides parsed by spirit.SettingsFromMetadata
+	// (enable_experimental_autoscaling, checkpoint_max_age,
+	// checksum_yield_timeout).
 	Metadata map[string]string
 
 	// SchemaOverrides maps a requested (canonical) MySQL namespace to the
@@ -282,6 +285,11 @@ func NewLocalClient(cfg LocalConfig, stor storage.Storage, logger *slog.Logger) 
 		customEngine = eng
 	}
 
+	spiritSettings, err := spirit.SettingsFromMetadata(cfg.Metadata)
+	if err != nil {
+		return nil, fmt.Errorf("parse Spirit settings for database %q: %w", cfg.Database, err)
+	}
+
 	return &LocalClient{
 		config:  cfg,
 		storage: stor,
@@ -290,6 +298,7 @@ func NewLocalClient(cfg LocalConfig, stor storage.Storage, logger *slog.Logger) 
 			// Pending drops quarantine is on by default; deployments opt out
 			// via the pending_drops metadata key.
 			DisablePendingDrops: cfg.Metadata["pending_drops"] == "false",
+			Settings:            spiritSettings,
 		}),
 		planetscaleEngine: psEngine,
 		customEngine:      customEngine,


### PR DESCRIPTION
## Why this matters

SchemaBot's Spirit engine has been running large copies with library-default settings, while the settings proven in production for the same kind of targets differ in ways that matter at scale: fixed write-thread counts sized for one instance class silently starve or overload another, stale checkpoints replay days of old binlogs instead of restarting cleanly, and long checksum transactions can pin InnoDB purge on a busy target. On multi-terabyte tables the difference is measured in days.

## What it does

Aligns every Spirit run with production-proven defaults and adds a `spirit:` server-config block for the rare case where a deployment needs to deviate:

- **Write threads are auto-sized and autoscaled** (`WriteThreads: 0` + `EnableExperimentalAutoscaling` on by default). On non-Aurora targets this resolves to Spirit's standard fixed default, identical to today; the autoscaler engages only where Spirit supports it. The operator control for copy aggressiveness remains the apply's `volume`. `enable_experimental_autoscaling: false` exists as an incident kill switch.
- **`checkpoint_max_age: 72h`** and **`checksum_yield_timeout: 12h`** become the defaults, overridable via the config block or per-database metadata (the database's entry wins).
- **GTID change source is auto-detected per target** (no knob): targets with `gtid_mode=ON` and `enforce_gtid_consistency=ON` get Spirit's GTID-based change source; everything else keeps binlog file+position.
- **`MaxCommitLatency` is set explicitly to 100ms** — Spirit's `default:"100ms"` tag only applies to its CLI, and a zero value disables the commit-latency throttler, which in redo-aware mode also caps the autoscaler at its starting size.
- Defaults live in `pkg/engine/spirit` (zero-value `Settings` resolves to the aligned default), so every embedder of the engine picks them up on a version bump with no config changes.

```
ServerConfig spirit: block ──► engine metadata keys ──► spirit.SettingsFromMetadata
        (server-wide default)     (per-database wins)          (engine Config)
```

Documented in `docs/configuration.md` (§ Spirit Run Settings) with the rationale for each default.

## Northstar

Every schema change runs with the same battle-tested engine behavior regardless of which deployment or embedder drives it — configuration exists to deviate deliberately, never to remember to opt in to safety.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
